### PR TITLE
Enable file upload limit for applicant files on Azure. (100 Mb)

### DIFF
--- a/server/app/services/cloud/azure/AzureApplicantStorage.java
+++ b/server/app/services/cloud/azure/AzureApplicantStorage.java
@@ -18,6 +18,7 @@ import services.cloud.StorageServiceName;
 /** An Azure Blob Storage implementation of {@link ApplicantStorageClient}. */
 @Singleton
 public class AzureApplicantStorage implements ApplicantStorageClient {
+  @VisibleForTesting static final String AZURE_FILE_LIMIT_MB_CONF_PATH = "azure.blob.file_limit_mb";
 
   public static final String AZURE_STORAGE_ACCT_CONF_PATH = "azure.blob.account";
   public static final String AZURE_CONTAINER_NAME_CONF_PATH = "azure.blob.container_name";
@@ -31,6 +32,7 @@ public class AzureApplicantStorage implements ApplicantStorageClient {
 
   private final String containerName;
   private final AzureBlobStorageClientInterface client;
+  private final int fileLimitMb;
   private final String accountName;
 
   @Inject
@@ -39,6 +41,7 @@ public class AzureApplicantStorage implements ApplicantStorageClient {
 
     this.containerName = checkNotNull(config).getString(AZURE_CONTAINER_NAME_CONF_PATH);
     this.accountName = checkNotNull(config).getString(AZURE_STORAGE_ACCT_CONF_PATH);
+    this.fileLimitMb = checkNotNull(config).getInt(AZURE_FILE_LIMIT_MB_CONF_PATH);
 
     String blobEndpoint = String.format("https://%s.blob.core.windows.net", accountName);
 
@@ -67,9 +70,7 @@ public class AzureApplicantStorage implements ApplicantStorageClient {
 
   @Override
   public int getFileLimitMb() {
-    // We currently don't enforce a file limit for Azure, so use the max integer value.
-    // TODO(#7013): Enforce a file size limit for Azure.
-    return Integer.MAX_VALUE;
+    return fileLimitMb;
   }
 
   @Override

--- a/server/app/services/settings/SettingsManifest.java
+++ b/server/app/services/settings/SettingsManifest.java
@@ -547,6 +547,11 @@ public final class SettingsManifest extends AbstractSettingsManifest {
     return getString("AZURE_STORAGE_ACCOUNT_PUBLIC_CONTAINER_NAME");
   }
 
+  /** The max size (in Mb) of files uploaded to Azure blob storage. */
+  public Optional<String> getAzureStorageAccountFileLimitMb() {
+    return getString("AZURE_STORAGE_ACCOUNT_FILE_LIMIT_MB");
+  }
+
   /** The max size (in Mb) of **publicly accessible** files uploaded to Azure blob storage. */
   public Optional<String> getAzureStorageAccountPublicFileLimitMb() {
     return getString("AZURE_STORAGE_ACCOUNT_PUBLIC_FILE_LIMIT_MB");
@@ -1650,6 +1655,12 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                           SettingDescription.create(
                               "AZURE_STORAGE_ACCOUNT_PUBLIC_CONTAINER_NAME",
                               "Azure blob storage container name to store public files in.",
+                              /* isRequired= */ false,
+                              SettingType.STRING,
+                              SettingMode.HIDDEN),
+                          SettingDescription.create(
+                              "AZURE_STORAGE_ACCOUNT_FILE_LIMIT_MB",
+                              "The max size (in Mb) of files uploaded to Azure blob storage.",
                               /* isRequired= */ false,
                               SettingType.STRING,
                               SettingMode.HIDDEN),

--- a/server/conf/env-var-docs.json
+++ b/server/conf/env-var-docs.json
@@ -463,6 +463,11 @@
             "description": "Azure blob storage container name to store public files in.",
             "type": "string"
           },
+          "AZURE_STORAGE_ACCOUNT_FILE_LIMIT_MB": {
+            "mode": "HIDDEN",
+            "description": "The max size (in Mb) of files uploaded to Azure blob storage.",
+            "type": "string"
+          },
           "AZURE_STORAGE_ACCOUNT_PUBLIC_FILE_LIMIT_MB": {
             "mode": "HIDDEN",
             "description": "The max size (in Mb) of **publicly accessible** files uploaded to Azure blob storage.",

--- a/server/conf/helper/cloud.conf
+++ b/server/conf/helper/cloud.conf
@@ -22,7 +22,7 @@ azure.blob.public_container_name=${?AZURE_STORAGE_ACCOUNT_PUBLIC_CONTAINER_NAME}
 azure.local.connection="DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://azurite:10000/devstoreaccount1;"
 azure.local.connection=${?AZURE_LOCAL_CONNECTION_STRING}
 # Max size of file in Mb allowed to be uploaded to Azure
-azure.blob.file_limit_mb=1
+azure.blob.file_limit_mb=100
 azure.blob.file_limit_mb=${?AZURE_STORAGE_ACCOUNT_FILE_LIMIT_MB}
 azure.blob.public_file_limit_mb=1
 azure.blob.public_file_limit_mb=${?AZURE_STORAGE_ACCOUNT_PUBLIC_FILE_LIMIT_MB}

--- a/server/conf/helper/cloud.conf
+++ b/server/conf/helper/cloud.conf
@@ -22,6 +22,8 @@ azure.blob.public_container_name=${?AZURE_STORAGE_ACCOUNT_PUBLIC_CONTAINER_NAME}
 azure.local.connection="DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://azurite:10000/devstoreaccount1;"
 azure.local.connection=${?AZURE_LOCAL_CONNECTION_STRING}
 # Max size of file in Mb allowed to be uploaded to Azure
+azure.blob.file_limit_mb=1
+azure.blob.file_limit_mb=${?AZURE_STORAGE_ACCOUNT_FILE_LIMIT_MB}
 azure.blob.public_file_limit_mb=1
 azure.blob.public_file_limit_mb=${?AZURE_STORAGE_ACCOUNT_PUBLIC_FILE_LIMIT_MB}
 

--- a/server/test/services/cloud/azure/AzureApplicantStorageTest.java
+++ b/server/test/services/cloud/azure/AzureApplicantStorageTest.java
@@ -1,7 +1,9 @@
 package services.cloud.azure;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static services.cloud.azure.AzureApplicantStorage.AZURE_FILE_LIMIT_MB_CONF_PATH;
 
+import com.typesafe.config.Config;
 import java.util.Optional;
 import org.junit.Before;
 import org.junit.Test;
@@ -24,6 +26,14 @@ public class AzureApplicantStorageTest extends ResetPostgres {
 
     assertThat(client).isInstanceOf(TestAzureBlobStorageClient.class);
     assertThat(client).isInstanceOf(AzureBlobStorageClientInterface.class);
+  }
+
+  @Test
+  public void getFileLimitMb() {
+    int sizeLimit = azureApplicantStorage.getFileLimitMb();
+    assertThat(sizeLimit)
+        .isEqualTo(
+            Integer.parseInt(instanceOf(Config.class).getString(AZURE_FILE_LIMIT_MB_CONF_PATH)));
   }
 
   @Test


### PR DESCRIPTION
### Description
Enables upload limits for applicant files on Azure.  Set to 100MB (same as AWS)

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [X] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [X] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [X] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [X] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [X] Created unit and/or browser tests which fail without the change (if possible)
- [X] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [X] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [X] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`

#### User visible changes

- [X] Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
  - [X] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [X] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [X] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [X] Made equivalent changes in Thymeleaf for applicant-facing features and changes (or created an issue in the [Northstar epic](https://github.com/orgs/civiform/projects/1/views/94) to track that it's missing from Thymeleaf)
- [X] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [X] Manually tested at 200% size
- [X] Manually evaluated tab order
- [X] Manually tested with a screen reader if the feature is applicant-facing. See [screen reader testing](https://github.com/civiform/civiform/wiki/Testing#screen-reader-testing)

### Issue(s) this completes

Fixes #7013