### PR TITLE
Adding phone validation for non-user interactive code with E.164 support

### DIFF
--- a/server/app/services/PhoneValidationUtils.java
+++ b/server/app/services/PhoneValidationUtils.java
@@ -109,4 +109,80 @@ public final class PhoneValidationUtils {
 
     return PhoneValidationResult.create(phoneNumber, countryCode);
   }
+
+  /**
+   * Checks the supplied phone number with supported country codes to determine which, if any,
+   * country code is valid.
+   *
+   * <p>Really deep dive into E.164 can be found on the <a
+   * href="https://www.itu.int/rec/t-rec-e.164/en">ITU site</a>, but a short overview can be seen on
+   * <a href="https://www.twilio.com/docs/glossary/what-e164">Twilio's site</a>.
+   *
+   * @param phoneNumber {@link Optional<String>}} of the Phone Number
+   * @return an {@link Optional<String>} representing the <a
+   *     href="https://www.javadoc.io/doc/com.googlecode.libphonenumber/libphonenumber/8.4.1/com/google/i18n/phonenumbers/PhoneNumberUtil.html">CLDR
+   *     format</a> Country Code if the phone number is valid, or an Optional.empty() if the phone
+   *     number is invalid
+   */
+  public static PhoneValidationResult determineCountryCodeForE164PhoneNumber(
+      Optional<String> phoneNumber) {
+    PhoneValidationResult result = PhoneValidationResult.builder().build();
+
+    for (String potentialCountryCode : POTENTIAL_COUNTRY_CODES) {
+      result = validateForE164PhoneNumber(phoneNumber, Optional.of(potentialCountryCode));
+
+      // Return early when we hit a valid country code.
+      if (result.isValid()) {
+        return result;
+      }
+    }
+
+    return result;
+  }
+
+  /**
+   * Validates a phone number and country code.
+   *
+   * <p>Really deep dive into E.164 can be found on the <a
+   * href="https://www.itu.int/rec/t-rec-e.164/en">ITU site</a>, but a short overview can be seen on
+   * <a href="https://www.twilio.com/docs/glossary/what-e164">Twilio's site</a>.
+   *
+   * @param phoneNumber {@link Optional<String>}} of the Phone Number
+   * @param countryCode {@link Optional<String>}} of the Country Code in <a
+   *     href="https://www.javadoc.io/doc/com.googlecode.libphonenumber/libphonenumber/8.4.1/com/google/i18n/phonenumbers/PhoneNumberUtil.html">CLDR
+   *     format</a>
+   * @return a {@link PhoneValidationResult} containing the phone number, country code, and possible
+   *     validation error
+   */
+  private static PhoneValidationResult validateForE164PhoneNumber(
+      Optional<String> phoneNumber, Optional<String> countryCode) {
+    try {
+      boolean isE164NumberFormat = phoneNumber.orElse("").startsWith("+");
+
+      Phonenumber.PhoneNumber parsedPhoneNumber =
+          PHONE_NUMBER_UTIL.parse(
+              phoneNumber.orElse(""), isE164NumberFormat ? null : countryCode.orElse(""));
+
+      if (isE164NumberFormat) {
+        countryCode = Optional.of(PHONE_NUMBER_UTIL.getRegionCodeForNumber(parsedPhoneNumber));
+      }
+
+      if (!PHONE_NUMBER_UTIL.isValidNumber(parsedPhoneNumber)
+          || !PHONE_NUMBER_UTIL.isValidNumberForRegion(parsedPhoneNumber, countryCode.orElse(""))) {
+        return PhoneValidationResult.createError(
+            phoneNumber, MessageKey.PHONE_VALIDATION_INVALID_PHONE_NUMBER);
+      }
+
+      if (!POTENTIAL_COUNTRY_CODES.contains(countryCode.orElse(""))) {
+        return PhoneValidationResult.createError(
+            phoneNumber, MessageKey.PHONE_VALIDATION_INVALID_PHONE_NUMBER);
+      }
+
+      return PhoneValidationResult.create(
+          Optional.of(Long.toString(parsedPhoneNumber.getNationalNumber())), countryCode);
+    } catch (NumberParseException e) {
+      return PhoneValidationResult.createError(
+          phoneNumber, MessageKey.PHONE_VALIDATION_INVALID_PHONE_NUMBER);
+    }
+  }
 }

--- a/server/test/services/PhoneValidationUtilsTest.java
+++ b/server/test/services/PhoneValidationUtilsTest.java
@@ -136,4 +136,41 @@ public class PhoneValidationUtilsTest {
     assertThat(phoneValidationResult.getPhoneNumber()).isEqualTo(phoneNumber);
     assertThat(phoneValidationResult.getCountryCode()).isEqualTo(expectedCountryCode);
   }
+
+  @Test
+  public void determineCountryCodeForE164PhoneNumber_handlesDisallowedE164Numbers() {
+    // E164 format phone number for GB
+    PhoneValidationResult phoneValidationResult =
+        PhoneValidationUtils.determineCountryCodeForE164PhoneNumber(Optional.of("+447911123456"));
+
+    assertThat(phoneValidationResult.isValid()).isFalse();
+  }
+
+  private Object[] numbersWithAllowedE164FormatOptions() {
+
+    return new Object[] {
+      // E164 format phone number for US
+      new Object[] {Optional.of("+12538675309"), COUNTRY_CODE_US, Optional.of("2538675309")},
+      // E164 format phone number for CA
+      new Object[] {Optional.of("+12503613152"), COUNTRY_CODE_CA, Optional.of("2503613152")},
+      new Object[] {Optional.of("253-867-5309"), COUNTRY_CODE_US, Optional.of("2538675309")},
+      new Object[] {Optional.of("250-361-3152"), COUNTRY_CODE_CA, Optional.of("2503613152")},
+      new Object[] {Optional.of("2538675309"), COUNTRY_CODE_US, Optional.of("2538675309")},
+      new Object[] {Optional.of("2503613152"), COUNTRY_CODE_CA, Optional.of("2503613152")}
+    };
+  }
+
+  @Test
+  @Parameters(method = "numbersWithAllowedE164FormatOptions")
+  public void determineCountryCodeForE164PhoneNumber_handlesAllowedNumbers(
+      Optional<String> phoneNumber,
+      Optional<String> expectedCountryCode,
+      Optional<String> expectedPhoneNumber) {
+    PhoneValidationResult phoneValidationResult =
+        PhoneValidationUtils.determineCountryCodeForE164PhoneNumber(phoneNumber);
+
+    assertThat(phoneValidationResult.isValid()).isTrue();
+    assertThat(phoneValidationResult.getPhoneNumber()).isEqualTo(expectedPhoneNumber);
+    assertThat(phoneValidationResult.getCountryCode()).isEqualTo(expectedCountryCode);
+  }
 }


### PR DESCRIPTION
### Description

Adds phone validation to support for [E164 format numbers](https://www.twilio.com/docs/glossary/what-e164) ([E164 Spec](https://www.itu.int/rec/t-rec-e.164/en)).

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Created unit and/or browser tests which fail without the change (if possible)

### Issue(s) this completes

Related to: #5461
