### PR TITLE
Issue 8914 migrate static_text.test.ts to northstar

### DIFF
--- a/browser-test/src/applicant/questions/northstar_static_text.test.ts
+++ b/browser-test/src/applicant/questions/northstar_static_text.test.ts
@@ -1,0 +1,104 @@
+import {Page} from 'playwright'
+import {test, expect} from '../../support/civiform_fixtures'
+import {
+  AdminQuestions,
+  AdminPrograms,
+  enableFeatureFlag,
+  loginAsAdmin,
+  logout,
+  validateAccessibility,
+  validateScreenshot,
+} from '../../support'
+
+const staticText = 'Hello, I am some static text!'
+const markdownText = '\n[This is a link](https://www.example.com)\n' +
+  'This is a list:\n' +
+  '* Item 1\n' +
+  '* Item 2\n' +
+  '\n' +
+  'There are some empty lines below this that should be preserved\n' +
+  '\n' +
+  '\n' +
+  'This link should be autodetected: https://www.example.com\n' +
+  '__Last line of content should be bold__'
+const programName = 'Test program for static text'
+
+test.describe('Static text question for applicant flow', () => {
+  test.beforeEach(async ({page, adminQuestions, adminPrograms}) => {
+    await setUpForSingleQuestion(
+      programName,
+      page,
+      adminQuestions,
+      adminPrograms,
+    )
+    await enableFeatureFlag(page, 'north_star_applicant_ui')
+  })
+
+  test('parses markdown', async ({page, applicantQuestions}) => {
+    await applicantQuestions.applyProgram(
+      programName,
+      /* northStarEnabled= */ true,
+    )
+    await validateScreenshot(
+      page.getByTestId('staticQuestionRoot'),
+      'markdown-text-north-star',
+      /* fullPage= */ false,
+      /* mobileScreenshot= */ false,
+    )
+    await verifyMarkdownHtml(page)
+  })
+
+  test('has no accessiblity violations', async ({
+    page,
+    applicantQuestions,
+  }) => {
+    await applicantQuestions.applyProgram(
+      programName,
+      /* northStarEnabled= */ true,
+    )
+    await validateAccessibility(page)
+  })
+})
+
+async function setUpForSingleQuestion(
+  programName: string,
+  page: Page,
+  adminQuestions: AdminQuestions,
+  adminPrograms: AdminPrograms,
+) {
+  // As admin, create program with static text question.
+  await loginAsAdmin(page)
+  await adminQuestions.addStaticQuestion({
+    questionName: 'static-text-q',
+    questionText: staticText,
+    markdownText: markdownText,
+  })
+  // Must add an answerable question for text to show.
+  await adminQuestions.addEmailQuestion({questionName: 'partner-email-q'})
+  await adminPrograms.addAndPublishProgramWithQuestions(
+    ['static-text-q', 'partner-email-q'],
+    programName,
+  )
+  await logout(page)
+}
+
+async function verifyMarkdownHtml(page: Page) {
+    expect(await page.innerHTML('.cf-applicant-question-text')).toContain(
+      '<p>Hello, I am some static text!<br>',
+    )
+    expect(await page.innerHTML('.cf-applicant-question-text')).toContain(
+      '<a href="https://www.example.com" class="text-blue-900 font-bold opacity-75 underline hover:opacity-100" target="_blank" aria-label="opens in a new tab" rel="nofollow noopener noreferrer">This is a link<svg',
+    )
+    expect(await page.innerHTML('.cf-applicant-question-text')).toContain(
+      '<ul class="list-disc mx-8"><li>Item 1</li><li>Item 2<br>&nbsp;</li></ul>',
+    )
+    expect(await page.innerHTML('.cf-applicant-question-text')).toContain(
+      '<p>There are some empty lines below this that should be preserved<br>&nbsp;</p>\n<p>&nbsp;</p>',
+    )
+    expect(await page.innerHTML('.cf-applicant-question-text')).toContain(
+      '<p>This link should be autodetected: <a href="https://www.example.com" class="text-blue-900 font-bold opacity-75 underline hover:opacity-100" target="_blank" aria-label="opens in a new tab" rel="nofollow noopener noreferrer">https://www.example.com<svg',
+    )
+    expect(await page.innerHTML('.cf-applicant-question-text')).toContain(
+      '<strong>Last line of content should be bold</strong>',
+    )
+  }

