### PR TITLE
Extract metrics from AWS email sending class, so they could be reused for graph API

### DIFF
--- a/server/app/services/monitoring/EmailSendMetrics.java
+++ b/server/app/services/monitoring/EmailSendMetrics.java
@@ -1,0 +1,47 @@
+package services.monitoring;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import io.prometheus.client.Counter;
+import io.prometheus.client.Histogram;
+
+@Singleton
+public final class EmailSendMetrics {
+  private final Histogram emailExecutionTime;
+  private final Counter emailSendCount;
+  private final Counter emailFailCount;
+
+  @Inject
+  public EmailSendMetrics() {
+    emailExecutionTime =
+        Histogram.build()
+            .name("email_send_time_seconds")
+            .help("Execution time of email send")
+            .register();
+
+    emailSendCount =
+        Counter.build()
+            .name("email_send_total")
+            .help("Number of emails sent")
+            .labelNames("status")
+            .register();
+
+    emailFailCount =
+        Counter.build()
+            .name("email_fail_total")
+            .help("Number of emails that failed to send")
+            .register();
+  }
+
+  public Histogram getEmailExecutionTime() {
+    return emailExecutionTime;
+  }
+
+  public Counter getEmailSendCount() {
+    return emailSendCount;
+  }
+
+  public Counter getEmailFailCount() {
+    return emailFailCount;
+  }
+}


### PR DESCRIPTION
### Description

This doesn't change any functionality, but refactors the metrics to a common class, which will be used by both the AWS SES and Graph API paths

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`

### Issue(s) this completes

[#9260](https://github.com/civiform/civiform/issues/9260)
