### PR TITLE
Add "noopener noreferrer" if we open a link in a new tab

### DIFF
--- a/server/app/views/CiviFormMarkdown.java
+++ b/server/app/views/CiviFormMarkdown.java
@@ -50,6 +50,7 @@ public final class CiviFormMarkdown {
       if (node instanceof Link) {
         attributes.put("class", StyleUtils.removeStyles(ApplicantStyles.LINK, "text-sm"));
         attributes.put("target", "_blank");
+        attributes.put("rel", "noopener noreferrer"); 
         attributes.put("aria-label", ariaLabel);
       } else if (node instanceof BulletList) {
         attributes.put("class", "list-disc mx-8");

--- a/server/app/views/CiviFormMarkdown.java
+++ b/server/app/views/CiviFormMarkdown.java
@@ -50,7 +50,7 @@ public final class CiviFormMarkdown {
       if (node instanceof Link) {
         attributes.put("class", StyleUtils.removeStyles(ApplicantStyles.LINK, "text-sm"));
         attributes.put("target", "_blank");
-        attributes.put("rel", "noopener noreferrer"); 
+        attributes.put("rel", "noopener noreferrer");
         attributes.put("aria-label", ariaLabel);
       } else if (node instanceof BulletList) {
         attributes.put("class", "list-disc mx-8");

--- a/server/app/views/components/LinkElement.java
+++ b/server/app/views/components/LinkElement.java
@@ -96,7 +96,7 @@ public final class LinkElement {
     return tag.withCondId(!Strings.isNullOrEmpty(id), id)
         .withCondHref(!Strings.isNullOrEmpty(href), href)
         .withCondTarget(doesOpenInNewTab, "_blank")
-        .withCondData(doesOpenInNewTab, "rel", "noopener noreferrer")
+        .withCondRel(doesOpenInNewTab, "noopener noreferrer")
         .withClasses(DEFAULT_LINK_STYLES, styles);
   }
 

--- a/server/app/views/components/LinkElement.java
+++ b/server/app/views/components/LinkElement.java
@@ -96,6 +96,7 @@ public final class LinkElement {
     return tag.withCondId(!Strings.isNullOrEmpty(id), id)
         .withCondHref(!Strings.isNullOrEmpty(href), href)
         .withCondTarget(doesOpenInNewTab, "_blank")
+        .withCondAttr(doesOpenInNewTab, "rel", "noopener noreferrer")
         .withClasses(DEFAULT_LINK_STYLES, styles);
   }
 

--- a/server/app/views/components/LinkElement.java
+++ b/server/app/views/components/LinkElement.java
@@ -96,7 +96,7 @@ public final class LinkElement {
     return tag.withCondId(!Strings.isNullOrEmpty(id), id)
         .withCondHref(!Strings.isNullOrEmpty(href), href)
         .withCondTarget(doesOpenInNewTab, "_blank")
-        .withCondAttr(doesOpenInNewTab, "rel", "noopener noreferrer")
+        .withCondData(doesOpenInNewTab, "rel", "noopener noreferrer")
         .withClasses(DEFAULT_LINK_STYLES, styles);
   }
 

--- a/server/test/views/CiviFormMarkdownTest.java
+++ b/server/test/views/CiviFormMarkdownTest.java
@@ -16,7 +16,7 @@ public class CiviFormMarkdownTest {
         .isEqualTo(
             "<h1>one</h1>\n"
                 + "<p>two <a href=\"http://example.com\" class=\"text-blue-900 font-bold opacity-75"
-                + " underline hover:opacity-100\" target=\"_blank\" aria-label=\"opens in a new"
-                + " tab\">three</a></p>\n");
+                + " underline hover:opacity-100\" target=\"_blank\" rel=\"noopener noreferrer\""
+                + " aria-label=\"opens in a new tab\">three</a></p>\n");
   }
 }

--- a/server/test/views/components/FieldWithLabelTest.java
+++ b/server/test/views/components/FieldWithLabelTest.java
@@ -325,8 +325,8 @@ public class FieldWithLabelTest {
     assertThat(renderedWithDefaultUrl)
         .contains(
             "<a href=\"https://docs.civiform.us/user-manual/civiform-admin-guide/using-markdown\""
-                + " target=\"_blank\" class=\"text-blue-600 hover:text-blue-500 inline-flex"
-                + " items-center\">see how it works</a>");
+                + " target=\"_blank\" rel=\"noopener noreferrer\" class=\"text-blue-600"
+                + " hover:text-blue-500 inline-flex items-center\">see how it works</a>");
 
     // Set custom url for link text
     fieldWithLabel.setMarkdownLinkText("click here for details", "https://www.example.com");
@@ -334,7 +334,8 @@ public class FieldWithLabelTest {
     // Assert default url was overridden with new url
     assertThat(renderedWithCustomUrl)
         .contains(
-            "<a href=\"https://www.example.com\" target=\"_blank\" class=\"text-blue-600"
-                + " hover:text-blue-500 inline-flex items-center\">click here for details</a>");
+            "<a href=\"https://www.example.com\" target=\"_blank\" rel=\"noopener noreferrer\""
+                + " class=\"text-blue-600 hover:text-blue-500 inline-flex items-center\">click here"
+                + " for details</a>");
   }
 }


### PR DESCRIPTION
### Description

Ensure we have these ref attributes on any link with target blank_. This is for security purposes.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`

### Issue(s) this completes

Fixes https://github.com/civiform/civiform/issues/9406