--- a/browser-test/src/applicant/questions/northstar_static_text.test.ts
+++ b/browser-test/src/applicant/questions/northstar_static_text.test.ts
@@ -11,7 +11,8 @@ import {
 } from '../../support'
 
 const staticText = 'Hello, I am some static text!'
-const markdownText = '\n[This is a link](https://www.example.com)\n' +
+const markdownText =
+  '\n[This is a link](https://www.example.com)\n' +
   'This is a list:\n' +
   '* Item 1\n' +
   '* Item 2\n' +
@@ -48,10 +49,7 @@ test.describe('Static text question for applicant flow', () => {
     await verifyMarkdownHtml(page)
   })
 
-  test('has no accessiblity violations', async ({
-    page,
-    applicantQuestions,
-  }) => {
+  test('has no accessiblity violations', async ({page, applicantQuestions}) => {
     await applicantQuestions.applyProgram(
       programName,
       /* northStarEnabled= */ true,
@@ -83,22 +81,22 @@ async function setUpForSingleQuestion(
 }
 
 async function verifyMarkdownHtml(page: Page) {
-    expect(await page.innerHTML('.cf-applicant-question-text')).toContain(
-      '<p>Hello, I am some static text!<br>',
-    )
-    expect(await page.innerHTML('.cf-applicant-question-text')).toContain(
-      '<a href="https://www.example.com" class="text-blue-900 font-bold opacity-75 underline hover:opacity-100" target="_blank" aria-label="opens in a new tab" rel="nofollow noopener noreferrer">This is a link<svg',
-    )
-    expect(await page.innerHTML('.cf-applicant-question-text')).toContain(
-      '<ul class="list-disc mx-8"><li>Item 1</li><li>Item 2<br>&nbsp;</li></ul>',
-    )
-    expect(await page.innerHTML('.cf-applicant-question-text')).toContain(
-      '<p>There are some empty lines below this that should be preserved<br>&nbsp;</p>\n<p>&nbsp;</p>',
-    )
-    expect(await page.innerHTML('.cf-applicant-question-text')).toContain(
-      '<p>This link should be autodetected: <a href="https://www.example.com" class="text-blue-900 font-bold opacity-75 underline hover:opacity-100" target="_blank" aria-label="opens in a new tab" rel="nofollow noopener noreferrer">https://www.example.com<svg',
-    )
-    expect(await page.innerHTML('.cf-applicant-question-text')).toContain(
-      '<strong>Last line of content should be bold</strong>',
-    )
-  }
+  expect(await page.innerHTML('.cf-applicant-question-text')).toContain(
+    '<p>Hello, I am some static text!<br>',
+  )
+  expect(await page.innerHTML('.cf-applicant-question-text')).toContain(
+    '<a href="https://www.example.com" class="text-blue-900 font-bold opacity-75 underline hover:opacity-100" target="_blank" aria-label="opens in a new tab" rel="nofollow noopener noreferrer">This is a link<svg',
+  )
+  expect(await page.innerHTML('.cf-applicant-question-text')).toContain(
+    '<ul class="list-disc mx-8"><li>Item 1</li><li>Item 2<br>&nbsp;</li></ul>',
+  )
+  expect(await page.innerHTML('.cf-applicant-question-text')).toContain(
+    '<p>There are some empty lines below this that should be preserved<br>&nbsp;</p>\n<p>&nbsp;</p>',
+  )
+  expect(await page.innerHTML('.cf-applicant-question-text')).toContain(
+    '<p>This link should be autodetected: <a href="https://www.example.com" class="text-blue-900 font-bold opacity-75 underline hover:opacity-100" target="_blank" aria-label="opens in a new tab" rel="nofollow noopener noreferrer">https://www.example.com<svg',
+  )
+  expect(await page.innerHTML('.cf-applicant-question-text')).toContain(
+    '<strong>Last line of content should be bold</strong>',
+  )
+}

--- a/browser-test/src/applicant/questions/northstar_static_text.test.ts
+++ b/browser-test/src/applicant/questions/northstar_static_text.test.ts
@@ -24,7 +24,7 @@ const markdownText =
   '__Last line of content should be bold__'
 const programName = 'Test program for static text'
 
-test.describe('Static text question for applicant flow', () => {
+test.describe('Static text question for applicant flow',  {tag: ['@northstar']}, () => {
   test.beforeEach(async ({page, adminQuestions, adminPrograms}) => {
     await setUpForSingleQuestion(
       programName,

--- a/browser-test/src/applicant/questions/static_text.test.ts
+++ b/browser-test/src/applicant/questions/static_text.test.ts
@@ -9,88 +9,86 @@ import {
   validateScreenshot,
 } from '../../support'
 
-  const staticText = 'Hello, I am some static text!'
-const markdownText = '\n[This is a link](https://www.example.com)\n' +
-    'This is a list:\n' +
-    '* Item 1\n' +
-    '* Item 2\n' +
-    '\n' +
-    'There are some empty lines below this that should be preserved\n' +
-    '\n' +
-    '\n' +
-    'This link should be autodetected: https://www.example.com\n' +
-    '__Last line of content should be bold__'
-  const programName = 'Test program for static text'
+const staticText = 'Hello, I am some static text!'
+const markdownText =
+  '\n[This is a link](https://www.example.com)\n' +
+  'This is a list:\n' +
+  '* Item 1\n' +
+  '* Item 2\n' +
+  '\n' +
+  'There are some empty lines below this that should be preserved\n' +
+  '\n' +
+  '\n' +
+  'This link should be autodetected: https://www.example.com\n' +
+  '__Last line of content should be bold__'
+const programName = 'Test program for static text'
 
 test.describe('Static text question for applicant flow', () => {
-    test.beforeEach(async ({page, adminQuestions, adminPrograms}) => {
-      await setUpForSingleQuestion(
-        programName,
-        page,
-        adminQuestions,
-        adminPrograms,
-      )
-    })
-
-    test('displays static text', async ({applicantQuestions}) => {
-      await applicantQuestions.applyProgram(programName)
-      await applicantQuestions.seeStaticQuestion(staticText)
-    })
-
-    test('has no accessiblity violations', async ({
+  test.beforeEach(async ({page, adminQuestions, adminPrograms}) => {
+    await setUpForSingleQuestion(
+      programName,
       page,
-      applicantQuestions,
-    }) => {
-      await applicantQuestions.applyProgram(programName)
-      await validateAccessibility(page)
-    })
-
-    test('parses markdown', async ({page, applicantQuestions}) => {
-      await applicantQuestions.applyProgram(programName)
-      await validateScreenshot(page, 'markdown-text')
-      await verifyMarkdownHtml(page)
-    })
+      adminQuestions,
+      adminPrograms,
+    )
   })
 
-  async function setUpForSingleQuestion(
-    programName: string,
-    page: Page,
-    adminQuestions: AdminQuestions,
-    adminPrograms: AdminPrograms,
-  ) {
-    // As admin, create program with static text question.
-    await loginAsAdmin(page)
-    await adminQuestions.addStaticQuestion({
-      questionName: 'static-text-q',
-      questionText: staticText,
-      markdownText: markdownText,
-    })
-    // Must add an answerable question for text to show.
-    await adminQuestions.addEmailQuestion({questionName: 'partner-email-q'})
-    await adminPrograms.addAndPublishProgramWithQuestions(
-      ['static-text-q', 'partner-email-q'],
-      programName,
-    )
-    await logout(page)
-  }
+  test('displays static text', async ({applicantQuestions}) => {
+    await applicantQuestions.applyProgram(programName)
+    await applicantQuestions.seeStaticQuestion(staticText)
+  })
 
-  async function verifyMarkdownHtml(page: Page) {
-    expect(await page.innerHTML('.cf-applicant-question-text')).toContain(
-      '<p>Hello, I am some static text!<br>',
-    )
-    expect(await page.innerHTML('.cf-applicant-question-text')).toContain(
-      '<a href="https://www.example.com" class="text-blue-900 font-bold opacity-75 underline hover:opacity-100" target="_blank" aria-label="opens in a new tab" rel="nofollow noopener noreferrer">This is a link<svg',
-    )
-    expect(await page.innerHTML('.cf-applicant-question-text')).toContain(
-      '<ul class="list-disc mx-8"><li>Item 1</li><li>Item 2<br>&nbsp;</li></ul>',
-    )
-    expect(await page.innerHTML('.cf-applicant-question-text')).toContain(
-      '<p>There are some empty lines below this that should be preserved<br>&nbsp;</p>\n<p>&nbsp;</p>',
-    )
-    expect(await page.innerHTML('.cf-applicant-question-text')).toContain(
-      '<p>This link should be autodetected: <a href="https://www.example.com" class="text-blue-900 font-bold opacity-75 underline hover:opacity-100" target="_blank" aria-label="opens in a new tab" rel="nofollow noopener noreferrer">https://www.example.com<svg',
-    )
-    expect(await page.innerHTML('.cf-applicant-question-text')).toContain(
-      '<strong>Last line of content should be bold</strong>',
-    )
-  }
+  test('has no accessiblity violations', async ({page, applicantQuestions}) => {
+    await applicantQuestions.applyProgram(programName)
+    await validateAccessibility(page)
+  })
+
+  test('parses markdown', async ({page, applicantQuestions}) => {
+    await applicantQuestions.applyProgram(programName)
+    await validateScreenshot(page, 'markdown-text')
+    await verifyMarkdownHtml(page)
+  })
+})
+
+async function setUpForSingleQuestion(
+  programName: string,
+  page: Page,
+  adminQuestions: AdminQuestions,
+  adminPrograms: AdminPrograms,
+) {
+  // As admin, create program with static text question.
+  await loginAsAdmin(page)
+  await adminQuestions.addStaticQuestion({
+    questionName: 'static-text-q',
+    questionText: staticText,
+    markdownText: markdownText,
+  })
+  // Must add an answerable question for text to show.
+  await adminQuestions.addEmailQuestion({questionName: 'partner-email-q'})
+  await adminPrograms.addAndPublishProgramWithQuestions(
+    ['static-text-q', 'partner-email-q'],
+    programName,
+  )
+  await logout(page)
+}
+
+async function verifyMarkdownHtml(page: Page) {
+  expect(await page.innerHTML('.cf-applicant-question-text')).toContain(
+    '<p>Hello, I am some static text!<br>',
+  )
+  expect(await page.innerHTML('.cf-applicant-question-text')).toContain(
+    '<a href="https://www.example.com" class="text-blue-900 font-bold opacity-75 underline hover:opacity-100" target="_blank" aria-label="opens in a new tab" rel="nofollow noopener noreferrer">This is a link<svg',
+  )
+  expect(await page.innerHTML('.cf-applicant-question-text')).toContain(
+    '<ul class="list-disc mx-8"><li>Item 1</li><li>Item 2<br>&nbsp;</li></ul>',
+  )
+  expect(await page.innerHTML('.cf-applicant-question-text')).toContain(
+    '<p>There are some empty lines below this that should be preserved<br>&nbsp;</p>\n<p>&nbsp;</p>',
+  )
+  expect(await page.innerHTML('.cf-applicant-question-text')).toContain(
+    '<p>This link should be autodetected: <a href="https://www.example.com" class="text-blue-900 font-bold opacity-75 underline hover:opacity-100" target="_blank" aria-label="opens in a new tab" rel="nofollow noopener noreferrer">https://www.example.com<svg',
+  )
+  expect(await page.innerHTML('.cf-applicant-question-text')).toContain(
+    '<strong>Last line of content should be bold</strong>',
+  )
+}

--- a/browser-test/src/applicant/questions/static_text.test.ts
+++ b/browser-test/src/applicant/questions/static_text.test.ts
@@ -3,17 +3,14 @@ import {test, expect} from '../../support/civiform_fixtures'
 import {
   AdminQuestions,
   AdminPrograms,
-  enableFeatureFlag,
   loginAsAdmin,
   logout,
   validateAccessibility,
   validateScreenshot,
 } from '../../support'
 
-test.describe('Static text question for applicant flow', () => {
   const staticText = 'Hello, I am some static text!'
-  const markdownText =
-    '\n[This is a link](https://www.example.com)\n' +
+const markdownText = '\n[This is a link](https://www.example.com)\n' +
     'This is a list:\n' +
     '* Item 1\n' +
     '* Item 2\n' +
@@ -25,7 +22,7 @@ test.describe('Static text question for applicant flow', () => {
     '__Last line of content should be bold__'
   const programName = 'Test program for static text'
 
-  test.describe('With north star flag disabled', () => {
+test.describe('Static text question for applicant flow', () => {
     test.beforeEach(async ({page, adminQuestions, adminPrograms}) => {
       await setUpForSingleQuestion(
         programName,
@@ -37,7 +34,6 @@ test.describe('Static text question for applicant flow', () => {
 
     test('displays static text', async ({applicantQuestions}) => {
       await applicantQuestions.applyProgram(programName)
-
       await applicantQuestions.seeStaticQuestion(staticText)
     })
 
@@ -46,54 +42,13 @@ test.describe('Static text question for applicant flow', () => {
       applicantQuestions,
     }) => {
       await applicantQuestions.applyProgram(programName)
-
       await validateAccessibility(page)
     })
 
     test('parses markdown', async ({page, applicantQuestions}) => {
       await applicantQuestions.applyProgram(programName)
       await validateScreenshot(page, 'markdown-text')
-
       await verifyMarkdownHtml(page)
-    })
-  })
-
-  test.describe('With north star flag enabled', {tag: ['@northstar']}, () => {
-    test.beforeEach(async ({page, adminQuestions, adminPrograms}) => {
-      await setUpForSingleQuestion(
-        programName,
-        page,
-        adminQuestions,
-        adminPrograms,
-      )
-      await enableFeatureFlag(page, 'north_star_applicant_ui')
-    })
-
-    test('parses markdown', async ({page, applicantQuestions}) => {
-      await applicantQuestions.applyProgram(
-        programName,
-        /* northStarEnabled= */ true,
-      )
-      await validateScreenshot(
-        page.getByTestId('staticQuestionRoot'),
-        'markdown-text-north-star',
-        /* fullPage= */ false,
-        /* mobileScreenshot= */ false,
-      )
-
-      await verifyMarkdownHtml(page)
-    })
-
-    test('has no accessiblity violations', async ({
-      page,
-      applicantQuestions,
-    }) => {
-      await applicantQuestions.applyProgram(
-        programName,
-        /* northStarEnabled= */ true,
-      )
-
-      await validateAccessibility(page)
     })
   })
 
@@ -105,7 +60,6 @@ test.describe('Static text question for applicant flow', () => {
   ) {
     // As admin, create program with static text question.
     await loginAsAdmin(page)
-
     await adminQuestions.addStaticQuestion({
       questionName: 'static-text-q',
       questionText: staticText,
@@ -140,4 +94,3 @@ test.describe('Static text question for applicant flow', () => {
       '<strong>Last line of content should be bold</strong>',
     )
   }
-})


### PR DESCRIPTION
### Description

Please explain the changes you made here.

## Release notes

Remove this section if the title of the pull request can be used as the default release notes description. If more detail is needed to communicate to partners the scope of the PR's changes, use this release notes section (and remove this placeholder text).

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [ ] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [ ] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`

#### Database evolutions

Read the guidelines [here](https://github.com/civiform/civiform/wiki/Database#writing-database-evolutions)

- [ ] Assigned two reviewers
- [ ] Guarded against already existing resources using `IF NOT EXISTS` and `IF EXISTS`
- [ ] Downs created to undo changes in Ups
- [ ] Every comment in script should begin with -- and not # --- unless it denotes Ups or Downs. See [here](https://www.playframework.com/documentation/2.9.x/Evolutions) for details.
- [ ] Tested both the Downs and the Ups scripts manually (When testing, include all comments from the evolution in your test script to ensure any syntax errors in the comments are caught.)
- [ ] Data migrations aren't being done (please use a [Durable Job](https://github.com/civiform/civiform/wiki/Database#durable-jobs-for-data-updates) if doing a data migration)
- [ ] Update the model documentation in our [wiki](https://github.com/civiform/civiform/wiki/Database) if necessary

#### Durable jobs

Read the docs [here](https://github.com/civiform/civiform/wiki/Database#durable-jobs-for-data-updates)

- [ ] Assigned two reviewers
- [ ] Included a rollback plan and a job to undo the data changes if appropriate

#### User visible changes

- [ ] Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
  - [ ] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [ ] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Made equivalent changes in Thymeleaf for applicant-facing features and changes (or created an issue in the [Northstar epic](https://github.com/orgs/civiform/projects/1/views/94) to track that it's missing from Thymeleaf)
- [ ] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order
- [ ] Manually tested with a screen reader if the feature is applicant-facing. See [screen reader testing](https://github.com/civiform/civiform/wiki/Testing#screen-reader-testing)

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/helper/feature-flags.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://github.com/civiform/civiform/wiki/Feature-Flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Instructions for manual testing

If instructions are needed for manual testing by reviewers, include them here.

### Issue(s) this completes

Fixes #<issue_number>; Fixes #<issue_number>...
