### PR TITLE
Add ability to set account for graph api email sending

### DIFF
--- a/server/app/services/email/graph/GraphApiEmailClient.java
+++ b/server/app/services/email/graph/GraphApiEmailClient.java
@@ -114,6 +114,7 @@ public class GraphApiEmailClient implements EmailSendClient {
       if (settingsManifest.getGraphApiEmailAccount().isEmpty()) {
         logger.error(
             "GRAPH_API_EMAIL_ACCOUNT is not set. This is needed to send emails through graph API");
+        client.get().me().sendMail().post(sendMailPostRequestBody);
       } else {
         client
             .get()

--- a/server/app/services/email/graph/GraphApiEmailClient.java
+++ b/server/app/services/email/graph/GraphApiEmailClient.java
@@ -114,8 +114,9 @@ public class GraphApiEmailClient implements EmailSendClient {
       if (settingsManifest.getGraphApiEmailAccount().isEmpty()) {
         logger.error(
             "GRAPH_API_EMAIL_ACCOUNT is not set. This is needed to send emails through graph API");
+      } else {
+        client.get().users().byUserId(settingsManifest.getGraphApiEmailAccount().get()).sendMail();
       }
-      client.get().users().byUserId(settingsManifest.getGraphApiEmailAccount().get()).sendMail();
     } catch (ApiException e) {
       logger.error(e.toString());
       e.printStackTrace();

--- a/server/app/services/email/graph/GraphApiEmailClient.java
+++ b/server/app/services/email/graph/GraphApiEmailClient.java
@@ -112,8 +112,8 @@ public class GraphApiEmailClient implements EmailSendClient {
       // This can be a configurable value if that is something the team wants.
       sendMailPostRequestBody.setSaveToSentItems(false);
       if (settingsManifest.getGraphApiEmailAccount().isEmpty()) {
-        logger.error(
-            "GRAPH_API_EMAIL_ACCOUNT is not set. This is needed to send emails through graph API");
+        logger.info(
+            "GRAPH_API_EMAIL_ACCOUNT is not set. Attempting to send email with root account.");
         client.get().me().sendMail().post(sendMailPostRequestBody);
       } else {
         client

--- a/server/app/services/email/graph/GraphApiEmailClient.java
+++ b/server/app/services/email/graph/GraphApiEmailClient.java
@@ -115,7 +115,12 @@ public class GraphApiEmailClient implements EmailSendClient {
         logger.error(
             "GRAPH_API_EMAIL_ACCOUNT is not set. This is needed to send emails through graph API");
       } else {
-        client.get().users().byUserId(settingsManifest.getGraphApiEmailAccount().get()).sendMail();
+        client
+            .get()
+            .users()
+            .byUserId(settingsManifest.getGraphApiEmailAccount().get())
+            .sendMail()
+            .post(sendMailPostRequestBody);
       }
     } catch (ApiException e) {
       logger.error(e.toString());

--- a/server/app/services/settings/SettingsManifest.java
+++ b/server/app/services/settings/SettingsManifest.java
@@ -512,6 +512,11 @@ public final class SettingsManifest extends AbstractSettingsManifest {
     return getString("EMAIL_PROVIDER");
   }
 
+  /** The email or account ID that graph API should use to send the email. */
+  public Optional<String> getGraphApiEmailAccount() {
+    return getString("GRAPH_API_EMAIL_ACCOUNT");
+  }
+
   /** What static file storage provider to use. */
   public Optional<String> getStorageServiceName() {
     return getString("STORAGE_SERVICE_NAME");
@@ -1828,7 +1833,13 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                       /* isRequired= */ false,
                       SettingType.ENUM,
                       SettingMode.HIDDEN,
-                      ImmutableList.of("aws-ses", "graph-api")))),
+                      ImmutableList.of("aws-ses", "graph-api")),
+                  SettingDescription.create(
+                      "GRAPH_API_EMAIL_ACCOUNT",
+                      "The email or account ID that graph API should use to send the email.",
+                      /* isRequired= */ false,
+                      SettingType.STRING,
+                      SettingMode.HIDDEN))),
           "Email Addresses",
           SettingsSection.create(
               "Email Addresses",

--- a/server/conf/env-var-docs.json
+++ b/server/conf/env-var-docs.json
@@ -425,6 +425,11 @@
         "type": "string",
         "values": ["aws-ses", "graph-api"]
       },
