### PR TITLE
Skip test suite file.test.ts on Azure

### DIFF
--- a/browser-test/src/applicant/questions/file.test.ts
+++ b/browser-test/src/applicant/questions/file.test.ts
@@ -8,7 +8,7 @@ import {
 } from '../../support'
 import {BASE_URL} from '../../support/config'
 
-test.describe('file upload applicant flow', () => {
+test.describe('file upload applicant flow', {tag: ['@skip-on-azure']}, () => {
   test.beforeEach(async ({page}) => {
     await seedQuestions(page)
     await page.goto(BASE_URL)


### PR DESCRIPTION
### Description

Multi file upload tests do not work on Azure if Northstar is disabled.

Disable the tests in file.test.ts until Northstar is the only test suite.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [X] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [X] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [X] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [X] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [X] Created unit and/or browser tests which fail without the change (if possible)
- [X] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [X] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [X] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`

