### PR TITLE
issue-8942 remove unnecessary wrapping nav element from guest login alert

### DIFF
--- a/server/app/services/MessageKey.java
+++ b/server/app/services/MessageKey.java
@@ -263,6 +263,7 @@ public enum MessageKey {
   LINK_OPENS_NEW_TAB_SR("link.opensNewTabSr"),
   LABEL_PRIMARY_NAVIGATION("label.primaryNavigation"),
   LABEL_AGENCY_IDENTIFIER("label.agencyIdentifier"),
+  LABEL_GUEST_SESSION_ALERT("label.guestSessionAlert"),
   LABEL_IN_PROGRESS("label.inProgress"), // North Star only
   LABEL_SUBMITTED("label.submitted"), // North Star only
   LABEL_SUBMITTED_ON("label.submittedOn"), // North Star only

--- a/server/app/views/applicant/NavigationFragment.html
+++ b/server/app/views/applicant/NavigationFragment.html
@@ -150,8 +150,13 @@
   </svg>
 </span>
 
-<nav th:fragment="guestSessionAlert" th:if="${isGuest and hasProfile}">
-  <section
+<section
+  th:fragment="guestSessionAlert"
+  th:if="${isGuest and hasProfile}"
+  role="region"
+  th:aria-label="#{label.guestSessionAlert}"
+>
+  <div
     class="usa-site-alert usa-site-alert--info usa-site-alert--slim cf-alert"
   >
     <div class="usa-alert">
@@ -162,8 +167,8 @@
         ></p>
       </div>
     </div>
-  </section>
-</nav>
+  </div>
+</section>
 
 <div th:fragment="tiAlert" th:if="${isTrustedIntermediary}">
   <section

--- a/server/conf/i18n/messages
+++ b/server/conf/i18n/messages
@@ -67,6 +67,8 @@ link.opensNewTabSr=opens in a new tab
 label.primaryNavigation=Primary navigation
 # Aria-label for agency identifier
 label.agencyIdentifier=Agency identifier,
+# Aria-label for guest session alert 
+label.guestSessionAlert=Guest session informational alert
 
 #-------------------------------------------------------------#
 # LOGIN - contains text that for login page.                  #


### PR DESCRIPTION
### Description

remove unnecessary wrapping nav element from guest login alert message and add appropriate Aria attributes.


### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [N/A] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [x] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`

#### Database evolutions

Read the guidelines [here](https://github.com/civiform/civiform/wiki/Database#writing-database-evolutions)

N/A

#### Durable jobs

Read the docs [here](https://github.com/civiform/civiform/wiki/Database#durable-jobs-for-data-updates)

N/A

#### User visible changes

- [x] Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
  - [x] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [ ] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [covered by existing tests] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [N/A] Made equivalent changes in Thymeleaf for applicant-facing features and changes (or created an issue in the [Northstar epic](https://github.com/orgs/civiform/projects/1/views/94) to track that it's missing from Thymeleaf)
- [x] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [x] Manually tested at 200% size
- [x] Manually evaluated tab order
- [x] Manually tested with a screen reader if the feature is applicant-facing. See [screen reader testing](https://github.com/civiform/civiform/wiki/Testing#screen-reader-testing)

#### New Features

N/A

### Instructions for manual testing

start an application without login, use browser dev tool to verify the guest loggin message section is not wrapped with a nav element

### Issue(s) this completes

Fixes #9254
