### PR TITLE
[North Star] Add aria label to "View and apply" program card button

### DIFF
--- a/server/app/services/MessageKey.java
+++ b/server/app/services/MessageKey.java
@@ -125,6 +125,7 @@ public enum MessageKey {
   BUTTON_VIEW_APPLICATIONS("button.viewApplications"),
   BUTTON_VIEW_AND_ADD_CLIENTS("button.viewAndAddClients"),
   BUTTON_VIEW_AND_APPLY("button.viewAndApply"), // North Star only
+  BUTTON_VIEW_AND_APPLY_SR("button.viewAndApplySr"),
   BUTTON_HOME_PAGE("button.homePage"),
   CURRENCY_VALIDATION_MISFORMATTED("validation.currencyMisformatted"),
   CONTACT_INFO_LABEL("label.contactInfo"),

--- a/server/app/services/MessageKey.java
+++ b/server/app/services/MessageKey.java
@@ -125,7 +125,6 @@ public enum MessageKey {
   BUTTON_VIEW_APPLICATIONS("button.viewApplications"),
   BUTTON_VIEW_AND_ADD_CLIENTS("button.viewAndAddClients"),
   BUTTON_VIEW_AND_APPLY("button.viewAndApply"), // North Star only
-  BUTTON_VIEW_AND_APPLY_SR("button.viewAndApplySr"),
   BUTTON_HOME_PAGE("button.homePage"),
   CURRENCY_VALIDATION_MISFORMATTED("validation.currencyMisformatted"),
   CONTACT_INFO_LABEL("label.contactInfo"),

--- a/server/app/services/MessageKey.java
+++ b/server/app/services/MessageKey.java
@@ -125,6 +125,7 @@ public enum MessageKey {
   BUTTON_VIEW_APPLICATIONS("button.viewApplications"),
   BUTTON_VIEW_AND_ADD_CLIENTS("button.viewAndAddClients"),
   BUTTON_VIEW_AND_APPLY("button.viewAndApply"), // North Star only
+  BUTTON_VIEW_AND_APPLY_SR("button.viewAndApplySr"), // North Star only
   BUTTON_HOME_PAGE("button.homePage"),
   CURRENCY_VALIDATION_MISFORMATTED("validation.currencyMisformatted"),
   CONTACT_INFO_LABEL("label.contactInfo"),

--- a/server/app/views/applicant/ProgramCardsSectionFragment.html
+++ b/server/app/views/applicant/ProgramCardsSectionFragment.html
@@ -133,6 +133,7 @@
         th:href="${card.actionUrl()}"
         class="usa-button usa-button--outline cf-apply-button"
         th:text="${card.actionText()}"
+        th:aria-label="#{button.viewAndApplySr(${card.title()})}"
       ></a>
     </div>
   </div>

--- a/server/conf/i18n/messages
+++ b/server/conf/i18n/messages
@@ -177,6 +177,8 @@ button.continueSr=Continue application to {0}
 button.startHere=Start here
 # The text on a button to view and apply to a program. Clicking the button leads to the program overview page.
 button.viewAndApply=View and apply
+# The screen reader text on a button to view and apply to a program. The variable represents the program name.
+button.viewAndApplySr=View and apply to {0}
 # The text for the button that allows a guest to bypass the login prompt modal.
 button.continueToApplication=Continue to application
 # The screen reader text for a button an applicant clicks to start filling out a pre-screener form.


### PR DESCRIPTION
### Description

Adds an aria label to the home page program card "View and apply" button so that each button's text is distinct in that it contains the specific program name.  The screen reader will announce "View and apply to 'program name'".

### Instructions for manual testing

1. Go to the home page with the North Star flag on.
2. Turn on the screen reader.
3. Tab to the "View and apply" button.
4. The screen reader should announce "View and apply to 'program name'".

### Issue(s) this partially completes

Part of #7686 
