### PR TITLE
Disable durable jobs module in unit tests

### DIFF
--- a/server/conf/application.test.conf
+++ b/server/conf/application.test.conf
@@ -5,6 +5,7 @@ play.modules {
   # empty empty database at setup time.
   disabled += modules.DatabaseSeedModule
   disabled += modules.SettingsMigrationModule
+  disabled += modules.DurableJobModule
 }
 
 db {


### PR DESCRIPTION
### Description

Disable the durable jobs from running during unit tests. There's no need to have these running in the background.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
