### PR TITLE
Revert "Fix AWS Multifile Upload Bug (#9629)"

### DIFF
--- a/server/app/controllers/applicant/ApplicantProgramBlocksController.java
+++ b/server/app/controllers/applicant/ApplicantProgramBlocksController.java
@@ -591,15 +591,36 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
                   new ImmutableMap.Builder<>();
               Optional<ImmutableList<String>> keysOptional =
                   fileUploadQuestion.getFileKeyListValue();
+              Optional<ImmutableList<String>> originalFileNamesOptional =
+                  fileUploadQuestion.getOriginalFileNameListValue();
+
+              int fileKeyIndexRemoved = -1;
 
               if (keysOptional.isPresent()) {
                 ImmutableList<String> keys = keysOptional.get();
                 // Write all existing keys back to the form data, except the one we want to delete.
                 for (int i = 0; i < keys.size(); i++) {
                   String keyValue = keys.get(i);
+                  boolean removeKey = false;
+                  if (keyValue.equals(fileKeyToRemove)) {
+                    removeKey = true;
+                    fileKeyIndexRemoved = i;
+                  }
                   fileUploadQuestionFormData.put(
                       fileUploadQuestion.getFileKeyListPathForIndex(i).toString(),
-                      !keyValue.equals(fileKeyToRemove) ? keyValue : "");
+                      removeKey ? "" : keyValue);
+                }
+              }
+
+              if (originalFileNamesOptional.isPresent() && (fileKeyIndexRemoved >= 0)) {
+                // Write all existing original file names back to the form data, except the one
+                // that was removed from the file keys list.
+                ImmutableList<String> originalFileNames = originalFileNamesOptional.get();
+                for (int i = 0; i < originalFileNames.size(); i++) {
+                  String originalFileNameValue = originalFileNames.get(i);
+                  fileUploadQuestionFormData.put(
+                      fileUploadQuestion.getOriginalFileNameListPathForIndex(i).toString(),
+                      i == fileKeyIndexRemoved ? "" : originalFileNameValue);
                 }
               }
 
@@ -686,6 +707,14 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
               Optional<String> bucket = request.queryString("bucket");
               Optional<String> key = request.queryString("key");
 
+              // Original file name is only set for Azure, where we have to generate a UUID when
+              // uploading a file to Azure Blob storage because we cannot upload a file without a
+              // name. For AWS, the file key and original file name are the same. For the future,
+              // GCS supports POST uploads so this field won't be needed either:
+              // <link> https://cloud.google.com/storage/docs/xml-api/post-object-forms </link>
+              // This is only really needed for Azure blob storage.
+              Optional<String> originalFileName = request.queryString("originalFileName");
+
               if (bucket.isEmpty() || key.isEmpty()) {
                 return failedFuture(
                     new IllegalArgumentException("missing file key and bucket names"));
@@ -702,6 +731,8 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
                   new ImmutableMap.Builder<>();
               Optional<ImmutableList<String>> keysOptional =
                   fileUploadQuestion.getFileKeyListValue();
+              Optional<ImmutableList<String>> originalFileNamesOptional =
+                  fileUploadQuestion.getOriginalFileNameListValue();
 
               if (keysOptional.isPresent()) {
                 ImmutableList<String> keys = keysOptional.get();
@@ -748,7 +779,40 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
                     fileUploadQuestion.getFileKeyListPathForIndex(0).toString(), key.get());
               }
 
