### PR TITLE
Revert to saving trace on first retry

### DIFF
--- a/browser-test/playwright.config.ts
+++ b/browser-test/playwright.config.ts
@@ -17,11 +17,7 @@ export default defineConfig({
   globalSetup: './src/setup/global-setup.ts',
   fullyParallel: false,
   workers: 1,
-  // For us, having retries enabled does not appear to have been particularly
-  // beneficial. Instead it makes failues end up taking 2 * timeout. As long
-  // as retain-on-failure used below works correctly we're probably fine not
-  // retrying.
-  retries: 0,
+  retries: process.env.CI === 'true' ? 1 : 0,
   outputDir: './tmp/test-output',
   expect: {
     toHaveScreenshot: {
@@ -33,10 +29,10 @@ export default defineConfig({
     },
   },
   use: {
-    // retain-on-failure should remove trace and video files when a test succeeds allowing
-    // for minimizing cloud storage needs.
-    trace: process.env.CI === 'true' ? 'retain-on-failure' : 'on',
-    video: process.env.RECORD_VIDEO === 'true' ? 'retain-on-failure' : 'off',
+    // retain-on-failure may not be removing files in a timely manner
+    // causing disk usage on github actions to fill the disk
+    trace: process.env.CI === 'true' ? 'on-first-retry' : 'on',
+    video: process.env.RECORD_VIDEO === 'true' ? 'on-first-retry' : 'off',    
     // Fall back support config file until it is removed
     baseURL: process.env.BASE_URL || BASE_URL, // 'http://civiform:9000'
   },

--- a/browser-test/playwright.config.ts
+++ b/browser-test/playwright.config.ts
@@ -32,7 +32,7 @@ export default defineConfig({
     // retain-on-failure may not be removing files in a timely manner
     // causing disk usage on github actions to fill the disk
     trace: process.env.CI === 'true' ? 'on-first-retry' : 'on',
-    video: process.env.RECORD_VIDEO === 'true' ? 'on-first-retry' : 'off',    
+    video: process.env.RECORD_VIDEO === 'true' ? 'on-first-retry' : 'off',
     // Fall back support config file until it is removed
     baseURL: process.env.BASE_URL || BASE_URL, // 'http://civiform:9000'
   },


### PR DESCRIPTION
### Description

When running probers against a deployed staging tests are failing at (seemingly) random sometimes with an error that the disk is full. It may be that playwright's `retain-on-failure` isn't deleting files in a timely manner causing all trace files to pile up filling the disk. Switching back to `on-first-retry` which will only create the traces when a test fails and it retries running that failed test.

Not sure this will fix it, but it's worth a shot, in an attempt to unblock staging prober failures.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
