### PR TITLE
Enable multi-file upload for Azure deployments using Northstar

### DIFF
--- a/server/app/views/applicant/ApplicantProgramFileUploadBlockEditTemplate.html
+++ b/server/app/views/applicant/ApplicantProgramFileUploadBlockEditTemplate.html
@@ -2,7 +2,8 @@
 <html th:attr="lang=${preferredLanguage.code()}">
   <head
     th:replace="~{applicant/ApplicantBaseFragment :: pageHeaderScriptsAndLinks}"
-  ></head>
+  >
+  </head>
   <body>
     <div th:replace="~{applicant/NavigationFragment :: pageHeader}"></div>
     <main
@@ -22,11 +23,12 @@
       <div class="grid-container usa-form usa-form--large">
         <div class="grid-row">
           <div class="tablet:grid-col-8">
+            <!-- /* Northstar templates only support multi-file uploads for applicant forms */ -->
             <form
               enctype="multipart/form-data"
               method="POST"
               id="cf-block-form"
-              th:class="${fileUploadViewStrategy.getUploadFormClass()}"
+              th:class="${fileUploadViewStrategy.getMultiFileUploadFormClass()}"
               th:action="${fileUploadViewStrategy.formAction(questionParams.signedFileUploadRequest().get())}"
             >
               <!--/* Render hidden inputs (actual inputs vary depending on whether it's AWS or Azure) */-->
@@ -124,6 +126,9 @@
           </div>
         </div>
       </div>
+      <th:block th:each="footerTag : ${fileUploadFooterTags}">
+        [(${footerTag.render()})]
+      </th:block>
     </main>
     <footer th:replace="~{applicant/NavigationFragment :: pageFooter}"></footer>
   </body>

--- a/server/app/views/applicant/ApplicantProgramFileUploadBlockEditTemplate.html
+++ b/server/app/views/applicant/ApplicantProgramFileUploadBlockEditTemplate.html
@@ -2,8 +2,7 @@
 <html th:attr="lang=${preferredLanguage.code()}">
   <head
     th:replace="~{applicant/ApplicantBaseFragment :: pageHeaderScriptsAndLinks}"
-  >
-  </head>
+  ></head>
   <body>
     <div th:replace="~{applicant/NavigationFragment :: pageHeader}"></div>
     <main

--- a/server/app/views/applicant/NorthStarApplicantProgramBlockEditView.java
+++ b/server/app/views/applicant/NorthStarApplicantProgramBlockEditView.java
@@ -104,7 +104,7 @@ public final class NorthStarApplicantProgramBlockEditView extends NorthStarBaseV
 
     // Include file upload specific parameters.
     if (applicationParams.block().isFileUpload()) {
-      this.addFileUploadParameters(applicationParams, context);
+      this.addFileUploadParameters(request, applicationParams, context);
 
       return templateEngine.process(
           "applicant/ApplicantProgramFileUploadBlockEditTemplate", context);
@@ -221,8 +221,11 @@ public final class NorthStarApplicantProgramBlockEditView extends NorthStarBaseV
   }
 
   private void addFileUploadParameters(
-      ApplicationBaseViewParams params, ThymeleafModule.PlayThymeleafContext context) {
+      Request request,
+      ApplicationBaseViewParams params,
+      ThymeleafModule.PlayThymeleafContext context) {
     context.setVariable("fileUploadViewStrategy", fileUploadViewStrategy);
+    context.setVariable("fileUploadFooterTags", fileUploadViewStrategy.footerTags(request));
     context.setVariable("maxFileSizeMb", params.applicantStorageClient().getFileLimitMb());
     context.setVariable(
         "fileUploadAllowedFileTypeSpecifiers",

--- a/server/app/views/fileupload/FileUploadViewStrategy.java
+++ b/server/app/views/fileupload/FileUploadViewStrategy.java
@@ -172,5 +172,9 @@ public abstract class FileUploadViewStrategy {
    */
   public abstract String getMultiFileUploadFormClass();
 
+  /**
+   * Internal method returns extra script tags needed to support file upload from the client.
+   * Invoked by the method footerTags() in this file.
+   */
   protected abstract ImmutableList<ScriptTag> extraScriptTags();
 }


### PR DESCRIPTION
### Description

Enables applicant multi-fiile uploads for Azure deployments with Northstar enabled.

- Adds the script tag to load the azure javascript library to file upload views.

This is not the final PR for this feature, outstanding items:
- #9444 File names for uploaded files are not properly displayed on azure deployments (UID shown instead)

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [X] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [X] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [X] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [X] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [X] Created unit and/or browser tests which fail without the change (if possible)
- [X] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [X] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [X] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`

### Issue(s) this completes

Fixes #8108