### PR TITLE
Removing Application Card related functions from Browser tests

### DIFF
--- a/browser-test/src/admin/admin_application_download.test.ts
+++ b/browser-test/src/admin/admin_application_download.test.ts
@@ -381,11 +381,11 @@ test.describe('csv json pdf download test- two applications', () => {
       await loginAsProgramAdmin(page)
       await adminPrograms.viewApplications(programName)
       await adminPrograms.filterProgramApplications({searchFragment: 'SARA'})
-      await adminPrograms.viewApplicationForApplicantForBulkStatus(
+      await adminPrograms.viewApplicationForApplicant(
         'smith, sarah',
       )
 
-      const pdfFile = await adminPrograms.getApplicationPdfForBulkStatus()
+      const pdfFile = await adminPrograms.getApplicationPdf()
       expect(pdfFile.length).toBeGreaterThan(1)
       await page.getByRole('link', {name: 'Back'}).click()
       await logout(page)

--- a/browser-test/src/admin/admin_application_download.test.ts
+++ b/browser-test/src/admin/admin_application_download.test.ts
@@ -381,9 +381,7 @@ test.describe('csv json pdf download test- two applications', () => {
       await loginAsProgramAdmin(page)
       await adminPrograms.viewApplications(programName)
       await adminPrograms.filterProgramApplications({searchFragment: 'SARA'})
-      await adminPrograms.viewApplicationForApplicant(
-        'smith, sarah',
-      )
+      await adminPrograms.viewApplicationForApplicant('smith, sarah')
 
       const pdfFile = await adminPrograms.getApplicationPdf()
       expect(pdfFile.length).toBeGreaterThan(1)

--- a/browser-test/src/admin/admin_application_statuses.test.ts
+++ b/browser-test/src/admin/admin_application_statuses.test.ts
@@ -45,11 +45,11 @@ test.describe('view program statuses', () => {
       // Navigate to the submitted application as the program admin.
       await loginAsProgramAdmin(page)
       await adminPrograms.viewApplications(programWithoutStatusesName)
-      await adminPrograms.viewApplicationForApplicantForBulkStatus('Guest')
+      await adminPrograms.viewApplicationForApplicant('Guest')
     })
 
     test('does not show status options', async ({adminPrograms}) => {
-      expect(await adminPrograms.isStatusSelectorVisibleForBulkStatus()).toBe(
+      expect(await adminPrograms.isStatusSelectorVisible()).toBe(
         false,
       )
     })
@@ -59,14 +59,14 @@ test.describe('view program statuses', () => {
       adminPrograms,
     }) => {
       await page.getByRole('link', {name: 'Back'}).click()
-      await adminPrograms.expectApplicationStatusDoesntContainForBulkStatus(
+      await adminPrograms.expectApplicationStatusDoesntContain(
         'Guest',
         'Status: ',
       )
     })
 
     test('does not show edit note', async ({page, adminPrograms}) => {
-      expect(await adminPrograms.isEditNoteVisibleForBulkStatus()).toBe(false)
+      expect(await adminPrograms.isEditNoteVisible()).toBe(false)
       await page.getByRole('link', {name: 'Back'}).click()
     })
 
@@ -128,18 +128,18 @@ test.describe('view program statuses', () => {
         await enableFeatureFlag(page, 'bulk_status_update_enabled')
         await loginAsProgramAdmin(page)
         await adminPrograms.viewApplications(programWithStatusesName)
-        await adminPrograms.viewApplicationForApplicantForBulkStatus('Guest')
+        await adminPrograms.viewApplicationForApplicant('Guest')
       },
     )
 
     test('shows status selector', async ({adminPrograms}) => {
-      expect(await adminPrograms.isStatusSelectorVisibleForBulkStatus()).toBe(
+      expect(await adminPrograms.isStatusSelectorVisible()).toBe(
         true,
       )
     })
 
     test('shows placeholder option', async ({adminPrograms}) => {
-      expect(await adminPrograms.getStatusOptionForBulkStatus()).toBe(
+      expect(await adminPrograms.getStatusOption()).toBe(
         'Choose an option:',
       )
     })
@@ -152,7 +152,7 @@ test.describe('view program statuses', () => {
       adminPrograms,
     }) => {
       await adminPrograms.viewApplications(programWithStatusesName)
-      await adminPrograms.expectApplicationHasStatusStringForBulkStatus(
+      await adminPrograms.expectApplicationHasStatusString(
         'Guest',
         'None',
       )
@@ -160,7 +160,7 @@ test.describe('view program statuses', () => {
 
     test.describe('when a status is changed, a confirmation dialog is shown', () => {
       test('renders', async ({page, adminPrograms}) => {
-        await adminPrograms.setStatusOptionAndAwaitModalForBulkStatus(
+        await adminPrograms.setStatusOptionAndAwaitModal(
           noEmailStatusName,
         )
         await validateScreenshot(page, 'change-status-modal')
@@ -170,11 +170,11 @@ test.describe('view program statuses', () => {
         page,
         adminPrograms,
       }) => {
-        await adminPrograms.setStatusOptionAndAwaitModalForBulkStatus(
+        await adminPrograms.setStatusOptionAndAwaitModal(
           noEmailStatusName,
         )
         await dismissModal(page)
-        expect(await adminPrograms.getStatusOptionForBulkStatus()).toBe(
+        expect(await adminPrograms.getStatusOption()).toBe(
           'Choose an option:',
         )
       })
@@ -183,14 +183,14 @@ test.describe('view program statuses', () => {
         adminPrograms,
       }) => {
         const modal =
-          await adminPrograms.setStatusOptionAndAwaitModalForBulkStatus(
+          await adminPrograms.setStatusOptionAndAwaitModal(
             noEmailStatusName,
           )
         expect(await modal.innerText()).toContain(
           `Status Change: Unset -> ${noEmailStatusName}`,
         )
-        await adminPrograms.confirmStatusUpdateModalForBulkStatus(modal)
-        expect(await adminPrograms.getStatusOptionForBulkStatus()).toBe(
+        await adminPrograms.confirmStatusUpdateModal(modal)
+        expect(await adminPrograms.getStatusOption()).toBe(
           noEmailStatusName,
         )
         await adminPrograms.expectUpdateStatusToast()
@@ -201,7 +201,7 @@ test.describe('view program statuses', () => {
         adminPrograms,
       }) => {
         const modal =
-          await adminPrograms.setStatusOptionAndAwaitModalForBulkStatus(
+          await adminPrograms.setStatusOptionAndAwaitModal(
             noEmailStatusName,
           )
         expect(await modal.innerText()).toContain(
@@ -215,7 +215,7 @@ test.describe('view program statuses', () => {
         adminPrograms,
       }) => {
         const modal =
-          await adminPrograms.setStatusOptionAndAwaitModalForBulkStatus(
+          await adminPrograms.setStatusOptionAndAwaitModal(
             emailStatusName,
           )
         expect(await modal.innerText()).toContain(
@@ -230,17 +230,17 @@ test.describe('view program statuses', () => {
       }) => {
         await test.step('Set initial status', async () => {
           const modal =
-            await adminPrograms.setStatusOptionAndAwaitModalForBulkStatus(
+            await adminPrograms.setStatusOptionAndAwaitModal(
               noEmailStatusName,
             )
-          await adminPrograms.confirmStatusUpdateModalForBulkStatus(modal)
-          expect(await adminPrograms.getStatusOptionForBulkStatus()).toBe(
+          await adminPrograms.confirmStatusUpdateModal(modal)
+          expect(await adminPrograms.getStatusOption()).toBe(
             noEmailStatusName,
           )
         })
 
         const modal =
-          await adminPrograms.setStatusOptionAndAwaitModalForBulkStatus(
+          await adminPrograms.setStatusOptionAndAwaitModal(
             emailStatusName,
           )
         expect(await modal.innerText()).toContain(
@@ -255,29 +255,29 @@ test.describe('view program statuses', () => {
       }) => {
         await test.step('Set initial status', async () => {
           const modal =
-            await adminPrograms.setStatusOptionAndAwaitModalForBulkStatus(
+            await adminPrograms.setStatusOptionAndAwaitModal(
               noEmailStatusName,
             )
-          await adminPrograms.confirmStatusUpdateModalForBulkStatus(modal)
-          expect(await adminPrograms.getStatusOptionForBulkStatus()).toBe(
+          await adminPrograms.confirmStatusUpdateModal(modal)
+          expect(await adminPrograms.getStatusOption()).toBe(
             noEmailStatusName,
           )
         })
 
         await page.getByRole('link', {name: 'Back'}).click()
 
-        await adminPrograms.expectApplicationHasStatusStringForBulkStatus(
+        await adminPrograms.expectApplicationHasStatusString(
           'Guest',
           noEmailStatusName,
         )
-        await adminPrograms.viewApplicationForApplicantForBulkStatus('Guest')
+        await adminPrograms.viewApplicationForApplicant('Guest')
         const modal =
-          await adminPrograms.setStatusOptionAndAwaitModalForBulkStatus(
+          await adminPrograms.setStatusOptionAndAwaitModal(
             emailStatusName,
           )
-        await adminPrograms.confirmStatusUpdateModalForBulkStatus(modal)
+        await adminPrograms.confirmStatusUpdateModal(modal)
         await page.getByRole('link', {name: 'Back'}).click()
-        await adminPrograms.expectApplicationHasStatusStringForBulkStatus(
+        await adminPrograms.expectApplicationHasStatusString(
           'Guest',
           emailStatusName,
         )
@@ -287,7 +287,7 @@ test.describe('view program statuses', () => {
         test.beforeEach(async ({page, adminPrograms}) => {
           await enableFeatureFlag(page, 'bulk_status_update_enabled')
           await adminPrograms.viewApplications(programWithStatusesName)
-          await adminPrograms.viewApplicationForApplicantForBulkStatus(
+          await adminPrograms.viewApplicationForApplicant(
             testUserDisplayName(),
           )
         })
@@ -300,15 +300,15 @@ test.describe('view program statuses', () => {
             ? await extractEmailsForRecipient(page, testUserDisplayName())
             : []
           const modal =
-            await adminPrograms.setStatusOptionAndAwaitModalForBulkStatus(
+            await adminPrograms.setStatusOptionAndAwaitModal(
               emailStatusName,
             )
           const notifyCheckbox = await modal.$('input[type=checkbox]')
           expect(notifyCheckbox).not.toBeNull()
           await notifyCheckbox!.uncheck()
           expect(await notifyCheckbox!.isChecked()).toBe(false)
-          await adminPrograms.confirmStatusUpdateModalForBulkStatus(modal)
-          expect(await adminPrograms.getStatusOptionForBulkStatus()).toBe(
+          await adminPrograms.confirmStatusUpdateModal(modal)
+          expect(await adminPrograms.getStatusOption()).toBe(
             emailStatusName,
           )
           await adminPrograms.expectUpdateStatusToast()
@@ -330,15 +330,15 @@ test.describe('view program statuses', () => {
             ? await extractEmailsForRecipient(page, testUserDisplayName())
             : []
           const modal =
-            await adminPrograms.setStatusOptionAndAwaitModalForBulkStatus(
+            await adminPrograms.setStatusOptionAndAwaitModal(
               emailStatusName,
             )
           const notifyCheckbox = await modal.$('input[type=checkbox]')
           expect(notifyCheckbox).not.toBeNull()
           expect(await notifyCheckbox!.isChecked()).toBe(true)
           expect(await modal.innerText()).toContain(' of this change at ')
-          await adminPrograms.confirmStatusUpdateModalForBulkStatus(modal)
-          expect(await adminPrograms.getStatusOptionForBulkStatus()).toBe(
+          await adminPrograms.confirmStatusUpdateModal(modal)
+          expect(await adminPrograms.getStatusOption()).toBe(
             emailStatusName,
           )
           await adminPrograms.expectUpdateStatusToast()
@@ -359,7 +359,7 @@ test.describe('view program statuses', () => {
       page,
       adminPrograms,
     }) => {
-      await adminPrograms.editNoteForBulkStatus('Some note content')
+      await adminPrograms.editNote('Some note content')
       await adminPrograms.expectNoteUpdatedToast()
 
       // Confirm that the application is shown after reloading the page.
@@ -370,7 +370,7 @@ test.describe('view program statuses', () => {
     })
 
     test('renders the note dialog', async ({page, adminPrograms}) => {
-      await adminPrograms.awaitEditNoteModalForBulkStatus()
+      await adminPrograms.awaitEditNoteModal()
       await page.evaluate(() => {
         window.scrollTo(0, 0)
       })
@@ -379,31 +379,31 @@ test.describe('view program statuses', () => {
 
     test('shows the current note content', async ({adminPrograms}) => {
       const noteText = 'Some note content'
-      await adminPrograms.editNoteForBulkStatus(noteText)
+      await adminPrograms.editNote(noteText)
       await adminPrograms.expectNoteUpdatedToast()
 
       // Reload the note editor.
       await adminPrograms.viewApplications(programWithStatusesName)
-      await adminPrograms.viewApplicationForApplicantForBulkStatus('Guest')
+      await adminPrograms.viewApplicationForApplicant('Guest')
 
-      expect(await adminPrograms.getNoteContentForBulkStatus()).toBe(noteText)
+      expect(await adminPrograms.getNoteContent()).toBe(noteText)
     })
 
     test('allows updating a note', async ({adminPrograms}) => {
       const noteText = 'Some note content'
-      await adminPrograms.editNoteForBulkStatus('first note content')
+      await adminPrograms.editNote('first note content')
       await adminPrograms.expectNoteUpdatedToast()
-      await adminPrograms.editNoteForBulkStatus(noteText)
+      await adminPrograms.editNote(noteText)
       await adminPrograms.expectNoteUpdatedToast()
 
       // Reload the note editor.
       await adminPrograms.viewApplications(programWithStatusesName)
-      await adminPrograms.viewApplicationForApplicantForBulkStatus('Guest')
+      await adminPrograms.viewApplicationForApplicant('Guest')
 
-      expect(await adminPrograms.getNoteContentForBulkStatus()).toBe(noteText)
+      expect(await adminPrograms.getNoteContent()).toBe(noteText)
     })
     test('allow notes to be exported', async ({page, adminPrograms}) => {
-      await adminPrograms.editNoteForBulkStatus('Note is exported')
+      await adminPrograms.editNote('Note is exported')
       await adminPrograms.expectNoteUpdatedToast()
       const noApplyFilters = false
       await page.getByRole('link', {name: 'Back'}).click()
@@ -413,19 +413,19 @@ test.describe('view program statuses', () => {
     })
 
     test('export only the latest note', async ({page, adminPrograms}) => {
-      await adminPrograms.editNoteForBulkStatus('Note is exported')
+      await adminPrograms.editNote('Note is exported')
       await adminPrograms.expectNoteUpdatedToast()
       const noApplyFilters = false
 
       // Update note only gets exported
-      await adminPrograms.editNoteForBulkStatus('Note is updated')
+      await adminPrograms.editNote('Note is updated')
       await adminPrograms.expectNoteUpdatedToast()
       await page.getByRole('link', {name: 'Back'}).click()
       const csvContent = await adminPrograms.getCsv(noApplyFilters)
       expect(csvContent).toContain('Note is updated')
 
-      await adminPrograms.viewApplicationForApplicantForBulkStatus('Guest')
-      await adminPrograms.editNoteForBulkStatus('Note is finalized')
+      await adminPrograms.viewApplicationForApplicant('Guest')
+      await adminPrograms.editNote('Note is finalized')
       await page.getByRole('link', {name: 'Back'}).click()
       const csvContentFinal = await adminPrograms.getCsv(noApplyFilters)
       expect(csvContentFinal).toContain('Note is finalized')
@@ -433,12 +433,12 @@ test.describe('view program statuses', () => {
 
     test('preserves newlines in notes', async ({adminPrograms}) => {
       await adminPrograms.viewApplications(programWithStatusesName)
-      await adminPrograms.viewApplicationForApplicantForBulkStatus('Guest')
+      await adminPrograms.viewApplicationForApplicant('Guest')
       const noteText = 'Some note content\nwithseparatelines'
-      await adminPrograms.editNoteForBulkStatus(noteText)
+      await adminPrograms.editNote(noteText)
       await adminPrograms.expectNoteUpdatedToast()
 
-      expect(await adminPrograms.getNoteContentForBulkStatus()).toBe(noteText)
+      expect(await adminPrograms.getNoteContent()).toBe(noteText)
     })
   })
 
@@ -500,37 +500,37 @@ test.describe('view program statuses', () => {
       page,
       adminPrograms,
     }) => {
-      await adminPrograms.expectApplicationHasStatusStringForBulkStatus(
+      await adminPrograms.expectApplicationHasStatusString(
         'Guest',
         `${waitingStatus} (default)`,
       )
-      await adminPrograms.expectApplicationHasStatusStringForBulkStatus(
+      await adminPrograms.expectApplicationHasStatusString(
         testUserDisplayName(),
         `${waitingStatus} (default)`,
       )
 
       // Approve guest application
-      await adminPrograms.viewApplicationForApplicantForBulkStatus('Guest')
+      await adminPrograms.viewApplicationForApplicant('Guest')
       const modal =
-        await adminPrograms.setStatusOptionAndAwaitModalForBulkStatus(
+        await adminPrograms.setStatusOptionAndAwaitModal(
           approvedStatus,
         )
       expect(await modal.innerText()).toContain(
         `Status Change: ${waitingStatus} -> ${approvedStatus}`,
       )
-      await adminPrograms.confirmStatusUpdateModalForBulkStatus(modal)
-      expect(await adminPrograms.getStatusOptionForBulkStatus()).toBe(
+      await adminPrograms.confirmStatusUpdateModal(modal)
+      expect(await adminPrograms.getStatusOption()).toBe(
         approvedStatus,
       )
       await adminPrograms.expectUpdateStatusToast()
 
       await page.getByRole('link', {name: 'Back'}).click()
 
-      await adminPrograms.expectApplicationStatusDoesntContainForBulkStatus(
+      await adminPrograms.expectApplicationStatusDoesntContain(
         'Guest',
         '(default)',
       )
-      await adminPrograms.expectApplicationHasStatusStringForBulkStatus(
+      await adminPrograms.expectApplicationHasStatusString(
         testUserDisplayName(),
         `${waitingStatus} (default)`,
       )
@@ -590,31 +590,31 @@ test.describe('view program statuses', () => {
     }) => {
       await adminPrograms.viewApplications(programForFilteringName)
       // Default page shows all applications.
-      await adminPrograms.expectApplicationCountForBulkStatus(1)
+      await adminPrograms.expectApplicationCount(1)
 
       // Included when filtering to applications without statuses.
       await adminPrograms.filterProgramApplications({
         applicationStatusOption:
           AdminPrograms.NO_STATUS_APPLICATION_FILTER_OPTION,
       })
-      await adminPrograms.expectApplicationCountForBulkStatus(1)
+      await adminPrograms.expectApplicationCount(1)
 
       // Excluded when selecting specific statuses.
       await adminPrograms.filterProgramApplications({
         applicationStatusOption: approvedStatusName,
       })
-      await adminPrograms.expectApplicationCountForBulkStatus(0)
+      await adminPrograms.expectApplicationCount(0)
       await adminPrograms.filterProgramApplications({
         applicationStatusOption: rejectedStatusName,
       })
-      await adminPrograms.expectApplicationCountForBulkStatus(0)
+      await adminPrograms.expectApplicationCount(0)
 
       // Included when explicitly selecting the default option to show all applications.
       await adminPrograms.filterProgramApplications({
         applicationStatusOption:
           AdminPrograms.ANY_STATUS_APPLICATION_FILTER_OPTION,
       })
-      await adminPrograms.expectApplicationCountForBulkStatus(1)
+      await adminPrograms.expectApplicationCount(1)
     })
 
     test('applied application status filter is used when downloading', async ({
@@ -658,12 +658,12 @@ test.describe('view program statuses', () => {
     }) => {
       await test.step('explicitly set a status for the application', async () => {
         await adminPrograms.viewApplications(programForFilteringName)
-        await adminPrograms.viewApplicationForApplicantForBulkStatus('Guest')
+        await adminPrograms.viewApplicationForApplicant('Guest')
         const modal =
-          await adminPrograms.setStatusOptionAndAwaitModalForBulkStatus(
+          await adminPrograms.setStatusOptionAndAwaitModal(
             approvedStatusName,
           )
-        await adminPrograms.confirmStatusUpdateModalForBulkStatus(modal)
+        await adminPrograms.confirmStatusUpdateModal(modal)
         await page.getByRole('link', {name: 'Back'}).click()
       })
 
@@ -672,26 +672,26 @@ test.describe('view program statuses', () => {
         applicationStatusOption:
           AdminPrograms.NO_STATUS_APPLICATION_FILTER_OPTION,
       })
-      await adminPrograms.expectApplicationCountForBulkStatus(0)
+      await adminPrograms.expectApplicationCount(0)
 
       // Included when selecting the "approved" status.
       await adminPrograms.filterProgramApplications({
         applicationStatusOption: approvedStatusName,
       })
-      await adminPrograms.expectApplicationCountForBulkStatus(1)
+      await adminPrograms.expectApplicationCount(1)
 
       // Excluded when selecting the "rejected" status.
       await adminPrograms.filterProgramApplications({
         applicationStatusOption: rejectedStatusName,
       })
-      await adminPrograms.expectApplicationCountForBulkStatus(0)
+      await adminPrograms.expectApplicationCount(0)
 
       // Included when explicitly selecting the default option to show all applications.
       await adminPrograms.filterProgramApplications({
         applicationStatusOption:
           AdminPrograms.ANY_STATUS_APPLICATION_FILTER_OPTION,
       })
-      await adminPrograms.expectApplicationCountForBulkStatus(1)
+      await adminPrograms.expectApplicationCount(1)
     })
 
     test('shows the application on reload after the status is updated to something no longer in the filter', async ({
@@ -700,26 +700,26 @@ test.describe('view program statuses', () => {
     }) => {
       await test.step('explicitly set a status for the application', async () => {
         await adminPrograms.viewApplications(programForFilteringName)
-        await adminPrograms.viewApplicationForApplicantForBulkStatus('Guest')
+        await adminPrograms.viewApplicationForApplicant('Guest')
         const modal =
-          await adminPrograms.setStatusOptionAndAwaitModalForBulkStatus(
+          await adminPrograms.setStatusOptionAndAwaitModal(
             approvedStatusName,
           )
-        await adminPrograms.confirmStatusUpdateModalForBulkStatus(modal)
+        await adminPrograms.confirmStatusUpdateModal(modal)
         await page.getByRole('link', {name: 'Back'}).click()
       })
 
       await adminPrograms.filterProgramApplications({
         applicationStatusOption: approvedStatusName,
       })
-      await adminPrograms.expectApplicationCountForBulkStatus(1)
+      await adminPrograms.expectApplicationCount(1)
 
-      await adminPrograms.viewApplicationForApplicantForBulkStatus('Guest')
+      await adminPrograms.viewApplicationForApplicant('Guest')
       const modal =
-        await adminPrograms.setStatusOptionAndAwaitModalForBulkStatus(
+        await adminPrograms.setStatusOptionAndAwaitModal(
           rejectedStatusName,
         )
-      await adminPrograms.confirmStatusUpdateModalForBulkStatus(modal)
+      await adminPrograms.confirmStatusUpdateModal(modal)
       await page.getByRole('link', {name: 'Back'}).click()
 
       // The application should no longer be in the list, since its status is no longer "approved".
@@ -728,11 +728,11 @@ test.describe('view program statuses', () => {
       await adminPrograms.filterProgramApplications({
         applicationStatusOption: approvedStatusName,
       })
-      await adminPrograms.expectApplicationCountForBulkStatus(0)
+      await adminPrograms.expectApplicationCount(0)
       await adminPrograms.filterProgramApplications({
         applicationStatusOption: rejectedStatusName,
       })
-      await adminPrograms.viewApplicationForApplicantForBulkStatus('Guest')
+      await adminPrograms.viewApplicationForApplicant('Guest')
       const applicationText = await page
         .locator('#application-view')
         .innerText()
@@ -877,7 +877,7 @@ test.describe('view program statuses', () => {
         await logout(page)
         await loginAsProgramAdmin(page)
         await adminPrograms.viewApplications(programWithStatusesName)
-        await adminPrograms.viewApplicationForApplicantForBulkStatus(
+        await adminPrograms.viewApplicationForApplicant(
           `${guestEmail} (${id})`,
         )
       })
@@ -891,7 +891,7 @@ test.describe('view program statuses', () => {
 
       await test.step('set new status and confirm change via modal', async () => {
         const modal =
-          await adminPrograms.setStatusOptionAndAwaitModalForBulkStatus(
+          await adminPrograms.setStatusOptionAndAwaitModal(
             emailStatusName,
           )
 
@@ -901,8 +901,8 @@ test.describe('view program statuses', () => {
         expect(await modal.innerText()).toContain(
           ' of this change at ' + guestEmail,
         )
-        await adminPrograms.confirmStatusUpdateModalForBulkStatus(modal)
-        expect(await adminPrograms.getStatusOptionForBulkStatus()).toBe(
+        await adminPrograms.confirmStatusUpdateModal(modal)
+        expect(await adminPrograms.getStatusOption()).toBe(
           emailStatusName,
         )
         await adminPrograms.expectUpdateStatusToast()
@@ -935,7 +935,7 @@ test.describe('view program statuses', () => {
         await logout(page)
         await loginAsProgramAdmin(page)
         await adminPrograms.viewApplications(programWithStatusesName)
-        await adminPrograms.viewApplicationForApplicantForBulkStatus(
+        await adminPrograms.viewApplicationForApplicant(
           `${otherTestUserEmail} (${id})`,
         )
       })
@@ -953,7 +953,7 @@ test.describe('view program statuses', () => {
 
       await test.step('set new status and confirm change via modal', async () => {
         const modal =
-          await adminPrograms.setStatusOptionAndAwaitModalForBulkStatus(
+          await adminPrograms.setStatusOptionAndAwaitModal(
             emailStatusName,
           )
         expect(await modal.innerText()).toContain(
@@ -963,7 +963,7 @@ test.describe('view program statuses', () => {
             otherTestUserEmail,
         )
 
-        await adminPrograms.confirmStatusUpdateModalForBulkStatus(modal)
+        await adminPrograms.confirmStatusUpdateModal(modal)
         await adminPrograms.expectUpdateStatusToast()
       })
       await test.step('verify status update email was sent to both email addresses', async () => {
@@ -998,7 +998,7 @@ test.describe('view program statuses', () => {
         await logout(page)
         await loginAsProgramAdmin(page)
         await adminPrograms.viewApplications(programWithStatusesName)
-        await adminPrograms.viewApplicationForApplicantForBulkStatus(
+        await adminPrograms.viewApplicationForApplicant(
           `${testUserDisplayName()} (${id})`,
         )
       })
@@ -1012,7 +1012,7 @@ test.describe('view program statuses', () => {
 
       await test.step('set new status and confirm change via modal', async () => {
         const modal =
-          await adminPrograms.setStatusOptionAndAwaitModalForBulkStatus(
+          await adminPrograms.setStatusOptionAndAwaitModal(
             emailStatusName,
           )
         expect(await modal.innerText()).toContain(
@@ -1020,7 +1020,7 @@ test.describe('view program statuses', () => {
         )
         expect(await modal.innerText()).not.toContain(' and ')
 
-        await adminPrograms.confirmStatusUpdateModalForBulkStatus(modal)
+        await adminPrograms.confirmStatusUpdateModal(modal)
         await adminPrograms.expectUpdateStatusToast()
       })
       await test.step('verify status update email was sent to the applicant', async () => {

--- a/browser-test/src/admin/admin_application_statuses.test.ts
+++ b/browser-test/src/admin/admin_application_statuses.test.ts
@@ -49,9 +49,7 @@ test.describe('view program statuses', () => {
     })
 
     test('does not show status options', async ({adminPrograms}) => {
-      expect(await adminPrograms.isStatusSelectorVisible()).toBe(
-        false,
-      )
+      expect(await adminPrograms.isStatusSelectorVisible()).toBe(false)
     })
 
     test('does not show application status in table', async ({
@@ -133,15 +131,11 @@ test.describe('view program statuses', () => {
     )
 
     test('shows status selector', async ({adminPrograms}) => {
-      expect(await adminPrograms.isStatusSelectorVisible()).toBe(
-        true,
-      )
+      expect(await adminPrograms.isStatusSelectorVisible()).toBe(true)
     })
 
     test('shows placeholder option', async ({adminPrograms}) => {
-      expect(await adminPrograms.getStatusOption()).toBe(
-        'Choose an option:',
-      )
+      expect(await adminPrograms.getStatusOption()).toBe('Choose an option:')
     })
 
     test('renders', async ({page}) => {
@@ -152,17 +146,12 @@ test.describe('view program statuses', () => {
       adminPrograms,
     }) => {
       await adminPrograms.viewApplications(programWithStatusesName)
-      await adminPrograms.expectApplicationHasStatusString(
-        'Guest',
-        'None',
-      )
+      await adminPrograms.expectApplicationHasStatusString('Guest', 'None')
     })
 
     test.describe('when a status is changed, a confirmation dialog is shown', () => {
       test('renders', async ({page, adminPrograms}) => {
-        await adminPrograms.setStatusOptionAndAwaitModal(
-          noEmailStatusName,
-        )
+        await adminPrograms.setStatusOptionAndAwaitModal(noEmailStatusName)
         await validateScreenshot(page, 'change-status-modal')
       })
 
@@ -170,29 +159,21 @@ test.describe('view program statuses', () => {
         page,
         adminPrograms,
       }) => {
-        await adminPrograms.setStatusOptionAndAwaitModal(
-          noEmailStatusName,
-        )
+        await adminPrograms.setStatusOptionAndAwaitModal(noEmailStatusName)
         await dismissModal(page)
-        expect(await adminPrograms.getStatusOption()).toBe(
-          'Choose an option:',
-        )
+        expect(await adminPrograms.getStatusOption()).toBe('Choose an option:')
       })
 
       test('when confirmed, the page is shown a success toast', async ({
         adminPrograms,
       }) => {
         const modal =
-          await adminPrograms.setStatusOptionAndAwaitModal(
-            noEmailStatusName,
-          )
+          await adminPrograms.setStatusOptionAndAwaitModal(noEmailStatusName)
         expect(await modal.innerText()).toContain(
           `Status Change: Unset -> ${noEmailStatusName}`,
         )
         await adminPrograms.confirmStatusUpdateModal(modal)
-        expect(await adminPrograms.getStatusOption()).toBe(
-          noEmailStatusName,
-        )
+        expect(await adminPrograms.getStatusOption()).toBe(noEmailStatusName)
         await adminPrograms.expectUpdateStatusToast()
       })
 
@@ -201,9 +182,7 @@ test.describe('view program statuses', () => {
         adminPrograms,
       }) => {
         const modal =
-          await adminPrograms.setStatusOptionAndAwaitModal(
-            noEmailStatusName,
-          )
+          await adminPrograms.setStatusOptionAndAwaitModal(noEmailStatusName)
         expect(await modal.innerText()).toContain(
           'will not receive an email because there is no email content set for this status. Connect with your CiviForm Admin to add an email to this status',
         )
@@ -215,9 +194,7 @@ test.describe('view program statuses', () => {
         adminPrograms,
       }) => {
         const modal =
-          await adminPrograms.setStatusOptionAndAwaitModal(
-            emailStatusName,
-          )
+          await adminPrograms.setStatusOptionAndAwaitModal(emailStatusName)
         expect(await modal.innerText()).toContain(
           'will not receive an email for this change since they have not provided an email address.',
         )
@@ -230,19 +207,13 @@ test.describe('view program statuses', () => {
       }) => {
         await test.step('Set initial status', async () => {
           const modal =
-            await adminPrograms.setStatusOptionAndAwaitModal(
-              noEmailStatusName,
-            )
+            await adminPrograms.setStatusOptionAndAwaitModal(noEmailStatusName)
           await adminPrograms.confirmStatusUpdateModal(modal)
-          expect(await adminPrograms.getStatusOption()).toBe(
-            noEmailStatusName,
-          )
+          expect(await adminPrograms.getStatusOption()).toBe(noEmailStatusName)
         })
 
         const modal =
-          await adminPrograms.setStatusOptionAndAwaitModal(
-            emailStatusName,
-          )
+          await adminPrograms.setStatusOptionAndAwaitModal(emailStatusName)
         expect(await modal.innerText()).toContain(
           `Status Change: ${noEmailStatusName} -> ${emailStatusName}`,
         )
@@ -255,13 +226,9 @@ test.describe('view program statuses', () => {
       }) => {
         await test.step('Set initial status', async () => {
           const modal =
-            await adminPrograms.setStatusOptionAndAwaitModal(
-              noEmailStatusName,
-            )
+            await adminPrograms.setStatusOptionAndAwaitModal(noEmailStatusName)
           await adminPrograms.confirmStatusUpdateModal(modal)
-          expect(await adminPrograms.getStatusOption()).toBe(
-            noEmailStatusName,
-          )
+          expect(await adminPrograms.getStatusOption()).toBe(noEmailStatusName)
         })
 
         await page.getByRole('link', {name: 'Back'}).click()
@@ -272,9 +239,7 @@ test.describe('view program statuses', () => {
         )
         await adminPrograms.viewApplicationForApplicant('Guest')
         const modal =
-          await adminPrograms.setStatusOptionAndAwaitModal(
-            emailStatusName,
-          )
+          await adminPrograms.setStatusOptionAndAwaitModal(emailStatusName)
         await adminPrograms.confirmStatusUpdateModal(modal)
         await page.getByRole('link', {name: 'Back'}).click()
         await adminPrograms.expectApplicationHasStatusString(
@@ -287,9 +252,7 @@ test.describe('view program statuses', () => {
         test.beforeEach(async ({page, adminPrograms}) => {
           await enableFeatureFlag(page, 'bulk_status_update_enabled')
           await adminPrograms.viewApplications(programWithStatusesName)
-          await adminPrograms.viewApplicationForApplicant(
-            testUserDisplayName(),
-          )
+          await adminPrograms.viewApplicationForApplicant(testUserDisplayName())
         })
 
         test('choosing not to notify applicant changes status and does not send email', async ({
@@ -300,17 +263,13 @@ test.describe('view program statuses', () => {
             ? await extractEmailsForRecipient(page, testUserDisplayName())
             : []
           const modal =
-            await adminPrograms.setStatusOptionAndAwaitModal(
-              emailStatusName,
-            )
+            await adminPrograms.setStatusOptionAndAwaitModal(emailStatusName)
           const notifyCheckbox = await modal.$('input[type=checkbox]')
           expect(notifyCheckbox).not.toBeNull()
           await notifyCheckbox!.uncheck()
           expect(await notifyCheckbox!.isChecked()).toBe(false)
           await adminPrograms.confirmStatusUpdateModal(modal)
-          expect(await adminPrograms.getStatusOption()).toBe(
-            emailStatusName,
-          )
+          expect(await adminPrograms.getStatusOption()).toBe(emailStatusName)
           await adminPrograms.expectUpdateStatusToast()
 
           if (supportsEmailInspection()) {
@@ -330,17 +289,13 @@ test.describe('view program statuses', () => {
             ? await extractEmailsForRecipient(page, testUserDisplayName())
             : []
           const modal =
-            await adminPrograms.setStatusOptionAndAwaitModal(
-              emailStatusName,
-            )
+            await adminPrograms.setStatusOptionAndAwaitModal(emailStatusName)
           const notifyCheckbox = await modal.$('input[type=checkbox]')
           expect(notifyCheckbox).not.toBeNull()
           expect(await notifyCheckbox!.isChecked()).toBe(true)
           expect(await modal.innerText()).toContain(' of this change at ')
           await adminPrograms.confirmStatusUpdateModal(modal)
-          expect(await adminPrograms.getStatusOption()).toBe(
-            emailStatusName,
-          )
+          expect(await adminPrograms.getStatusOption()).toBe(emailStatusName)
           await adminPrograms.expectUpdateStatusToast()
 
           if (supportsEmailInspection()) {
@@ -512,16 +467,12 @@ test.describe('view program statuses', () => {
       // Approve guest application
       await adminPrograms.viewApplicationForApplicant('Guest')
       const modal =
-        await adminPrograms.setStatusOptionAndAwaitModal(
-          approvedStatus,
-        )
+        await adminPrograms.setStatusOptionAndAwaitModal(approvedStatus)
       expect(await modal.innerText()).toContain(
         `Status Change: ${waitingStatus} -> ${approvedStatus}`,
       )
       await adminPrograms.confirmStatusUpdateModal(modal)
-      expect(await adminPrograms.getStatusOption()).toBe(
-        approvedStatus,
-      )
+      expect(await adminPrograms.getStatusOption()).toBe(approvedStatus)
       await adminPrograms.expectUpdateStatusToast()
 
       await page.getByRole('link', {name: 'Back'}).click()
@@ -660,9 +611,7 @@ test.describe('view program statuses', () => {
         await adminPrograms.viewApplications(programForFilteringName)
         await adminPrograms.viewApplicationForApplicant('Guest')
         const modal =
-          await adminPrograms.setStatusOptionAndAwaitModal(
-            approvedStatusName,
-          )
+          await adminPrograms.setStatusOptionAndAwaitModal(approvedStatusName)
         await adminPrograms.confirmStatusUpdateModal(modal)
         await page.getByRole('link', {name: 'Back'}).click()
       })
@@ -702,9 +651,7 @@ test.describe('view program statuses', () => {
         await adminPrograms.viewApplications(programForFilteringName)
         await adminPrograms.viewApplicationForApplicant('Guest')
         const modal =
-          await adminPrograms.setStatusOptionAndAwaitModal(
-            approvedStatusName,
-          )
+          await adminPrograms.setStatusOptionAndAwaitModal(approvedStatusName)
         await adminPrograms.confirmStatusUpdateModal(modal)
         await page.getByRole('link', {name: 'Back'}).click()
       })
@@ -716,9 +663,7 @@ test.describe('view program statuses', () => {
 
       await adminPrograms.viewApplicationForApplicant('Guest')
       const modal =
-        await adminPrograms.setStatusOptionAndAwaitModal(
-          rejectedStatusName,
-        )
+        await adminPrograms.setStatusOptionAndAwaitModal(rejectedStatusName)
       await adminPrograms.confirmStatusUpdateModal(modal)
       await page.getByRole('link', {name: 'Back'}).click()
 
@@ -877,9 +822,7 @@ test.describe('view program statuses', () => {
         await logout(page)
         await loginAsProgramAdmin(page)
         await adminPrograms.viewApplications(programWithStatusesName)
-        await adminPrograms.viewApplicationForApplicant(
-          `${guestEmail} (${id})`,
-        )
+        await adminPrograms.viewApplicationForApplicant(`${guestEmail} (${id})`)
       })
 
       const emailsBefore =
@@ -891,9 +834,7 @@ test.describe('view program statuses', () => {
 
       await test.step('set new status and confirm change via modal', async () => {
         const modal =
-          await adminPrograms.setStatusOptionAndAwaitModal(
-            emailStatusName,
-          )
+          await adminPrograms.setStatusOptionAndAwaitModal(emailStatusName)
 
         const notifyCheckbox = await modal.$('input[type=checkbox]')
         expect(notifyCheckbox).not.toBeNull()
@@ -902,9 +843,7 @@ test.describe('view program statuses', () => {
           ' of this change at ' + guestEmail,
         )
         await adminPrograms.confirmStatusUpdateModal(modal)
-        expect(await adminPrograms.getStatusOption()).toBe(
-          emailStatusName,
-        )
+        expect(await adminPrograms.getStatusOption()).toBe(emailStatusName)
         await adminPrograms.expectUpdateStatusToast()
       })
       await test.step('verify status update email was sent to applicant', async () => {
@@ -953,9 +892,7 @@ test.describe('view program statuses', () => {
 
       await test.step('set new status and confirm change via modal', async () => {
         const modal =
-          await adminPrograms.setStatusOptionAndAwaitModal(
-            emailStatusName,
-          )
+          await adminPrograms.setStatusOptionAndAwaitModal(emailStatusName)
         expect(await modal.innerText()).toContain(
           ' of this change at ' +
             testUserDisplayName() +
@@ -1012,9 +949,7 @@ test.describe('view program statuses', () => {
 
       await test.step('set new status and confirm change via modal', async () => {
         const modal =
-          await adminPrograms.setStatusOptionAndAwaitModal(
-            emailStatusName,
-          )
+          await adminPrograms.setStatusOptionAndAwaitModal(emailStatusName)
         expect(await modal.innerText()).toContain(
           ' of this change at ' + testUserDisplayName(),
         )

--- a/browser-test/src/admin/admin_bulk_update_statuses.test.ts
+++ b/browser-test/src/admin/admin_bulk_update_statuses.test.ts
@@ -50,8 +50,8 @@ test.describe('with program statuses', () => {
     adminPrograms,
   }) => {
     // Default page shows all applications.
-    await adminPrograms.expectApplicationCountForBulkStatus(1)
-    await adminPrograms.expectApplicationHasStatusStringForBulkStatus(
+    await adminPrograms.expectApplicationCount(1)
+    await adminPrograms.expectApplicationHasStatusString(
       testUserDisplayName(),
       'None',
     )
@@ -59,7 +59,7 @@ test.describe('with program statuses', () => {
     await page.locator('#bulk-status-selector').selectOption('Approved')
     await page.getByRole('button', {name: 'Status change'}).click()
     await waitForPageJsLoad(page)
-    await adminPrograms.expectApplicationHasStatusStringForBulkStatus(
+    await adminPrograms.expectApplicationHasStatusString(
       testUserDisplayName(),
       approvedStatusName,
     )
@@ -96,14 +96,14 @@ test.describe('with program statuses', () => {
     )
 
     for (let i = 0; i < 100; i++) {
-      await adminPrograms.expectApplicationHasStatusStringForBulkStatus(
+      await adminPrograms.expectApplicationHasStatusString(
         `Guest (${id - i})`,
         approvedStatusName,
       )
     }
     await page.locator('.usa-pagination__button:has-text("2")').click()
     // last applicant
-    await adminPrograms.expectApplicationHasStatusStringForBulkStatus(
+    await adminPrograms.expectApplicationHasStatusString(
       testUserDisplayName(),
       'None',
     )
@@ -142,7 +142,7 @@ test.describe('when email is configured for the status and applicant, a checkbox
     await page.getByRole('button', {name: 'Status change'}).click()
     await waitForPageJsLoad(page)
 
-    await adminPrograms.expectApplicationHasStatusStringForBulkStatus(
+    await adminPrograms.expectApplicationHasStatusString(
       testUserDisplayName(),
       emailStatusName,
     )
@@ -170,7 +170,7 @@ test.describe('when email is configured for the status and applicant, a checkbox
     await page.getByRole('button', {name: 'Status change'}).click()
     await waitForPageJsLoad(page)
 
-    await adminPrograms.expectApplicationHasStatusStringForBulkStatus(
+    await adminPrograms.expectApplicationHasStatusString(
       testUserDisplayName(),
       emailStatusName,
     )

--- a/browser-test/src/admin/admin_predicates.test.ts
+++ b/browser-test/src/admin/admin_predicates.test.ts
@@ -103,9 +103,7 @@ test.describe('create and edit predicates', () => {
     await logout(page)
     await loginAsProgramAdmin(page)
     await adminPrograms.viewApplications(programName)
-    await adminPrograms.viewApplicationForApplicant(
-      testUserDisplayName(),
-    )
+    await adminPrograms.viewApplicationForApplicant(testUserDisplayName())
 
     expect(await page.innerHTML('#application-view')).not.toContain('Screen 2')
 
@@ -208,9 +206,7 @@ test.describe('create and edit predicates', () => {
     await loginAsProgramAdmin(page)
     await adminPrograms.viewApplications(programName)
 
-    await adminPrograms.viewApplicationForApplicant(
-      testUserDisplayName(),
-    )
+    await adminPrograms.viewApplicationForApplicant(testUserDisplayName())
     expect(await page.locator('#application-view').innerText()).toContain(
       'Screen 2',
     )
@@ -354,9 +350,7 @@ test.describe('create and edit predicates', () => {
     await loginAsProgramAdmin(page)
     await adminPrograms.viewApplications(programName)
 
-    await adminPrograms.viewApplicationForApplicant(
-      testUserDisplayName(),
-    )
+    await adminPrograms.viewApplicationForApplicant(testUserDisplayName())
     expect(await page.locator('#application-view').innerText()).toContain(
       'Screen 1',
     )

--- a/browser-test/src/admin/admin_predicates.test.ts
+++ b/browser-test/src/admin/admin_predicates.test.ts
@@ -103,7 +103,7 @@ test.describe('create and edit predicates', () => {
     await logout(page)
     await loginAsProgramAdmin(page)
     await adminPrograms.viewApplications(programName)
-    await adminPrograms.viewApplicationForApplicantForBulkStatus(
+    await adminPrograms.viewApplicationForApplicant(
       testUserDisplayName(),
     )
 
@@ -208,7 +208,7 @@ test.describe('create and edit predicates', () => {
     await loginAsProgramAdmin(page)
     await adminPrograms.viewApplications(programName)
 
-    await adminPrograms.viewApplicationForApplicantForBulkStatus(
+    await adminPrograms.viewApplicationForApplicant(
       testUserDisplayName(),
     )
     expect(await page.locator('#application-view').innerText()).toContain(
@@ -354,7 +354,7 @@ test.describe('create and edit predicates', () => {
     await loginAsProgramAdmin(page)
     await adminPrograms.viewApplications(programName)
 
-    await adminPrograms.viewApplicationForApplicantForBulkStatus(
+    await adminPrograms.viewApplicationForApplicant(
       testUserDisplayName(),
     )
     expect(await page.locator('#application-view').innerText()).toContain(

--- a/browser-test/src/applicant/applicant_application_index.test.ts
+++ b/browser-test/src/applicant/applicant_application_index.test.ts
@@ -1312,11 +1312,8 @@ test.describe('applicant program index page with images', () => {
     // Set a status as a program admin
     await loginAsProgramAdmin(page)
     await adminPrograms.viewApplications(programName)
-    await adminPrograms.viewApplicationForApplicant(
-      testUserDisplayName(),
-    )
-    const modal =
-      await adminPrograms.setStatusOptionAndAwaitModal(statusName)
+    await adminPrograms.viewApplicationForApplicant(testUserDisplayName())
+    const modal = await adminPrograms.setStatusOptionAndAwaitModal(statusName)
     await adminPrograms.confirmStatusUpdateModal(modal)
     await page.getByRole('link', {name: 'Back'}).click()
     await logout(page)

--- a/browser-test/src/applicant/applicant_application_index.test.ts
+++ b/browser-test/src/applicant/applicant_application_index.test.ts
@@ -1130,7 +1130,7 @@ test.describe('applicant program index page with images', () => {
     await adminPrograms.expectActiveProgram(programName)
     await logout(page)
 
-    await submitApplicationAndApplyStatusForBulkStatus(
+    await submitApplicationAndApplyStatus(
       page,
       programName,
       approvedStatusName,
@@ -1217,7 +1217,7 @@ test.describe('applicant program index page with images', () => {
     )
     await logout(page)
 
-    await submitApplicationAndApplyStatusForBulkStatus(
+    await submitApplicationAndApplyStatus(
       page,
       programNameSubmittedWithImageAndStatus,
       approvedStatusName,
@@ -1251,7 +1251,7 @@ test.describe('applicant program index page with images', () => {
     await adminPrograms.expectActiveProgram(programNameSubmittedWithStatus)
     await logout(page)
 
-    await submitApplicationAndApplyStatusForBulkStatus(
+    await submitApplicationAndApplyStatus(
       page,
       programNameSubmittedWithStatus,
       approvedStatusName,
@@ -1296,7 +1296,7 @@ test.describe('applicant program index page with images', () => {
     await validateAccessibility(page)
   })
 
-  async function submitApplicationAndApplyStatusForBulkStatus(
+  async function submitApplicationAndApplyStatus(
     page: Page,
     programName: string,
     statusName: string,
@@ -1312,12 +1312,12 @@ test.describe('applicant program index page with images', () => {
     // Set a status as a program admin
     await loginAsProgramAdmin(page)
     await adminPrograms.viewApplications(programName)
-    await adminPrograms.viewApplicationForApplicantForBulkStatus(
+    await adminPrograms.viewApplicationForApplicant(
       testUserDisplayName(),
     )
     const modal =
-      await adminPrograms.setStatusOptionAndAwaitModalForBulkStatus(statusName)
-    await adminPrograms.confirmStatusUpdateModalForBulkStatus(modal)
+      await adminPrograms.setStatusOptionAndAwaitModal(statusName)
+    await adminPrograms.confirmStatusUpdateModal(modal)
     await page.getByRole('link', {name: 'Back'}).click()
     await logout(page)
   }

--- a/browser-test/src/applicant/applicant_application_statuses.test.ts
+++ b/browser-test/src/applicant/applicant_application_statuses.test.ts
@@ -35,13 +35,9 @@ test.describe('with program statuses', () => {
       // Navigate to the submitted application as the program admin and set a status.
       await loginAsProgramAdmin(page)
       await adminPrograms.viewApplications(programName)
-      await adminPrograms.viewApplicationForApplicant(
-        testUserDisplayName(),
-      )
+      await adminPrograms.viewApplicationForApplicant(testUserDisplayName())
       const modal =
-        await adminPrograms.setStatusOptionAndAwaitModal(
-          approvedStatusName,
-        )
+        await adminPrograms.setStatusOptionAndAwaitModal(approvedStatusName)
       await adminPrograms.confirmStatusUpdateModal(modal)
       await page.getByRole('link', {name: 'Back'}).click()
       await logout(page)

--- a/browser-test/src/applicant/applicant_application_statuses.test.ts
+++ b/browser-test/src/applicant/applicant_application_statuses.test.ts
@@ -35,14 +35,14 @@ test.describe('with program statuses', () => {
       // Navigate to the submitted application as the program admin and set a status.
       await loginAsProgramAdmin(page)
       await adminPrograms.viewApplications(programName)
-      await adminPrograms.viewApplicationForApplicantForBulkStatus(
+      await adminPrograms.viewApplicationForApplicant(
         testUserDisplayName(),
       )
       const modal =
-        await adminPrograms.setStatusOptionAndAwaitModalForBulkStatus(
+        await adminPrograms.setStatusOptionAndAwaitModal(
           approvedStatusName,
         )
-      await adminPrograms.confirmStatusUpdateModalForBulkStatus(modal)
+      await adminPrograms.confirmStatusUpdateModal(modal)
       await page.getByRole('link', {name: 'Back'}).click()
       await logout(page)
     },

--- a/browser-test/src/applicant/application_download.test.ts
+++ b/browser-test/src/applicant/application_download.test.ts
@@ -359,10 +359,10 @@ test.describe('normal application flow', () => {
     await loginAsProgramAdmin(page)
     await adminPrograms.viewApplications(programName)
     await adminPrograms.filterProgramApplications({searchFragment: 'SARA'})
-    await adminPrograms.viewApplicationForApplicantForBulkStatus('smith, sarah')
+    await adminPrograms.viewApplicationForApplicant('smith, sarah')
     await validateScreenshot(page, 'applications-page')
 
-    const pdfFile = await adminPrograms.getApplicationPdfForBulkStatus()
+    const pdfFile = await adminPrograms.getApplicationPdf()
     expect(pdfFile.length).toBeGreaterThan(1)
 
     await page.getByRole('link', {name: 'Back'}).click()

--- a/browser-test/src/applicant/application_previous_version.test.ts
+++ b/browser-test/src/applicant/application_previous_version.test.ts
@@ -43,10 +43,10 @@ test.describe('view an application in an older version', () => {
 
     // See the application in admin page
     await adminPrograms.viewApplications(programName)
-    await adminPrograms.viewApplicationForApplicantForBulkStatus(
+    await adminPrograms.viewApplicationForApplicant(
       testUserDisplayName(),
     )
-    await adminPrograms.expectApplicationAnswersForBulkStatus(
+    await adminPrograms.expectApplicationAnswers(
       'Screen 1',
       questionName,
       'some text',
@@ -64,10 +64,10 @@ test.describe('view an application in an older version', () => {
 
     // See the application in admin page in the old version
     await adminPrograms.viewApplications(programName)
-    await adminPrograms.viewApplicationForApplicantForBulkStatus(
+    await adminPrograms.viewApplicationForApplicant(
       testUserDisplayName(),
     )
-    await adminPrograms.expectApplicationAnswersForBulkStatus(
+    await adminPrograms.expectApplicationAnswers(
       'Screen 1',
       questionName,
       'some text',

--- a/browser-test/src/applicant/application_previous_version.test.ts
+++ b/browser-test/src/applicant/application_previous_version.test.ts
@@ -43,9 +43,7 @@ test.describe('view an application in an older version', () => {
 
     // See the application in admin page
     await adminPrograms.viewApplications(programName)
-    await adminPrograms.viewApplicationForApplicant(
-      testUserDisplayName(),
-    )
+    await adminPrograms.viewApplicationForApplicant(testUserDisplayName())
     await adminPrograms.expectApplicationAnswers(
       'Screen 1',
       questionName,
@@ -64,9 +62,7 @@ test.describe('view an application in an older version', () => {
 
     // See the application in admin page in the old version
     await adminPrograms.viewApplications(programName)
-    await adminPrograms.viewApplicationForApplicant(
-      testUserDisplayName(),
-    )
+    await adminPrograms.viewApplicationForApplicant(testUserDisplayName())
     await adminPrograms.expectApplicationAnswers(
       'Screen 1',
       questionName,

--- a/browser-test/src/applicant/application_review.test.ts
+++ b/browser-test/src/applicant/application_review.test.ts
@@ -245,34 +245,34 @@ test.describe('Program admin review of submitted applications', () => {
 
       await test.step('View the submitted application', async () => {
         await adminPrograms.viewApplications(programName)
-        await adminPrograms.viewApplicationForApplicantForBulkStatus(
+        await adminPrograms.viewApplicationForApplicant(
           testUserDisplayName(),
         )
       })
 
       await test.step('Review screen 1', async () => {
-        await adminPrograms.expectApplicationAnswersForBulkStatus(
+        await adminPrograms.expectApplicationAnswers(
           'Screen 1',
           'address-q',
           '1234 St',
         )
-        await adminPrograms.expectApplicationAnswersForBulkStatus(
+        await adminPrograms.expectApplicationAnswers(
           'Screen 1',
           'name-q',
           'Queen',
         )
 
-        await adminPrograms.expectApplicationAnswersForBulkStatus(
+        await adminPrograms.expectApplicationAnswers(
           'Screen 1',
           'radio-q',
           '2',
         )
-        await adminPrograms.expectApplicationAnswersForBulkStatus(
+        await adminPrograms.expectApplicationAnswers(
           'Screen 1',
           'date-q',
           '05/10/2021',
         )
-        await adminPrograms.expectApplicationAnswersForBulkStatus(
+        await adminPrograms.expectApplicationAnswers(
           'Screen 1',
           'email-q',
           'test1@gmail.com',
@@ -280,23 +280,23 @@ test.describe('Program admin review of submitted applications', () => {
       })
 
       await test.step('Review screen 2', async () => {
-        await adminPrograms.expectApplicationAnswersForBulkStatus(
+        await adminPrograms.expectApplicationAnswers(
           'Screen 2',
           'ice-cream-q',
           '2',
         )
-        await adminPrograms.expectApplicationAnswersForBulkStatus(
+        await adminPrograms.expectApplicationAnswers(
           'Screen 2',
           'favorite-trees-q',
           'pine; cherry',
         )
 
-        await adminPrograms.expectApplicationAnswersForBulkStatus(
+        await adminPrograms.expectApplicationAnswers(
           'Screen 2',
           'number-q',
           '42',
         )
-        await adminPrograms.expectApplicationAnswersForBulkStatus(
+        await adminPrograms.expectApplicationAnswers(
           'Screen 2',
           'text-q',
           'some text',
@@ -304,12 +304,12 @@ test.describe('Program admin review of submitted applications', () => {
       })
 
       await test.step('Review screen 3', async () => {
-        await adminPrograms.expectApplicationAnswersForBulkStatus(
+        await adminPrograms.expectApplicationAnswers(
           'Screen 3',
           'fileupload-q',
           'file-upload.png',
         )
-        await adminPrograms.expectApplicationAnswersForBulkStatus(
+        await adminPrograms.expectApplicationAnswers(
           'Screen 3',
           'fileupload-q',
           'file-upload-second.png',
@@ -339,10 +339,10 @@ test.describe('Program admin review of submitted applications', () => {
 
       await test.step('Review updated screen 2', async () => {
         await adminPrograms.viewApplications(programName)
-        await adminPrograms.viewApplicationForApplicantForBulkStatus(
+        await adminPrograms.viewApplicationForApplicant(
           testUserDisplayName(),
         )
-        await adminPrograms.expectApplicationAnswersForBulkStatus(
+        await adminPrograms.expectApplicationAnswers(
           'Screen 2',
           'favorite-trees-q',
           'pine; cherry',
@@ -635,34 +635,34 @@ test.describe('Program admin review of submitted applications', () => {
 
     await test.step('View the submitted application', async () => {
       await adminPrograms.viewApplications(programName)
-      await adminPrograms.viewApplicationForApplicantForBulkStatus(
+      await adminPrograms.viewApplicationForApplicant(
         testUserDisplayName(),
       )
     })
 
     await test.step('Review screen 1', async () => {
-      await adminPrograms.expectApplicationAnswersForBulkStatus(
+      await adminPrograms.expectApplicationAnswers(
         'Screen 1',
         'address-q',
         '1234 St',
       )
-      await adminPrograms.expectApplicationAnswersForBulkStatus(
+      await adminPrograms.expectApplicationAnswers(
         'Screen 1',
         'name-q',
         'Queen',
       )
 
-      await adminPrograms.expectApplicationAnswersForBulkStatus(
+      await adminPrograms.expectApplicationAnswers(
         'Screen 1',
         'radio-q',
         '2',
       )
-      await adminPrograms.expectApplicationAnswersForBulkStatus(
+      await adminPrograms.expectApplicationAnswers(
         'Screen 1',
         'date-q',
         '05/10/2021',
       )
-      await adminPrograms.expectApplicationAnswersForBulkStatus(
+      await adminPrograms.expectApplicationAnswers(
         'Screen 1',
         'email-q',
         'test1@gmail.com',
@@ -670,23 +670,23 @@ test.describe('Program admin review of submitted applications', () => {
     })
 
     await test.step('Review screen 2', async () => {
-      await adminPrograms.expectApplicationAnswersForBulkStatus(
+      await adminPrograms.expectApplicationAnswers(
         'Screen 2',
         'ice-cream-q',
         '2',
       )
-      await adminPrograms.expectApplicationAnswersForBulkStatus(
+      await adminPrograms.expectApplicationAnswers(
         'Screen 2',
         'favorite-trees-q',
         'pine; cherry',
       )
 
-      await adminPrograms.expectApplicationAnswersForBulkStatus(
+      await adminPrograms.expectApplicationAnswers(
         'Screen 2',
         'number-q',
         '42',
       )
-      await adminPrograms.expectApplicationAnswersForBulkStatus(
+      await adminPrograms.expectApplicationAnswers(
         'Screen 2',
         'text-q',
         'some text',
@@ -694,7 +694,7 @@ test.describe('Program admin review of submitted applications', () => {
     })
 
     await test.step('Review screen 3', async () => {
-      await adminPrograms.expectApplicationAnswerLinksForBulkStatus(
+      await adminPrograms.expectApplicationAnswerLinks(
         'Screen 3',
         'fileupload-q',
       )
@@ -723,10 +723,10 @@ test.describe('Program admin review of submitted applications', () => {
 
     await test.step('Review updated screen 2', async () => {
       await adminPrograms.viewApplications(programName)
-      await adminPrograms.viewApplicationForApplicantForBulkStatus(
+      await adminPrograms.viewApplicationForApplicant(
         testUserDisplayName(),
       )
-      await adminPrograms.expectApplicationAnswersForBulkStatus(
+      await adminPrograms.expectApplicationAnswers(
         'Screen 2',
         'favorite-trees-q',
         'pine; cherry',
@@ -836,7 +836,7 @@ test.describe('Program admin review of submitted applications', () => {
           `:nth-match(.cf-admin-application-row, ${i + 1}) a:text("Guest")`,
         )
         await waitForPageJsLoad(page)
-        await adminPrograms.expectApplicationAnswersForBulkStatus(
+        await adminPrograms.expectApplicationAnswers(
           'Screen 1',
           'fruit-text-q',
           answers[answers.length - i - 1],

--- a/browser-test/src/applicant/application_review.test.ts
+++ b/browser-test/src/applicant/application_review.test.ts
@@ -245,9 +245,7 @@ test.describe('Program admin review of submitted applications', () => {
 
       await test.step('View the submitted application', async () => {
         await adminPrograms.viewApplications(programName)
-        await adminPrograms.viewApplicationForApplicant(
-          testUserDisplayName(),
-        )
+        await adminPrograms.viewApplicationForApplicant(testUserDisplayName())
       })
 
       await test.step('Review screen 1', async () => {
@@ -262,11 +260,7 @@ test.describe('Program admin review of submitted applications', () => {
           'Queen',
         )
 
-        await adminPrograms.expectApplicationAnswers(
-          'Screen 1',
-          'radio-q',
-          '2',
-        )
+        await adminPrograms.expectApplicationAnswers('Screen 1', 'radio-q', '2')
         await adminPrograms.expectApplicationAnswers(
           'Screen 1',
           'date-q',
@@ -339,9 +333,7 @@ test.describe('Program admin review of submitted applications', () => {
 
       await test.step('Review updated screen 2', async () => {
         await adminPrograms.viewApplications(programName)
-        await adminPrograms.viewApplicationForApplicant(
-          testUserDisplayName(),
-        )
+        await adminPrograms.viewApplicationForApplicant(testUserDisplayName())
         await adminPrograms.expectApplicationAnswers(
           'Screen 2',
           'favorite-trees-q',
@@ -635,9 +627,7 @@ test.describe('Program admin review of submitted applications', () => {
 
     await test.step('View the submitted application', async () => {
       await adminPrograms.viewApplications(programName)
-      await adminPrograms.viewApplicationForApplicant(
-        testUserDisplayName(),
-      )
+      await adminPrograms.viewApplicationForApplicant(testUserDisplayName())
     })
 
     await test.step('Review screen 1', async () => {
@@ -652,11 +642,7 @@ test.describe('Program admin review of submitted applications', () => {
         'Queen',
       )
 
-      await adminPrograms.expectApplicationAnswers(
-        'Screen 1',
-        'radio-q',
-        '2',
-      )
+      await adminPrograms.expectApplicationAnswers('Screen 1', 'radio-q', '2')
       await adminPrograms.expectApplicationAnswers(
         'Screen 1',
         'date-q',
@@ -681,11 +667,7 @@ test.describe('Program admin review of submitted applications', () => {
         'pine; cherry',
       )
 
-      await adminPrograms.expectApplicationAnswers(
-        'Screen 2',
-        'number-q',
-        '42',
-      )
+      await adminPrograms.expectApplicationAnswers('Screen 2', 'number-q', '42')
       await adminPrograms.expectApplicationAnswers(
         'Screen 2',
         'text-q',
@@ -723,9 +705,7 @@ test.describe('Program admin review of submitted applications', () => {
 
     await test.step('Review updated screen 2', async () => {
       await adminPrograms.viewApplications(programName)
-      await adminPrograms.viewApplicationForApplicant(
-        testUserDisplayName(),
-      )
+      await adminPrograms.viewApplicationForApplicant(testUserDisplayName())
       await adminPrograms.expectApplicationAnswers(
         'Screen 2',
         'favorite-trees-q',

--- a/browser-test/src/applicant/northstar_applicant_application_statuses.test.ts
+++ b/browser-test/src/applicant/northstar_applicant_application_statuses.test.ts
@@ -36,13 +36,9 @@ test.describe('with program statuses', {tag: ['@northstar']}, () => {
       // Navigate to the submitted application as the program admin and set a status.
       await loginAsProgramAdmin(page)
       await adminPrograms.viewApplications(programName)
-      await adminPrograms.viewApplicationForApplicant(
-        testUserDisplayName(),
-      )
+      await adminPrograms.viewApplicationForApplicant(testUserDisplayName())
       const modal =
-        await adminPrograms.setStatusOptionAndAwaitModal(
-          approvedStatusName,
-        )
+        await adminPrograms.setStatusOptionAndAwaitModal(approvedStatusName)
       await adminPrograms.confirmStatusUpdateModal(modal)
       await page.getByRole('link', {name: 'Back'}).click()
       await logout(page)

--- a/browser-test/src/applicant/northstar_applicant_application_statuses.test.ts
+++ b/browser-test/src/applicant/northstar_applicant_application_statuses.test.ts
@@ -36,14 +36,14 @@ test.describe('with program statuses', {tag: ['@northstar']}, () => {
       // Navigate to the submitted application as the program admin and set a status.
       await loginAsProgramAdmin(page)
       await adminPrograms.viewApplications(programName)
-      await adminPrograms.viewApplicationForApplicantForBulkStatus(
+      await adminPrograms.viewApplicationForApplicant(
         testUserDisplayName(),
       )
       const modal =
-        await adminPrograms.setStatusOptionAndAwaitModalForBulkStatus(
+        await adminPrograms.setStatusOptionAndAwaitModal(
           approvedStatusName,
         )
-      await adminPrograms.confirmStatusUpdateModalForBulkStatus(modal)
+      await adminPrograms.confirmStatusUpdateModal(modal)
       await page.getByRole('link', {name: 'Back'}).click()
       await logout(page)
 

--- a/browser-test/src/applicant/northstar_application_previous_version.test.ts
+++ b/browser-test/src/applicant/northstar_application_previous_version.test.ts
@@ -53,9 +53,7 @@ test.describe(
 
       // See the application in admin page
       await adminPrograms.viewApplications(programName)
-      await adminPrograms.viewApplicationForApplicant(
-        testUserDisplayName(),
-      )
+      await adminPrograms.viewApplicationForApplicant(testUserDisplayName())
       await adminPrograms.expectApplicationAnswers(
         'Screen 1',
         questionName,
@@ -74,9 +72,7 @@ test.describe(
 
       // See the application in admin page in the old version
       await adminPrograms.viewApplications(programName)
-      await adminPrograms.viewApplicationForApplicant(
-        testUserDisplayName(),
-      )
+      await adminPrograms.viewApplicationForApplicant(testUserDisplayName())
       await adminPrograms.expectApplicationAnswers(
         'Screen 1',
         questionName,

--- a/browser-test/src/applicant/northstar_application_previous_version.test.ts
+++ b/browser-test/src/applicant/northstar_application_previous_version.test.ts
@@ -53,10 +53,10 @@ test.describe(
 
       // See the application in admin page
       await adminPrograms.viewApplications(programName)
-      await adminPrograms.viewApplicationForApplicantForBulkStatus(
+      await adminPrograms.viewApplicationForApplicant(
         testUserDisplayName(),
       )
-      await adminPrograms.expectApplicationAnswersForBulkStatus(
+      await adminPrograms.expectApplicationAnswers(
         'Screen 1',
         questionName,
         'some text',
@@ -74,10 +74,10 @@ test.describe(
 
       // See the application in admin page in the old version
       await adminPrograms.viewApplications(programName)
-      await adminPrograms.viewApplicationForApplicantForBulkStatus(
+      await adminPrograms.viewApplicationForApplicant(
         testUserDisplayName(),
       )
-      await adminPrograms.expectApplicationAnswersForBulkStatus(
+      await adminPrograms.expectApplicationAnswers(
         'Screen 1',
         questionName,
         'some text',

--- a/browser-test/src/support/admin_programs.ts
+++ b/browser-test/src/support/admin_programs.ts
@@ -1,5 +1,5 @@
 import {expect} from './civiform_fixtures'
-import {ElementHandle, Frame, Page, Locator} from 'playwright'
+import {ElementHandle, Page, Locator} from 'playwright'
 import {readFileSync} from 'fs'
 import {
   clickAndWaitForModal,
@@ -1112,10 +1112,7 @@ export class AdminPrograms {
     expect(blockText).toContain(answer)
   }
 
-  async expectApplicationAnswerLinks(
-    blockName: string,
-    questionName: string,
-  ) {
+  async expectApplicationAnswerLinks(blockName: string, questionName: string) {
     await expect(
       this.page.locator(this.selectApplicationBlock(blockName)),
     ).toContainText(questionName)


### PR DESCRIPTION
### Description

Removing Application Card related functions from Browser tests and removing "ForBulkStatus" from common function names. 


### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [ ] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`


### Issue(s) this completes

Fixes #9499 
