### PR TITLE
Use add toast message helper methods in views

### DIFF
--- a/server/app/views/admin/programs/ProgramApplicationListView.java
+++ b/server/app/views/admin/programs/ProgramApplicationListView.java
@@ -18,7 +18,6 @@ import auth.CiviFormProfile;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
-import controllers.FlashKey;
 import controllers.admin.routes;
 import j2html.TagCreator;
 import j2html.tags.specialized.ATag;
@@ -51,7 +50,6 @@ import views.components.Icons;
 import views.components.LinkElement;
 import views.components.Modal;
 import views.components.SelectWithLabel;
-import views.components.ToastMessage;
 import views.style.ReferenceClasses;
 import views.style.StyleUtils;
 
@@ -153,15 +151,7 @@ public final class ProgramApplicationListView extends BaseHtmlView {
             .addModals(downloadModal)
             .addMainStyles("flex")
             .addMainContent(makeCsrfTokenInputTag(request), applicationListDiv, applicationShowDiv);
-
-    Optional<String> maybeSuccessMessage = request.flash().get(FlashKey.SUCCESS);
-    if (maybeSuccessMessage.isPresent()) {
-      htmlBundle.addToastMessages(ToastMessage.success(maybeSuccessMessage.get()));
-    }
-    Optional<String> maybeErrorMessage = request.flash().get(FlashKey.ERROR);
-    if (maybeErrorMessage.isPresent()) {
-      htmlBundle.addToastMessages(ToastMessage.errorNonLocalized(maybeErrorMessage.get()));
-    }
+    addSuccessAndErrorToasts(htmlBundle, request.flash());
     return layout.renderCentered(htmlBundle);
   }
 

--- a/server/app/views/admin/programs/ProgramApplicationView.java
+++ b/server/app/views/admin/programs/ProgramApplicationView.java
@@ -19,7 +19,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ListMultimap;
 import com.google.inject.Inject;
-import controllers.FlashKey;
 import controllers.admin.routes;
 import j2html.tags.DomContent;
 import j2html.tags.specialized.ATag;
@@ -55,7 +54,6 @@ import views.components.Icons;
 import views.components.LinkElement;
 import views.components.Modal;
 import views.components.Modal.Width;
-import views.components.ToastMessage;
 import views.style.BaseStyles;
 import views.style.ReferenceClasses;
 import views.style.StyleUtils;
@@ -174,10 +172,7 @@ public final class ProgramApplicationView extends BaseHtmlView {
             .addModals(updateNoteModal)
             .addModals(statusUpdateConfirmationModals)
             .setJsBundle(JsBundle.ADMIN);
-    Optional<String> maybeSuccessMessage = request.flash().get(FlashKey.SUCCESS);
-    if (maybeSuccessMessage.isPresent()) {
-      htmlBundle.addToastMessages(ToastMessage.success(maybeSuccessMessage.get()));
-    }
+    addToastMessagesOnSuccess(htmlBundle, request.flash());
     return layout.render(htmlBundle);
   }
 

--- a/server/app/views/admin/programs/ProgramImageView.java
+++ b/server/app/views/admin/programs/ProgramImageView.java
@@ -58,7 +58,6 @@ import views.components.FieldWithLabel;
 import views.components.Icons;
 import views.components.LinkElement;
 import views.components.Modal;
-import views.components.ToastMessage;
 import views.fileupload.FileUploadViewStrategy;
 import views.style.StyleUtils;
 
@@ -175,14 +174,7 @@ public final class ProgramImageView extends BaseHtmlView {
             .addMainContent(div().with(backButton, mainContent))
             .addModals(deleteImageModal);
 
-    // TODO(#6593): Write a helper method for this toast display logic.
-    Http.Flash flash = request.flash();
-    if (flash.get("success").isPresent()) {
-      htmlBundle.addToastMessages(ToastMessage.success(flash.get("success").get()));
-    } else if (flash.get("error").isPresent()) {
-      htmlBundle.addToastMessages(ToastMessage.errorNonLocalized(flash.get("error").get()));
-    }
-
+    addSuccessAndErrorToasts(htmlBundle, request.flash());
     return layout.renderCentered(htmlBundle);
   }
 

--- a/server/app/views/admin/programs/ProgramIndexView.java
+++ b/server/app/views/admin/programs/ProgramIndexView.java
@@ -53,7 +53,6 @@ import views.components.Icons;
 import views.components.LinkElement;
 import views.components.Modal;
 import views.components.ProgramCardFactory;
