### PR TITLE
Use original Line 2 of address if ESRI returns an empty string

### DIFF
--- a/server/app/services/geo/esri/EsriClient.java
+++ b/server/app/services/geo/esri/EsriClient.java
@@ -173,7 +173,9 @@ public abstract class EsriClient {
         // If there is no value in SubAddr return the value the user entered. It may not be
         // returned by the ESRI instance and we don't want to lose the value.
         .setLine2(
-            attributes.subAddr().isPresent() ? attributes.subAddr().get() : address.getLine2())
+            attributes.subAddr().orElse("").isBlank()
+                ? address.getLine2()
+                : attributes.subAddr().get())
         .setCity(attributes.city())
         .setState(getStateAbbreviationFromAttributes(attributes, address))
         .setZip(attributes.postal())

--- a/server/test/services/geo/esri/EsriClientTest.java
+++ b/server/test/services/geo/esri/EsriClientTest.java
@@ -272,6 +272,16 @@ public class EsriClientTest {
         attributes, "street-expected", "line2-user", "city-expected", "WA", "11111-expected");
   }
 
+  @Test
+  public void verifyMappingAddressFromJsonAttributes_useLine2AsEnteredIfEmpty() {
+    Attributes attributes =
+        new Attributes(
+            "", "street-expected", "city-expected", "WA", "Washington", "11111-expected");
+
+    runMapAddressAttributesJsonAndAssertResults(
+        attributes, "street-expected", "line2-user", "city-expected", "WA", "11111-expected");
+  }
+
   private void runMapAddressAttributesJsonAndAssertResults(
       Attributes attributes,
       String streetExpected,


### PR DESCRIPTION
### Description

Make sure to use the original Line 2 of the address if the result from ESRI is Optional.IsEmpty -or- an empty string.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
