### PR TITLE
Fix prober tests

### DIFF
--- a/server/app/views/admin/programs/ProgramImageView.java
+++ b/server/app/views/admin/programs/ProgramImageView.java
@@ -290,7 +290,6 @@ public final class ProgramImageView extends BaseHtmlView {
     FormTag form =
         fileUploadViewStrategy
             .renderFileUploadFormElement(storageUploadRequest)
-            .with(makeCsrfTokenInputTag(request))
             .withId(IMAGE_FILE_UPLOAD_FORM_ID);
     ImmutableList<InputTag> additionalFileUploadFormInputs =
         fileUploadViewStrategy.additionalFileUploadFormInputs(Optional.of(storageUploadRequest));


### PR DESCRIPTION
### Description

After clicking "Save Image" on the program image page, we're getting an error, which is causing our prober tests to fail. 

![Screenshot 2024-11-26 at 10 30 32 AM](https://github.com/user-attachments/assets/454ef9b7-07a7-4ad1-9de1-c797a5b61f19)

We recently added this CSRF token as part of getting azure program image to work, so we may need to set it conditionally if we need it there https://github.com/civiform/civiform/pull/9276/files.

We should probably see if there are any AWS tests that are missing that would have caught this.
### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`


### Issue(s) this completes

https://github.com/civiform/civiform/issues/9315