-import views.components.ToastMessage;
 import views.style.AdminStyles;
 import views.style.ReferenceClasses;
 import views.style.StyleUtils;
@@ -218,12 +217,7 @@ public final class ProgramIndexView extends BaseHtmlView {
 
     maybePublishModal.ifPresent(htmlBundle::addModals);
 
-    Http.Flash flash = request.flash();
-    if (flash.get("error").isPresent()) {
-      htmlBundle.addToastMessages(ToastMessage.errorNonLocalized(flash.get("error").get()));
-    } else if (flash.get("success").isPresent()) {
-      htmlBundle.addToastMessages(ToastMessage.success(flash.get("success").get()));
-    }
+    addSuccessAndErrorToasts(htmlBundle, request.flash());
 
     return layout.renderCentered(htmlBundle);
   }

--- a/server/app/views/admin/programs/ProgramPredicatesEditView.java
+++ b/server/app/views/admin/programs/ProgramPredicatesEditView.java
@@ -44,7 +44,6 @@ import views.components.Icons;
 import views.components.LinkElement;
 import views.components.LinkElement.IconPosition;
 import views.components.TextFormatter;
-import views.components.ToastMessage;
 import views.style.ReferenceClasses;
 
 /** Renders a page for editing predicates of a block in a program. */
@@ -266,14 +265,7 @@ public final class ProgramPredicatesEditView extends ProgramBaseView {
                     ImmutableList.of(ProgramHeaderButton.EDIT_PROGRAM_DETAILS),
                     request),
                 content);
-
-    Http.Flash flash = request.flash();
-    if (flash.get("error").isPresent()) {
-      htmlBundle.addToastMessages(ToastMessage.errorNonLocalized(flash.get("error").get()));
-    } else if (flash.get("success").isPresent()) {
-      htmlBundle.addToastMessages(ToastMessage.success(flash.get("success").get()));
-    }
-
+    addSuccessAndErrorToasts(htmlBundle, request.flash());
     return layout.renderCentered(htmlBundle);
   }
 

--- a/server/app/views/admin/programs/ProgramStatusesView.java
+++ b/server/app/views/admin/programs/ProgramStatusesView.java
@@ -41,7 +41,6 @@ import views.components.FieldWithLabel;
 import views.components.Icons;
 import views.components.Modal;
 import views.components.Modal.Width;
-import views.components.ToastMessage;
 import views.style.BaseStyles;
 import views.style.ReferenceClasses;
 
@@ -128,13 +127,7 @@ public final class ProgramStatusesView extends BaseHtmlView {
             .addModals(createStatusModal)
             .addModals(statusContainerAndModals.getRight());
 
-    Http.Flash flash = request.flash();
-    if (flash.get("error").isPresent()) {
-      htmlBundle.addToastMessages(ToastMessage.errorNonLocalized(flash.get("error").get()));
-    } else if (flash.get("success").isPresent()) {
-      htmlBundle.addToastMessages(ToastMessage.success(flash.get("success").get()));
-    }
-
+    addSuccessAndErrorToasts(htmlBundle, request.flash());
     return layout.renderCentered(htmlBundle);
   }
 

--- a/server/app/views/admin/questions/QuestionsListView.java
+++ b/server/app/views/admin/questions/QuestionsListView.java
@@ -55,7 +55,6 @@ import views.components.Modal.Width;
 import views.components.QuestionBank;
 import views.components.QuestionSortOption;
 import views.components.TextFormatter;
-import views.components.ToastMessage;
 import views.style.AdminStyles;
 import views.style.BaseStyles;
 import views.style.ReferenceClasses;
@@ -113,16 +112,7 @@ public final class QuestionsListView extends BaseHtmlView {
             .setTitle(title)
             .addModals(questionRowsAndModals.getRight())
             .addMainContent(contentDiv);
-
-    Http.Flash flash = request.flash();
-    if (flash.get("success").isPresent()) {
-      htmlBundle.addToastMessages(
-          ToastMessage.success(flash.get("success").get()).setDismissible(false));
-    } else if (flash.get("error").isPresent()) {
-      htmlBundle.addToastMessages(
-          ToastMessage.errorNonLocalized(flash.get("error").get()).setDismissible(false));
-    }
-
+    addSuccessAndErrorToasts(htmlBundle, request.flash());
     return layout.renderCentered(htmlBundle);
   }
 

