### PR TITLE
Fixed IT email address handling in InternalServerError page

### DIFF
--- a/server/app/views/errors/InternalServerError.java
+++ b/server/app/views/errors/InternalServerError.java
@@ -65,12 +65,12 @@ public final class InternalServerError extends BaseHtmlView {
 
   private UnescapedText buildAdditionalInfo(
       Http.RequestHeader requestHeader, Messages messages, String exceptionId) {
-    String supportEmail = settingsManifest.getSupportEmailAddress(requestHeader).get();
+    String itEmail = settingsManifest.getString("IT_EMAIL_ADDRESS", requestHeader).get();
     String emailLinkHref =
-        String.format("mailto:%s?body=[CiviForm Error ID: %s]", supportEmail, exceptionId);
+        String.format("mailto:%s?body=[CiviForm Error ID: %s]", itEmail, exceptionId);
     ATag emailAction =
         new LinkElement()
-            .setText(supportEmail)
+            .setText(itEmail)
             .setHref(emailLinkHref)
             .asAnchorText()
             .withClasses(ApplicantStyles.LINK);

--- a/server/conf/env-var-docs.json
+++ b/server/conf/env-var-docs.json
@@ -568,7 +568,7 @@
       },
       "IT_EMAIL_ADDRESS": {
         "mode": "ADMIN_WRITEABLE",
-        "description": "This email address receives error notifications from CiviForm when things break.",
+        "description": "This email address receives error notifications from CiviForm when there is an internal server error or a durable job fails.",
         "type": "string"
       },
       "STAGING_PROGRAM_ADMIN_NOTIFICATION_MAILING_LIST": {


### PR DESCRIPTION
### Description

Fixes the handling of the IT email address in the internal server error page. Before the code attempted to reference a non existing support email variable which generate the error page for 500 server errors. The email address being displayed supposed to be fetched from the settings configuration, but the code referenced (supportEmail) that was not defined causing an error.

So, the issue that was fixed was replaced the reference to the undefined support email variable with the correct IT_EMAIL_ADDRESS received from the SettingManifest class.  The IT email address is now retrieved using settingsManifest.getString("IT_EMAIL_ADDRESS , requestHeader).get(), this ensuring the correct email address is displayed on the error page for server issues. Making this allow users to easily contact IT support with relevant error ID.

This update endures that the IT support email address is correctly received and displayed to users when they encounter a 50o error. The error page now works as intended. 




Fixes #<issue_number>; Fixes #<issue_number>...
