### PR TITLE
Pass block definition through to rendering ineligible block view

### DIFF
--- a/server/app/controllers/applicant/ApplicantProgramBlocksController.java
+++ b/server/app/controllers/applicant/ApplicantProgramBlocksController.java
@@ -54,6 +54,7 @@ import services.applicant.question.FileUploadQuestion;
 import services.cloud.ApplicantStorageClient;
 import services.geo.AddressSuggestion;
 import services.geo.AddressSuggestionGroup;
+import services.program.BlockDefinition;
 import services.program.PathNotInBlockException;
 import services.program.ProgramBlockDefinitionNotFoundException;
 import services.program.ProgramDefinition;
@@ -1225,19 +1226,21 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
     } else {
       return supplyAsync(
           () -> {
+            Optional<BlockDefinition> blockDefinition = Optional.empty();
             try {
-              return ok(
-                  ineligibleBlockView.render(
-                      request,
-                      profile,
-                      roApplicantProgramService,
-                      messagesApi.preferred(request),
-                      applicantId,
-                      programDefinition,
-                      Optional.of(blockId)));
+              blockDefinition = Optional.of(programDefinition.getBlockDefinition(blockId));
             } catch (ProgramBlockDefinitionNotFoundException e) {
-              throw new RuntimeException(e);
+              notFound(e.toString());
             }
+            return ok(
+                ineligibleBlockView.render(
+                    request,
+                    profile,
+                    roApplicantProgramService,
+                    messagesApi.preferred(request),
+                    applicantId,
+                    programDefinition,
+                    blockDefinition));
           });
     }
   }

--- a/server/app/controllers/applicant/ApplicantProgramReviewController.java
+++ b/server/app/controllers/applicant/ApplicantProgramReviewController.java
@@ -39,7 +39,6 @@ import services.applicant.exception.ApplicationNotEligibleException;
 import services.applicant.exception.ApplicationOutOfDateException;
 import services.applicant.exception.ApplicationSubmissionException;
 import services.applicant.exception.DuplicateApplicationException;
-import services.program.ProgramBlockDefinitionNotFoundException;
 import services.program.ProgramDefinition;
 import services.program.ProgramNotFoundException;
 import services.program.ProgramService;
@@ -426,19 +425,15 @@ public class ApplicantProgramReviewController extends CiviFormController {
               .build();
       return ok(northStarApplicantIneligibleView.render(params)).as(Http.MimeTypes.HTML);
     } else {
-      try {
-        return ok(
-            ineligibleBlockView.render(
-                request,
-                profile,
-                roApplicantProgramService,
-                messagesApi.preferred(request),
-                applicantId,
-                programDefinition,
-                /* blockId= */ Optional.empty()));
-      } catch (ProgramBlockDefinitionNotFoundException e) {
-        throw new RuntimeException(e);
-      }
+      return ok(
+          ineligibleBlockView.render(
+              request,
+              profile,
+              roApplicantProgramService,
+              messagesApi.preferred(request),
+              applicantId,
+              programDefinition,
+              /* blockDefinition= */ Optional.empty()));
     }
   }
 

--- a/server/app/views/applicant/IneligibleBlockView.java
+++ b/server/app/views/applicant/IneligibleBlockView.java
@@ -23,7 +23,6 @@ import services.MessageKey;
 import services.applicant.ApplicantService;
 import services.applicant.ReadOnlyApplicantProgramService;
 import services.program.BlockDefinition;
-import services.program.ProgramBlockDefinitionNotFoundException;
 import services.program.ProgramDefinition;
 import services.settings.SettingsManifest;
 import views.ApplicationBaseView;
@@ -62,8 +61,7 @@ public final class IneligibleBlockView extends ApplicationBaseView {
       Messages messages,
       long applicantId,
       ProgramDefinition programDefinition,
-      Optional<String> blockId)
-      throws ProgramBlockDefinitionNotFoundException {
+      Optional<BlockDefinition> blockDefinition) {
     long programId = roApplicantProgramService.getProgramId();
     boolean isTrustedIntermediary = submittingProfile.isTrustedIntermediary();
     String programDetailsLink = programDefinition.externalLink();
@@ -71,11 +69,11 @@ public final class IneligibleBlockView extends ApplicationBaseView {
     String eligibilityMsg = "";
     boolean isEligibilityMsgEnabled =
         settingsManifest.getCustomizedEligibilityMessageEnabled(request);
-    if (blockId.isPresent()) {
-      BlockDefinition blockDefinition = programDefinition.getBlockDefinition(blockId.get());
+    if (blockDefinition.isPresent()) {
       Locale preferredLocale = messages.lang().toLocale();
       eligibilityMsg =
           blockDefinition
+              .get()
               .localizedEligibilityMessage()
               .map(localizedStrings -> localizedStrings.getOrDefault(preferredLocale))
               .orElse("");


### PR DESCRIPTION
### Description

This is an update to https://github.com/civiform/civiform/pull/9421/files to pass the blockDefinition through to the function to allow just the function that throws the exception to be wrapped in the try / catch. Seems more readable and also allows us to cut down on some code. 

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`