-              return ensureFileRecord(key.get(), Optional.empty())
+              // Original file names are only set for Azure deployments, when the form contains
+              // the original file name field. The value will be stored in the file record.
+              if (originalFileName.isPresent()) {
+                // If there are no originalFileNames in the question data, we don't need to append.
+                if (originalFileNamesOptional.isPresent()) {
+                  ImmutableList<String> orignalFileNames = originalFileNamesOptional.get();
+
+                  // Write the existing filenames so that we don't delete any.
+                  for (int i = 0; i < orignalFileNames.size(); i++) {
+                    String originalFileNameValue = orignalFileNames.get(i);
+                    fileUploadQuestionFormData.put(
+                        fileUploadQuestion.getOriginalFileNameListPathForIndex(i).toString(),
+                        originalFileNameValue);
+                    // We do not need to check if this original file name already exists.
+                    // Original file names are stored in the record and not used to reference the
+                    // file in storage, so collisions in the names do not affect the application.
+                    //
+                    // The actual file key is a UID in this case, and we've already checked for
+                    // key collisions above.
+                  }
+
+                  fileUploadQuestionFormData.put(
+                      fileUploadQuestion
+                          .getOriginalFileNameListPathForIndex(orignalFileNames.size())
+                          .toString(),
+                      originalFileName.get());
+                } else {
+                  fileUploadQuestionFormData.put(
+                      fileUploadQuestion.getOriginalFileNameListPathForIndex(0).toString(),
+                      originalFileName.get());
+                }
+              }
+
+              return ensureFileRecord(key.get(), originalFileName)
                   .thenComposeAsync(
                       (StoredFileModel unused) ->
                           applicantService.stageAndUpdateIfValid(

--- a/server/app/services/applicant/ReadOnlyApplicantProgramService.java
+++ b/server/app/services/applicant/ReadOnlyApplicantProgramService.java
@@ -467,8 +467,12 @@ public final class ReadOnlyApplicantProgramService {
 
           if (fileUploadQuestion.getFileKeyListValue().isPresent()) {
             ImmutableList<String> fileKeys = fileUploadQuestion.getFileKeyListValue().get();
+            ImmutableList<String> originalFileNames =
+                fileUploadQuestion.getOriginalFileNameListValue().get();
             fileNames =
-                fileKeys.stream().map(FileUploadQuestion::getFileName).collect(toImmutableList());
+                originalFileNames.stream()
+                    .map(FileUploadQuestion::getFileName)
+                    .collect(toImmutableList());
             encodedFileKeys =
                 fileKeys.stream()
                     .map((fileKey) -> URLEncoder.encode(fileKey, StandardCharsets.UTF_8))

--- a/server/app/services/question/QuestionAnswerer.java
+++ b/server/app/services/question/QuestionAnswerer.java
@@ -73,18 +73,40 @@ public final class QuestionAnswerer {
     applicantData.putString(contextualizedPath.join(Scalar.FILE_KEY), fileKey);
   }
 
+  // Will set the given file key in the applicant data under the FILE_KEY_LIST scalar.
   public static void answerFileQuestionWithMultipleUpload(
       ApplicantData applicantData, Path contextualizedPath, int index, String fileKey) {
     applicantData.putString(
         contextualizedPath.join(Scalar.FILE_KEY_LIST + Path.ARRAY_SUFFIX).atIndex(index), fileKey);
   }
 
+  // Will set the given file keys in the applicant data under the FILE_KEY_LIST scalar.
   public static void answerFileQuestionWithMultipleUpload(
       ApplicantData applicantData, Path contextualizedPath, ImmutableList<String> fileKeys) {
     for (int i = 0; i < fileKeys.size(); i++) {
       applicantData.putString(
           contextualizedPath.join(Scalar.FILE_KEY_LIST + Path.ARRAY_SUFFIX).atIndex(i),
           fileKeys.get(i));
+    }
+  }
+
+  // Will set the given original file name in the applicant data under the ORIGINAL_FILE_NAME_LIST
+  // scalar.
+  public static void answerFileQuestionWithMultipleUploadOriginalNames(
+      ApplicantData applicantData, Path contextualizedPath, int index, String originalName) {
+    applicantData.putString(
+        contextualizedPath.join(Scalar.ORIGINAL_FILE_NAME_LIST + Path.ARRAY_SUFFIX).atIndex(index),
+        originalName);
+  }
+
+  // Will set the given original file names in the applicant data under the ORIGINAL_FILE_NAME_LIST
+  // scalar.
+  public static void answerFileQuestionWithMultipleUploadOriginalNames(
+      ApplicantData applicantData, Path contextualizedPath, ImmutableList<String> originalNames) {
+    for (int i = 0; i < originalNames.size(); i++) {
+      applicantData.putString(
+          contextualizedPath.join(Scalar.ORIGINAL_FILE_NAME_LIST + Path.ARRAY_SUFFIX).atIndex(i),
+          originalNames.get(i));
     }
   }
 

--- a/server/app/views/applicant/ApplicantProgramFileUploadBlockEditTemplate.html
+++ b/server/app/views/applicant/ApplicantProgramFileUploadBlockEditTemplate.html
@@ -66,11 +66,11 @@
                 class="grid"
               >
                 <li
-                  th:each="fileKey: ${fileUploadQuestion.getFileKeyListValue().get()}"
+                  th:each="fileKey, iter: ${fileUploadQuestion.getFileKeyListValue().get()}"
                   class="grid-row margin-y-1"
                 >
                   <span
-                    th:text="${fileUploadViewStrategy.getFileName(fileKey)}"
+                    th:text="${fileUploadViewStrategy.getFileName(fileUploadQuestion.getOriginalFileNameValueForIndex(iter.index).get())}"
                     class="overflow-hidden grid-col flex-fill"
                   ></span>
                   <a

--- a/server/test/controllers/applicant/ApplicantProgramBlocksControllerTest.java
+++ b/server/test/controllers/applicant/ApplicantProgramBlocksControllerTest.java
@@ -2096,7 +2096,10 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
             .call(
                 routes.ApplicantProgramBlocksController.addFileWithApplicantId(
                     applicant.id, program.id, /* blockId= */ "1", /* inReview= */ false));
-    addQueryString(request, ImmutableMap.of("key", "fake-key", "bucket", "fake-bucket"));
+    addQueryString(
+        request,
+        ImmutableMap.of(
+            "key", "fake-key", "bucket", "fake-bucket", "originalFileName", "fake-file-name"));
 
     Result result =
         subject
@@ -2115,7 +2118,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
 
     applicant.refresh();
     String applicantData = applicant.getApplicantData().asJsonString();
-    assertThat(applicantData).contains("fake-key");
+    assertThat(applicantData).contains("fake-key", "fake-file-name");
   }
 
   @Test
@@ -2201,7 +2204,10 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
             .call(
                 routes.ApplicantProgramBlocksController.addFileWithApplicantId(
                     applicant.id, program.id, /* blockId= */ "1", /* inReview= */ false));
-    addQueryString(requestOne, ImmutableMap.of("key", "keyOne", "bucket", "fake-bucket"));
+    addQueryString(
+        requestOne,
+        ImmutableMap.of(
+            "key", "keyOne", "bucket", "fake-bucket", "originalFileName", "fileNameOne"));
 
     subject
         .addFileWithApplicantId(
@@ -2214,7 +2220,10 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
             .call(
                 routes.ApplicantProgramBlocksController.addFileWithApplicantId(
                     applicant.id, program.id, /* blockId= */ "1", /* inReview= */ false));
-    addQueryString(requestTwo, ImmutableMap.of("key", "keyTwo", "bucket", "fake-bucket"));
+    addQueryString(
+        requestTwo,
+        ImmutableMap.of(
+            "key", "keyTwo", "bucket", "fake-bucket", "originalFileName", "fileNameTwo"));
 
     subject
         .addFileWithApplicantId(
@@ -2224,8 +2233,8 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
 
     applicant.refresh();
     String applicantData = applicant.getApplicantData().asJsonString();
-    assertThat(applicantData).contains("keyOne");
-    assertThat(applicantData).contains("keyTwo");
+    assertThat(applicantData).contains("keyOne", "fileNameOne");
+    assertThat(applicantData).contains("keyTwo", "fileNameTwo");
 
     // Assert that corresponding entries were created in the stored file repo.
     var storedFileRepo = instanceOf(StoredFileRepository.class);
@@ -2590,6 +2599,63 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     String applicantDataString = applicant.getApplicantData().asJsonString();
     assertThat(applicantDataString).contains("file-key-1", "file-key-2");
     assertThat(applicantDataString).doesNotContain("key-to-remove");
+  }
+
+  @Test
+  public void removeFile_removesFileWithOriginalNamesAndRerenders() {
+    program =
+        ProgramBuilder.newActiveProgram()
+            .withBlock("block 1")
+            .withRequiredQuestion(testQuestionBank().fileUploadApplicantFile())
+            .build();
+
+    QuestionAnswerer.answerFileQuestionWithMultipleUpload(
+        applicant.getApplicantData(),
+        ApplicantData.APPLICANT_PATH.join(
+            testQuestionBank()
+                .fileUploadApplicantFile()
+                .getQuestionDefinition()
+                .getQuestionPathSegment()),
+        ImmutableList.of("file-key-1", "key-to-remove", "file-key-2"));
+
+    QuestionAnswerer.answerFileQuestionWithMultipleUploadOriginalNames(
+        applicant.getApplicantData(),
+        ApplicantData.APPLICANT_PATH.join(
+            testQuestionBank()
+                .fileUploadApplicantFile()
+                .getQuestionDefinition()
+                .getQuestionPathSegment()),
+        ImmutableList.of("file-name-1", "key-name-to-remove", "file-name-2"));
+
+    applicant.save();
+
+    RequestBuilder request =
+        fakeRequestBuilder()
+            .call(
+                routes.ApplicantProgramBlocksController.removeFile(
+                    program.id,
+                    /* blockId= */ "1",
+                    /* fileKey= */ "key-to-remove",
+                    /* inReview= */ false));
+
+    Result result =
+        subject
+            .removeFile(
+                request.build(),
+                program.id,
+                /* blockId= */ "1",
+                /* fileKey= */ "key-to-remove",
+                /* inReview= */ false)
+            .toCompletableFuture()
+            .join();
+
+    assertThat(result.status()).isEqualTo(SEE_OTHER);
+
+    applicant.refresh();
+    String applicantDataString = applicant.getApplicantData().asJsonString();
+    assertThat(applicantDataString)
+        .contains("file-key-1", "file-key-2", "file-name-1", "file-name-2");
+    assertThat(applicantDataString).doesNotContain("key-to-remove", "file-name-to-remove");
   }
 
   @Test

--- a/server/test/services/applicant/ReadOnlyApplicantProgramServiceTest.java
+++ b/server/test/services/applicant/ReadOnlyApplicantProgramServiceTest.java
@@ -1328,6 +1328,44 @@ public class ReadOnlyApplicantProgramServiceTest extends ResetPostgres {
   }
 
   @Test
+  public void getSummaryDataOnlyActive_returnsFileNamesForUploadedFiles() {
+    // Create a program with a fileupload question and a non-fileupload question
+    QuestionDefinition fileUploadQuestionDefinition =
+        testQuestionBank.fileUploadApplicantFile().getQuestionDefinition();
+    programDefinition =
+        ProgramBuilder.newDraftProgram("My Program")
+            .withBlock("Block one")
+            .withRequiredQuestionDefinition(nameQuestion)
+            .withRequiredQuestionDefinition(fileUploadQuestionDefinition)
+            .buildDefinition();
+    // Answer the questions
+    answerNameQuestion(programDefinition.id());
+    QuestionAnswerer.answerFileQuestionWithMultipleUpload(
+        applicantData,
+        ApplicantData.APPLICANT_PATH.join(fileUploadQuestionDefinition.getQuestionPathSegment()),
+        ImmutableList.of("file-key-1", "file-key-2"));
+    QuestionAnswerer.answerFileQuestionWithMultipleUploadOriginalNames(
+        applicantData,
+        ApplicantData.APPLICANT_PATH.join(fileUploadQuestionDefinition.getQuestionPathSegment()),
+        ImmutableList.of("file-name-1", "file-name-2"));
+
+    // Test the summary data
+    ReadOnlyApplicantProgramService subject =
+        new ReadOnlyApplicantProgramService(
+            jsonPathPredicateGeneratorFactory, applicant, applicantData, programDefinition);
+    ImmutableList<AnswerData> result = subject.getSummaryDataOnlyActive();
+
+    assertThat(result).hasSize(2);
+    // The file set will be returned (as expected)
+    assertThat(result.get(0).encodedFileKeys()).isEmpty();
+    assertThat(result.get(1).encodedFileKeys()).containsExactly("file-key-1", "file-key-2");
+
+    // The set original filenames will be returned (instead of the filekeys)
+    assertThat(result.get(0).fileNames()).isEmpty();
+    assertThat(result.get(1).fileNames()).containsExactly("file-name-1", "file-name-2");
+  }
+
+  @Test
   @Parameters({"5, true", "1, false"})
   public void getSummaryDataOnlyActive_isEligible(long answer, boolean expectedResult) {
     // Create a program with an eligibility condition == 5 and answer it with different values.

--- a/server/test/services/applicant/question/FileUploadQuestionTest.java
+++ b/server/test/services/applicant/question/FileUploadQuestionTest.java
@@ -1,6 +1,7 @@
 package services.applicant.question;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertFalse;
 
 import com.google.common.collect.ImmutableList;
 import java.util.Locale;
@@ -83,6 +84,47 @@ public class FileUploadQuestionTest extends ResetPostgres {
     assertThat(fileUploadQuestion.getFileKeyValueForIndex(0).get()).isEqualTo("filekey1");
     assertThat(fileUploadQuestion.getFileKeyValueForIndex(1).get()).isEqualTo("filekey2");
     assertThat(fileUploadQuestion.getValidationErrors()).isEmpty();
+  }
+
+  @Test
+  public void getOriginalFileName_multiFile_notAnswered_returnsNotPresent() {
+    ApplicantQuestion applicantQuestion =
+        new ApplicantQuestion(
+            fileUploadQuestionDefinition, applicant, applicantData, Optional.empty());
+
+    FileUploadQuestion fileUploadQuestion = new FileUploadQuestion(applicantQuestion);
+    assertFalse(fileUploadQuestion.getOriginalFileNameListValue().isPresent());
+    assertFalse(fileUploadQuestion.getOriginalFileNameValueForIndex(0).isPresent());
+  }
+
+  @Test
+  public void getOriginalFileName_multiFile_emptyAnswer_returnsNotPresent() {
+    ApplicantQuestion applicantQuestion =
+        new ApplicantQuestion(
+            fileUploadQuestionDefinition, applicant, applicantData, Optional.empty());
+
+    FileUploadQuestion fileUploadQuestion = new FileUploadQuestion(applicantQuestion);
+    QuestionAnswerer.answerFileQuestionWithMultipleUploadOriginalNames(
+        applicantData, applicantQuestion.getContextualizedPath(), ImmutableList.of(""));
+    assertFalse(fileUploadQuestion.getOriginalFileNameListValue().isPresent());
+    assertFalse(fileUploadQuestion.getOriginalFileNameValueForIndex(0).isPresent());
+  }
+
+  @Test
+  public void getOriginalFileName_multiFile() {
+    ApplicantQuestion applicantQuestion =
+        new ApplicantQuestion(
+            fileUploadQuestionDefinition, applicant, applicantData, Optional.empty());
+
+    FileUploadQuestion fileUploadQuestion = new FileUploadQuestion(applicantQuestion);
+    QuestionAnswerer.answerFileQuestionWithMultipleUploadOriginalNames(
+        applicantData,
+        applicantQuestion.getContextualizedPath(),
+        ImmutableList.of("filename1", "filename2"));
+    assertThat(fileUploadQuestion.getOriginalFileNameListValue().get())
+        .containsExactly("filename1", "filename2");
+    assertThat(fileUploadQuestion.getOriginalFileNameValueForIndex(0).get()).isEqualTo("filename1");
+    assertThat(fileUploadQuestion.getOriginalFileNameValueForIndex(1).get()).isEqualTo("filename2");
   }
 
   @Test


### PR DESCRIPTION
This reverts commit 523ada102b5846fde838dba68cc39df18c0ae4a8.

### Description

Please explain the changes you made here.

## Release notes

Remove this section if the title of the pull request can be used as the default release notes description. If more detail is needed to communicate to partners the scope of the PR's changes, use this release notes section (and remove this placeholder text).

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [ ] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [ ] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`

#### Database evolutions

Read the guidelines [here](https://github.com/civiform/civiform/wiki/Database#writing-database-evolutions)

- [ ] Assigned two reviewers
- [ ] Guarded against already existing resources using `IF NOT EXISTS` and `IF EXISTS`
- [ ] Downs created to undo changes in Ups
- [ ] Every comment in script should begin with -- and not # --- unless it denotes Ups or Downs. See [here](https://www.playframework.com/documentation/2.9.x/Evolutions) for details.
- [ ] Tested both the Downs and the Ups scripts manually (When testing, include all comments from the evolution in your test script to ensure any syntax errors in the comments are caught.)
- [ ] Data migrations aren't being done (please use a [Durable Job](https://github.com/civiform/civiform/wiki/Database#durable-jobs-for-data-updates) if doing a data migration)
- [ ] Update the model documentation in our [wiki](https://github.com/civiform/civiform/wiki/Database) if necessary

#### Durable jobs

Read the docs [here](https://github.com/civiform/civiform/wiki/Database#durable-jobs-for-data-updates)

- [ ] Assigned two reviewers
- [ ] Included a rollback plan and a job to undo the data changes if appropriate

#### User visible changes

- [ ] Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
  - [ ] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [ ] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Made equivalent changes in Thymeleaf for applicant-facing features and changes (or created an issue in the [Northstar epic](https://github.com/orgs/civiform/projects/1/views/94) to track that it's missing from Thymeleaf)
- [ ] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order
- [ ] Manually tested with a screen reader if the feature is applicant-facing. See [screen reader testing](https://github.com/civiform/civiform/wiki/Testing#screen-reader-testing)

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/helper/feature-flags.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://github.com/civiform/civiform/wiki/Feature-Flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Instructions for manual testing

If instructions are needed for manual testing by reviewers, include them here.

### Issue(s) this completes

Fixes #<issue_number>; Fixes #<issue_number>...
