### PR TITLE
Remove old error string

### DIFF
--- a/server/app/services/MessageKey.java
+++ b/server/app/services/MessageKey.java
@@ -182,7 +182,6 @@ public enum MessageKey {
   ERROR_EMAIL_IN_USE_CLIENT_EDIT("label.errorEmailInUseForClientEdit"),
   ERROR_FIRST_NAME("label.errorFirstName"),
   ERROR_LAST_NAME("label.errorLastName"),
-  ERROR_INTERNAL_SERVER_TITLE("error.internalServerTitle"),
   ERROR_INTERNAL_SERVER_TITLE_V2("error.internalServerTitle.v2"),
   ERROR_INTERNAL_SERVER_SUBTITLE("error.internalServerSubtitle"),
   ERROR_INTERNAL_SERVER_DESCRIPTION("error.internalServerDescription"),

--- a/server/conf/i18n/messages
+++ b/server/conf/i18n/messages
@@ -822,8 +822,6 @@ adminValidation.multiOptionAdminError=Admin names can only contain lowercase let
 error.notFoundTitle=We were unable to find the page you tried to visit
 error.notFoundDescription=Please go back or return to the {0}
 error.notFoundDescriptionLink=homepage
-# This occurs when an unhandled exception happens.
-error.internalServerTitle=An error occurred
 # The title on the error page that is show to the user in large font
 error.internalServerTitle.v2=An error has occurred
 # The subtitle on the error page that is show to the user in medium font

--- a/server/conf/i18n/messages.am
+++ b/server/conf/i18n/messages.am
@@ -818,8 +818,6 @@ adminValidation.multiOptionAdminError=የአስተዳዳሪ ስሞች መያዝ 
 error.notFoundTitle=ለመጎብኘት የሞከሩትን ገጽ ማግኘት አልቻልንም
 error.notFoundDescription=እባክዎ ወደ ኋላ ይመለሱ ወይም ወደ {0} ይመለሱ
 error.notFoundDescriptionLink=መነሻ ገጽ
-# This occurs when an unhandled exception happens.
-error.internalServerTitle=ስህተት ተከስቷል
 # The title on the error page that is show to the user in large font
 error.internalServerTitle.v2=ስህተት ተከስቷል
 # The subtitle on the error page that is show to the user in medium font

--- a/server/conf/i18n/messages.ar
+++ b/server/conf/i18n/messages.ar
@@ -818,8 +818,6 @@ adminValidation.multiOptionAdminError=يمكن أن تتضمن أسماء الم
 error.notFoundTitle=لم نتمكن من العثور على الصفحة التي حاولت زيارتها
 error.notFoundDescription=يُرجى الرجوع أو العودة إلى {0}
 error.notFoundDescriptionLink=الصفحة الرئيسية
-# This occurs when an unhandled exception happens.
-error.internalServerTitle=حدث خطأ ما
 # The title on the error page that is show to the user in large font
 error.internalServerTitle.v2=حدث خطأ ما
 # The subtitle on the error page that is show to the user in medium font

--- a/server/conf/i18n/messages.es-US
+++ b/server/conf/i18n/messages.es-US
@@ -818,8 +818,6 @@ adminValidation.multiOptionAdminError=Los nombres de administrador solo pueden i
 error.notFoundTitle=No Pudimos encontrar la página que intentó visitar
 error.notFoundDescription=Regresa a {0}
 error.notFoundDescriptionLink=página de inicio
-# This occurs when an unhandled exception happens.
-error.internalServerTitle=Se produjo un error.
 # The title on the error page that is show to the user in large font
 error.internalServerTitle.v2=Se produjo un error
 # The subtitle on the error page that is show to the user in medium font

--- a/server/conf/i18n/messages.fr
+++ b/server/conf/i18n/messages.fr
@@ -818,8 +818,6 @@ adminValidation.multiOptionAdminError=Les noms d''administrateur ne peuvent cont
 error.notFoundTitle=Impossible de trouver la page que vous avez essayé de consulter
 error.notFoundDescription=Veuillez revenir en arrière ou retourner à la {0}
 error.notFoundDescriptionLink=page d''accueil
-# This occurs when an unhandled exception happens.
-error.internalServerTitle=Une erreur s''est produite
 # The title on the error page that is show to the user in large font
 error.internalServerTitle.v2=Une erreur s''est produite
 # The subtitle on the error page that is show to the user in medium font

--- a/server/conf/i18n/messages.ja
+++ b/server/conf/i18n/messages.ja
@@ -818,8 +818,6 @@ adminValidation.multiOptionAdminError=管理者名に使用できるのは、小
 error.notFoundTitle=アクセスしようとしているページが見つかりませんでした
 error.notFoundDescription=戻る、または{0}に戻ってください
 error.notFoundDescriptionLink=ホームページ
-# This occurs when an unhandled exception happens.
-error.internalServerTitle=エラーが発生しました
 # The title on the error page that is show to the user in large font
 error.internalServerTitle.v2=エラーが発生しました
 # The subtitle on the error page that is show to the user in medium font

--- a/server/conf/i18n/messages.ko
+++ b/server/conf/i18n/messages.ko
@@ -818,8 +818,6 @@ adminValidation.multiOptionAdminError=관리자 이름에는 소문자, 숫자, 
 error.notFoundTitle=방문하려는 페이지를 찾지 못했습니다
 error.notFoundDescription=뒤로 이동하거나 {0} 페이지로 돌아가세요.
 error.notFoundDescriptionLink=홈페이지
-# This occurs when an unhandled exception happens.
-error.internalServerTitle=오류가 발생했습니다.
 # The title on the error page that is show to the user in large font
 error.internalServerTitle.v2=오류가 발생했습니다
 # The subtitle on the error page that is show to the user in medium font

--- a/server/conf/i18n/messages.lo
+++ b/server/conf/i18n/messages.lo
@@ -819,8 +819,6 @@ error.notFoundTitle=ພວກເຮົາບໍ່ສາມາດຊອກຫາ
 error.notFoundDescription=ກະລຸນາກັບຄືນ ຫຼື ກັບໄປຫາ {0}
 error.notFoundDescriptionLink=ໜ້າຫຼັກ
 # This occurs when an unhandled exception happens.
-error.internalServerTitle=ເກີດຂໍ້ຜິດພາດຂຶ້ນ
-# The title on the error page that is show to the user in large font
 error.internalServerTitle.v2=ເກີດຂໍ້ຜິດພາດຂຶ້ນ
 # The subtitle on the error page that is show to the user in medium font
 error.internalServerSubtitle=ພວກເຮົາຂໍອະໄພ, ມີຂໍ້ຜິດພາດພາຍໃນເກີດຂຶ້ນໃນລະບົບຂອງພວກເຮົາ.

--- a/server/conf/i18n/messages.ru
+++ b/server/conf/i18n/messages.ru
@@ -818,8 +818,6 @@ adminValidation.multiOptionAdminError=В названиях, предназна�
 error.notFoundTitle=Нам не удалось найти страницу, которую вы пытались открыть
 error.notFoundDescription=Перейдите на {0} или вернитесь на предыдущую.
 error.notFoundDescriptionLink=главную страницу
-# This occurs when an unhandled exception happens.
-error.internalServerTitle=Произошла ошибка
 # The title on the error page that is show to the user in large font
 error.internalServerTitle.v2=Произошла ошибка
 # The subtitle on the error page that is show to the user in medium font

--- a/server/conf/i18n/messages.so
+++ b/server/conf/i18n/messages.so
@@ -818,8 +818,6 @@ adminValidation.multiOptionAdminError=Magacyada maamulka keliya waxay ka koobnaa
 error.notFoundTitle=Waanu awoodi waynay inaan helno bogga aad isku dayday inaad booqato
 error.notFoundDescription=Fadlan dib ugu noqo ama ku noqo {0}
 error.notFoundDescriptionLink=bogga internatka
-# This occurs when an unhandled exception happens.
-error.internalServerTitle=Khalad ayaa dhacay
 # The title on the error page that is show to the user in large font
 error.internalServerTitle.v2=Cillad ayaa dhacday
 # The subtitle on the error page that is show to the user in medium font

--- a/server/conf/i18n/messages.tl
+++ b/server/conf/i18n/messages.tl
@@ -818,8 +818,6 @@ adminValidation.multiOptionAdminError=Maliliit na titik, numero, underscore, at 
 error.notFoundTitle=Hindi namin nahanap ang page na sinubukan mong puntahan
 error.notFoundDescription=Bumalik o pumunta ulit sa {0}
 error.notFoundDescriptionLink=homepage
-# This occurs when an unhandled exception happens.
-error.internalServerTitle=Nagkaroon ng error
 # The title on the error page that is show to the user in large font
 error.internalServerTitle.v2=Nagkaroon ng error
 # The subtitle on the error page that is show to the user in medium font

--- a/server/conf/i18n/messages.vi
+++ b/server/conf/i18n/messages.vi
@@ -818,8 +818,6 @@ adminValidation.multiOptionAdminError=Tên của quản trị viên chỉ có th
 error.notFoundTitle=Chúng tôi không tìm thấy trang mà bạn cố gắng truy cập
 error.notFoundDescription=Vui lòng quay lại hoặc chuyển đến {0}
 error.notFoundDescriptionLink=trang chủ
-# This occurs when an unhandled exception happens.
-error.internalServerTitle=Đã xảy ra lỗi
 # The title on the error page that is show to the user in large font
 error.internalServerTitle.v2=Đã xảy ra lỗi
 # The subtitle on the error page that is show to the user in medium font

--- a/server/conf/i18n/messages.zh-TW
+++ b/server/conf/i18n/messages.zh-TW
@@ -818,8 +818,6 @@ adminValidation.multiOptionAdminError=管理員名稱只能使用小寫英文字
 error.notFoundTitle=我們找不到你嘗試前往的頁面
 error.notFoundDescription=請回到上一個頁面或返回 {0}
 error.notFoundDescriptionLink=首頁
-# This occurs when an unhandled exception happens.
-error.internalServerTitle=發生錯誤
 # The title on the error page that is show to the user in large font
 error.internalServerTitle.v2=發生錯誤
 # The subtitle on the error page that is show to the user in medium font

--- a/server/test/views/components/FieldWithLabelTest.java
+++ b/server/test/views/components/FieldWithLabelTest.java
@@ -207,7 +207,7 @@ public class FieldWithLabelTest {
         FieldWithLabel.number()
             .setId("field-id")
             .setFieldErrors(
-                messages, new ValidationError("error.internalServerTitle", "an error message"));
+                messages, new ValidationError("error.internalServerTitle.v2", "an error message"));
     String rendered = fieldWithLabel.getNumberTag().render();
 
     assertThat(rendered).contains("aria-invalid=\"true\"");


### PR DESCRIPTION
### Description

Remove the old error string that is no longer in use as of [this PR](https://github.com/civiform/civiform/pull/9093/files#diff-af62199d2460d043f58acb60ac16e512637af1cfae9cddd2f2f327a4776798f9).

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)


### Issue(s) this completes

Related to PR: https://github.com/civiform/civiform/pull/9093