+      "GRAPH_API_EMAIL_ACCOUNT": {
+        "mode": "HIDDEN",
+        "description": "The email or account ID that graph API should use to send the email.",
+        "type": "string"
+      },
       "Application File Upload Storage": {
         "group_description": "Configuration options for the application file upload storage provider",
         "members": {

--- a/server/conf/helper/email.conf
+++ b/server/conf/helper/email.conf
@@ -1,5 +1,5 @@
-email.provider="aws-ses"
-email.provider=${?EMAIL_PROVIDER}
+email.provider = "aws-ses"
+email.provider = ${?EMAIL_PROVIDER}
 
-email.sender="noreply@fake.identity"
-email.sender=${?SENDER_EMAIL_ADDRESS}
+email.sender = "noreply@fake.identity"
+email.sender = ${?SENDER_EMAIL_ADDRESS}

--- a/server/conf/helper/email.conf
+++ b/server/conf/helper/email.conf
@@ -3,3 +3,6 @@ email.provider = ${?EMAIL_PROVIDER}
 
 email.sender = "noreply@fake.identity"
 email.sender = ${?SENDER_EMAIL_ADDRESS}
+
+email.graphapi.account = ""
+email.graphapi.account = ${?GRAPH_API_EMAIL_ACCOUNT}

--- a/server/test/services/email/graph/GraphApiEmailClientTest.java
+++ b/server/test/services/email/graph/GraphApiEmailClientTest.java
@@ -24,6 +24,7 @@ import play.Environment;
 import repository.ResetPostgres;
 import services.cloud.azure.Credentials;
 import services.monitoring.EmailSendMetrics;
+import services.settings.SettingsManifest;
 
 public class GraphApiEmailClientTest extends ResetPostgres {
   private final Config mockConfig = mock(Config.class);
@@ -42,7 +43,8 @@ public class GraphApiEmailClientTest extends ResetPostgres {
             instanceOf(Credentials.class),
             mockConfig,
             mockEnvironment,
-            instanceOf(EmailSendMetrics.class));
+            instanceOf(EmailSendMetrics.class),
+            instanceOf(SettingsManifest.class));
 
     graphClient = emailClient.getClient().get();
 

--- a/server/test/services/email/graph/GraphApiEmailClientTest.java
+++ b/server/test/services/email/graph/GraphApiEmailClientTest.java
@@ -55,8 +55,10 @@ public class GraphApiEmailClientTest extends ResetPostgres {
 
     graphClient = emailClient.getClient().get();
     when(graphClient.users()).thenReturn(mock(UsersRequestBuilder.class));
-    when(graphClient.users().byUserId(GRAPH_ACCOUNT_ID)).thenReturn(mock(UserItemRequestBuilder.class));
-    when(graphClient.users().byUserId(GRAPH_ACCOUNT_ID).sendMail()).thenReturn(mock(SendMailRequestBuilder.class));
+    when(graphClient.users().byUserId(GRAPH_ACCOUNT_ID))
+        .thenReturn(mock(UserItemRequestBuilder.class));
+    when(graphClient.users().byUserId(GRAPH_ACCOUNT_ID).sendMail())
+        .thenReturn(mock(SendMailRequestBuilder.class));
   }
 
   @Test
@@ -131,7 +133,8 @@ public class GraphApiEmailClientTest extends ResetPostgres {
 
     emailClient.send(toAddress, subject, body);
 
-    assertThrows(ApiException.class, () -> graphClient.users().byUserId(GRAPH_ACCOUNT_ID).sendMail());
+    assertThrows(
+        ApiException.class, () -> graphClient.users().byUserId(GRAPH_ACCOUNT_ID).sendMail());
   }
 
   @Test
@@ -149,7 +152,8 @@ public class GraphApiEmailClientTest extends ResetPostgres {
 
     emailClient.send(toAddress, subject, body);
 
-    assertThrows(ApiException.class, () -> graphClient.users().byUserId(GRAPH_ACCOUNT_ID).sendMail());
+    assertThrows(
+        ApiException.class, () -> graphClient.users().byUserId(GRAPH_ACCOUNT_ID).sendMail());
   }
 
   @Test

--- a/server/test/services/email/graph/GraphApiEmailClientTest.java
+++ b/server/test/services/email/graph/GraphApiEmailClientTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -43,7 +44,7 @@ public class GraphApiEmailClientTest extends ResetPostgres {
     when(mockConfig.getString(GraphApiEmailClient.AZURE_SENDER_CONF_PATH))
         .thenReturn("test@example.com");
     when(mockEnvironment.isProd()).thenReturn(false);
-    when(mockSettingsManifest.getGraphApiEmailAccount()).thenReturn(Optional.of("emailId"));
+    when(mockSettingsManifest.getGraphApiEmailAccount()).thenReturn(Optional.of(GRAPH_ACCOUNT_ID));
 
     emailClient =
         new GraphApiEmailClient(
@@ -55,9 +56,8 @@ public class GraphApiEmailClientTest extends ResetPostgres {
 
     graphClient = emailClient.getClient().get();
     when(graphClient.users()).thenReturn(mock(UsersRequestBuilder.class));
-    when(graphClient.users().byUserId(GRAPH_ACCOUNT_ID))
-        .thenReturn(mock(UserItemRequestBuilder.class));
-    when(graphClient.users().byUserId(GRAPH_ACCOUNT_ID).sendMail())
+    when(graphClient.users().byUserId(anyString())).thenReturn(mock(UserItemRequestBuilder.class));
+    when(graphClient.users().byUserId(anyString()).sendMail())
         .thenReturn(mock(SendMailRequestBuilder.class));
   }
 

--- a/server/test/services/email/graph/GraphApiEmailClientTest.java
+++ b/server/test/services/email/graph/GraphApiEmailClientTest.java
@@ -6,7 +6,6 @@ import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;


### PR DESCRIPTION
### Description

Using `.me()` throws an error `com.microsoft.graph.models.odataerrors.ODataError: /me request is only valid with delegated authentication flow.`. We don't have access to email sending yet in our account, but after changing this to the user email that owns our azure account, we see a message: `2025-02-11T20:05:08.3462368Z com.microsoft.graph.models.odataerrors.ODataError: The mailbox is either inactive, soft-deleted, or is hosted on-premise.`

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [x] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`


### Issue(s) this completes

https://github.com/civiform/civiform/issues/9260
