### PR TITLE
Add createAccountHeading variable

### DIFF
--- a/browser-test/src/support/applicant_questions.ts
+++ b/browser-test/src/support/applicant_questions.ts
@@ -758,18 +758,13 @@ export class ApplicantQuestions {
       ).toBeVisible()
     }
 
+    const createAccountHeading = this.page.getByRole('heading', {
+      name: 'Create an account to save your application information',
+    })
     if (wantUpsell) {
-      await expect(
-        this.page.getByRole('heading', {
-          name: 'Create an account to save your application information',
-        }),
-      ).toBeVisible()
+      await expect(createAccountHeading).toBeVisible()
     } else {
-      await expect(
-        this.page.getByRole('heading', {
-          name: 'Create an account to save your application information',
-        }),
-      ).toBeHidden()
+      await expect(createAccountHeading).toBeHidden()
     }
 
     // TODO(#9304): Rename class, presumably to .cf-applicant-cif-eligible-program-name.


### PR DESCRIPTION
### Description

Simplify logic in `expectCommonIntakeConfirmationPageNorthStar()`. This change was inadvertently left out of [#9300](https://github.com/civiform/civiform/pull/9300).


#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [X] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [X] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [X] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [X] Created unit and/or browser tests which fail without the change (if possible)
- [X] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [X] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [X] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
