### PR TITLE
Remove the session from the database on logout and check request against session ID behind a feature flag

### DIFF
--- a/server/app/filters/ValidAccountFilter.java
+++ b/server/app/filters/ValidAccountFilter.java
@@ -4,6 +4,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import auth.CiviFormProfile;
 import auth.ProfileUtils;
+import com.typesafe.config.Config;
 import java.util.Optional;
 import javax.inject.Inject;
 import play.libs.streams.Accumulator;
@@ -11,7 +12,6 @@ import play.mvc.EssentialAction;
 import play.mvc.EssentialFilter;
 import play.mvc.Http;
 import play.mvc.Results;
-import services.settings.SettingsManifest;
 
 /**
  * A filter to ensure the account referenced in the browser cookie is valid. This should only matter
@@ -19,12 +19,12 @@ import services.settings.SettingsManifest;
  */
 public class ValidAccountFilter extends EssentialFilter {
   private final ProfileUtils profileUtils;
-  private final SettingsManifest settingsManifest;
+  private final Config config;
 
   @Inject
-  public ValidAccountFilter(ProfileUtils profileUtils, SettingsManifest settingsManifest) {
+  public ValidAccountFilter(ProfileUtils profileUtils, Config config) {
     this.profileUtils = checkNotNull(profileUtils);
-    this.settingsManifest = checkNotNull(settingsManifest);
+    this.config = checkNotNull(config);
   }
 
   @Override
@@ -50,7 +50,7 @@ public class ValidAccountFilter extends EssentialFilter {
   }
 
   private boolean isValidSession(CiviFormProfile profile) {
-    if (settingsManifest.getSessionReplayProtectionEnabled()) {
+    if (config.getBoolean("session_replay_protection_enabled")) {
       profile
           .getAccount()
           .thenApply(

--- a/server/app/filters/ValidAccountFilter.java
+++ b/server/app/filters/ValidAccountFilter.java
@@ -51,7 +51,7 @@ public class ValidAccountFilter extends EssentialFilter {
 
   private boolean isValidSession(CiviFormProfile profile) {
     if (config.getBoolean("session_replay_protection_enabled")) {
-      profile
+      return profile
           .getAccount()
           .thenApply(
               account ->

--- a/server/app/modules/CiviFormLogoutLogic.java
+++ b/server/app/modules/CiviFormLogoutLogic.java
@@ -52,10 +52,12 @@ class CiviFormLogoutLogic extends DefaultLogoutLogic {
           CiviFormProfile profile = maybeProfile.get();
           profile
               .getAccount()
-              .thenAccept(account -> {
-                account.removeActiveSession(profile.getProfileData().getSessionId());
-                account.save();
-              }).join();
+              .thenAccept(
+                  account -> {
+                    account.removeActiveSession(profile.getProfileData().getSessionId());
+                    account.save();
+                  })
+              .join();
         }
       } catch (RuntimeException e) {
         logger.error("Error clearing session from account", e);

--- a/server/app/modules/CiviFormLogoutLogic.java
+++ b/server/app/modules/CiviFormLogoutLogic.java
@@ -50,14 +50,18 @@ class CiviFormLogoutLogic extends DefaultLogoutLogic {
             profileUtils.optionalCurrentUserProfile(callContext.webContext());
         if (maybeProfile.isPresent()) {
           CiviFormProfile profile = maybeProfile.get();
-          var unused =
-              profile
-                  .getAccount()
-                  .thenAccept(
-                      account -> {
-                        account.removeActiveSession(profile.getProfileData().getSessionId());
-                        account.save();
-                      });
+          profile
+              .getAccount()
+              .thenAccept(
+                  account -> {
+                    account.removeActiveSession(profile.getProfileData().getSessionId());
+                    account.save();
+                  })
+              .exceptionally(
+                  e -> {
+                    logger.error(e.getMessage(), e);
+                    return null;
+                  });
         }
       } catch (RuntimeException e) {
         logger.error("Error clearing session from account", e);

--- a/server/app/modules/CiviFormLogoutLogic.java
+++ b/server/app/modules/CiviFormLogoutLogic.java
@@ -50,14 +50,14 @@ class CiviFormLogoutLogic extends DefaultLogoutLogic {
             profileUtils.optionalCurrentUserProfile(callContext.webContext());
         if (maybeProfile.isPresent()) {
           CiviFormProfile profile = maybeProfile.get();
-          profile
-              .getAccount()
-              .thenAccept(
-                  account -> {
-                    account.removeActiveSession(profile.getProfileData().getSessionId());
-                    account.save();
-                  })
-              .join();
+          var unused =
+              profile
+                  .getAccount()
+                  .thenAccept(
+                      account -> {
+                        account.removeActiveSession(profile.getProfileData().getSessionId());
+                        account.save();
+                      });
         }
       } catch (RuntimeException e) {
         logger.error("Error clearing session from account", e);

--- a/server/app/modules/CiviFormLogoutLogic.java
+++ b/server/app/modules/CiviFormLogoutLogic.java
@@ -1,6 +1,10 @@
 package modules;
 
+import auth.CiviFormProfile;
+import auth.ProfileUtils;
+import java.util.Optional;
 import org.pac4j.core.config.Config;
+import org.pac4j.core.context.CallContext;
 import org.pac4j.core.context.FrameworkParameters;
 import org.pac4j.core.engine.DefaultLogoutLogic;
 import org.slf4j.Logger;
@@ -12,8 +16,11 @@ import org.slf4j.LoggerFactory;
  */
 class CiviFormLogoutLogic extends DefaultLogoutLogic {
   private static final Logger logger = LoggerFactory.getLogger(CiviFormLogoutLogic.class);
+  private final ProfileUtils profileUtils;
 
-  public CiviFormLogoutLogic() {}
+  public CiviFormLogoutLogic(ProfileUtils profileUtils) {
+    this.profileUtils = profileUtils;
+  }
 
   @Override
   public Object perform(
@@ -36,7 +43,23 @@ class CiviFormLogoutLogic extends DefaultLogoutLogic {
               inputCentralLogout,
               parameters);
 
-      // TODO(#6975): Remove the session ID from the database at logout
+      // Remove the session ID from the database
+      try {
+        CallContext callContext = buildContext(config, parameters);
+        Optional<CiviFormProfile> maybeProfile =
+            profileUtils.optionalCurrentUserProfile(callContext.webContext());
+        if (maybeProfile.isPresent()) {
+          CiviFormProfile profile = maybeProfile.get();
+          profile
+              .getAccount()
+              .thenAccept(account -> {
+                account.removeActiveSession(profile.getProfileData().getSessionId());
+                account.save();
+              }).join();
+        }
+      } catch (RuntimeException e) {
+        logger.error("Error clearing session from account", e);
+      }
 
       return result;
     } catch (RuntimeException e) {

--- a/server/app/modules/SecurityModule.java
+++ b/server/app/modules/SecurityModule.java
@@ -14,6 +14,7 @@ import auth.CiviFormSessionStoreFactory;
 import auth.FakeAdminClient;
 import auth.GuestClient;
 import auth.ProfileFactory;
+import auth.ProfileUtils;
 import auth.Role;
 import auth.oidc.admin.AdfsClientProvider;
 import auth.oidc.applicant.Auth0ClientProvider;
@@ -32,6 +33,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import javax.annotation.Nullable;
+import javax.inject.Provider;
 import org.pac4j.core.authorization.authorizer.Authorizer;
 import org.pac4j.core.authorization.authorizer.RequireAllRolesAuthorizer;
 import org.pac4j.core.authorization.authorizer.RequireAnyRoleAuthorizer;
@@ -88,7 +90,7 @@ public class SecurityModule extends AbstractModule {
 
     bind(SessionStore.class).toInstance(civiFormSessionStoreFactory.newSessionStore());
     bind(CiviFormSessionStoreFactory.class).toInstance(civiFormSessionStoreFactory);
-
+  
     bindAdminIdpProvider(configuration);
     bindApplicantIdpProvider(configuration);
   }
@@ -159,6 +161,12 @@ public class SecurityModule extends AbstractModule {
       default:
         logger.info("No provider specified for for applicants");
     }
+  }
+
+  @Provides
+  @Singleton
+  protected CiviFormLogoutLogic civiFormLogoutLogic(ProfileUtils profileUtils) {
+    return new CiviFormLogoutLogic(checkNotNull(profileUtils));
   }
 
   @Provides
@@ -296,13 +304,14 @@ public class SecurityModule extends AbstractModule {
       Clients clients,
       ImmutableMap<String, Authorizer> authorizors,
       CiviFormHttpActionAdapter civiFormHttpActionAdapter,
-      CiviFormSessionStoreFactory civiFormSessionStoreFactory) {
+      CiviFormSessionStoreFactory civiFormSessionStoreFactory,
+      CiviFormLogoutLogic civiformLogoutLogic) {
     Config config = new Config();
     config.setClients(clients);
     config.setAuthorizers(authorizors);
     config.setHttpActionAdapter(civiFormHttpActionAdapter);
     config.setSessionStoreFactory(civiFormSessionStoreFactory);
-    config.setLogoutLogic(new CiviFormLogoutLogic());
+    config.setLogoutLogic(civiformLogoutLogic);
     return config;
   }
 }

--- a/server/app/modules/SecurityModule.java
+++ b/server/app/modules/SecurityModule.java
@@ -33,7 +33,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import javax.annotation.Nullable;
-import javax.inject.Provider;
 import org.pac4j.core.authorization.authorizer.Authorizer;
 import org.pac4j.core.authorization.authorizer.RequireAllRolesAuthorizer;
 import org.pac4j.core.authorization.authorizer.RequireAnyRoleAuthorizer;
@@ -90,7 +89,7 @@ public class SecurityModule extends AbstractModule {
 
     bind(SessionStore.class).toInstance(civiFormSessionStoreFactory.newSessionStore());
     bind(CiviFormSessionStoreFactory.class).toInstance(civiFormSessionStoreFactory);
-  
+
     bindAdminIdpProvider(configuration);
     bindApplicantIdpProvider(configuration);
   }


### PR DESCRIPTION
### Description

These are the final changes needed to fix the session replay issue (behind feature flag).

Remove the active session from the database on logout which follows [this section](https://docs.google.com/document/d/1edlqzDQUY0Df7alpuArt6FJYF_eLOm5jd7CaE1aZkHQ/edit?tab=t.0#heading=h.2xvuqlh0orl) of TDD. 

Check each request against valid session ID ([this section](https://docs.google.com/document/d/1edlqzDQUY0Df7alpuArt6FJYF_eLOm5jd7CaE1aZkHQ/edit?tab=t.0#heading=h.pompz7j8zql0) of TDD) - this will what we do to ensure the user has a valid session (behind a flag)

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [x] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`

### Instructions for manual testing

Turn on `session_replay_protection_enabled = true` and run pgadmin locally (bin/dev-pgadmin) while also running bin/run-dev. Query `select * from accounts` and then create a session by clicking to apply to a program. Run the query again and see the new account appear with an active session in the active_sessions json blob. Click end session and then see the active session removed.

### Issue(s) this completes

https://github.com/civiform/civiform/issues/6975
