### PR TITLE
Use letters to de-dupe imported questions

### DIFF
--- a/browser-test/src/admin/admin_program_migration.test.ts
+++ b/browser-test/src/admin/admin_program_migration.test.ts
@@ -390,9 +390,9 @@ test.describe('program migration', () => {
       await expect(programDataDiv).toContainText('What is your address?')
       // question help text
       await expect(programDataDiv).toContainText('help text')
-      // admin name (should be updated with "-1" on the end)
+      // admin name (should be updated with " -_- a" on the end)
       await expect(programDataDiv).toContainText(
-        'Admin name: Sample Address Question-1',
+        'Admin name: Sample Address Question -_- a',
       )
       // admin description
       await expect(programDataDiv).toContainText(
@@ -579,7 +579,7 @@ test.describe('program migration', () => {
       await expect(programDataDiv).toContainText('What is your address?')
       // question help text
       await expect(programDataDiv).toContainText('help text')
-      // admin name (should not be updated with "-1" on the end)
+      // admin name (should not be updated with " -_- a" on the end)
       await expect(programDataDiv).toContainText(
         'Admin name: Sample Address Question',
       )

--- a/server/app/repository/QuestionRepository.java
+++ b/server/app/repository/QuestionRepository.java
@@ -75,23 +75,6 @@ public final class QuestionRepository {
         executionContext);
   }
 
-  /** Get any similar admin names to the admin name passed in */
-  public ImmutableList<String> getSimilarAdminNames(String adminName) {
-    return database
-        .find(QuestionModel.class)
-        .setLabel("QuestionModel.findList")
-        .setProfileLocation(queryProfileLocationBuilder.create("getSimilarAdminNames"))
-        .where()
-        .ilike("name", adminName + "%")
-        .findList()
-        .stream()
-        .map(
-            question -> {
-              return question.getQuestionDefinition().getName();
-            })
-        .collect(ImmutableList.toImmutableList());
-  }
-
   /**
    * Find and update the DRAFT of the question with this name, if one already exists. Create a new
    * DRAFT if there isn't one.

--- a/server/app/services/migration/ProgramMigrationService.java
+++ b/server/app/services/migration/ProgramMigrationService.java
@@ -13,22 +13,35 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Inject;
 import controllers.admin.ProgramMigrationWrapper;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import models.ProgramNotificationPreference;
 import repository.QuestionRepository;
 import services.ErrorAnd;
+import services.LocalizedStrings;
 import services.program.ProgramDefinition;
 import services.program.ProgramType;
 import services.question.exceptions.UnsupportedQuestionTypeException;
 import services.question.types.QuestionDefinition;
 import services.question.types.QuestionDefinitionBuilder;
+import services.question.types.QuestionDefinitionConfig;
+import services.question.types.TextQuestionDefinition;
 
 /**
  * A service responsible for helping admins migrate program definitions between different
  * environments.
  */
 public final class ProgramMigrationService {
+  // We use `-_-` as the delimiter because it's unlikely to already be used in a question with a
+  // name like `name - parent`.
+  // It will transform to a key formatted like `%s__%s`
+  private static final String CONFLICTING_QUESTION_FORMAT = "%s -_- %s";
+  private static final Pattern SUFFIX_PATTERN = Pattern.compile(" -_- [a-z]+$");
+  private static final String ALPHABET = "abcdefghijklmnopqrstuvwxyz";
+
   private final ObjectMapper objectMapper;
   private final QuestionRepository questionRepository;
 
@@ -84,18 +97,21 @@ public final class ProgramMigrationService {
 
   /**
    * Checks if there are existing questions that match the admin id of any of the incoming
-   * questions. If a match is found, generate a new admin name of the format "orginal admin name-n".
+   * questions. If a match is found, generate a new admin name of the <br>
+   * format `orginal admin name -_- a`.
    *
    * <p>Return a map of old_question_name -> updated_question_data
    */
   public ImmutableMap<String, QuestionDefinition> maybeOverwriteQuestionName(
       ImmutableList<QuestionDefinition> questions) {
+    List<String> newNamesSoFar = new ArrayList<>();
     return questions.stream()
         .collect(
             ImmutableMap.toImmutableMap(
                 QuestionDefinition::getName,
                 question -> {
-                  String newAdminName = maybeGenerateNewAdminName(question.getName());
+                  String newAdminName = findUniqueAdminName(question.getName(), newNamesSoFar);
+                  newNamesSoFar.add(newAdminName);
                   try {
                     return new QuestionDefinitionBuilder(question).setName(newAdminName).build();
                   } catch (UnsupportedQuestionTypeException error) {
@@ -105,32 +121,82 @@ public final class ProgramMigrationService {
   }
 
   /**
-   * Generate a new admin name for questions of the format "orginal admin name-n" where "n" is the
-   * next consecutive number such that we don't already have a question with that admin name saved.
-   * For example if the admin name is "sample question" and we already have "sample question-1" and
-   * "sample question-2" saved in the db, the generated name will be "sample question-3"
+   * Generate a new admin name for questions of the format "orginal admin name -_- a" where "a" is
+   * the next consecutive letter such that we don't already have a question with that admin name
+   * saved. For example if the admin name is "sample question" and we already have <br>
+   * "sample question -_- a" and "sample question -_- b" saved in the db, the generated name will be
+   * "sample question -_- c".
    */
-  public String maybeGenerateNewAdminName(String adminName) {
-    // If the question name contains a suffix of the form "-n" (for example "admin-name-1"), we want
-    // to strip off the "-n" before searching for the admin name to ensure all similar names are
-    // returned. This also allows us to correctly increment the suffix of the base admin name so we
-    // don't end up with admin names like "admin-name-1-1".
-    Pattern HYPHEN_DIGIT_PATTERN = Pattern.compile("-[0-9]+");
-    Matcher matcher = HYPHEN_DIGIT_PATTERN.matcher(adminName);
-    if (matcher.find()) {
-      int lastHyphenIndex = adminName.lastIndexOf("-");
-      adminName = adminName.substring(0, lastHyphenIndex);
+  String findUniqueAdminName(String adminName, List<String> newNamesSoFar) {
+    if (!nameHasConflict(adminName, newNamesSoFar)) {
+      return adminName;
     }
-    ImmutableList<String> similarAdminNames = questionRepository.getSimilarAdminNames(adminName);
 
-    String newAdminName = adminName;
-    int n = 1;
-    while (similarAdminNames.contains(newAdminName)) {
-      newAdminName = adminName + "-" + n;
-      n++;
-      continue;
+    // If the question name contains a suffix of the form " -_- a" (for example "admin name -_- a"),
+    // we want to strip off the " -_- n" to find the base name. This also allows us to correctly
+    // increment the suffix of the base admin name so we don't end up with admin names like "admin
+    // name -_- a -_- a".
+    Matcher matcher = SUFFIX_PATTERN.matcher(adminName);
+    String adminNameBase = adminName;
+    if (matcher.find()) {
+      adminNameBase = adminName.substring(0, matcher.start());
     }
-    return newAdminName;
+
+    int extension = 0;
+    String newName = "";
+    do {
+      extension++;
+      newName =
+          CONFLICTING_QUESTION_FORMAT.formatted(adminNameBase, convertNumberToSuffix(extension));
+    } while (nameHasConflict(newName, newNamesSoFar));
+
+    return newName;
+  }
+
+  private boolean nameHasConflict(String name, List<String> newNamesSoFar) {
+    // Check if any of the names we've already generated might conflict with this one.
+    // We can compare raw names, rather than keys, because everything we generate
+    // follows the same pattern and will reduce to keys in the same way.
+    if (newNamesSoFar.contains(name)) {
+      return true;
+    }
+
+    QuestionDefinition testQuestion =
+        new TextQuestionDefinition(
+            QuestionDefinitionConfig.builder()
+                .setName(name)
+                .setDescription("description")
+                .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
+                .build());
+
+    return questionRepository.findConflictingQuestion(testQuestion).isPresent();
+  }
+
+  /**
+   * Convert a number to the equivalent "excel column name".
+   *
+   * <p>For example, 5 maps to "e", and 28 maps to "ab".
+   *
+   * @param num to convert
+   * @return The "excel column name" form of the number
+   */
+  String convertNumberToSuffix(int num) {
+    String result = "";
+
+    // Division algorithm to convert from base 10 to "base 26"
+    int dividend = num; // 28
+    while (dividend > 0) {
+      // Subtract one so we're doing math with a zero-based index.
+      // We need "a" to be 0, and "z" to be 25, so that 26 wraps around
+      // to be "aa". "a" is "ten" in base 26.
+      dividend = dividend - 1;
+      int remainder = dividend % 26;
+      result = ALPHABET.charAt(remainder) + result;
+      dividend = dividend / 26;
+      ;
+    }
+
+    return result;
   }
 
   /**

--- a/server/test/controllers/admin/AdminImportControllerTest.java
+++ b/server/test/controllers/admin/AdminImportControllerTest.java
@@ -453,7 +453,7 @@ public class AdminImportControllerTest extends ResetPostgres {
     assertThat(contentAsString(result))
         .contains("Importing this program will add 1 duplicate question to the question bank.");
     // question has the new admin name
-    assertThat(contentAsString(result)).contains("Name-1");
+    assertThat(contentAsString(result)).contains("Name -_- a");
     // other information in the question is unchanged
     assertThat(contentAsString(result)).contains("Please enter your first and last name");
   }

--- a/server/test/repository/QuestionRepositoryTest.java
+++ b/server/test/repository/QuestionRepositoryTest.java
@@ -3,7 +3,6 @@ package repository;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import io.ebean.DataIntegrityException;
 import java.util.Locale;
@@ -434,15 +433,6 @@ public class QuestionRepositoryTest extends ResetPostgres {
                 .getQuestionTags()
                 .contains(PrimaryApplicantInfoTag.APPLICANT_PHONE.getQuestionTag()))
         .isFalse();
-  }
-
-  @Test
-  public void getQuestionsWithSimilarAdminNames_returnsSimilarAdminNames() {
-    resourceCreator.insertQuestion("name-question");
-    resourceCreator.insertQuestion("name-question-1");
-    resourceCreator.insertQuestion("name-question-2");
-    ImmutableList<String> adminNames = repo.getSimilarAdminNames("name-question");
-    assertThat(adminNames.size()).isEqualTo(3);
   }
 
   private QuestionDefinition addTagToDefinition(QuestionModel question)

--- a/server/test/services/migration/ProgramMigrationServiceTest.java
+++ b/server/test/services/migration/ProgramMigrationServiceTest.java
@@ -15,7 +15,9 @@ import com.fasterxml.jackson.databind.ObjectWriter;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import controllers.admin.ProgramMigrationWrapper;
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Locale;
 import models.CategoryModel;
 import models.DisplayMode;
@@ -166,31 +168,52 @@ public final class ProgramMigrationServiceTest extends ResetPostgres {
         service.maybeOverwriteQuestionName(questionsTwo);
 
     // "id-test" should have been updated by the method
-    assertThat(updatedQuestions.get("id-test").getName()).isEqualTo("id-test-1");
+    assertThat(updatedQuestions.get("id-test").getName()).isEqualTo("id-test -_- a");
     // "new text test" should have not have been changed
     assertThat(updatedQuestions.get("new text test").getName()).isEqualTo("new text test");
   }
 
   @Test
-  public void maybeGenerateNewAdminName_generatesCorrectAdminNames() {
+  public void findUniqueAdminName_generatesCorrectAdminNames() {
     resourceCreator.insertQuestion("name-question");
-    resourceCreator.insertQuestion("name-question-1");
-    resourceCreator.insertQuestion("name-question-2");
+    resourceCreator.insertQuestion("name-question -_- a");
+    resourceCreator.insertQuestion("name-question -_- b");
 
-    String newAdminName = service.maybeGenerateNewAdminName("name-question");
-    assertThat(newAdminName).isEqualTo("name-question-3");
-    String unmatchedAdminName = service.maybeGenerateNewAdminName("admin-name-unmatched");
+    String newAdminName = service.findUniqueAdminName("name-question", new ArrayList<>());
+    assertThat(newAdminName).isEqualTo("name-question -_- c");
+    String unmatchedAdminName =
+        service.findUniqueAdminName("admin-name-unmatched", new ArrayList<>());
     assertThat(unmatchedAdminName).isEqualTo("admin-name-unmatched");
   }
 
   @Test
-  public void maybeGenerateNewAdminName_generatesCorrectAdminNamesForAdminNamesWithSuffixes() {
+  public void findUniqueAdminName_generatesCorrectAdminNamesForAdminNamesWithSuffixes() {
     resourceCreator.insertQuestion("name-question");
-    resourceCreator.insertQuestion("name-question-1");
-    resourceCreator.insertQuestion("name-question-2");
+    resourceCreator.insertQuestion("name-question -_- a");
+    resourceCreator.insertQuestion("name-question -_- b");
 
-    String newAdminName = service.maybeGenerateNewAdminName("name-question-1");
-    assertThat(newAdminName).isEqualTo("name-question-3");
+    String newAdminName = service.findUniqueAdminName("name-question -_- a", new ArrayList<>());
+    assertThat(newAdminName).isEqualTo("name-question -_- c");
+  }
+
+  @Test
+  public void
+      findUniqueAdminName_generatesCorrectAdminNamesWhenAlreadyGeneratedNameMightConflict() {
+    List<String> namesSoFar = List.of("name-question -_- a", "name-question -_- b");
+
+    String newAdminName = service.findUniqueAdminName("name-question -_- a", namesSoFar);
+    assertThat(newAdminName).isEqualTo("name-question -_- c");
+  }
+
+  @Test
+  public void convertNumberToSuffix_generatesCorrectSuffix() {
+    assertThat(service.convertNumberToSuffix(10)).isEqualTo("j");
+    assertThat(service.convertNumberToSuffix(26)).isEqualTo("z");
+    assertThat(service.convertNumberToSuffix(26 + 2)).isEqualTo("ab");
+    assertThat(service.convertNumberToSuffix(26 + 26)).isEqualTo("az");
+    assertThat(service.convertNumberToSuffix(26 + 26 + 26)).isEqualTo("bz");
+    assertThat(service.convertNumberToSuffix(26 * 26 + 11)).isEqualTo("zk");
+    assertThat(service.convertNumberToSuffix(27 * 26 + 11)).isEqualTo("aak");
   }
 
   @Test


### PR DESCRIPTION
### Description

Use letters instead of numbers to de-dupe imported questions during program migration.

Details:
- Numbers are stripped from question names when generating keys[1], so they end up colliding when exported or used to access ApplicantData.
- Instead, we use "excel column name" style letters to de-duplicate questions with conflicting names.

[1] https://github.com/civiform/civiform/blob/0c57746d98eaba7471d65bd8fe50d792701c2990/server/app/services/question/types/QuestionDefinition.java#L60

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [x] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [x] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`


### Instructions for manual testing

- Try importing questions with duplicate names
- Also try importing a program with questions that both need to be deduplicated, to ensure they don't collide with each other.

### Issue(s) this completes

Part of #9212
