### PR TITLE
Update HSTS filter to include subdomains

### DIFF
--- a/server/app/filters/HSTSFilter.java
+++ b/server/app/filters/HSTSFilter.java
@@ -26,7 +26,9 @@ public class HSTSFilter extends EssentialFilter {
             next.apply(request)
                 .map(
                     // https://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security
-                    result -> result.withHeader("Strict-Transport-Security", "max-age=31536000; includeSubDomains"),
+                    result ->
+                        result.withHeader(
+                            "Strict-Transport-Security", "max-age=31536000; includeSubDomains"),
                     exec));
   }
 }

--- a/server/app/filters/HSTSFilter.java
+++ b/server/app/filters/HSTSFilter.java
@@ -26,7 +26,7 @@ public class HSTSFilter extends EssentialFilter {
             next.apply(request)
                 .map(
                     // https://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security
-                    result -> result.withHeader("Strict-Transport-Security", "max-age=31536000"),
+                    result -> result.withHeader("Strict-Transport-Security", "max-age=31536000; includeSubDomains"),
                     exec));
   }
 }


### PR DESCRIPTION
### Description

The recommendations of HSTS are to include subdomains to ensure all requests are using HTTPS. This also means an automatic redirect, but with this inclusion of subdomains, cookies are not included in the request and only the play session is. This seems to mean that requests can't be sent to replay a session with different privledges


### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [ ] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [ ] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`

### Instructions for manual testing

Using blurp proxy - happy to show

### Issue(s) this completes

https://github.com/civiform/civiform/issues/6975