### PR TITLE
Create TransactionManager helper class and wrap question creation

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -166,7 +166,7 @@ jobs:
           retention-days: 3
           path: browser-test/diff_output
 
-      # We only want updated snapshots for aws. Otherwise we'll hit conflicts if both aws and azure 
+      # We only want updated snapshots for aws. Otherwise we'll hit conflicts if both aws and azure
       # attempt to update the same images
       - name: Upload updated snapshots
         if: ${{ matrix.cloud == 'aws' && failure() }}
@@ -176,7 +176,7 @@ jobs:
           retention-days: 3
           path: browser-test/updated_snapshots
 
-      # Upload Playwright trace files and recorded videos. We want this for aws and azure so we 
+      # Upload Playwright trace files and recorded videos. We want this for aws and azure so we
       # have access to what happened in failed tests.
       - name: Upload test videos on failure
         if: failure()

--- a/server/app/repository/TransactionManager.java
+++ b/server/app/repository/TransactionManager.java
@@ -1,0 +1,65 @@
+package repository;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import io.ebean.DB;
+import io.ebean.SerializableConflictException;
+import io.ebean.Transaction;
+import io.ebean.TxScope;
+import io.ebean.annotation.TxIsolation;
+import java.util.function.Supplier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A class for managing workflows that span multiple repositories, but should still be wrapped in a
+ * transaction to prevent race conditions and data integrity errors.
+ *
+ * <p>See https://www.postgresql.org/docs/current/transaction-iso.html#XACT-SERIALIZABLE for details
+ * on transactions.
+ */
+public final class TransactionManager {
+  private static final Logger LOGGER = LoggerFactory.getLogger(TransactionManager.class);
+
+  /**
+   * Run the supplied code in a {@link TxIsolation.SERIALIZABLE} transaction, calling the failure
+   * handler if the transaction is rolled back due to a concurrent transaction.
+   *
+   * <p>Warning: This has not been tested with a supplier that does work asynchronously.
+   *
+   * <p>Notes:
+   *
+   * <ul>
+   *   <li>If there is already an active transaction, it will be used, and any changes won't be
+   *       committed until the outer transaction commits. Otherwise, a new transaction will be
+   *       created.
+   *   <li>If the transaction fails, any database changes will be rolled back, but any other side
+   *       effects from the provided functions will persist.
+   *   <li>If there is an outer transaction, it must have been created with a {@link TxScope} to
+   *       avoid a runtime casting error.
+   * </ul>
+   *
+   * @param synchronousWork the synchronous {@link Supplier} to run inside a transaction
+   * @param onSerializationFailure the {@link Supplier} to run in the event of a failure due to a
+   *     conflict with a concurrent transaction
+   * @param <T> the return type of the suppliers
+   */
+  public <T> T executeInTransaction(
+      Supplier<T> synchronousWork, Supplier<T> onSerializationFailure) {
+    checkNotNull(synchronousWork);
+    checkNotNull(onSerializationFailure);
+    try (Transaction transaction =
+        DB.beginTransaction(TxScope.required().setIsolation(TxIsolation.SERIALIZABLE))) {
+      T result = synchronousWork.get();
+      transaction.commit();
+      return result;
+    } catch (SerializableConflictException e) {
+      LOGGER.info(
+          String.format(
+              "Transaction wrapper prevented a race condition from causing data integrity errors:"
+                  + " %s.",
+              e.getMessage()));
+      return onSerializationFailure.get();
+    }
+  }
+}

--- a/server/app/services/question/QuestionService.java
+++ b/server/app/services/question/QuestionService.java
@@ -15,6 +15,7 @@ import models.QuestionModel;
 import models.QuestionTag;
 import models.VersionModel;
 import repository.QuestionRepository;
+import repository.TransactionManager;
 import repository.VersionRepository;
 import services.CiviFormError;
 import services.DeletionStatus;
