### PR TITLE
[North Star] Show program cards iff feature is enabled

### DIFF
--- a/browser-test/src/applicant/northstar_upsell.test.ts
+++ b/browser-test/src/applicant/northstar_upsell.test.ts
@@ -54,6 +54,10 @@ test.describe('Upsell tests', {tag: ['@northstar']}, () => {
 
     await enableFeatureFlag(page, 'north_star_applicant_ui')
     await enableFeatureFlag(page, 'application_exportable')
+    await enableFeatureFlag(
+      page,
+      'suggest_programs_on_application_confirmation_page',
+    )
 
     await test.step('Submit application', async () => {
       await applicantQuestions.clickApplyProgramButton(programName)
@@ -91,6 +95,35 @@ test.describe('Upsell tests', {tag: ['@northstar']}, () => {
         'Logged in as testuser@example.com',
       )
     })
+  })
+
+  test('view application submitted page with related program cards feature disabled', async ({
+    page,
+    adminPrograms,
+    applicantQuestions,
+  }) => {
+    // This test will only validate that no related programs are shown when the
+    // suggest_programs_on_application_confirmation_page flag is disabled
+    await createRelatedProgram(page, adminPrograms)
+    await loginAsTestUser(page)
+
+    await enableFeatureFlag(page, 'north_star_applicant_ui')
+    await enableFeatureFlag(page, 'application_exportable')
+    await disableFeatureFlag(
+      page,
+      'suggest_programs_on_application_confirmation_page',
+    )
+
+    await test.step('Submit application', async () => {
+      await applicantQuestions.clickApplyProgramButton(programName)
+      await applicantQuestions.clickSubmitApplication()
+    })
+
+    await validateApplicationSubmittedPage(
+      page,
+      /* expectRelatedProgram= */ false,
+      applicantQuestions,
+    )
   })
 
   test('view application submitted page while logged in without download link', async ({

--- a/server/app/views/applicant/ApplicantUpsellCreateAccountView.java
+++ b/server/app/views/applicant/ApplicantUpsellCreateAccountView.java
@@ -133,38 +133,34 @@ public final class ApplicantUpsellCreateAccountView extends ApplicantUpsellView 
     var htmlBundle =
         createHtmlBundle(request, layout, title, bannerMessage, loginPromptModal, content);
 
-    if (!settingsManifest.getSuggestProgramsOnApplicationConfirmationPage(request)) {
-      return layout.renderWithNav(
-          request, personalInfo, messages, htmlBundle, Optional.of(applicantId));
-    }
-
-    var relevantPrograms = applicantPrograms.unappliedAndPotentiallyEligible();
-
-    if (relevantPrograms.size() > 0) {
-      htmlBundle.addMainContent(
-          div()
-              .withClasses(ApplicantStyles.PROGRAM_CARDS_GRANDPARENT_CONTAINER)
-              .with(
-                  div()
-                      .withClasses(ApplicantStyles.PROGRAM_CARDS_PARENT_CONTAINER)
-                      .with(
-                          h2(messages.at(CONTENT_OTHER_PROGRAMS_TO_APPLY_FOR.getKeyName()))
-                              .withClasses("mb-4 font-bold"),
-                          programCardViewRenderer.programCardsSection(
-                              request,
-                              messages,
-                              personalInfo,
-                              /* sectionTitle= */ Optional.empty(),
-                              ProgramCardViewRenderer.programCardsContainerStyles(
-                                  relevantPrograms.size()),
-                              Optional.of(applicantId),
-                              locale,
-                              relevantPrograms,
-                              MessageKey.BUTTON_APPLY,
-                              MessageKey.BUTTON_APPLY_SR,
-                              htmlBundle,
-                              Optional.of(profile),
-                              /* isMyApplicationsSection= */ false))));
+    if (settingsManifest.getSuggestProgramsOnApplicationConfirmationPage(request)) {
+      var relevantPrograms = applicantPrograms.unappliedAndPotentiallyEligible();
+      if (relevantPrograms.size() > 0) {
+        htmlBundle.addMainContent(
+            div()
+                .withClasses(ApplicantStyles.PROGRAM_CARDS_GRANDPARENT_CONTAINER)
+                .with(
+                    div()
+                        .withClasses(ApplicantStyles.PROGRAM_CARDS_PARENT_CONTAINER)
+                        .with(
+                            h2(messages.at(CONTENT_OTHER_PROGRAMS_TO_APPLY_FOR.getKeyName()))
+                                .withClasses("mb-4 font-bold"),
+                            programCardViewRenderer.programCardsSection(
+                                request,
+                                messages,
+                                personalInfo,
+                                /* sectionTitle= */ Optional.empty(),
+                                ProgramCardViewRenderer.programCardsContainerStyles(
+                                    relevantPrograms.size()),
+                                Optional.of(applicantId),
+                                locale,
+                                relevantPrograms,
+                                MessageKey.BUTTON_APPLY,
+                                MessageKey.BUTTON_APPLY_SR,
+                                htmlBundle,
+                                Optional.of(profile),
+                                /* isMyApplicationsSection= */ false))));
+      }
     }
 
     return layout.renderWithNav(

--- a/server/app/views/applicant/ApplicantUpsellTemplate.html
+++ b/server/app/views/applicant/ApplicantUpsellTemplate.html
@@ -117,7 +117,7 @@
         </div>
         <div class="section-internal">
           <div
-            th:replace="~{applicant/ProgramCardsSectionFragment :: cardsSection(${cardsSection})}"
+            th:replace="~{applicant/ProgramCardsSectionFragment :: cardsSection(${cardsSection.get()})}"
           ></div>
         </div>
       </section>

--- a/server/app/views/applicant/NorthStarApplicantUpsellView.java
+++ b/server/app/views/applicant/NorthStarApplicantUpsellView.java
@@ -93,20 +93,24 @@ public class NorthStarApplicantUpsellView extends NorthStarBaseView {
     context.setVariable("createAccountLink", controllers.routes.LoginController.register().url());
 
     // Cards section
-    ProgramSectionParams cardsSection =
-        programCardsSectionParamsFactory.getSection(
-            params.request(),
-            params.messages(),
-            Optional.empty(),
-            MessageKey.BUTTON_VIEW_AND_APPLY,
-            params.eligiblePrograms().get(),
-            /* preferredLocale= */ params.messages().lang().toLocale(),
-            Optional.of(params.profile()),
-            Optional.of(params.applicantId()),
-            params.applicantPersonalInfo(),
-            ProgramCardsSectionParamsFactory.SectionType.STANDARD);
+    Optional<ProgramSectionParams> cardsSection = Optional.empty();
+    if (settingsManifest.getSuggestProgramsOnApplicationConfirmationPage(params.request())) {
+      cardsSection =
+          Optional.of(
+              programCardsSectionParamsFactory.getSection(
+                  params.request(),
+                  params.messages(),
+                  Optional.empty(),
+                  MessageKey.BUTTON_VIEW_AND_APPLY,
+                  params.eligiblePrograms().get(),
+                  /* preferredLocale= */ params.messages().lang().toLocale(),
+                  Optional.of(params.profile()),
+                  Optional.of(params.applicantId()),
+                  params.applicantPersonalInfo(),
+                  ProgramCardsSectionParamsFactory.SectionType.STANDARD));
+    }
     context.setVariable("cardsSection", cardsSection);
-    context.setVariable("showProgramsCardsSection", cardsSection.cards().size() > 0);
+    context.setVariable("showProgramsCardsSection", cardsSection.get().cards().size() > 0);
 
     return templateEngine.process("applicant/ApplicantUpsellTemplate", context);
   }

--- a/server/app/views/applicant/NorthStarApplicantUpsellView.java
+++ b/server/app/views/applicant/NorthStarApplicantUpsellView.java
@@ -110,7 +110,9 @@ public class NorthStarApplicantUpsellView extends NorthStarBaseView {
                   ProgramCardsSectionParamsFactory.SectionType.STANDARD));
     }
     context.setVariable("cardsSection", cardsSection);
-    context.setVariable("showProgramsCardsSection", cardsSection.get().cards().size() > 0);
+    context.setVariable(
+        "showProgramsCardsSection",
+        cardsSection.isPresent() && cardsSection.get().cards().size() > 0);
 
     return templateEngine.process("applicant/ApplicantUpsellTemplate", context);
   }


### PR DESCRIPTION
### Description

Only show program cards in the `ApplicantUpsell` page after submission of a program when the SUGGEST_PROGRAMS_ON_CONFIRMATION_PAGE feature is enabled for North Star.

Previously, we would only check for SUGGEST_PROGRAMS_ON_CONFIRMATION_PAGE when not using North Star.

### Checklist

#### General
- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [n/a] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [n/a] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`

#### User visible changes

- [n/a] Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
  - [n/a] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [n/a] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [n/a] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [n/a] Made equivalent changes in Thymeleaf for applicant-facing features and changes (or created an issue in the [Northstar epic](https://github.com/orgs/civiform/projects/1/views/94) to track that it's missing from Thymeleaf)
- [x] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [x] Manually tested at 200% size
- [ ] Manually evaluated tab order
- [x] Manually tested with a screen reader if the feature is applicant-facing. See [screen reader testing](https://github.com/civiform/civiform/wiki/Testing#screen-reader-testing)

#### New Features

- [n/a] Add new FeatureFlag env vars to `server/conf/helper/feature-flags.conf`
- [n/a] Conditioned new functionality on a [FeatureFlag](https://github.com/civiform/civiform/wiki/Feature-Flags)
- [x] Wrote browser tests with the feature flag off and on, etc.

### Instructions for manual testing
1. Log in to CiviForm as an admin
2. Add two basic programs
3. Enable NORTH_STAR_APPLICANT_UI and SUGGEST_PROGRAMS_ON_APPLICATION_CONFIRMATION_PAGE flags
4. Log out of CiviForm as an admin
5. As an applicant, apply for the first program. After submitting, verify `ApplicantUpsell` page has program cards on the bottom
6. Log in to CiviForm as an admin
7. Disable SUGGEST_PROGRAMS_ON_APPLICATION_CONFIRMATION_PAGE flag
8. As an applicant, re-apply for the first program. After submitting, verify `ApplicantUpsell` page doesn't have program cards on the bottom

### Issue(s) this completes

Fixes #9631