--- a/server/app/views/admin/settings/AdminSettingsIndexView.java
+++ b/server/app/views/admin/settings/AdminSettingsIndexView.java
@@ -103,22 +103,15 @@ public final class AdminSettingsIndexView extends BaseHtmlView {
                     request, errorMessages, settingsManifest.getSections().get(sectionName))));
 
     HtmlBundle bundle = layout.getBundle(request).addMainContent(mainContent);
-
-    if (errorMessages.isPresent()) {
-      bundle.addToastMessages(
-          ToastMessage.error(
-              "That update didn't look quite right. Please fix the errors in the form and try"
-                  + " saving again.",
-              messagesApi.preferred(request)));
-    }
-    request
-        .flash()
-        .get("success")
-        .ifPresent(successMessage -> bundle.addToastMessages(ToastMessage.success(successMessage)));
-    request
-        .flash()
-        .get("warning")
-        .ifPresent(warningMessage -> bundle.addToastMessages(ToastMessage.warning(warningMessage)));
+    errorMessages
+        .map(
+            errors ->
+                ToastMessage.error(
+                    "That update didn't look quite right. Please fix the errors in the form and try"
+                        + " saving again.",
+                    messagesApi.preferred(request)))
+        .ifPresent(bundle::addToastMessages);
+    addSuccessAndWarningToasts(bundle, request.flash());
 
     return layout.render(bundle);
   }

--- a/server/app/views/admin/ti/EditTrustedIntermediaryGroupView.java
+++ b/server/app/views/admin/ti/EditTrustedIntermediaryGroupView.java
@@ -22,7 +22,6 @@ import j2html.tags.specialized.TheadTag;
 import j2html.tags.specialized.TrTag;
 import models.AccountModel;
 import models.TrustedIntermediaryGroupModel;
-import org.slf4j.LoggerFactory;
 import play.mvc.Http;
 import play.twirl.api.Content;
 import views.BaseHtmlView;
@@ -34,7 +33,6 @@ import views.admin.AdminLayoutFactory;
 import views.components.ButtonStyles;
 import views.components.FieldWithLabel;
 import views.components.Icons;
-import views.components.ToastMessage;
 import views.style.BaseStyles;
 import views.style.ReferenceClasses;
 import views.style.StyleUtils;
@@ -68,17 +66,8 @@ public class EditTrustedIntermediaryGroupView extends BaseHtmlView {
                                 each(
                                     tiGroup.getTrustedIntermediaries(),
                                     account -> renderTIRow(tiGroup, account, request))))));
-
-    if (request.flash().get(FlashKey.ERROR).isPresent()) {
-      LoggerFactory.getLogger(EditTrustedIntermediaryGroupView.class)
-          .info(request.flash().get(FlashKey.ERROR).get());
-      String error = request.flash().get(FlashKey.ERROR).get();
-      htmlBundle.addToastMessages(
-          ToastMessage.errorNonLocalized(error)
-              .setId("warning-message-ti-form-fill")
-              .setIgnorable(false)
-              .setDuration(0));
-    }
+    addToastMessagesOnError(
+        htmlBundle, request.flash(), this.getClass(), "warning-message-ti-form-fill");
 
     return layout.renderCentered(htmlBundle);
   }

--- a/server/app/views/admin/ti/TrustedIntermediaryGroupListView.java
+++ b/server/app/views/admin/ti/TrustedIntermediaryGroupListView.java
@@ -23,7 +23,6 @@ import j2html.tags.specialized.TheadTag;
 import j2html.tags.specialized.TrTag;
 import java.util.List;
 import models.TrustedIntermediaryGroupModel;
-import org.slf4j.LoggerFactory;
 import play.mvc.Http;
 import play.twirl.api.Content;
 import views.BaseHtmlView;
@@ -37,7 +36,6 @@ import views.components.FieldWithLabel;
 import views.components.Icons;
 import views.components.QuestionSortOption;
 import views.components.SelectWithLabel;
-import views.components.ToastMessage;
 import views.style.BaseStyles;
 import views.style.ReferenceClasses;
 import views.style.StyleUtils;
@@ -73,17 +71,8 @@ public class TrustedIntermediaryGroupListView extends BaseHtmlView {
                             ImmutableList.of(
                                 QuestionSortOption.TI_NAME, QuestionSortOption.TI_NUM_MEMBERS))),
                 renderTiGroupCards(tis, request));
