### PR TITLE
Generate swagger2 without application questions

### DIFF
--- a/server/app/services/openapi/AbstractOpenApiSchemaGenerator.java
+++ b/server/app/services/openapi/AbstractOpenApiSchemaGenerator.java
@@ -5,7 +5,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.google.common.collect.ImmutableList;
 import io.swagger.models.Scheme;
 
-public class AbstractOpenApiSchemaGenerator {
+public abstract class AbstractOpenApiSchemaGenerator {
   protected final OpenApiSchemaSettings openApiSchemaSettings;
 
   protected AbstractOpenApiSchemaGenerator(OpenApiSchemaSettings openApiSchemaSettings) {

--- a/server/app/services/openapi/AbstractOpenApiSchemaGenerator.java
+++ b/server/app/services/openapi/AbstractOpenApiSchemaGenerator.java
@@ -1,0 +1,31 @@
+package services.openapi;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.collect.ImmutableList;
+import io.swagger.models.Scheme;
+
+public class AbstractOpenApiSchemaGenerator {
+  protected final OpenApiSchemaSettings openApiSchemaSettings;
+
+  protected AbstractOpenApiSchemaGenerator(OpenApiSchemaSettings openApiSchemaSettings) {
+    this.openApiSchemaSettings = checkNotNull(openApiSchemaSettings);
+  }
+
+  /**
+   * Returns the list of schemes to allow in the swagger schema. Special case to allow http for
+   * non-prod environments for testing purposes.
+   */
+  protected ImmutableList<Scheme> getSchemes() {
+    if (openApiSchemaSettings.allowHttpScheme()) {
+      return ImmutableList.of(Scheme.HTTP, Scheme.HTTPS);
+    }
+
+    return ImmutableList.of(Scheme.HTTPS);
+  }
+
+  /** Gets the baseurl without scheme */
+  protected String getHostName() {
+    return openApiSchemaSettings.baseUrl().replace("https://", "").replace("http://", "");
+  }
+}

--- a/server/app/services/openapi/v2/Swagger2SchemaGenerator.java
+++ b/server/app/services/openapi/v2/Swagger2SchemaGenerator.java
@@ -92,7 +92,8 @@ public class Swagger2SchemaGenerator extends AbstractOpenApiSchemaGenerator
                                       .description(
                                           "An ISO-8601 formatted date (i.e. YYYY-MM-DD). Limits"
                                               + " results to applications submitted on or after the"
-                                              + " provided date."))
+                                              + " provided date, in the CiviForm instance's local"
+                                              + " time."))
                               .parameter(
                                   new QueryParameter()
                                       .name("toDate")
@@ -100,7 +101,8 @@ public class Swagger2SchemaGenerator extends AbstractOpenApiSchemaGenerator
                                       .description(
                                           "An ISO-8601 formatted date (i.e. YYYY-MM-DD). Limits"
                                               + " results to applications submitted on or after the"
-                                              + " provided date."))
+                                              + " provided date, in the CiviForm instance's local"
+                                              + " time."))
                               .parameter(
                                   new QueryParameter()
                                       .name("pageSize")

--- a/server/app/services/openapi/v2/Swagger2SchemaGenerator.java
+++ b/server/app/services/openapi/v2/Swagger2SchemaGenerator.java
@@ -1,0 +1,167 @@
+package services.openapi.v2;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.swagger.models.AuthorizationType;
+import io.swagger.models.Contact;
+import io.swagger.models.Info;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.Operation;
+import io.swagger.models.Path;
+import io.swagger.models.RefModel;
+import io.swagger.models.Response;
+import io.swagger.models.SecurityRequirement;
+import io.swagger.models.Swagger;
+import io.swagger.models.auth.BasicAuthDefinition;
+import io.swagger.models.parameters.QueryParameter;
+import io.swagger.models.properties.ArrayProperty;
+import io.swagger.models.properties.DateTimeProperty;
+import io.swagger.models.properties.IntegerProperty;
+import io.swagger.models.properties.ObjectProperty;
+import io.swagger.models.properties.Property;
+import io.swagger.models.properties.StringProperty;
+import io.swagger.util.Yaml;
+import services.openapi.AbstractOpenApiSchemaGenerator;
+import services.openapi.OpenApiSchemaGenerator;
+import services.openapi.OpenApiSchemaSettings;
+import services.program.ProgramDefinition;
+import services.question.exceptions.InvalidQuestionTypeException;
+import services.question.exceptions.UnsupportedQuestionTypeException;
+
+/** Configuration used to generate a program specific swagger 2 schema */
+public class Swagger2SchemaGenerator extends AbstractOpenApiSchemaGenerator
+    implements OpenApiSchemaGenerator {
+
+  public Swagger2SchemaGenerator(OpenApiSchemaSettings openApiSchemaSettings) {
+    super(openApiSchemaSettings);
+  }
+
+  @Override
+  public String createSchema(ProgramDefinition programDefinition) {
+    try {
+      Swagger swaggerRoot =
+          new Swagger()
+              .basePath("/api/v1/admin/programs/" + programDefinition.slug())
+              .host(getHostName())
+              .info(
+                  new Info()
+                      .title(programDefinition.adminName())
+                      .version(Long.toString(programDefinition.id()))
+                      .description(programDefinition.adminDescription())
+                      .contact(
+                          new Contact()
+                              .name("CiviForm Technical Support")
+                              .email(openApiSchemaSettings.itEmailAddress())))
+              .schemes(getSchemes())
+              .security(
+                  new SecurityRequirement().requirement(AuthorizationType.BASIC_AUTH.toValue()))
+              .securityDefinition(AuthorizationType.BASIC_AUTH.toValue(), new BasicAuthDefinition())
+              .path(
+                  "/applications",
+                  new Path()
+                      .get(
+                          new Operation()
+                              .operationId("list_applications")
+                              .description("List Applications")
+                              .summary("Export applications")
+                              .produces(MimeType.Json.getCode())
+                              .tag("programs")
+                              .response(
+                                  200,
+                                  new Response()
+                                      .description("For valid requests.")
+                                      .responseSchema(new RefModel("#/definitions/result"))
+                                      .header(
+                                          "x-next",
+                                          new StringProperty()
+                                              .description("A link to the next page of responses")))
+                              .response(
+                                  400,
+                                  new Response()
+                                      .description(
+                                          "Returned if any request parameters fail validation."))
+                              .response(
+                                  401,
+                                  new Response()
+                                      .description(
+                                          "Returned if the API key is invalid or does not have"
+                                              + " access to the program."))
+                              .parameter(
+                                  new QueryParameter()
+                                      .name("fromDate")
+                                      .type(DefinitionType.STRING.toString())
+                                      .description(
+                                          "An ISO-8601 formatted date (i.e. YYYY-MM-DD). Limits"
+                                              + " results to applications submitted on or after the"
+                                              + " provided date."))
+                              .parameter(
+                                  new QueryParameter()
+                                      .name("toDate")
+                                      .type(DefinitionType.STRING.toString())
+                                      .description(
+                                          "An ISO-8601 formatted date (i.e. YYYY-MM-DD). Limits"
+                                              + " results to applications submitted on or after the"
+                                              + " provided date."))
+                              .parameter(
+                                  new QueryParameter()
+                                      .name("pageSize")
+                                      .type(DefinitionType.INTEGER.toString())
+                                      .description(
+                                          "A positive integer. Limits the number of results per"
+                                              + " page. If pageSize is larger than CiviForm's"
+                                              + " maximum page size then the maximum will be used."
+                                              + " The default maximum is 1,000 and is"
+                                              + " configurable."))
+                              .parameter(
+                                  new QueryParameter()
+                                      .name("nextPageToken")
+                                      .type(DefinitionType.STRING.toString())
+                                      .description(
+                                          "An opaque, alphanumeric identifier for a specific page"
+                                              + " of results. When included CiviForm will return a"
+                                              + " page of results corresponding to the token."))));
+
+      swaggerRoot.addDefinition(
+          "result",
+          new ModelImpl()
+              .type("object")
+              .property(
+                  "payload",
+                  new ArrayProperty(
+                      new ObjectProperty()
+                          .property("applicant_id", new IntegerProperty())
+                          .property("application", buildApplicationDefinitions())
+                          .property("application_id", new IntegerProperty())
+                          .property("create_time", new DateTimeProperty())
+                          .property("language", new StringProperty())
+                          .property("program_name", new StringProperty())
+                          .property("program_version_id", new IntegerProperty())
+                          .property("revision_state", new StringProperty())
+                          .property(
+                              "status", new StringProperty().vendorExtension("x-nullable", true))
+                          .property("submit_time", new DateTimeProperty())
+                          .property("submitter_type", new StringProperty())
+                          .property(
+                              "ti_email", new StringProperty().vendorExtension("x-nullable", true))
+                          .property(
+                              "ti_organization",
+                              new StringProperty().vendorExtension("x-nullable", true))))
+              .property("nextPageToken", new StringProperty()));
+
+      return Yaml.pretty().writeValueAsString(swaggerRoot);
+    } catch (RuntimeException
+        | InvalidQuestionTypeException
+        | UnsupportedQuestionTypeException
+        | JsonProcessingException ex) {
+      throw new RuntimeException("Unable to generate OpenAPI schema for Swagger 2.", ex);
+    }
+  }
+
+  /***
+   * Entry point to start building the program specific definitions for questions
+   */
+  private Property buildApplicationDefinitions()
+      throws InvalidQuestionTypeException, UnsupportedQuestionTypeException {
+    var objectProperty = new ObjectProperty();
+    return objectProperty;
+  }
+}

--- a/server/test/services/openapi/v2/Swagger2SchemaGeneratorTest.java
+++ b/server/test/services/openapi/v2/Swagger2SchemaGeneratorTest.java
@@ -99,13 +99,15 @@ paths:
       - name: "fromDate"
         in: "query"
         description: "An ISO-8601 formatted date (i.e. YYYY-MM-DD). Limits results\\
-          \\ to applications submitted on or after the provided date."
+          \\ to applications submitted on or after the provided date, in the CiviForm\\
+          \\ instance's local time."
         required: false
         type: "string"
       - name: "toDate"
         in: "query"
         description: "An ISO-8601 formatted date (i.e. YYYY-MM-DD). Limits results\\
-          \\ to applications submitted on or after the provided date."
+          \\ to applications submitted on or after the provided date, in the CiviForm\\
+          \\ instance's local time."
         required: false
         type: "string"
       - name: "pageSize"

--- a/server/test/services/openapi/v2/Swagger2SchemaGeneratorTest.java
+++ b/server/test/services/openapi/v2/Swagger2SchemaGeneratorTest.java
@@ -1,0 +1,197 @@
+package services.openapi.v2;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import auth.ProgramAcls;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import controllers.dev.seeding.SampleQuestionDefinitions;
+import java.util.Locale;
+import java.util.stream.Stream;
+import junitparams.JUnitParamsRunner;
+import models.ApplicationStep;
+import models.CategoryModel;
+import models.DisplayMode;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import services.LocalizedStrings;
+import services.openapi.OpenApiSchemaSettings;
+import services.openapi.v2.serializers.OpenApiSerializationAsserter;
+import services.program.BlockDefinition;
+import services.program.ProgramDefinition;
+import services.program.ProgramType;
+import services.question.types.QuestionDefinition;
+
+@RunWith(JUnitParamsRunner.class)
+public class Swagger2SchemaGeneratorTest extends OpenApiSerializationAsserter {
+  private static final Stream<QuestionDefinition> ALL_SAMPLE_QUESTION_DEFINITIONS_WITH_IDS_STREAM =
+      SampleQuestionDefinitions.ALL_SAMPLE_QUESTION_DEFINITIONS.stream()
+          .map(QuestionDefinition::withPopulatedTestId);
+
+  @Test
+  public void createSchema_withNoPrograms() {
+    ImmutableList<BlockDefinition> blockDefinitions =
+        ImmutableList.of(
+            BlockDefinition.builder()
+                .setId(135L)
+                .setName("Test Block Definition")
+                .setDescription("Test Block Description")
+                .setLocalizedName(LocalizedStrings.builder().build())
+                .setLocalizedDescription(LocalizedStrings.builder().build())
+                .build());
+
+    ProgramDefinition programDefinition =
+        ProgramDefinition.builder()
+            .setId(789L)
+            .setAdminName("test-program-admin-name")
+            .setAdminDescription("Test Admin Description")
+            .setExternalLink("https://mytestlink.gov")
+            .setDisplayMode(DisplayMode.PUBLIC)
+            .setProgramType(ProgramType.DEFAULT)
+            .setEligibilityIsGating(false)
+            .setAcls(new ProgramAcls())
+            .setBlockDefinitions(blockDefinitions)
+            .setApplicationSteps(
+                ImmutableList.<ApplicationStep>builder()
+                    .add(new ApplicationStep("step-1-title", "step-1-description"))
+                    .build())
+            .setCategories(
+                ImmutableList.<CategoryModel>builder()
+                    .add(new CategoryModel(ImmutableMap.<Locale, String>builder().build()))
+                    .build())
+            .build();
+
+    OpenApiSchemaSettings settings =
+        new OpenApiSchemaSettings("baseUrl", "email123@example.com", true);
+
+    var generator = new Swagger2SchemaGenerator(settings);
+    String actual = generator.createSchema(programDefinition);
+
+    String expected =
+        """
+---
+swagger: "2.0"
+info:
+  description: "Test Admin Description"
+  version: "789"
+  title: "test-program-admin-name"
+  contact:
+    name: "CiviForm Technical Support"
+    email: "email123@example.com"
+host: "baseUrl"
+basePath: "/api/v1/admin/programs/test-program-admin-name"
+schemes:
+- "http"
+- "https"
+security:
+- basicAuth: []
+paths:
+  /applications:
+    get:
+      tags:
+      - "programs"
+      summary: "Export applications"
+      description: "List Applications"
+      operationId: "list_applications"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "fromDate"
+        in: "query"
+        description: "An ISO-8601 formatted date (i.e. YYYY-MM-DD). Limits results\\
+          \\ to applications submitted on or after the provided date."
+        required: false
+        type: "string"
+      - name: "toDate"
+        in: "query"
+        description: "An ISO-8601 formatted date (i.e. YYYY-MM-DD). Limits results\\
+          \\ to applications submitted on or after the provided date."
+        required: false
+        type: "string"
+      - name: "pageSize"
+        in: "query"
+        description: "A positive integer. Limits the number of results per page. If\\
+          \\ pageSize is larger than CiviForm's maximum page size then the maximum\\
+          \\ will be used. The default maximum is 1,000 and is configurable."
+        required: false
+        type: "integer"
+      - name: "nextPageToken"
+        in: "query"
+        description: "An opaque, alphanumeric identifier for a specific page of results.\\
+          \\ When included CiviForm will return a page of results corresponding to\\
+          \\ the token."
+        required: false
+        type: "string"
+      responses:
+        "200":
+          description: "For valid requests."
+          headers:
+            x-next:
+              type: "string"
+              description: "A link to the next page of responses"
+          schema:
+            $ref: "#/definitions/result"
+        "400":
+          description: "Returned if any request parameters fail validation."
+        "401":
+          description: "Returned if the API key is invalid or does not have access\\
+            \\ to the program."
+securityDefinitions:
+  basicAuth:
+    type: "basic"
+definitions:
+  result:
+    type: "object"
+    properties:
+      payload:
+        type: "array"
+        items:
+          type: "object"
+          properties:
+            applicant_id:
+              type: "integer"
+              format: "int32"
+            application:
+              type: "object"
+            application_id:
+              type: "integer"
+              format: "int32"
+            create_time:
+              type: "string"
+              format: "date-time"
+            language:
+              type: "string"
+            program_name:
+              type: "string"
+            program_version_id:
+              type: "integer"
+              format: "int32"
+            revision_state:
+              type: "string"
+            status:
+              type: "string"
+              x-nullable: true
+            submit_time:
+              type: "string"
+              format: "date-time"
+            submitter_type:
+              type: "string"
+            ti_email:
+              type: "string"
+              x-nullable: true
+            ti_organization:
+              type: "string"
+              x-nullable: true
+      nextPageToken:
+        type: "string"
+""";
+
+    System.out.println("**************************************");
+    System.out.println(actual);
+    System.out.println("**************************************");
+    System.out.println(expected);
+    System.out.println("**************************************");
+
+    assertThat(actual).isEqualTo(expected);
+  }
+}


### PR DESCRIPTION
### Description

Add to allow for easy building of openapi schemas

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Created unit and/or browser tests which fail without the change (if possible)

Related to https://github.com/civiform/civiform/issues/5358, https://github.com/civiform/civiform/issues/5359