### PR TITLE
Set Fastforward flag as default in dev/test

### DIFF
--- a/server/conf/application.dev.conf
+++ b/server/conf/application.dev.conf
@@ -48,3 +48,4 @@ application_exportable = true
 program_filtering_enabled = true
 bulk_status_update_enabled = true
 name_suffix_dropdown_enabled = true
+fastforward_enabled = true

--- a/server/test/controllers/applicant/ApplicantProgramReviewControllerTest.java
+++ b/server/test/controllers/applicant/ApplicantProgramReviewControllerTest.java
@@ -185,7 +185,6 @@ public class ApplicantProgramReviewControllerTest extends WithMockedProfiles {
             .toCompletableFuture()
             .join();
 
-    //    Result result = this.submit(applicant.id, programDefinition.id());
     assertThat(result.status()).isEqualTo(FOUND);
 
     // An application was submitted

--- a/server/test/controllers/applicant/ApplicantProgramReviewControllerTest.java
+++ b/server/test/controllers/applicant/ApplicantProgramReviewControllerTest.java
@@ -397,14 +397,6 @@ public class ApplicantProgramReviewControllerTest extends WithMockedProfiles {
         .join();
   }
 
-  public Result submit_fastforwarddisabled(long applicantId, long programId) {
-    Request request = fakeRequestBuilder().header(skipUserProfile, "false").build();
-    return subject
-        .submitWithApplicantId(request, applicantId, programId)
-        .toCompletableFuture()
-        .join();
-  }
-
   private void answer(long programId, boolean fastforwardEnabled) {
     Request request =
         fakeRequestBuilder()

--- a/server/test/controllers/applicant/ApplicantProgramReviewControllerTest.java
+++ b/server/test/controllers/applicant/ApplicantProgramReviewControllerTest.java
@@ -135,7 +135,7 @@ public class ApplicantProgramReviewControllerTest extends WithMockedProfiles {
             .withBlock()
             .withRequiredQuestion(testQuestionBank().nameApplicantName())
             .buildDefinition();
-    answer(draftProgramDefinition.id());
+    answer(draftProgramDefinition.id(), true);
 
     Result result = this.submit(applicant.id, draftProgramDefinition.id());
     assertThat(result.status()).isEqualTo(SEE_OTHER);
@@ -168,9 +168,24 @@ public class ApplicantProgramReviewControllerTest extends WithMockedProfiles {
     VersionRepository versionRepository = instanceOf(VersionRepository.class);
     versionRepository.publishNewSynchronizedVersion();
 
-    answer(programDefinition.id());
+    answer(programDefinition.id(), false);
 
-    Result result = this.submit(applicant.id, programDefinition.id());
+    Request request =
+        fakeRequestBuilder()
+            .addCiviFormSetting("FASTFORWARD_ENABLED", "false")
+            .call(
+                routes.ApplicantProgramReviewController.submitWithApplicantId(
+                    applicant.id, programDefinition.id()))
+            .header(skipUserProfile, "false")
+            .build();
+
+    Result result =
+        subject
+            .submitWithApplicantId(request, applicant.id, programDefinition.id())
+            .toCompletableFuture()
+            .join();
+
+    //    Result result = this.submit(applicant.id, programDefinition.id());
     assertThat(result.status()).isEqualTo(FOUND);
 
     // An application was submitted
@@ -196,7 +211,7 @@ public class ApplicantProgramReviewControllerTest extends WithMockedProfiles {
     VersionRepository versionRepository = instanceOf(VersionRepository.class);
     versionRepository.publishNewSynchronizedVersion();
 
-    answer(programDefinition.id());
+    answer(programDefinition.id(), true);
 
     var programId = programDefinition.id();
 
@@ -248,7 +263,7 @@ public class ApplicantProgramReviewControllerTest extends WithMockedProfiles {
     VersionRepository versionRepository = instanceOf(VersionRepository.class);
     versionRepository.publishNewSynchronizedVersion();
 
-    answer(programDefinition.id());
+    answer(programDefinition.id(), true);
 
     var programId = programDefinition.id();
 
@@ -290,7 +305,7 @@ public class ApplicantProgramReviewControllerTest extends WithMockedProfiles {
             .withBlock()
             .withRequiredQuestion(testQuestionBank().staticContent())
             .build();
-    answer(activeProgram.id);
+    answer(activeProgram.id, true);
 
     Result result = this.submit(applicant.id, activeProgram.id);
     assertThat(result.status()).isEqualTo(FOUND);
@@ -330,7 +345,7 @@ public class ApplicantProgramReviewControllerTest extends WithMockedProfiles {
             .withBlock()
             .withRequiredQuestion(testQuestionBank().staticContent())
             .build();
-    answer(activeProgram.id);
+    answer(activeProgram.id, true);
     this.submit(applicant.id, activeProgram.id);
 
     // Submit the application again without editing
@@ -339,7 +354,7 @@ public class ApplicantProgramReviewControllerTest extends WithMockedProfiles {
     assertThat(noEditsResult.status()).isEqualTo(OK);
 
     // Edit the application but re-enter the same values
-    answer(activeProgram.id);
+    answer(activeProgram.id, true);
     Result sameValuesResult = this.submit(applicant.id, activeProgram.id);
     // Error is handled and applicant is shown duplicates page
     assertThat(sameValuesResult.status()).isEqualTo(OK);
@@ -383,9 +398,18 @@ public class ApplicantProgramReviewControllerTest extends WithMockedProfiles {
         .join();
   }
 
-  private void answer(long programId) {
+  public Result submit_fastforwarddisabled(long applicantId, long programId) {
+    Request request = fakeRequestBuilder().header(skipUserProfile, "false").build();
+    return subject
+        .submitWithApplicantId(request, applicantId, programId)
+        .toCompletableFuture()
+        .join();
+  }
+
+  private void answer(long programId, boolean fastforwardEnabled) {
     Request request =
         fakeRequestBuilder()
+            .addCiviFormSetting("FASTFORWARD_ENABLED", Boolean.toString(fastforwardEnabled))
             .bodyForm(
                 ImmutableMap.of(
                     Path.create("applicant.applicant_name").join(Scalar.FIRST_NAME).toString(),

--- a/server/test/controllers/applicant/ApplicantProgramsControllerTest.java
+++ b/server/test/controllers/applicant/ApplicantProgramsControllerTest.java
@@ -133,7 +133,36 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
   }
 
   @Test
-  public void test_deduplicate_inProgressPrograms() {
+  public void test_deduplicate_inProgressPrograms_fastforward_disabled() {
+    versionRepository = instanceOf(VersionRepository.class);
+    String programName = "In Progress Program";
+    ProgramModel program = resourceCreator().insertActiveProgram(programName);
+
+    ApplicationModel app = new ApplicationModel(currentApplicant, program, LifecycleStage.DRAFT);
+    app.save();
+
+    resourceCreator().insertDraftProgram(programName);
+    this.versionRepository.publishNewSynchronizedVersion();
+
+    var fakeRequest =
+        fakeRequestBuilder().addCiviFormSetting("FASTFORWARD_ENABLED", "false").build();
+
+    Result result =
+        controller
+            .indexWithApplicantId(fakeRequest, currentApplicant.id, ImmutableList.of())
+            .toCompletableFuture()
+            .join();
+
+    assertThat(result.status()).isEqualTo(OK);
+    // A program's name appears in the index view page content 2 times:
+    //  1) Program card title
+    //  2) Apply button aria-label
+    // If it appears 6 times, that means there is a duplicate of the program.
+    assertThat(numberOfSubstringsInString(contentAsString(result), programName)).isEqualTo(2);
+  }
+
+  @Test
+  public void test_deduplicate_inProgressPrograms_fastforward_enabled() {
     versionRepository = instanceOf(VersionRepository.class);
     String programName = "In Progress Program";
     ProgramModel program = resourceCreator().insertActiveProgram(programName);
@@ -151,11 +180,12 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
             .join();
 
     assertThat(result.status()).isEqualTo(OK);
-    // A program's name appears in the index view page content 2 times:
+    // A program's name appears in the index view page content 3 times:
     //  1) Program card title
     //  2) Apply button aria-label
-    // If it appears 6 times, that means there is a duplicate of the program.
-    assertThat(numberOfSubstringsInString(contentAsString(result), programName)).isEqualTo(2);
+    //  3) Info link aria-label
+    // If it appears 9 times, that means there is a duplicate of the program.
+    assertThat(numberOfSubstringsInString(contentAsString(result), programName)).isEqualTo(3);
   }
 
   /** Returns the number of times a substring appears in the string. */


### PR DESCRIPTION
### Description

Enabled application fast forward feature in dev/test. Fixed a couple tests where needed.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)

Related #8047