### PR TITLE
Set frame ancestors to self for CSP

### DIFF
--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -357,7 +357,7 @@ play.filters {
     reportOnly = false
     nonce.enabled = true
     directives.script-src = ${play.filters.csp.nonce.pattern} "'strict-dynamic' https: 'unsafe-inline'"
-    directives.frame-ancestors = 'none'
+    directives.frame-ancestors = 'self'
   }
 
   gzip {

--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -357,6 +357,7 @@ play.filters {
     reportOnly = false
     nonce.enabled = true
     directives.script-src = ${play.filters.csp.nonce.pattern} "'strict-dynamic' https: 'unsafe-inline'"
+    directives.frame-ancestors = 'none'
   }
 
   gzip {
@@ -603,3 +604,6 @@ num_trusted_proxies = ${?NUM_TRUSTED_PROXIES}
 # These are file types allowed to be uploaded by the file upload components
 file_upload_allowed_file_type_specifiers = "image/*,.pdf"
 file_upload_allowed_file_type_specifiers = ${?FILE_UPLOAD_ALLOWED_FILE_TYPE_SPECIFIERS}
+
+session_replay_protection_enabled = true
+admin_oidc_enhanced_logout_enabled = true

--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -604,6 +604,3 @@ num_trusted_proxies = ${?NUM_TRUSTED_PROXIES}
 # These are file types allowed to be uploaded by the file upload components
 file_upload_allowed_file_type_specifiers = "image/*,.pdf"
 file_upload_allowed_file_type_specifiers = ${?FILE_UPLOAD_ALLOWED_FILE_TYPE_SPECIFIERS}
-
-session_replay_protection_enabled = true
-admin_oidc_enhanced_logout_enabled = true


### PR DESCRIPTION
### Description

Since x-frame-headers is deprecated, this is the recommended approach for preventing clickjacking https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors. The reason we can't do "none" is because the program application list uses an iframe (https://github.com/civiform/civiform/blob/e441158503b1a965a22a1840e82d36e48edf91f1/server/app/views/admin/programs/ProgramApplicationListView.java#L142)

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`

### Issue(s) this completes

https://github.com/civiform/civiform/issues/9404