-
-    if (request.flash().get(FlashKey.ERROR).isPresent()) {
-      LoggerFactory.getLogger(TrustedIntermediaryGroupListView.class)
-          .info(request.flash().get(FlashKey.ERROR).get());
-      String error = request.flash().get(FlashKey.ERROR).get();
-      htmlBundle.addToastMessages(
-          ToastMessage.errorNonLocalized(error)
-              .setId("warning-message-ti-form-fill")
-              .setIgnorable(false)
-              .setDuration(0));
-    }
+    addToastMessagesOnError(
+        htmlBundle, request.flash(), this.getClass(), "warning-message-ti-form-fill");
     return layout.renderCentered(htmlBundle);
   }
 

--- a/server/app/views/applicant/TrustedIntermediaryAccountSettingsView.java
+++ b/server/app/views/applicant/TrustedIntermediaryAccountSettingsView.java
@@ -14,7 +14,6 @@ import static j2html.TagCreator.tr;
 import com.google.common.base.Strings;
 import com.google.inject.Inject;
 import com.typesafe.config.Config;
-import controllers.FlashKey;
 import j2html.tags.specialized.DivTag;
 import j2html.tags.specialized.TdTag;
 import j2html.tags.specialized.TheadTag;
@@ -24,15 +23,12 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import models.AccountModel;
 import models.TrustedIntermediaryGroupModel;
-import org.slf4j.LoggerFactory;
 import play.i18n.Messages;
 import play.mvc.Http;
 import play.twirl.api.Content;
 import services.MessageKey;
 import services.applicant.ApplicantPersonalInfo;
 import views.HtmlBundle;
-import views.admin.ti.TrustedIntermediaryGroupListView;
-import views.components.ToastMessage;
 import views.style.BaseStyles;
 import views.style.ReferenceClasses;
 
@@ -70,13 +66,7 @@ public class TrustedIntermediaryAccountSettingsView extends TrustedIntermediaryD
                         .withClass("px-20")))
             .addMainStyles("bg-white");
 
-    Http.Flash flash = request.flash();
-    if (flash.get("error").isPresent()) {
-      LoggerFactory.getLogger(TrustedIntermediaryGroupListView.class)
-          .info(request.flash().get(FlashKey.ERROR).get());
-      bundle.addToastMessages(
-          ToastMessage.errorNonLocalized(flash.get(FlashKey.ERROR).get()).setDuration(-1));
-    }
+    addToastMessagesOnError(bundle, request.flash(), this.getClass());
     return layout.renderWithNav(
         request, personalInfo, messages, bundle, Optional.of(currentTisApplicantId));
   }

--- a/server/app/views/applicant/TrustedIntermediaryClientListView.java
+++ b/server/app/views/applicant/TrustedIntermediaryClientListView.java
@@ -21,7 +21,6 @@ import com.google.i18n.phonenumbers.PhoneNumberUtil;
 import com.google.i18n.phonenumbers.Phonenumber;
 import com.google.inject.Inject;
 import com.typesafe.config.Config;
-import controllers.FlashKey;
 import controllers.ti.routes;
 import j2html.tags.specialized.ATag;
 import j2html.tags.specialized.DivTag;
@@ -51,10 +50,8 @@ import services.program.ProgramService;
 import services.ti.TrustedIntermediaryService;
 import views.HtmlBundle;
 import views.ViewUtils;
-import views.admin.ti.TrustedIntermediaryGroupListView;
 import views.components.Icons;
 import views.components.LinkElement;
-import views.components.ToastMessage;
 import views.style.BaseStyles;
 import views.style.ReferenceClasses;
 
@@ -108,13 +105,7 @@ public class TrustedIntermediaryClientListView extends TrustedIntermediaryDashbo
                     .withClasses("px-20"))
             .addMainStyles("bg-white");
 
-    Http.Flash flash = request.flash();
-    if (flash.get(FlashKey.ERROR).isPresent()) {
-      LoggerFactory.getLogger(TrustedIntermediaryGroupListView.class)
-          .info(request.flash().get(FlashKey.ERROR).get());
-      bundle.addToastMessages(
-          ToastMessage.errorNonLocalized(flash.get(FlashKey.ERROR).get()).setDuration(-1));
-    }
+    addToastMessagesOnError(bundle, request.flash(), this.getClass());
     return layout.renderWithNav(
         request, personalInfo, messages, bundle, Optional.of(currentTisApplicantId));
   }


### PR DESCRIPTION
### Description

This refactor removes duplicate code to setup toast messages in View classes by adding static helper methods in BaseHtmlView. 

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [x] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`

### Instructions for manual testing

This is a pure refactor and a basic manual testing of toast messages on all screens would suffice.

### Issue(s) this completes

Fixes #6593
