### PR TITLE
Handle draft only program in program disabled action

### DIFF
--- a/server/app/actions/ProgramDisabledAction.java
+++ b/server/app/actions/ProgramDisabledAction.java
@@ -35,12 +35,20 @@ public class ProgramDisabledAction extends Action.Simple {
   }
 
   private boolean programIsDisabled(String programSlug) {
-    ProgramDefinition programDefiniton =
-        programService
-            .getActiveFullProgramDefinitionAsync(programSlug)
-            .toCompletableFuture()
-            .join();
-    return programDefiniton.displayMode() == DisplayMode.DISABLED;
+    try {
+      ProgramDefinition programDefiniton =
+          programService
+              .getActiveFullProgramDefinitionAsync(programSlug)
+              .toCompletableFuture()
+              .join();
+
+      return programDefiniton.displayMode() == DisplayMode.DISABLED;
+    } catch (RuntimeException e) {
+      // No active program was found. Return false here on error and
+      // let the rest of the application take over to handle programs
+      // that are missing or only have a draft version
+      return false;
+    }
   }
 
   private ProgramDefinition getProgram(long programId) {

--- a/server/test/actions/ProgramDisabledActionTest.java
+++ b/server/test/actions/ProgramDisabledActionTest.java
@@ -217,7 +217,7 @@ public class ProgramDisabledActionTest extends ResetPostgres {
   }
 
   @Test
-  public void testProgramOnlyHasDraftVersion_whenFastForwardIsDisabled() {
+  public void testProgramOnlyHasDraftVersion_whenFastForwardIsEnabled() {
     ProgramModel program = createProgram(DisplayMode.DISABLED, LifecycleStage.DRAFT);
 
     Request request =

--- a/server/test/actions/ProgramDisabledActionTest.java
+++ b/server/test/actions/ProgramDisabledActionTest.java
@@ -14,14 +14,16 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import models.ApplicationStep;
 import models.DisplayMode;
+import models.LifecycleStage;
 import models.ProgramModel;
+import models.VersionModel;
 import org.junit.Test;
 import org.mockito.Mockito;
 import play.mvc.Action;
 import play.mvc.Http.Request;
 import play.mvc.Result;
 import play.routing.Router;
-import play.test.WithApplication;
+import repository.ResetPostgres;
 import repository.VersionRepository;
 import services.LocalizedStrings;
 import services.program.BlockDefinition;
@@ -29,8 +31,8 @@ import services.program.ProgramService;
 import services.program.ProgramType;
 import services.settings.SettingsManifest;
 
-public class ProgramDisabledActionTest extends WithApplication {
-  private ProgramModel createProgram(DisplayMode displayMode) {
+public class ProgramDisabledActionTest extends ResetPostgres {
+  private ProgramModel createProgram(DisplayMode displayMode, LifecycleStage lifecycleStage) {
     BlockDefinition emptyFirstBlock =
         BlockDefinition.builder()
             .setId(1)
@@ -41,6 +43,10 @@ public class ProgramDisabledActionTest extends WithApplication {
             .build();
 
     VersionRepository versionRepository = instanceOf(VersionRepository.class);
+    VersionModel version =
+        lifecycleStage == LifecycleStage.DRAFT
+            ? versionRepository.getDraftVersionOrCreate()
+            : versionRepository.getActiveVersion();
 
     ProgramModel program =
         new ProgramModel(
@@ -54,7 +60,7 @@ public class ProgramDisabledActionTest extends WithApplication {
             /* displayMode */ displayMode.getValue(),
             /* notificationPreferences */ ImmutableList.of(),
             /* blockDefinitions */ ImmutableList.of(emptyFirstBlock),
-            /* associatedVersion */ versionRepository.getActiveVersion(),
+            /* associatedVersion */ version,
             /* programType */ ProgramType.DEFAULT,
             /* eligibilityIsGating= */ true,
             /* ProgramAcls */ new ProgramAcls(),
@@ -87,8 +93,33 @@ public class ProgramDisabledActionTest extends WithApplication {
   }
 
   @Test
+  public void testProgramOnlyHasDraftVersion_whenFastForwardIsDisabled() {
+    ProgramModel program = createProgram(DisplayMode.DISABLED, LifecycleStage.DRAFT);
+
+    Request request =
+        fakeRequestBuilder()
+            .flash(Map.of(FlashKey.REDIRECTED_FROM_PROGRAM_SLUG, program.getSlug()))
+            .build();
+
+    SettingsManifest mockSettingsManifest = Mockito.mock(SettingsManifest.class);
+    when(mockSettingsManifest.getFastforwardEnabled(request)).thenReturn(false);
+
+    ProgramDisabledAction action =
+        new ProgramDisabledAction(instanceOf(ProgramService.class), mockSettingsManifest);
+
+    // Set up a mock for the delegate action
+    Action.Simple delegateMock = mock(Action.Simple.class);
+    when(delegateMock.call(request)).thenReturn(CompletableFuture.completedFuture(null));
+    action.delegate = delegateMock;
+    Result result = action.call(request).toCompletableFuture().join();
+
+    // Verify that the delegate action was called
+    assertNull(result);
+  }
+
+  @Test
   public void testDisabledProgramFromFlashKey_whenFastForwardIsDisabled() {
-    ProgramModel program = createProgram(DisplayMode.DISABLED);
+    ProgramModel program = createProgram(DisplayMode.DISABLED, LifecycleStage.ACTIVE);
 
     Request request =
         fakeRequestBuilder()
@@ -111,7 +142,7 @@ public class ProgramDisabledActionTest extends WithApplication {
 
   @Test
   public void testDisabledProgramFromUriPathProgramId_whenFastForwardIsDisabled() {
-    ProgramModel program = createProgram(DisplayMode.PUBLIC);
+    ProgramModel program = createProgram(DisplayMode.PUBLIC, LifecycleStage.ACTIVE);
 
     var routePattern =
         "/programs/$programId<[^/]+>/applicant/$applicantId<[^/]+>/blocks/$blockId<[^/]+>/edit";
@@ -142,7 +173,7 @@ public class ProgramDisabledActionTest extends WithApplication {
 
   @Test
   public void testNonDisabledProgram_whenFastForwardIsDisabled() {
-    ProgramModel program = createProgram(DisplayMode.PUBLIC);
+    ProgramModel program = createProgram(DisplayMode.PUBLIC, LifecycleStage.ACTIVE);
 
     Request request =
         fakeRequestBuilder()
@@ -186,8 +217,33 @@ public class ProgramDisabledActionTest extends WithApplication {
   }
 
   @Test
+  public void testProgramOnlyHasDraftVersion_whenFastForwardIsDisabled() {
+    ProgramModel program = createProgram(DisplayMode.DISABLED, LifecycleStage.DRAFT);
+
+    Request request =
+        fakeRequestBuilder()
+            .flash(Map.of(FlashKey.REDIRECTED_FROM_PROGRAM_SLUG, program.getSlug()))
+            .build();
+
+    SettingsManifest mockSettingsManifest = Mockito.mock(SettingsManifest.class);
+    when(mockSettingsManifest.getFastforwardEnabled(request)).thenReturn(true);
+
+    ProgramDisabledAction action =
+        new ProgramDisabledAction(instanceOf(ProgramService.class), mockSettingsManifest);
+
+    // Set up a mock for the delegate action
+    Action.Simple delegateMock = mock(Action.Simple.class);
+    when(delegateMock.call(request)).thenReturn(CompletableFuture.completedFuture(null));
+    action.delegate = delegateMock;
+    Result result = action.call(request).toCompletableFuture().join();
+
+    // Verify that the delegate action was called
+    assertNull(result);
+  }
+
+  @Test
   public void testDisabledProgramFromFlashKey_whenFastForwardIsEnabled() {
-    ProgramModel program = createProgram(DisplayMode.DISABLED);
+    ProgramModel program = createProgram(DisplayMode.DISABLED, LifecycleStage.ACTIVE);
 
     Request request =
         fakeRequestBuilder()
@@ -210,7 +266,7 @@ public class ProgramDisabledActionTest extends WithApplication {
 
   @Test
   public void testDisabledProgramFromUriPathProgramId_whenFastForwardIsEnabled() {
-    ProgramModel program = createProgram(DisplayMode.DISABLED);
+    ProgramModel program = createProgram(DisplayMode.DISABLED, LifecycleStage.ACTIVE);
 
     var routePattern =
         "/programs/$programId<[^/]+>/applicant/$applicantId<[^/]+>/blocks/$blockId<[^/]+>/edit";
@@ -240,7 +296,7 @@ public class ProgramDisabledActionTest extends WithApplication {
 
   @Test
   public void testNonDisabledProgramFromFlashKey_whenFastForwardIsEnabled() {
-    ProgramModel program = createProgram(DisplayMode.PUBLIC);
+    ProgramModel program = createProgram(DisplayMode.PUBLIC, LifecycleStage.ACTIVE);
 
     Request request =
         fakeRequestBuilder()


### PR DESCRIPTION
### Description

Handle draft only program in program disabled action. Found that the program disabled tests were not clearing the database between each test leading to a false positive when there was only a draft version of the program. This only looks to have been an issue if an admin create a draft program and tried to previous it.

### Release Notes

Handle draft only program in program disabled action.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)

