### PR TITLE
Do not show gov banner when not production banner is enabled

### DIFF
--- a/server/app/assets/javascripts/toast.ts
+++ b/server/app/assets/javascripts/toast.ts
@@ -35,7 +35,7 @@ export class ToastController {
       'top-6',
       'transform',
       '-translate-x-1/2',
-      'z-20',
+      'z-100',
     )
     document.body.appendChild(toastContainer)
 

--- a/server/app/views/admin/AdminLayout.java
+++ b/server/app/views/admin/AdminLayout.java
@@ -136,7 +136,12 @@ public final class AdminLayout extends BaseHtmlLayout {
             .withClasses("font-normal", "text-xl", "inline", "pl-10", "py-0", "mr-4")
             .with(span("Civi"), span("Form").withClasses("font-thin"));
 
-    NavTag navBar = nav().with(getGovBanner(Optional.empty())).withClasses(AdminStyles.NAV_STYLES);
+    NavTag navBar =
+        nav()
+            .condWith(
+                !settingsManifest.getShowNotProductionBannerEnabled(request),
+                getGovBanner(Optional.empty()))
+            .withClasses(AdminStyles.NAV_STYLES);
 
     DivTag adminHeader =
         div().with(headerIcon, headerTitle).withClasses(AdminStyles.INNER_NAV_STYLES);

--- a/server/app/views/applicant/ApplicantLayout.java
+++ b/server/app/views/applicant/ApplicantLayout.java
@@ -213,8 +213,10 @@ public class ApplicantLayout extends BaseHtmlLayout {
     Optional<CiviFormProfile> profile = profileUtils.optionalCurrentUserProfile(request);
 
     return nav()
+        .condWith(
+            !settingsManifest.getShowNotProductionBannerEnabled(request),
+            getGovBanner(Optional.of(messages)))
         .with(
-            getGovBanner(Optional.of(messages)),
             div()
                 .withClasses(
                     "bg-white", "border-b", "align-middle", "p-1", "flex", "flex-row", "flex-wrap")

--- a/server/app/views/applicant/NavigationFragment.html
+++ b/server/app/views/applicant/NavigationFragment.html
@@ -4,7 +4,9 @@
       th:replace="~{components/AlertFragment :: alert(alertSettings=${notProductionAlertSettings}, headingLevel='H2')}"
     ></div>
   </div>
-  <div th:replace="~{this :: officialGovermentWebsiteBanner}"></div>
+  <div th:unless="${showNotProductionBannerEnabled}">
+    <div th:replace="~{this :: officialGovermentWebsiteBanner}"></div>
+  </div>
   <div class="usa-overlay"></div>
   <header class="usa-header usa-header--basic" role="banner">
     <div class="usa-nav-container">

--- a/server/app/views/components/PageNotProductionBanner.java
+++ b/server/app/views/components/PageNotProductionBanner.java
@@ -35,7 +35,7 @@ public final class PageNotProductionBanner {
     this.settingsManifest = checkNotNull(settingsManifest);
   }
 
-  public Optional<DivTag> render(Http.Request request, Messages messages) {
+  public Optional<DivTag> render(Http.RequestHeader request, Messages messages) {
     if (!settingsManifest.getShowNotProductionBannerEnabled(request)) {
       return Optional.empty();
     }
@@ -67,8 +67,6 @@ public final class PageNotProductionBanner {
                 "text-white",
                 "bg-red-600",
                 "p-6",
-                "shadow-xl",
-                "shadow-slate-900",
                 "flex",
                 "flex-col",
                 "justify-center",


### PR DESCRIPTION
We don't want to show the gov banner when SHOW_NOT_PRODUCTION_BANNER_ENABLED is enabled. Additionally, this fixes the banner on the J2HTML applicant UI so that toast messages render on top of it. They were previously hidden underneath it. This does not show the not production banner in the admin UI because the way the admin UI is laid out makes it more difficult, but it does hide the gov banner on the admin UI.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.

#### User visible changes

- [x] Made equivalent changes in Thymeleaf for applicant-facing features and changes (or created an issue in the [Northstar epic](https://github.com/orgs/civiform/projects/1/views/94) to track that it's missing from Thymeleaf)
- [x] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)

### Issue(s) this completes

https://github.com/civiform/civiform/issues/6305
https://github.com/civiform/civiform/issues/7413

