### PR TITLE
Hide tabs when there are no disabled programs

### DIFF
--- a/browser-test/src/admin/admin_program_list.test.ts
+++ b/browser-test/src/admin/admin_program_list.test.ts
@@ -100,6 +100,8 @@ test.describe('Program list page.', () => {
     const publicProgram = 'List test public program'
     const disabledProgram = 'List test disabled program'
     await adminPrograms.addProgram(publicProgram)
+    await expect(page.locator('a:has-text("Disabled")')).toBeHidden()
+
     await adminPrograms.addDisabledProgram(disabledProgram)
 
     await expectProgramListElements(adminPrograms, [publicProgram])

--- a/server/app/repository/ProgramRepository.java
+++ b/server/app/repository/ProgramRepository.java
@@ -138,12 +138,15 @@ public final class ProgramRepository {
   }
 
   /**
-   * Gets the program definition without the associated question data.
+   * Retrieves the program definition for the given program.
+   *
+   * <p>This method prioritizes fetching the program definition from the cache. If not found in the
+   * cache, it retrieves the definition directly from the program model.
    *
    * <p>This method should replace any calls to ProgramModel.getProgramDefinition()
    */
   public ProgramDefinition getShallowProgramDefinition(ProgramModel program) {
-    return program.getProgramDefinition();
+    return getFullProgramDefinitionFromCache(program).orElseGet(program::getProgramDefinition);
   }
 
   /**

--- a/server/app/repository/VersionRepository.java
+++ b/server/app/repository/VersionRepository.java
@@ -29,6 +29,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Predicate;
 import javax.inject.Inject;
+import models.DisplayMode;
 import models.LifecycleStage;
 import models.ProgramModel;
 import models.QuestionModel;
@@ -547,6 +548,19 @@ public final class VersionRepository {
     return getProgramsForVersion(maybeVersion).stream()
         .filter(p -> programRepository.getShallowProgramDefinition(p).adminName().equals(name))
         .findAny();
+  }
+
+  public boolean anyDisabledPrograms() {
+    return anyDisabledPrograms(Optional.of(getActiveVersion()))
+        || anyDisabledPrograms(getDraftVersion());
+  }
+
+  private boolean anyDisabledPrograms(Optional<VersionModel> maybeVersion) {
+    return getProgramsForVersion(maybeVersion).stream()
+        .anyMatch(
+            p ->
+                programRepository.getShallowProgramDefinition(p).displayMode()
+                    == DisplayMode.DISABLED);
   }
 
   /** Returns the names of all the programs. */

--- a/server/app/services/program/ProgramService.java
+++ b/server/app/services/program/ProgramService.java
@@ -162,6 +162,11 @@ public final class ProgramService {
     return ActiveAndDraftPrograms.buildInUseProgramFromCurrentVersionsUnsynced(versionRepository);
   }
 
+  /** Checks if there is any disabled program in active or draft version. */
+  public boolean anyDisabledPrograms() {
+    return versionRepository.anyDisabledPrograms();
+  }
+
   /*
    * Looks at the most recent version of each program and returns the program marked as the
    * common intake form if it exists. The most recent version may be in the draft or active stage.

--- a/server/app/views/admin/programs/ProgramIndexView.java
+++ b/server/app/views/admin/programs/ProgramIndexView.java
@@ -168,7 +168,8 @@ public final class ProgramIndexView extends BaseHtmlView {
                         div().withClass("flex-grow"),
                         p("Sorting by most recently updated").withClass("text-sm")));
 
-    if (settingsManifest.getDisabledVisibilityConditionEnabled(request)) {
+    if (settingsManifest.getDisabledVisibilityConditionEnabled(request)
+        && programService.anyDisabledPrograms()) {
       contentDiv.with(
           renderFilterLink(
               ProgramTab.IN_USE,

--- a/server/test/repository/VersionRepositoryTest.java
+++ b/server/test/repository/VersionRepositoryTest.java
@@ -1094,4 +1094,19 @@ public class VersionRepositoryTest extends ResetPostgres {
 
     assertThat(programsByVersionCache.get(version1Key).isPresent()).isFalse();
   }
+
+  @Test
+  public void testAnyDisabledPrograms() {
+    // When no programs, there are no disabled programs
+    assertThat(versionRepository.anyDisabledPrograms()).isFalse();
+
+    // Adding non-disabled programs and verify that there are still no disabled programs
+    ProgramBuilder.newActiveProgram("active-program").build();
+    ProgramBuilder.newDraftProgram("draft-program").build();
+    assertThat(versionRepository.anyDisabledPrograms()).isFalse();
+
+    // Adding a disabled program and verify that now we have disabled programs
+    ProgramBuilder.newDisabledDraftProgram("disabled-program").build();
+    assertThat(versionRepository.anyDisabledPrograms()).isTrue();
+  }
 }

--- a/server/test/repository/VersionRepositoryTest.java
+++ b/server/test/repository/VersionRepositoryTest.java
@@ -1096,17 +1096,30 @@ public class VersionRepositoryTest extends ResetPostgres {
   }
 
   @Test
-  public void testAnyDisabledPrograms() {
+  public void testAnyDisabledPrograms_activeProgramDisabled() {
     // When no programs, there are no disabled programs
     assertThat(versionRepository.anyDisabledPrograms()).isFalse();
 
-    // Adding non-disabled programs and verify that there are still no disabled programs
+    // Adding a non-disabled active program and verify that there are still no disabled programs
     ProgramBuilder.newActiveProgram("active-program").build();
+    assertThat(versionRepository.anyDisabledPrograms()).isFalse();
+
+    // Adding a disabled program and verify that now we have disabled programs
+    ProgramBuilder.newDisabledActiveProgram("disabled-active-program").build();
+    assertThat(versionRepository.anyDisabledPrograms()).isTrue();
+  }
+
+  @Test
+  public void testAnyDisabledPrograms_draftProgramDisabled() {
+    // When no programs, there are no disabled programs
+    assertThat(versionRepository.anyDisabledPrograms()).isFalse();
+
+    // Adding non-disabled draft programs and verify that there are still no disabled programs
     ProgramBuilder.newDraftProgram("draft-program").build();
     assertThat(versionRepository.anyDisabledPrograms()).isFalse();
 
     // Adding a disabled program and verify that now we have disabled programs
-    ProgramBuilder.newDisabledDraftProgram("disabled-program").build();
+    ProgramBuilder.newDisabledDraftProgram("disabled-draft-program").build();
     assertThat(versionRepository.anyDisabledPrograms()).isTrue();
   }
 }

--- a/server/test/services/program/ProgramServiceTest.java
+++ b/server/test/services/program/ProgramServiceTest.java
@@ -185,7 +185,7 @@ public class ProgramServiceTest extends ResetPostgres {
         .withBlock()
         .withRequiredQuestionDefinition(questionThree)
         .buildDefinition();
-    ProgramBuilder.newActiveDisabledProgram("program2")
+    ProgramBuilder.newDisabledActiveProgram("program2")
         .withBlock()
         .withRequiredQuestionDefinition(questionTwo)
         .withBlock()
@@ -3275,5 +3275,30 @@ public class ProgramServiceTest extends ResetPostgres {
     ProgramDefinition deleteResult = ps.deleteSummaryImageFileKey(program.id());
 
     assertThat(deleteResult.summaryImageFileKey()).isEmpty();
+  }
+
+  @Test
+  public void anyDisabledPrograms_checks_disabledProgramExist() {
+    when(mockSettingsManifest.getDisabledVisibilityConditionEnabled(request)).thenReturn(true);
+    // When there are no programs, there are no disabled programs.
+    assertThat(ps.anyDisabledPrograms()).isFalse();
+
+    // Adding an active program doesn't change the result.
+    ProgramBuilder.newActiveProgram("active-program").buildDefinition();
+    assertThat(ps.anyDisabledPrograms()).isFalse();
+
+    // Adding a draft program doesn't change the result.
+    ProgramBuilder.newDraftProgram("draft-program").buildDefinition();
+    assertThat(ps.anyDisabledPrograms()).isFalse();
+
+    // Adding disabled programs changes the result.
+    ProgramBuilder.newDisabledDraftProgram("program1").buildDefinition();
+    assertThat(ps.anyDisabledPrograms()).isTrue();
+    ProgramBuilder.newDisabledActiveProgram("program2").buildDefinition();
+    assertThat(ps.anyDisabledPrograms()).isTrue();
+
+    // Adding an active program doesn't change the result.
+    ProgramBuilder.newActiveProgram("another-active-program").buildDefinition();
+    assertThat(ps.anyDisabledPrograms()).isTrue();
   }
 }

--- a/server/test/support/ProgramBuilder.java
+++ b/server/test/support/ProgramBuilder.java
@@ -160,7 +160,7 @@ public class ProgramBuilder {
    * Creates a {@link ProgramBuilder} with a new {@link ProgramModel} in the active state, with a
    * blank description and disabled.
    */
-  public static ProgramBuilder newActiveDisabledProgram(String name) {
+  public static ProgramBuilder newDisabledActiveProgram(String name) {
     return newActiveProgram(
         /* adminName= */ name,
         /* displayName= */ name,

--- a/server/test/support/ResourceCreator.java
+++ b/server/test/support/ResourceCreator.java
@@ -133,7 +133,7 @@ public class ResourceCreator {
   }
 
   public ProgramModel insertActiveDisabledProgram(String name) {
-    return ProgramBuilder.newActiveDisabledProgram(name).build();
+    return ProgramBuilder.newDisabledActiveProgram(name).build();
   }
 
   public ProgramModel insertActiveTiOnlyProgram(String name) {


### PR DESCRIPTION
### Description

Hide the "In Use"/"Disabled" tabs from the Admin program list view when there are no disabled programs.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [x] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`


#### User visible changes

- [x] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [x] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [x] Manually tested at 200% size
- [x] Manually evaluated tab order

### Instructions for manual testing
- Open program admin page
- Ensure that there are no existing programs
- Add a program that is not disabled.
- Make sure that "In Use/Disabled" tabs is not visible. 
- Add a new programs that is disabled.
- Verify that on Admin program list page, the "In Use/Disabled" tabs are now visible.
- Click on "Disabled" tab link to verify that the disabled program is listed.
- Click on "In Use" tab link to verify that the in-use program(non-disabled) is listed.

### Issue(s) this completes

Fixes #9380 
