### PR TITLE
Issue 9381 fix navigation on the error modal  for incomplete application step

### DIFF
--- a/browser-test/src/applicant/navigation/northstar_application_navigation_buttons.test.ts
+++ b/browser-test/src/applicant/navigation/northstar_application_navigation_buttons.test.ts
@@ -802,7 +802,7 @@ test.describe('Applicant navigation flow', {tag: ['@northstar']}, () => {
         await applicantQuestions.clickReview(/* northStarEnabled= */ true)
 
         // The date question is required, so expect the error modal.
-        await applicantQuestions.expectErrorOnPreviousModal(
+        await applicantQuestions.expectErrorOnReviewModal(
           /* northStarEnabled= */ true,
         )
       })
@@ -834,7 +834,7 @@ test.describe('Applicant navigation flow', {tag: ['@northstar']}, () => {
         await applicantQuestions.answerEmailQuestion('test1@gmail.com')
 
         await applicantQuestions.clickReview(/* northStarEnabled= */ true)
-        await applicantQuestions.expectErrorOnPreviousModal(
+        await applicantQuestions.expectErrorOnReviewModal(
           /* northStarEnabled= */ true,
         )
 
@@ -879,16 +879,12 @@ test.describe('Applicant navigation flow', {tag: ['@northstar']}, () => {
         await applicantQuestions.answerEmailQuestion('')
 
         await applicantQuestions.clickReview(/* northStarEnabled= */ true)
-        // FIX it !! this should expect error on review
-
-        await applicantQuestions.expectErrorOnPreviousModal(
+        await applicantQuestions.expectErrorOnReviewModal(
           /* northStarEnabled= */ true,
         )
 
         // Proceed to the Review page, acknowledging that answers won't be saved
-        // FIX it !! this should clickReview
-
-        await applicantQuestions.clickPreviousWithoutSaving()
+        await applicantQuestions.clickReviewWithoutSaving()
 
         await applicantQuestions.expectReviewPage(/* northStarEnabled= */ true)
         await applicantQuestions.validateNoPreviouslyAnsweredText(
@@ -926,7 +922,7 @@ test.describe('Applicant navigation flow', {tag: ['@northstar']}, () => {
           // Because the questions were previously answered and the date and email questions are required,
           // we don't let the user save the deletion of answers.
           await applicantQuestions.clickReview(/* northStarEnabled= */ true)
-          await applicantQuestions.expectErrorOnPreviousModal(
+          await applicantQuestions.expectErrorOnReviewModal(
             /* northStarEnabled= */ true,
           )
         })

--- a/browser-test/src/applicant/navigation/northstar_application_navigation_buttons.test.ts
+++ b/browser-test/src/applicant/navigation/northstar_application_navigation_buttons.test.ts
@@ -879,11 +879,15 @@ test.describe('Applicant navigation flow', {tag: ['@northstar']}, () => {
         await applicantQuestions.answerEmailQuestion('')
 
         await applicantQuestions.clickReview(/* northStarEnabled= */ true)
+        // FIX it !! this should expect error on review
+
         await applicantQuestions.expectErrorOnPreviousModal(
           /* northStarEnabled= */ true,
         )
 
         // Proceed to the Review page, acknowledging that answers won't be saved
+        // FIX it !! this should clickReview
+
         await applicantQuestions.clickPreviousWithoutSaving()
 
         await applicantQuestions.expectReviewPage(/* northStarEnabled= */ true)

--- a/browser-test/src/support/applicant_questions.ts
+++ b/browser-test/src/support/applicant_questions.ts
@@ -971,7 +971,7 @@ export class ApplicantQuestions {
       ).toBeVisible()
       await expect(
         modal.getByText(
-          "There are some errors with the information you''ve filled in. Would you like to stay and fix your answers, or go to the review page without saving your answers?",
+          "There are some errors with the information you've filled in. Would you like to stay and fix your answers, or go to the review page without saving your answers?",
         ),
       ).toBeVisible()
       await expect(

--- a/browser-test/src/support/applicant_questions.ts
+++ b/browser-test/src/support/applicant_questions.ts
@@ -961,26 +961,32 @@ export class ApplicantQuestions {
     )
   }
   async expectErrorOnReviewModal(northStarEnabled = false) {
-    const modalTitle = 'Questions on this page are not complete. Would you still like to leave and begin reviewing?';
-  const modalContent = "There are some errors with the information you've filled in. Would you like to stay and fix your answers, or go to the review page without saving your answers?";
-  const buttonReviewText = 'Continue to review page without saving';
-  const buttonStayText = 'Stay and fix your answers';
+    const modalTitle =
+      'Questions on this page are not complete. Would you still like to leave and begin reviewing?'
+    const modalContent =
+      "There are some errors with the information you've filled in. Would you like to stay and fix your answers, or go to the review page without saving your answers?"
+    const buttonReviewText = 'Continue to review page without saving'
+    const buttonStayText = 'Stay and fix your answers'
 
-  if (northStarEnabled) {
-    const modal = this.page.getByRole('dialog', { state: 'visible' });
+    if (northStarEnabled) {
+      const modal = this.page.getByRole('dialog', {state: 'visible'})
 
-    await expect(modal.getByText(modalTitle)).toBeVisible();
-    await expect(modal.getByText(modalContent)).toBeVisible();
-    await expect(modal.getByRole('button').getByText(buttonReviewText)).toBeVisible();
-    await expect(modal.getByRole('button').getByText(buttonStayText)).toBeVisible();
-  } else {
-    const modal = await waitForAnyModal(this.page);
-    const modalText = await modal.innerText();
+      await expect(modal.getByText(modalTitle)).toBeVisible()
+      await expect(modal.getByText(modalContent)).toBeVisible()
+      await expect(
+        modal.getByRole('button').getByText(buttonReviewText),
+      ).toBeVisible()
+      await expect(
+        modal.getByRole('button').getByText(buttonStayText),
+      ).toBeVisible()
+    } else {
+      const modal = await waitForAnyModal(this.page)
+      const modalText = await modal.innerText()
 
-    expect(modalText).toContain(modalContent);
-    expect(modalText).toContain(buttonReviewText);
-    expect(modalText).toContain(buttonStayText);
-  }
+      expect(modalText).toContain(modalContent)
+      expect(modalText).toContain(buttonReviewText)
+      expect(modalText).toContain(buttonStayText)
+    }
   }
 
   async clickReviewWithoutSaving() {

--- a/browser-test/src/support/applicant_questions.ts
+++ b/browser-test/src/support/applicant_questions.ts
@@ -961,37 +961,26 @@ export class ApplicantQuestions {
     )
   }
   async expectErrorOnReviewModal(northStarEnabled = false) {
-    if (northStarEnabled) {
-      const modal = this.page.getByRole('dialog', {state: 'visible'})
+    const modalTitle = 'Questions on this page are not complete. Would you still like to leave and begin reviewing?';
+  const modalContent = "There are some errors with the information you've filled in. Would you like to stay and fix your answers, or go to the review page without saving your answers?";
+  const buttonReviewText = 'Continue to review page without saving';
+  const buttonStayText = 'Stay and fix your answers';
 
-      await expect(
-        modal.getByText(
-          'Questions on this page are not complete. Would you still like to leave and begin reviewing?',
-        ),
-      ).toBeVisible()
-      await expect(
-        modal.getByText(
-          "There are some errors with the information you've filled in. Would you like to stay and fix your answers, or go to the review page without saving your answers?",
-        ),
-      ).toBeVisible()
-      await expect(
-        modal
-          .getByRole('button')
-          .getByText('Continue to review page without saving'),
-      ).toBeVisible()
-      await expect(
-        modal.getByRole('button').getByText('Stay and fix your answers'),
-      ).toBeVisible()
-    } else {
-      const modal = await waitForAnyModal(this.page)
-      expect(await modal.innerText()).toContain(
-        `Questions on this page are not complete`,
-      )
-      expect(await modal.innerText()).toContain(
-        `Continue to review page without saving`,
-      )
-      expect(await modal.innerText()).toContain(`Stay and fix your answers`)
-    }
+  if (northStarEnabled) {
+    const modal = this.page.getByRole('dialog', { state: 'visible' });
+
+    await expect(modal.getByText(modalTitle)).toBeVisible();
+    await expect(modal.getByText(modalContent)).toBeVisible();
+    await expect(modal.getByRole('button').getByText(buttonReviewText)).toBeVisible();
+    await expect(modal.getByRole('button').getByText(buttonStayText)).toBeVisible();
+  } else {
+    const modal = await waitForAnyModal(this.page);
+    const modalText = await modal.innerText();
+
+    expect(modalText).toContain(modalContent);
+    expect(modalText).toContain(buttonReviewText);
+    expect(modalText).toContain(buttonStayText);
+  }
   }
 
   async clickReviewWithoutSaving() {

--- a/browser-test/src/support/applicant_questions.ts
+++ b/browser-test/src/support/applicant_questions.ts
@@ -960,16 +960,38 @@ export class ApplicantQuestions {
       'This question is required',
     )
   }
+  async expectErrorOnReviewModal(northStarEnabled = false) {
+    if (northStarEnabled) {
+      const modal = this.page.getByRole('dialog', {state: 'visible'})
 
-  async expectErrorOnReviewModal() {
-    const modal = await waitForAnyModal(this.page)
-    expect(await modal.innerText()).toContain(
-      `Questions on this page are not complete`,
-    )
-    expect(await modal.innerText()).toContain(
-      `Continue to review page without saving`,
-    )
-    expect(await modal.innerText()).toContain(`Stay and fix your answers`)
+      await expect(
+        modal.getByText(
+          'Questions on this page are not complete. Would you still like to leave and begin reviewing?',
+        ),
+      ).toBeVisible()
+      await expect(
+        modal.getByText(
+          "There are some errors with the information you''ve filled in. Would you like to stay and fix your answers, or go to the review page without saving your answers?",
+        ),
+      ).toBeVisible()
+      await expect(
+        modal
+          .getByRole('button')
+          .getByText('Continue to review page without saving'),
+      ).toBeVisible()
+      await expect(
+        modal.getByRole('button').getByText('Stay and fix your answers'),
+      ).toBeVisible()
+    } else {
+      const modal = await waitForAnyModal(this.page)
+      expect(await modal.innerText()).toContain(
+        `Questions on this page are not complete`,
+      )
+      expect(await modal.innerText()).toContain(
+        `Continue to review page without saving`,
+      )
+      expect(await modal.innerText()).toContain(`Stay and fix your answers`)
+    }
   }
 
   async clickReviewWithoutSaving() {

--- a/server/app/views/applicant/ModalFragment.html
+++ b/server/app/views/applicant/ModalFragment.html
@@ -183,48 +183,11 @@
 
         <p th:text="#{${errorModalContent}}"></p>
 
-
-        <!-- Debug Statement -->
-
-        <button
-        type="button"
-        th:data-redirect-to="${errorModalDataRedirectTo}"
-        data-close-modal
-        th:text="#{${errorModalButtonText}}"
-        class="usa-button usa-button--outline margin-y-2"
-      ></button>
-
-        <!-- MODAL_ERROR_SAVING_REVIEW_TITLE("modal.errorSaving.review.title"), -->
-        <p th:text="#{modal.errorSaving.previous.content}"></p>
-        <p th:text="#{modal.errorSaving.review.content}"></p>
-
-        <p class="text-small text-secondary"
-        th:utext="
-           'DEBUG:' + '&#10;' + 
-           'errorDisplayMode = ' + ${errorDisplayMode} + '&#10;' + 
-           'errorModalTitle = ' + ${errorModalTitle} + '&#10;' + 
-           'errorModalContent = ' + ${errorModalContent} + '&#10;' + 
-           'errorModal-data-redirect-to = ' + ${errorModal-data-redirect-to} + '&#10;' +
-           'previousWithoutSaving = ' + ${previousWithoutSaving} + '&#10;' +
-           'reviewWithoutSaving = ' + ${reviewWithoutSaving} + '&#10;' 
-           ">
-     </p>
-     
-     
-      
         <button
           type="button"
-          th:data-redirect-to="${reviewWithoutSaving}"
+          th:data-redirect-to="${errorModalDataRedirectTo}"
           data-close-modal
-          th:text="#{modal.errorSaving.review.noSaveButton}"
-          class="usa-button usa-button--outline margin-y-2"
-        ></button>
-
-        <button
-          type="button"
-          th:data-redirect-to="${previousWithoutSaving}"
-          data-close-modal
-          th:text="#{modal.errorSaving.previous.noSaveButton}"
+          th:text="#{${errorModalButtonText}}"
           class="usa-button usa-button--outline margin-y-2"
         ></button>
 
@@ -234,8 +197,6 @@
           data-close-modal
           class="usa-button margin-y-2"
         ></button>
-
-
       </div>
 
       <button

--- a/server/app/views/applicant/ModalFragment.html
+++ b/server/app/views/applicant/ModalFragment.html
@@ -178,9 +178,47 @@
         <h2
           class="usa-modal__heading"
           id="validation-modal-heading"
-          th:text="#{modal.errorSaving.previous.title}"
+          th:text="#{${errorModalTitle}}"
         ></h2>
+
+        <p th:text="#{${errorModalContent}}"></p>
+
+
+        <!-- Debug Statement -->
+
+        <button
+        type="button"
+        th:data-redirect-to="${errorModalDataRedirectTo}"
+        data-close-modal
+        th:text="#{${errorModalButtonText}}"
+        class="usa-button usa-button--outline margin-y-2"
+      ></button>
+
+        <!-- MODAL_ERROR_SAVING_REVIEW_TITLE("modal.errorSaving.review.title"), -->
         <p th:text="#{modal.errorSaving.previous.content}"></p>
+        <p th:text="#{modal.errorSaving.review.content}"></p>
+
+        <p class="text-small text-secondary"
+        th:utext="
+           'DEBUG:' + '&#10;' + 
+           'errorDisplayMode = ' + ${errorDisplayMode} + '&#10;' + 
+           'errorModalTitle = ' + ${errorModalTitle} + '&#10;' + 
+           'errorModalContent = ' + ${errorModalContent} + '&#10;' + 
+           'errorModal-data-redirect-to = ' + ${errorModal-data-redirect-to} + '&#10;' +
+           'previousWithoutSaving = ' + ${previousWithoutSaving} + '&#10;' +
+           'reviewWithoutSaving = ' + ${reviewWithoutSaving} + '&#10;' 
+           ">
+     </p>
+     
+     
+      
+        <button
+          type="button"
+          th:data-redirect-to="${reviewWithoutSaving}"
+          data-close-modal
+          th:text="#{modal.errorSaving.review.noSaveButton}"
+          class="usa-button usa-button--outline margin-y-2"
+        ></button>
 
         <button
           type="button"
@@ -196,6 +234,8 @@
           data-close-modal
           class="usa-button margin-y-2"
         ></button>
+
+
       </div>
 
       <button

--- a/server/app/views/applicant/NorthStarApplicantProgramBlockEditView.java
+++ b/server/app/views/applicant/NorthStarApplicantProgramBlockEditView.java
@@ -10,9 +10,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
-
 import javax.naming.Context;
-
 import models.ApplicantModel.Suffix;
 import modules.ThymeleafModule;
 import org.thymeleaf.TemplateEngine;
@@ -113,11 +111,11 @@ public final class NorthStarApplicantProgramBlockEditView extends NorthStarBaseV
       return templateEngine.process(
           "applicant/ApplicantProgramFileUploadBlockEditTemplate", context);
     } else {
-        if (applicationParams.errorDisplayMode() == ApplicantQuestionRendererParams.ErrorDisplayMode.DISPLAY_ERRORS_WITH_MODAL_REVIEW) {
-            setContextForReview(context, applicationParams);
-        } else {
-            setContextForPrevious(context, applicationParams);
-        }
+      if (applicationParams.errorDisplayMode()
+          == ApplicantQuestionRendererParams.ErrorDisplayMode.DISPLAY_ERRORS_WITH_MODAL_REVIEW) {
+        setContextForReview(context, applicationParams);
+      } else {
+        setContextForPrevious(context, applicationParams);
       }
 
       // TODO(#6910): Why am I unable to access static vars directly from Thymeleaf
@@ -130,40 +128,47 @@ public final class NorthStarApplicantProgramBlockEditView extends NorthStarBaseV
   }
 
   // Helper function to set the modal context
-private void setContextForFormModal(Context context, String formAction, String title, String content, String buttonText, String redirectTo) {
+  private void setContextForFormModal(
+      Context context,
+      String formAction,
+      String title,
+      String content,
+      String buttonText,
+      String redirectTo) {
     context.setVariable("errorModalFormAction", formAction);
     context.setVariable("errorModalTitle", title);
     context.setVariable("errorModalContent", content);
     context.setVariable("errorModalButtonText", buttonText);
     context.setVariable("errorModalDataRedirectTo", redirectTo);
-}
+  }
 
-// Function to set context for the previous action
-private void setContextForPrevious(Context context, ApplicationParams applicationParams) {
-    context.setVariable("previousFormAction", getFormAction(applicationParams, ApplicantRequestedAction.PREVIOUS_BLOCK));
+  // Function to set context for the previous action
+  private void setContextForPrevious(Context context, ApplicationParams applicationParams) {
+    context.setVariable(
+        "previousFormAction",
+        getFormAction(applicationParams, ApplicantRequestedAction.PREVIOUS_BLOCK));
     setContextForFormModal(
         context,
         getFormAction(applicationParams, ApplicantRequestedAction.PREVIOUS_BLOCK),
         MessageKey.MODAL_ERROR_SAVING_PREVIOUS_TITLE.getKeyName(),
         MessageKey.MODAL_ERROR_SAVING_PREVIOUS_CONTENT.getKeyName(),
         MessageKey.MODAL_ERROR_SAVING_PREVIOUS_NO_SAVE_BUTTON.getKeyName(),
-        previousWithoutSaving(applicationParams)
-    );
-}
+        previousWithoutSaving(applicationParams));
+  }
 
-// Function to set context for the review action
-private void setContextForReview(Context context, ApplicationParams applicationParams) {
-    context.setVariable("reviewFormAction", getFormAction(applicationParams, ApplicantRequestedAction.REVIEW_PAGE));
+  // Function to set context for the review action
+  private void setContextForReview(Context context, ApplicationParams applicationParams) {
+    context.setVariable(
+        "reviewFormAction", getFormAction(applicationParams, ApplicantRequestedAction.REVIEW_PAGE));
     setContextForFormModal(
         context,
         getFormAction(applicationParams, ApplicantRequestedAction.REVIEW_PAGE),
         MessageKey.MODAL_ERROR_SAVING_REVIEW_TITLE.getKeyName(),
         MessageKey.MODAL_ERROR_SAVING_REVIEW_CONTENT.getKeyName(),
         MessageKey.MODAL_ERROR_SAVING_REVIEW_NO_SAVE_BUTTON.getKeyName(),
-        reviewWithoutSaving(applicationParams)
-    );
-}
-  
+        reviewWithoutSaving(applicationParams));
+  }
+
   private String getFormAction(
       ApplicationBaseViewParams params, ApplicantRequestedAction nextAction) {
     return applicantRoutes

--- a/server/app/views/applicant/NorthStarApplicantProgramBlockEditView.java
+++ b/server/app/views/applicant/NorthStarApplicantProgramBlockEditView.java
@@ -128,7 +128,6 @@ public final class NorthStarApplicantProgramBlockEditView extends NorthStarBaseV
           MessageKey.MODAL_ERROR_SAVING_PREVIOUS_NO_SAVE_BUTTON.getKeyName());
       context.setVariable("errorModalDataRedirectTo", previousWithoutSaving(applicationParams));
 
-      /// debugging
       if (applicationParams.errorDisplayMode()
           == ApplicantQuestionRendererParams.ErrorDisplayMode.DISPLAY_ERRORS_WITH_MODAL_REVIEW) {
         context.setVariable(
@@ -143,8 +142,6 @@ public final class NorthStarApplicantProgramBlockEditView extends NorthStarBaseV
             getFormAction(applicationParams, ApplicantRequestedAction.REVIEW_PAGE));
         context.setVariable("errorModalDataRedirectTo", reviewWithoutSaving(applicationParams));
       }
-
-      /// debugging
 
       // TODO(#6910): Why am I unable to access static vars directly from Thymeleaf
       context.setVariable("stateAbbreviations", AddressQuestion.STATE_ABBREVIATIONS);

--- a/server/app/views/applicant/NorthStarApplicantProgramBlockEditView.java
+++ b/server/app/views/applicant/NorthStarApplicantProgramBlockEditView.java
@@ -1,21 +1,18 @@
 package views.applicant;
 
-import java.util.Map;
-import java.util.Optional;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collectors;
-
-import org.thymeleaf.TemplateEngine;
-
 import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.Inject;
-
 import controllers.AssetsFinder;
 import controllers.LanguageUtils;
 import controllers.applicant.ApplicantRequestedAction;
 import controllers.applicant.ApplicantRoutes;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 import models.ApplicantModel.Suffix;
 import modules.ThymeleafModule;
+import org.thymeleaf.TemplateEngine;
 import play.mvc.Http.Request;
 import services.DeploymentType;
 import services.MessageKey;
@@ -116,44 +113,38 @@ public final class NorthStarApplicantProgramBlockEditView extends NorthStarBaseV
       context.setVariable(
           "previousFormAction",
           getFormAction(applicationParams, ApplicantRequestedAction.PREVIOUS_BLOCK));
-      context.setVariable("previousWithoutSaving", previousWithoutSaving(applicationParams));
-      context.setVariable("errorModalDataRedirectTo", previousWithoutSaving(applicationParams));
-
       context.setVariable(
           "reviewFormAction",
           getFormAction(applicationParams, ApplicantRequestedAction.REVIEW_PAGE));
-      context.setVariable("reviewWithoutSaving", reviewWithoutSaving(applicationParams));
       context.setVariable(
-        "errorModalTitle",
-        MessageKey.MODAL_ERROR_SAVING_PREVIOUS_TITLE.getKeyName());
-        context.setVariable(
-            "errorModalContent",
-            MessageKey.MODAL_ERROR_SAVING_PREVIOUS_CONTENT.getKeyName());
-        context.setVariable(
-                "errorModalButtonText",
-                MessageKey.MODAL_ERROR_SAVING_PREVIOUS_NO_SAVE_BUTTON.getKeyName());
-       /// context.setVariable("errorModal-data-redirect-to", previousWithoutSaving(applicationParams));
-        context.setVariable("errorModalDataRedirectTo", previousWithoutSaving(applicationParams));
-
-/// debugging
-   if (applicationParams.errorDisplayMode() == ApplicantQuestionRendererParams.ErrorDisplayMode.DISPLAY_ERRORS_WITH_MODAL_REVIEW) {
-
+          "errorModalFormAction",
+          getFormAction(applicationParams, ApplicantRequestedAction.PREVIOUS_BLOCK));
       context.setVariable(
-        "errorModalTitle",
-        MessageKey.MODAL_ERROR_SAVING_REVIEW_TITLE.getKeyName());
-        context.setVariable(
-            "errorModalContent",
-            MessageKey.MODAL_ERROR_SAVING_REVIEW_CONTENT.getKeyName());
-        context.setVariable(
-                "errorModalButtonText",
-                MessageKey.MODAL_ERROR_SAVING_REVIEW_NO_SAVE_BUTTON.getKeyName());
+          "errorModalTitle", MessageKey.MODAL_ERROR_SAVING_PREVIOUS_TITLE.getKeyName());
       context.setVariable(
-        "errorModalFormAction",
-        getFormAction(applicationParams, ApplicantRequestedAction.REVIEW_PAGE));
-    context.setVariable("errorModalDataRedirectTo", reviewWithoutSaving(applicationParams));
-    } 
+          "errorModalContent", MessageKey.MODAL_ERROR_SAVING_PREVIOUS_CONTENT.getKeyName());
+      context.setVariable(
+          "errorModalButtonText",
+          MessageKey.MODAL_ERROR_SAVING_PREVIOUS_NO_SAVE_BUTTON.getKeyName());
+      context.setVariable("errorModalDataRedirectTo", previousWithoutSaving(applicationParams));
 
-/// debugging
+      /// debugging
+      if (applicationParams.errorDisplayMode()
+          == ApplicantQuestionRendererParams.ErrorDisplayMode.DISPLAY_ERRORS_WITH_MODAL_REVIEW) {
+        context.setVariable(
+            "errorModalTitle", MessageKey.MODAL_ERROR_SAVING_REVIEW_TITLE.getKeyName());
+        context.setVariable(
+            "errorModalContent", MessageKey.MODAL_ERROR_SAVING_REVIEW_CONTENT.getKeyName());
+        context.setVariable(
+            "errorModalButtonText",
+            MessageKey.MODAL_ERROR_SAVING_REVIEW_NO_SAVE_BUTTON.getKeyName());
+        context.setVariable(
+            "errorModalFormAction",
+            getFormAction(applicationParams, ApplicantRequestedAction.REVIEW_PAGE));
+        context.setVariable("errorModalDataRedirectTo", reviewWithoutSaving(applicationParams));
+      }
+
+      /// debugging
 
       // TODO(#6910): Why am I unable to access static vars directly from Thymeleaf
       context.setVariable("stateAbbreviations", AddressQuestion.STATE_ABBREVIATIONS);

--- a/server/app/views/applicant/NorthStarApplicantProgramBlockEditView.java
+++ b/server/app/views/applicant/NorthStarApplicantProgramBlockEditView.java
@@ -1,20 +1,24 @@
 package views.applicant;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.google.inject.Inject;
-import controllers.AssetsFinder;
-import controllers.LanguageUtils;
-import controllers.applicant.ApplicantRequestedAction;
-import controllers.applicant.ApplicantRoutes;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
+
+import org.thymeleaf.TemplateEngine;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.inject.Inject;
+
+import controllers.AssetsFinder;
+import controllers.LanguageUtils;
+import controllers.applicant.ApplicantRequestedAction;
+import controllers.applicant.ApplicantRoutes;
 import models.ApplicantModel.Suffix;
 import modules.ThymeleafModule;
-import org.thymeleaf.TemplateEngine;
 import play.mvc.Http.Request;
 import services.DeploymentType;
+import services.MessageKey;
 import services.applicant.question.AddressQuestion;
 import services.cloud.ApplicantFileNameFormatter;
 import services.cloud.StorageUploadRequest;
@@ -113,9 +117,44 @@ public final class NorthStarApplicantProgramBlockEditView extends NorthStarBaseV
           "previousFormAction",
           getFormAction(applicationParams, ApplicantRequestedAction.PREVIOUS_BLOCK));
       context.setVariable("previousWithoutSaving", previousWithoutSaving(applicationParams));
+      context.setVariable("errorModalDataRedirectTo", previousWithoutSaving(applicationParams));
+
       context.setVariable(
           "reviewFormAction",
           getFormAction(applicationParams, ApplicantRequestedAction.REVIEW_PAGE));
+      context.setVariable("reviewWithoutSaving", reviewWithoutSaving(applicationParams));
+      context.setVariable(
+        "errorModalTitle",
+        MessageKey.MODAL_ERROR_SAVING_PREVIOUS_TITLE.getKeyName());
+        context.setVariable(
+            "errorModalContent",
+            MessageKey.MODAL_ERROR_SAVING_PREVIOUS_CONTENT.getKeyName());
+        context.setVariable(
+                "errorModalButtonText",
+                MessageKey.MODAL_ERROR_SAVING_PREVIOUS_NO_SAVE_BUTTON.getKeyName());
+       /// context.setVariable("errorModal-data-redirect-to", previousWithoutSaving(applicationParams));
+        context.setVariable("errorModalDataRedirectTo", previousWithoutSaving(applicationParams));
+
+/// debugging
+   if (applicationParams.errorDisplayMode() == ApplicantQuestionRendererParams.ErrorDisplayMode.DISPLAY_ERRORS_WITH_MODAL_REVIEW) {
+
+      context.setVariable(
+        "errorModalTitle",
+        MessageKey.MODAL_ERROR_SAVING_REVIEW_TITLE.getKeyName());
+        context.setVariable(
+            "errorModalContent",
+            MessageKey.MODAL_ERROR_SAVING_REVIEW_CONTENT.getKeyName());
+        context.setVariable(
+                "errorModalButtonText",
+                MessageKey.MODAL_ERROR_SAVING_REVIEW_NO_SAVE_BUTTON.getKeyName());
+      context.setVariable(
+        "errorModalFormAction",
+        getFormAction(applicationParams, ApplicantRequestedAction.REVIEW_PAGE));
+    context.setVariable("errorModalDataRedirectTo", reviewWithoutSaving(applicationParams));
+    } 
+
+/// debugging
+
       // TODO(#6910): Why am I unable to access static vars directly from Thymeleaf
       context.setVariable("stateAbbreviations", AddressQuestion.STATE_ABBREVIATIONS);
       context.setVariable("nameSuffixOptions", Suffix.values());
@@ -159,6 +198,13 @@ public final class NorthStarApplicantProgramBlockEditView extends NorthStarBaseV
             params.programId(),
             params.blockIndex(),
             params.inReview())
+        .url();
+  }
+
+  private String reviewWithoutSaving(ApplicationBaseViewParams params) {
+    return params
+        .applicantRoutes()
+        .review(params.profile(), params.applicantId(), params.programId())
         .url();
   }
 

--- a/server/app/views/applicant/NorthStarApplicantProgramBlockEditView.java
+++ b/server/app/views/applicant/NorthStarApplicantProgramBlockEditView.java
@@ -10,6 +10,9 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
+
+import javax.naming.Context;
+
 import models.ApplicantModel.Suffix;
 import modules.ThymeleafModule;
 import org.thymeleaf.TemplateEngine;
@@ -110,37 +113,11 @@ public final class NorthStarApplicantProgramBlockEditView extends NorthStarBaseV
       return templateEngine.process(
           "applicant/ApplicantProgramFileUploadBlockEditTemplate", context);
     } else {
-      context.setVariable(
-          "previousFormAction",
-          getFormAction(applicationParams, ApplicantRequestedAction.PREVIOUS_BLOCK));
-      context.setVariable(
-          "reviewFormAction",
-          getFormAction(applicationParams, ApplicantRequestedAction.REVIEW_PAGE));
-      context.setVariable(
-          "errorModalFormAction",
-          getFormAction(applicationParams, ApplicantRequestedAction.PREVIOUS_BLOCK));
-      context.setVariable(
-          "errorModalTitle", MessageKey.MODAL_ERROR_SAVING_PREVIOUS_TITLE.getKeyName());
-      context.setVariable(
-          "errorModalContent", MessageKey.MODAL_ERROR_SAVING_PREVIOUS_CONTENT.getKeyName());
-      context.setVariable(
-          "errorModalButtonText",
-          MessageKey.MODAL_ERROR_SAVING_PREVIOUS_NO_SAVE_BUTTON.getKeyName());
-      context.setVariable("errorModalDataRedirectTo", previousWithoutSaving(applicationParams));
-
-      if (applicationParams.errorDisplayMode()
-          == ApplicantQuestionRendererParams.ErrorDisplayMode.DISPLAY_ERRORS_WITH_MODAL_REVIEW) {
-        context.setVariable(
-            "errorModalTitle", MessageKey.MODAL_ERROR_SAVING_REVIEW_TITLE.getKeyName());
-        context.setVariable(
-            "errorModalContent", MessageKey.MODAL_ERROR_SAVING_REVIEW_CONTENT.getKeyName());
-        context.setVariable(
-            "errorModalButtonText",
-            MessageKey.MODAL_ERROR_SAVING_REVIEW_NO_SAVE_BUTTON.getKeyName());
-        context.setVariable(
-            "errorModalFormAction",
-            getFormAction(applicationParams, ApplicantRequestedAction.REVIEW_PAGE));
-        context.setVariable("errorModalDataRedirectTo", reviewWithoutSaving(applicationParams));
+        if (applicationParams.errorDisplayMode() == ApplicantQuestionRendererParams.ErrorDisplayMode.DISPLAY_ERRORS_WITH_MODAL_REVIEW) {
+            setContextForReview(context, applicationParams);
+        } else {
+            setContextForPrevious(context, applicationParams);
+        }
       }
 
       // TODO(#6910): Why am I unable to access static vars directly from Thymeleaf
@@ -152,6 +129,41 @@ public final class NorthStarApplicantProgramBlockEditView extends NorthStarBaseV
     }
   }
 
+  // Helper function to set the modal context
+private void setContextForFormModal(Context context, String formAction, String title, String content, String buttonText, String redirectTo) {
+    context.setVariable("errorModalFormAction", formAction);
+    context.setVariable("errorModalTitle", title);
+    context.setVariable("errorModalContent", content);
+    context.setVariable("errorModalButtonText", buttonText);
+    context.setVariable("errorModalDataRedirectTo", redirectTo);
+}
+
+// Function to set context for the previous action
+private void setContextForPrevious(Context context, ApplicationParams applicationParams) {
+    context.setVariable("previousFormAction", getFormAction(applicationParams, ApplicantRequestedAction.PREVIOUS_BLOCK));
+    setContextForFormModal(
+        context,
+        getFormAction(applicationParams, ApplicantRequestedAction.PREVIOUS_BLOCK),
+        MessageKey.MODAL_ERROR_SAVING_PREVIOUS_TITLE.getKeyName(),
+        MessageKey.MODAL_ERROR_SAVING_PREVIOUS_CONTENT.getKeyName(),
+        MessageKey.MODAL_ERROR_SAVING_PREVIOUS_NO_SAVE_BUTTON.getKeyName(),
+        previousWithoutSaving(applicationParams)
+    );
+}
+
+// Function to set context for the review action
+private void setContextForReview(Context context, ApplicationParams applicationParams) {
+    context.setVariable("reviewFormAction", getFormAction(applicationParams, ApplicantRequestedAction.REVIEW_PAGE));
+    setContextForFormModal(
+        context,
+        getFormAction(applicationParams, ApplicantRequestedAction.REVIEW_PAGE),
+        MessageKey.MODAL_ERROR_SAVING_REVIEW_TITLE.getKeyName(),
+        MessageKey.MODAL_ERROR_SAVING_REVIEW_CONTENT.getKeyName(),
+        MessageKey.MODAL_ERROR_SAVING_REVIEW_NO_SAVE_BUTTON.getKeyName(),
+        reviewWithoutSaving(applicationParams)
+    );
+}
+  
   private String getFormAction(
       ApplicationBaseViewParams params, ApplicantRequestedAction nextAction) {
     return applicantRoutes

--- a/server/app/views/applicant/NorthStarApplicantProgramBlockEditView.java
+++ b/server/app/views/applicant/NorthStarApplicantProgramBlockEditView.java
@@ -10,7 +10,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
-import javax.naming.Context;
 import models.ApplicantModel.Suffix;
 import modules.ThymeleafModule;
 import org.thymeleaf.TemplateEngine;
@@ -111,11 +110,20 @@ public final class NorthStarApplicantProgramBlockEditView extends NorthStarBaseV
       return templateEngine.process(
           "applicant/ApplicantProgramFileUploadBlockEditTemplate", context);
     } else {
+
+      context.setVariable(
+          "previousFormAction",
+          getFormAction(applicationParams, ApplicantRequestedAction.PREVIOUS_BLOCK));
+      context.setVariable("previousWithoutSaving", previousWithoutSaving(applicationParams));
+      context.setVariable(
+          "reviewFormAction",
+          getFormAction(applicationParams, ApplicantRequestedAction.REVIEW_PAGE));
+
       if (applicationParams.errorDisplayMode()
           == ApplicantQuestionRendererParams.ErrorDisplayMode.DISPLAY_ERRORS_WITH_MODAL_REVIEW) {
-        setContextForReview(context, applicationParams);
+        setErrorContextForReview(context, applicationParams);
       } else {
-        setContextForPrevious(context, applicationParams);
+        setErrorContextForPrevious(context, applicationParams);
       }
 
       // TODO(#6910): Why am I unable to access static vars directly from Thymeleaf
@@ -128,8 +136,8 @@ public final class NorthStarApplicantProgramBlockEditView extends NorthStarBaseV
   }
 
   // Helper function to set the modal context
-  private void setContextForFormModal(
-      Context context,
+  private void setErrorContextForFormModal(
+      ThymeleafModule.PlayThymeleafContext context,
       String formAction,
       String title,
       String content,
@@ -143,11 +151,9 @@ public final class NorthStarApplicantProgramBlockEditView extends NorthStarBaseV
   }
 
   // Function to set context for the previous action
-  private void setContextForPrevious(Context context, ApplicationParams applicationParams) {
-    context.setVariable(
-        "previousFormAction",
-        getFormAction(applicationParams, ApplicantRequestedAction.PREVIOUS_BLOCK));
-    setContextForFormModal(
+  private void setErrorContextForPrevious(
+      ThymeleafModule.PlayThymeleafContext context, ApplicationBaseViewParams applicationParams) {
+    setErrorContextForFormModal(
         context,
         getFormAction(applicationParams, ApplicantRequestedAction.PREVIOUS_BLOCK),
         MessageKey.MODAL_ERROR_SAVING_PREVIOUS_TITLE.getKeyName(),
@@ -157,10 +163,9 @@ public final class NorthStarApplicantProgramBlockEditView extends NorthStarBaseV
   }
 
   // Function to set context for the review action
-  private void setContextForReview(Context context, ApplicationParams applicationParams) {
-    context.setVariable(
-        "reviewFormAction", getFormAction(applicationParams, ApplicantRequestedAction.REVIEW_PAGE));
-    setContextForFormModal(
+  private void setErrorContextForReview(
+      ThymeleafModule.PlayThymeleafContext context, ApplicationBaseViewParams applicationParams) {
+    setErrorContextForFormModal(
         context,
         getFormAction(applicationParams, ApplicantRequestedAction.REVIEW_PAGE),
         MessageKey.MODAL_ERROR_SAVING_REVIEW_TITLE.getKeyName(),


### PR DESCRIPTION
### Description

Conditionally set navigation and display text on the error modal dialog to either previous block or review page based on whether user click on "back" or "review and exit" button the the page.


### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`

#### Database evolutions

Read the guidelines [here](https://github.com/civiform/civiform/wiki/Database#writing-database-evolutions)

N/A

#### Durable jobs

Read the docs [here](https://github.com/civiform/civiform/wiki/Database#durable-jobs-for-data-updates)

N/A

#### User visible changes

- [ ] Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
  - [ ] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [ ] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Made equivalent changes in Thymeleaf for applicant-facing features and changes (or created an issue in the [Northstar epic](https://github.com/orgs/civiform/projects/1/views/94) to track that it's missing from Thymeleaf)
- [ ] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order
- [ ] Manually tested with a screen reader if the feature is applicant-facing. See [screen reader testing](https://github.com/civiform/civiform/wiki/Testing#screen-reader-testing)

#### New Features

N/A

### Instructions for manual testing

create a program with multiple steps, one of which contains required questions. Alternatively,  you can import the attached test program json.

start application, go the step which contains required questions, 
click on Back,  you should see the dialog saying

Click on "Review and exit", you should see the dialog saying " ", click on "go to review", UI should take you to the review page (whereas without the fix, user can only go back to previous page)



### Issue(s) this completes

Fixes #9381
