### PR TITLE
Handle duplicate questions during export

### DIFF
--- a/server/app/services/export/JsonExporterService.java
+++ b/server/app/services/export/JsonExporterService.java
@@ -212,7 +212,10 @@ public final class JsonExporterService {
         .setSubmitTime(application.getSubmitTime())
         .setStatus(application.getLatestStatus())
         .setRevisionState(toRevisionState(application.getLifecycleStage()))
-        .addApplicationEntries(entriesBuilder.build())
+        // TODO(#9212): There should never be duplicate entries because question paths should be
+        // unique, but due to #9212 there sometimes are. They point at the same location in the
+        // applicant data so it doesn't matter which one we keep.
+        .addApplicationEntries(entriesBuilder.buildKeepingLast())
         .build();
   }
 


### PR DESCRIPTION
### Description

Handle duplicate questions during export.

Details:
- There should not be questions with colliding keys but due to #9212 there sometimes are.
- If there's colliding keys, drop the first one and keep the second. This should not change the output, as colliding keys point to the same place in the applicant data.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [x] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [x] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`

### Issue(s) this completes

Part of #9212