@@ -33,16 +34,18 @@ import services.question.types.QuestionDefinition;
  * that can be collected for a given applicant across all programs.
  */
 public final class QuestionService {
-
   private final QuestionRepository questionRepository;
   private final Provider<VersionRepository> versionRepositoryProvider;
+  private final TransactionManager transactionManager;
 
   @Inject
   public QuestionService(
       QuestionRepository questionRepository,
-      Provider<VersionRepository> versionRepositoryProvider) {
+      Provider<VersionRepository> versionRepositoryProvider,
+      TransactionManager transactionManager) {
     this.questionRepository = checkNotNull(questionRepository);
     this.versionRepositoryProvider = checkNotNull(versionRepositoryProvider);
+    this.transactionManager = checkNotNull(transactionManager);
   }
 
   /**
@@ -55,19 +58,30 @@ public final class QuestionService {
    */
   public ErrorAnd<QuestionDefinition, CiviFormError> create(QuestionDefinition questionDefinition) {
     ImmutableSet<CiviFormError> validationErrors = questionDefinition.validate();
-    ImmutableSet<CiviFormError> conflictErrors = checkConflicts(questionDefinition);
-    ImmutableSet<CiviFormError> errors =
-        ImmutableSet.<CiviFormError>builder()
-            .addAll(validationErrors)
-            .addAll(conflictErrors)
-            .build();
-    if (!errors.isEmpty()) {
-      return ErrorAnd.error(errors);
-    }
-    QuestionModel question = new QuestionModel(questionDefinition);
-    question.addVersion(versionRepositoryProvider.get().getDraftVersionOrCreate());
-    questionRepository.insertQuestionSync(question);
-    return ErrorAnd.of(questionRepository.getQuestionDefinition(question));
+
+    return transactionManager.executeInTransaction(
+        /* synchronousWork */ () -> {
+          ImmutableSet<CiviFormError> conflictErrors = checkConflicts(questionDefinition);
+          ImmutableSet<CiviFormError> errors =
+              ImmutableSet.<CiviFormError>builder()
+                  .addAll(validationErrors)
+                  .addAll(conflictErrors)
+                  .build();
+          if (!errors.isEmpty()) {
+            return ErrorAnd.error(errors);
+          }
+          QuestionModel question = new QuestionModel(questionDefinition);
+          question.addVersion(versionRepositoryProvider.get().getDraftVersionOrCreate());
+          questionRepository.insertQuestionSync(question);
+          return ErrorAnd.of(question.getQuestionDefinition());
+        },
+        /* onSerializationFailure */ () -> {
+          return ErrorAnd.error(
+              ImmutableSet.of(
+                  CiviFormError.of(
+                      "A question with a conflicting admin name was created at the same time."
+                          + " Please try again")));
+        });
   }
 
   /**

--- a/server/test/repository/TransactionManagerTest.java
+++ b/server/test/repository/TransactionManagerTest.java
@@ -1,0 +1,186 @@
+package repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableSet;
+import io.ebean.DB;
+import io.ebean.SerializableConflictException;
+import io.ebean.Transaction;
+import io.ebean.TxScope;
+import io.ebean.annotation.TxIsolation;
+import java.util.function.Supplier;
+import models.AccountModel;
+import org.junit.Before;
+import org.junit.Test;
+import services.ErrorAnd;
+
+public class TransactionManagerTest extends ResetPostgres {
+
+  TransactionManager transactionManager;
+  AccountRepository accountRepo;
+
+  @Before
+  public void setUp() {
+    transactionManager = instanceOf(TransactionManager.class);
+    accountRepo = instanceOf(AccountRepository.class);
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void executeInTransaction_runsWorkSupplier() {
+    Supplier<String> mockWork = mock(Supplier.class);
+    when(mockWork.get()).thenReturn("work");
+    Supplier<String> mockOnFailure = mock(Supplier.class);
+    when(mockOnFailure.get()).thenReturn("onFailure");
+
+    transactionManager.executeInTransaction(mockWork, mockOnFailure);
+
+    verify(mockWork).get();
+    verify(mockOnFailure, times(0)).get();
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void executeInTransaction_runsFailureSupplier() {
+    Supplier<String> mockWork = mock(Supplier.class);
+    when(mockWork.get())
+        .thenThrow(
+            new SerializableConflictException("Simulate a concurrency issue", new Exception()));
+    Supplier<String> mockOnFailure = mock(Supplier.class);
+    when(mockOnFailure.get()).thenReturn("onFailure");
+
+    transactionManager.executeInTransaction(mockWork, mockOnFailure);
+
+    verify(mockWork).get();
+    verify(mockOnFailure).get();
+  }
+
+  @Test
+  public void executeInTransaction_modifiesEntitySuccessfully() {
+    AccountModel account = new AccountModel().setEmailAddress("initial@test.com");
+    account.insert();
+
+    Supplier<ErrorAnd<AccountModel, String>> modifyAccount =
+        () -> {
+          AccountModel accountToModify = accountRepo.lookupAccount(account.id).get();
+          accountToModify.setEmailAddress("updated@test.com");
+          accountToModify.save();
+          return ErrorAnd.of(accountToModify);
+        };
+    Supplier<ErrorAnd<AccountModel, String>> onFailure =
+        () -> ErrorAnd.error(ImmutableSet.of("error"));
+
+    ErrorAnd<AccountModel, String> result =
+        transactionManager.executeInTransaction(modifyAccount, onFailure);
+    account.refresh();
+
+    assertThat(result.hasResult()).isTrue();
+    assertThat(result.isError()).isFalse();
+    assertThat(account.getEmailAddress()).isEqualTo("updated@test.com");
+  }
+
+  @Test
+  public void executeInTransaction_rollsBackTransactionSuccessfully() {
+    AccountModel account = new AccountModel().setEmailAddress("initial@test.com");
+    account.insert();
+
+    Supplier<ErrorAnd<AccountModel, String>> modifyAccount =
+        () -> {
+          AccountModel accountToModify = accountRepo.lookupAccount(account.id).get();
+          accountToModify.setEmailAddress("updated@test.com");
+          accountToModify.save();
+          throw new SerializableConflictException("Simulate a concurrency issue", new Exception());
+        };
+    Supplier<ErrorAnd<AccountModel, String>> onFailure =
+        () -> ErrorAnd.error(ImmutableSet.of("error"));
+
+    ErrorAnd<AccountModel, String> result =
+        transactionManager.executeInTransaction(modifyAccount, onFailure);
+    account.refresh();
+
+    assertThat(result.hasResult()).isFalse();
+    assertThat(result.isError()).isTrue();
+    assertThat(account.getEmailAddress()).isEqualTo("initial@test.com");
+  }
+
+  /** Simulate when the work() supplier contains another transaction. */
+  @Test
+  public void executeInTransaction_transactionInsideSupplierRollsBackIfWrappedTransactionFails() {
+    Supplier<String> work =
+        () -> {
+          try (Transaction innerTransaction =
+              DB.beginTransaction(TxScope.required().setIsolation(TxIsolation.SERIALIZABLE))) {
+            new AccountModel().insert();
+            // Assert that from within this inner transaction, we see the new account
+            assertThat(DB.find(AccountModel.class).findCount()).isEqualTo(1);
+            innerTransaction.commit();
+          }
+
+          // Assert that, back in the outer transaction, we see the new account
+          assertThat(DB.find(AccountModel.class).findCount()).isEqualTo(1);
+          throw new SerializableConflictException("Simulate a concurrency issue", new Exception());
+        };
+
+    transactionManager.executeInTransaction(work, () -> "error");
+
+    // Outside of both transactions, everything should be rolled back.
+    assertThat(DB.find(AccountModel.class).findCount()).isEqualTo(0);
+  }
+
+  /** Simulate when we use the {@link TransactionManager} from inside another transaction. */
+  @Test
+  public void executeInTransaction_workInSupplierRollsBackIfOuterTransactionFails() {
+    Supplier<String> work =
+        () -> {
+          new AccountModel().insert();
+          // Assert that from within this inner transaction, we see the new account
+          assertThat(DB.find(AccountModel.class).findCount()).isEqualTo(1);
+          return "done";
+        };
+
+    try (Transaction outerTransaction =
+        DB.beginTransaction(TxScope.required().setIsolation(TxIsolation.SERIALIZABLE))) {
+      transactionManager.executeInTransaction(work, () -> "error");
+      // Assert that, back in the outer transaction, we see the new account
+      assertThat(DB.find(AccountModel.class).findCount()).isEqualTo(1);
+      outerTransaction.rollback();
+    }
+
+    // Outside of both transactions, everything should be rolled back.
+    assertThat(DB.find(AccountModel.class).findCount()).isEqualTo(0);
+  }
+
+  @Test
+  public void executeInTransaction_innerTransactionWithRequiresNewIsIndependent() {
+    Supplier<String> work =
+        () -> {
+          // Check initial number of accounts in the outer transaction's snapshot
+          assertThat(DB.find(AccountModel.class).findCount()).isEqualTo(0);
+
+          try (Transaction innerTransaction =
+              DB.beginTransaction(TxScope.requiresNew().setIsolation(TxIsolation.SERIALIZABLE))) {
+            new AccountModel().insert();
+
+            // Assert that from within this inner transaction, we see the new account
+            assertThat(DB.find(AccountModel.class).findCount()).isEqualTo(1);
+            innerTransaction.commit();
+          }
+
+          // Assert that, back in the outer transaction, we still see the original 0 accounts
+          // because we're working from an earlier snapshot.
+          assertThat(DB.find(AccountModel.class).findCount()).isEqualTo(0);
+          return "done";
+        };
+
+    transactionManager.executeInTransaction(work, () -> "error");
+
+    // Outside of both transactions, we should see the new account
+    assertThat(DB.find(AccountModel.class).findCount()).isEqualTo(1);
+  }
+}
+
+// what happens if the inner work is in a different thread?


### PR DESCRIPTION
### Description

Create a `TransactionManager` helper class and use it to wrap question creation flow in a transaction.

Note: I haven't tested that this works correctly with async flows. It probably doesn't because transactions are tracked on thread-local storage, and some repository methods use the DatabaseExecutionContext while other application code uses the ClassLoaderExecutionContext, and I don't know if the context is propagated between thread pools.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [x] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [x] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`

### Issue(s) this completes

Part of #9509
