### PR TITLE
Create a session if it doesn't exist and log these cases

### DIFF
--- a/server/app/auth/oidc/CiviformOidcProfileCreator.java
+++ b/server/app/auth/oidc/CiviformOidcProfileCreator.java
@@ -156,12 +156,16 @@ public abstract class CiviformOidcProfileCreator extends OidcProfileCreator {
           .getAccount()
           .thenAccept(
               account -> {
+                String sessionId = civiformProfile.getProfileData().getSessionId();
+                if (!account.getActiveSession(sessionId).isPresent()) {
+                  LOGGER.warn(
+                      "Session not in account's active sessions for role {}, and OIDC profile {}",
+                      roles,
+                      oidcProfile.getClass().getName());
+                }
                 accountRepositoryProvider
                     .get()
-                    .addIdTokenAndPrune(
-                        account,
-                        civiformProfile.getProfileData().getSessionId(),
-                        oidcProfile.getIdTokenString());
+                    .addIdTokenAndPrune(account, sessionId, oidcProfile.getIdTokenString());
               })
           .join();
     }

--- a/server/app/repository/AccountRepository.java
+++ b/server/app/repository/AccountRepository.java
@@ -487,7 +487,10 @@ public final class AccountRepository {
       // For now, we set the duration to Auth0s default of 10 hours.
       account.removeExpiredActiveSessions(sessionLifecycle);
       if (!account.getActiveSession(sessionId).isPresent()) {
-        logger.warn("Session ID not found in account when adding ID token. Adding new session.");
+        logger.warn(
+            "Session ID not found in account when adding ID token. Adding new session for account"
+                + " with ID: {}",
+            account.id);
         account.addActiveSession(sessionId, clock);
       }
       account.storeIdTokenInActiveSession(sessionId, idToken);

--- a/server/app/repository/AccountRepository.java
+++ b/server/app/repository/AccountRepository.java
@@ -27,6 +27,8 @@ import models.AccountModel;
 import models.ApplicantModel;
 import models.SessionLifecycle;
 import models.TrustedIntermediaryGroupModel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import services.CiviFormError;
 import services.program.ProgramDefinition;
 import services.settings.SettingsManifest;
@@ -40,6 +42,7 @@ import services.ti.NotEligibleToBecomeTiError;
  * ApplicantModel}.
  */
 public final class AccountRepository {
+  private static final Logger logger = LoggerFactory.getLogger(AccountRepository.class);
   private static final QueryProfileLocationBuilder queryProfileLocationBuilder =
       new QueryProfileLocationBuilder("AccountRepository");
 
@@ -483,6 +486,10 @@ public final class AccountRepository {
     if (settingsManifest.getSessionReplayProtectionEnabled()) {
       // For now, we set the duration to Auth0s default of 10 hours.
       account.removeExpiredActiveSessions(sessionLifecycle);
+      if (!account.getActiveSession(sessionId).isPresent()) {
+        logger.warn("Session ID not found in account when adding ID token. Adding new session.");
+        account.addActiveSession(sessionId, clock);
+      }
       account.storeIdTokenInActiveSession(sessionId, idToken);
     }
 

--- a/server/test/repository/AccountRepositoryTest.java
+++ b/server/test/repository/AccountRepositoryTest.java
@@ -2,7 +2,6 @@ package repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/server/test/repository/AccountRepositoryTest.java
+++ b/server/test/repository/AccountRepositoryTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.when;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
+import com.google.common.collect.ImmutableList;
 import com.nimbusds.jwt.JWT;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.PlainJWT;

--- a/server/test/repository/AccountRepositoryTest.java
+++ b/server/test/repository/AccountRepositoryTest.java
@@ -465,7 +465,7 @@ public class AccountRepositoryTest extends ResetPostgres {
         RuntimeException.class,
         () -> repo.addIdTokenAndPrune(account, "sessionId", validJwt.serialize()));
     ImmutableList<ILoggingEvent> logsList = ImmutableList.copyOf(listAppender.list);
-    assertThat(logsList.get(0).getMessage(""))
+    assertThat(logsList.get(0).getMessage())
         .isEqualTo("Session ID not found in account when adding ID token. Adding new session.");
   }
 

--- a/server/test/repository/AccountRepositoryTest.java
+++ b/server/test/repository/AccountRepositoryTest.java
@@ -460,7 +460,7 @@ public class AccountRepositoryTest extends ResetPostgres {
     Instant timeInFuture = now.plus(1, ChronoUnit.HOURS).toInstant(ZoneOffset.UTC);
     JWT validJwt = getJwtWithExpirationTime(timeInFuture);
 
-    repo.addIdTokenAndPrune(account, "sessionId", validJwt.serialize())
+    repo.addIdTokenAndPrune(account, "sessionId", validJwt.serialize());
 
     ImmutableList<ILoggingEvent> logsList = ImmutableList.copyOf(listAppender.list);
     assertThat(logsList.get(0).getMessage())

--- a/server/test/repository/AccountRepositoryTest.java
+++ b/server/test/repository/AccountRepositoryTest.java
@@ -441,7 +441,7 @@ public class AccountRepositoryTest extends ResetPostgres {
   }
 
   @Test
-  public void addIdTokenAndPrune_throwsWithoutActiveSession() {
+  public void addIdTokenAndPrune_logsWithoutActiveSession() {
     Logger logger = (Logger) LoggerFactory.getLogger(AccountRepository.class);
     ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
     listAppender.start();
@@ -461,9 +461,6 @@ public class AccountRepositoryTest extends ResetPostgres {
     Instant timeInFuture = now.plus(1, ChronoUnit.HOURS).toInstant(ZoneOffset.UTC);
     JWT validJwt = getJwtWithExpirationTime(timeInFuture);
 
-    assertThrows(
-        RuntimeException.class,
-        () -> repo.addIdTokenAndPrune(account, "sessionId", validJwt.serialize()));
     ImmutableList<ILoggingEvent> logsList = ImmutableList.copyOf(listAppender.list);
     assertThat(logsList.get(0).getMessage())
         .isEqualTo("Session ID not found in account when adding ID token. Adding new session.");

--- a/server/test/repository/AccountRepositoryTest.java
+++ b/server/test/repository/AccountRepositoryTest.java
@@ -464,7 +464,10 @@ public class AccountRepositoryTest extends ResetPostgres {
 
     ImmutableList<ILoggingEvent> logsList = ImmutableList.copyOf(listAppender.list);
     assertThat(logsList.get(0).getMessage())
-        .isEqualTo("Session ID not found in account when adding ID token. Adding new session.");
+        .isEqualTo(
+            "Session ID not found in account when adding ID token. Adding new session for account"
+                + " with ID: "
+                + account.id);
   }
 
   @Test

--- a/server/test/repository/AccountRepositoryTest.java
+++ b/server/test/repository/AccountRepositoryTest.java
@@ -463,7 +463,7 @@ public class AccountRepositoryTest extends ResetPostgres {
     repo.addIdTokenAndPrune(account, "sessionId", validJwt.serialize());
 
     ImmutableList<ILoggingEvent> logsList = ImmutableList.copyOf(listAppender.list);
-    assertThat(logsList.get(0).getMessage())
+    assertThat(logsList.get(0).getFormattedMessage())
         .isEqualTo(
             "Session ID not found in account when adding ID token. Adding new session for account"
                 + " with ID: "

--- a/server/test/repository/AccountRepositoryTest.java
+++ b/server/test/repository/AccountRepositoryTest.java
@@ -460,6 +460,8 @@ public class AccountRepositoryTest extends ResetPostgres {
     Instant timeInFuture = now.plus(1, ChronoUnit.HOURS).toInstant(ZoneOffset.UTC);
     JWT validJwt = getJwtWithExpirationTime(timeInFuture);
 
+    repo.addIdTokenAndPrune(account, "sessionId", validJwt.serialize())
+
     ImmutableList<ILoggingEvent> logsList = ImmutableList.copyOf(listAppender.list);
     assertThat(logsList.get(0).getMessage())
         .isEqualTo("Session ID not found in account when adding ID token. Adding new session.");


### PR DESCRIPTION
### Description

There seems to be an case with the session replay enabled flag where someone won't have a session created if they log in, log out and log back in. This causes an exception to be thrown [here](https://github.com/civiform/civiform/blob/343a7d9055ba9398a54f3b20e1c20e9d2b8a37f3/server/app/models/AccountModel.java#L210). I can't reproduce it locally, but we should create a session if it doesn't exist and log a warning, so we can better debug this case.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [x] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`

### Issue(s) this completes

https://github.com/civiform/civiform/issues/6975
