### PR TITLE
Validate that redirects point to relative paths

### DIFF
--- a/server/app/controllers/CallbackController.java
+++ b/server/app/controllers/CallbackController.java
@@ -6,6 +6,7 @@ import javax.inject.Inject;
 import play.mvc.Controller;
 import play.mvc.Http;
 import play.mvc.Result;
+import services.UrlUtils;
 
 /**
  * This is a convenience class to wrap org.pac4j.play.CallbackController. Controllers outside our
@@ -25,7 +26,7 @@ public class CallbackController extends Controller {
             result -> {
               Optional<String> redirectTo = request.session().get(REDIRECT_TO_SESSION_KEY);
               if (redirectTo.isPresent()) {
-                Result redirect = redirect(redirectTo.get());
+                Result redirect = redirect(UrlUtils.checkIsRelativeUrl(redirectTo.get()));
                 if (result.session() != null) {
                   redirect = redirect.withSession(result.session());
                   redirect = redirect.removingFromSession(request, REDIRECT_TO_SESSION_KEY);

--- a/server/app/controllers/applicant/ApplicantInformationController.java
+++ b/server/app/controllers/applicant/ApplicantInformationController.java
@@ -27,6 +27,7 @@ import play.mvc.Result;
 import play.mvc.Results;
 import repository.AccountRepository;
 import repository.VersionRepository;
+import services.UrlUtils;
 import services.applicant.ApplicantData;
 import services.applicant.exception.ApplicantNotFoundException;
 
@@ -85,7 +86,9 @@ public final class ApplicantInformationController extends CiviFormController {
 
               String redirectLink;
               if (request.session().data().containsKey(REDIRECT_TO_SESSION_KEY)) {
-                redirectLink = request.session().data().get(REDIRECT_TO_SESSION_KEY);
+                redirectLink =
+                    UrlUtils.checkIsRelativeUrl(
+                        request.session().data().get(REDIRECT_TO_SESSION_KEY));
               } else if (profileUtils.currentUserProfile(request).isTrustedIntermediary()) {
                 redirectLink =
                     controllers.ti.routes.TrustedIntermediaryController.dashboard(
@@ -99,7 +102,6 @@ public final class ApplicantInformationController extends CiviFormController {
                 CiviFormProfile profile = profileUtils.currentUserProfile(request);
                 redirectLink = applicantRoutes.index(profile, applicantId).url();
               }
-
               return redirect(redirectLink)
                   .withLang(preferredLocale, messagesApi)
                   .withSession(request.session());
@@ -133,7 +135,7 @@ public final class ApplicantInformationController extends CiviFormController {
     }
 
     ApplicantInformationForm infoForm = form.bindFromRequest(request).get();
-    String redirectLocation = infoForm.getRedirectLink();
+    String redirectLocation = UrlUtils.checkIsRelativeUrl(infoForm.getRedirectLink());
     Locale locale = infoForm.getLocale();
 
     return CompletableFuture.completedFuture(
@@ -161,7 +163,7 @@ public final class ApplicantInformationController extends CiviFormController {
       redirectLocation = applicantRoutes.index(profile, applicantId).url();
       session = request.session();
     } else {
-      redirectLocation = infoForm.getRedirectLink();
+      redirectLocation = UrlUtils.checkIsRelativeUrl(infoForm.getRedirectLink());
       session = request.session().removing(REDIRECT_TO_SESSION_KEY);
     }
 

--- a/server/test/support/FakeRequestBuilder.java
+++ b/server/test/support/FakeRequestBuilder.java
@@ -43,6 +43,11 @@ public final class FakeRequestBuilder extends RequestBuilder {
     return this;
   }
 
+  public FakeRequestBuilder addSessionValue(String key, String value) {
+    session(key, value);
+    return this;
+  }
+
   public FakeRequestBuilder addCSRFToken() {
     play.api.test.CSRFTokenHelper.addCSRFToken(this);
     return this;


### PR DESCRIPTION
Previously, if somehow a bad actor was able to modified the hidden redirectLink input field on a page, or the value in the submitted form, they could redirect anywhere. This updates several places to validate that the redirect read from the form is a relative link.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)

### Instructions for manual testing

Load the applicant home page, edit the HTML in-browser to change `redirectLink` to `https://google.com`, change the language, make sure it doesn't redirect to google.com.  It should show an error.

### Issue(s) this completes

https://github.com/civiform/civiform/issues/9452
