### PR TITLE
[North Star] Skip program overview page when applying to common intake program

### DIFF
--- a/browser-test/src/applicant/applicant_application_index.test.ts
+++ b/browser-test/src/applicant/applicant_application_index.test.ts
@@ -671,7 +671,7 @@ test.describe('applicant program index page', () => {
           await applicantQuestions.applyProgram(
             primaryProgramName,
             /* northStarEnabled= */ true,
-            /* isApplicationUnstarted= */ false,
+            /* showProgramOverviewPage= */ false,
           )
           // Expect clicking 'Continue' navigates to the next incomplete block. In this case, it is screen 3
           await expect(page.getByText('Screen 3')).toBeVisible()
@@ -705,7 +705,7 @@ test.describe('applicant program index page', () => {
           await applicantQuestions.applyProgram(
             primaryProgramName,
             /* northStarEnabled= */ true,
-            /* isApplicationUnstarted= */ false,
+            /* showProgramOverviewPage= */ false,
           )
 
           await expect(page.getByText('Review and submit')).toBeVisible()
@@ -903,7 +903,7 @@ test.describe('applicant program index page', () => {
             await applicantQuestions.applyProgram(
               primaryProgramName,
               /* northStarEnabled= */ true,
-              /* isApplicationUnstarted= */ false,
+              /* showProgramOverviewPage= */ false,
             )
             await applicantQuestions.answerTextQuestion('second answer')
             await applicantQuestions.clickContinue()

--- a/browser-test/src/applicant/navigation/northstar_application_navigation_buttons.test.ts
+++ b/browser-test/src/applicant/navigation/northstar_application_navigation_buttons.test.ts
@@ -1082,7 +1082,7 @@ test.describe('Applicant navigation flow', {tag: ['@northstar']}, () => {
         await applicantQuestions.applyProgram(
           programName,
           /* northStarEnabled= */ true,
-          /* isApplicationUnstarted= */ false,
+          /* showProgramOverviewPage= */ false,
         )
         await expect(page.getByText('2 of 3', {exact: true})).toBeVisible()
       })

--- a/browser-test/src/applicant/navigation/northstar_application_navigation_common_intake.test.ts
+++ b/browser-test/src/applicant/navigation/northstar_application_navigation_common_intake.test.ts
@@ -86,6 +86,8 @@ test.describe('Applicant navigation flow', {tag: ['@northstar']}, () => {
       await applicantQuestions.applyProgram(
         commonIntakeProgramName,
         /* northStarEnabled= */ true,
+        // common intake programs skip the program overview page
+        /* showProgramOverviewPage= */ false,
       )
       await applicantQuestions.answerNumberQuestion('4')
       await applicantQuestions.clickContinue()
@@ -109,6 +111,8 @@ test.describe('Applicant navigation flow', {tag: ['@northstar']}, () => {
       await applicantQuestions.applyProgram(
         commonIntakeProgramName,
         /* northStarEnabled= */ true,
+        // common intake programs skip the program overview page
+        /* showProgramOverviewPage= */ false,
       )
       await applicantQuestions.answerNumberQuestion(secondProgramCorrectAnswer)
       await applicantQuestions.clickContinue()
@@ -131,6 +135,8 @@ test.describe('Applicant navigation flow', {tag: ['@northstar']}, () => {
       await applicantQuestions.applyProgram(
         commonIntakeProgramName,
         /* northStarEnabled= */ true,
+        // common intake programs skip the program overview page
+        /* showProgramOverviewPage= */ false,
       )
       await applicantQuestions.answerNumberQuestion('4')
       await applicantQuestions.clickContinue()
@@ -159,6 +165,8 @@ test.describe('Applicant navigation flow', {tag: ['@northstar']}, () => {
       await applicantQuestions.applyProgram(
         commonIntakeProgramName,
         /* northStarEnabled= */ true,
+        // common intake programs skip the program overview page
+        /* showProgramOverviewPage= */ false,
       )
       await applicantQuestions.answerNumberQuestion(secondProgramCorrectAnswer)
       await applicantQuestions.clickContinue()
@@ -184,6 +192,8 @@ test.describe('Applicant navigation flow', {tag: ['@northstar']}, () => {
       await applicantQuestions.applyProgram(
         commonIntakeProgramName,
         /* northStarEnabled= */ true,
+        // common intake programs skip the program overview page
+        /* showProgramOverviewPage= */ false,
       )
       await applicantQuestions.answerNumberQuestion(secondProgramCorrectAnswer)
       await applicantQuestions.clickContinue()
@@ -237,6 +247,8 @@ test.describe('Applicant navigation flow', {tag: ['@northstar']}, () => {
       await applicantQuestions.applyProgram(
         commonIntakeProgramName,
         /* northStarEnabled= */ true,
+        // common intake programs skip the program overview page
+        /* showProgramOverviewPage= */ false,
       )
       await applicantQuestions.answerNumberQuestion('4')
       await applicantQuestions.clickContinue()
@@ -273,6 +285,8 @@ test.describe('Applicant navigation flow', {tag: ['@northstar']}, () => {
       await applicantQuestions.applyProgram(
         commonIntakeProgramName,
         /* northStarEnabled= */ true,
+        // common intake programs skip the program overview page
+        /* showProgramOverviewPage= */ false,
       )
       await applicantQuestions.answerNumberQuestion(secondProgramCorrectAnswer)
       await applicantQuestions.clickContinue()

--- a/browser-test/src/applicant/navigation/northstar_application_navigation_with_eligibility_conditions.test.ts
+++ b/browser-test/src/applicant/navigation/northstar_application_navigation_with_eligibility_conditions.test.ts
@@ -169,7 +169,7 @@ test.describe('Applicant navigation flow', {tag: ['@northstar']}, () => {
         await applicantQuestions.applyProgram(
           fullProgramName,
           /* northStarEnabled= */ true,
-          /* isApplicationUnstarted= */ false,
+          /* showProgramOverviewPage= */ false,
         )
         await applicantQuestions.answerEmailQuestion('test@test.com')
         await applicantQuestions.clickContinue()
@@ -331,7 +331,7 @@ test.describe('Applicant navigation flow', {tag: ['@northstar']}, () => {
         await applicantQuestions.applyProgram(
           fullProgramName,
           /* northStarEnabled= */ true,
-          /* isApplicationUnstarted= */ false,
+          /* showProgramOverviewPage= */ false,
         )
         await applicantQuestions.answerEmailQuestion('test@test.com')
         await applicantQuestions.clickContinue()
@@ -380,7 +380,7 @@ test.describe('Applicant navigation flow', {tag: ['@northstar']}, () => {
         await applicantQuestions.applyProgram(
           fullProgramName,
           /* northStarEnabled= */ true,
-          /* isApplicationUnstarted= */ false,
+          /* showProgramOverviewPage= */ false,
         )
         await applicantQuestions.answerEmailQuestion('test@test.com')
         await applicantQuestions.clickContinue()

--- a/browser-test/src/applicant/northstar_applicant_question_translation.test.ts
+++ b/browser-test/src/applicant/northstar_applicant_question_translation.test.ts
@@ -52,7 +52,7 @@ test.describe('Admin can manage translations', {tag: ['@northstar']}, () => {
     await applicantQuestions.applyProgram(
       programName,
       /* northStarEnabled= */ true,
-      /* isApplicationUnstarted= */ false, // in this case, the application is unstarted, but we pass in false so that we can use the translated version of the program overview page below
+      /* showProgramOverviewPage= */ false, // in this case, the application is unstarted, but we pass in false so that we can use the translated version of the program overview page below
     )
     await applicantProgramOverview.startApplicationFromTranslatedProgramOverviewPage(
       'Descripción general del programa', // translated page title

--- a/browser-test/src/applicant/northstar_common_intake_upsell.test.ts
+++ b/browser-test/src/applicant/northstar_common_intake_upsell.test.ts
@@ -41,7 +41,6 @@ test.describe(
       page,
       adminPrograms,
       applicantQuestions,
-      applicantProgramOverview,
     }) => {
       await test.step('Setup: publish one program', async () => {
         await adminPrograms.addProgram(eligibleProgram1)
@@ -55,10 +54,6 @@ test.describe(
 
       await test.step('Setup: submit application', async () => {
         await applicantQuestions.clickApplyProgramButton(programName)
-        await applicantProgramOverview.startApplicationFromProgramOverviewPage(
-          programName,
-        )
-
         await applicantQuestions.submitFromReviewPage(
           /* northStarEnabled= */ true,
         )
@@ -90,7 +85,6 @@ test.describe(
       page,
       adminPrograms,
       applicantQuestions,
-      applicantProgramOverview,
     }) => {
       await test.step('Setup: publish one program', async () => {
         await adminPrograms.addProgram(eligibleProgram1)
@@ -102,9 +96,6 @@ test.describe(
 
       await test.step('Setup: submit application', async () => {
         await applicantQuestions.clickApplyProgramButton(programName)
-        await applicantProgramOverview.startApplicationFromProgramOverviewPage(
-          programName,
-        )
         await applicantQuestions.submitFromReviewPage(
           /* northStarEnabled= */ true,
         )
@@ -128,7 +119,6 @@ test.describe(
     test('view application submitted page with zero eligible programs', async ({
       page,
       applicantQuestions,
-      applicantProgramOverview,
     }) => {
       await logout(page) // Log out as admin
       await loginAsTestUser(page)
@@ -137,9 +127,6 @@ test.describe(
 
       await test.step('Setup: submit application', async () => {
         await applicantQuestions.clickApplyProgramButton(programName)
-        await applicantProgramOverview.startApplicationFromProgramOverviewPage(
-          programName,
-        )
         await applicantQuestions.submitFromReviewPage(
           /* northStarEnabled= */ true,
         )
@@ -163,7 +150,6 @@ test.describe(
     test('As a guest, clicking on apply to more programs brings up login dialog', async ({
       page,
       applicantQuestions,
-      applicantProgramOverview,
     }) => {
       await logout(page) // Log out as admin
 
@@ -171,9 +157,6 @@ test.describe(
 
       await test.step('Setup: submit application', async () => {
         await applicantQuestions.clickApplyProgramButton(programName)
-        await applicantProgramOverview.startApplicationFromProgramOverviewPage(
-          programName,
-        )
         await applicantQuestions.submitFromReviewPage(
           /* northStarEnabled= */ true,
         )
@@ -195,7 +178,6 @@ test.describe(
       tiDashboard,
       adminPrograms,
       applicantQuestions,
-      applicantProgramOverview,
     }) => {
       await test.step('Setup: publish one program', async () => {
         await adminPrograms.addProgram(eligibleProgram1)
@@ -223,9 +205,6 @@ test.describe(
       await test.step('Setup: submit application', async () => {
         await tiDashboard.clickOnViewApplications()
         await applicantQuestions.clickApplyProgramButton(programName)
-        await applicantProgramOverview.startApplicationFromProgramOverviewPage(
-          programName,
-        )
         await applicantQuestions.submitFromReviewPage(
           /* northStarEnabled= */ true,
         )
@@ -243,7 +222,6 @@ test.describe(
       page,
       tiDashboard,
       applicantQuestions,
-      applicantProgramOverview,
     }) => {
       await logout(page) // Log out as admin
 
@@ -267,9 +245,6 @@ test.describe(
       await test.step('Setup: submit application', async () => {
         await tiDashboard.clickOnViewApplications()
         await applicantQuestions.clickApplyProgramButton(programName)
-        await applicantProgramOverview.startApplicationFromProgramOverviewPage(
-          programName,
-        )
         await applicantQuestions.submitFromReviewPage(
           /* northStarEnabled= */ true,
         )

--- a/browser-test/src/applicant/northstar_program_summary.test.ts
+++ b/browser-test/src/applicant/northstar_program_summary.test.ts
@@ -207,7 +207,7 @@ test.describe('Applicant navigation flow', {tag: ['@northstar']}, () => {
       await applicantQuestions.applyProgram(
         programName,
         /* northStarEnabled= */ true,
-        /* isApplicationUnstarted= */ false,
+        /* showProgramOverviewPage= */ false,
       )
 
       await expect(page.getByText(fileName)).toBeVisible()

--- a/browser-test/src/northstar_trusted_intermediary.test.ts
+++ b/browser-test/src/northstar_trusted_intermediary.test.ts
@@ -188,7 +188,7 @@ test.describe(
         await applicantQuestions.applyProgram(
           primaryProgramName,
           /* northStarEnabled= */ true,
-          /* isApplicationUnstarted= */ false,
+          /* showProgramOverviewPage= */ false,
         )
         await applicantQuestions.answerTextQuestion('second answer')
         await applicantQuestions.clickContinue()

--- a/browser-test/src/support/applicant_questions.ts
+++ b/browser-test/src/support/applicant_questions.ts
@@ -287,7 +287,7 @@ export class ApplicantQuestions {
   async applyProgram(
     programName: string,
     northStarEnabled = false,
-    isApplicationUnstarted = true,
+    showProgramOverviewPage = true,
   ) {
     await this.clickApplyProgramButton(programName)
 
@@ -295,7 +295,7 @@ export class ApplicantQuestions {
     // If the applicant has already submitted an application, it will take them to the review page.
     // If the applicant has a partially completed application, it will take them to the page with the first unanswered question.
     if (northStarEnabled) {
-      if (isApplicationUnstarted) {
+      if (showProgramOverviewPage) {
         await this.applicantProgramOverview.startApplicationFromProgramOverviewPage(
           programName,
         )

--- a/server/app/views/applicant/ProgramCardsSectionParamsFactory.java
+++ b/server/app/views/applicant/ProgramCardsSectionParamsFactory.java
@@ -260,7 +260,8 @@ public final class ProgramCardsSectionParamsFactory {
             ? applicantRoutes.show(profile.get(), applicantId.get(), programSlug).url()
             : applicantRoutes.show(programSlug).url();
 
-    // If they have applied before, render the edit or review page accordingly
+    // If the applicant has already started or submitted an application, render the edit or review
+    // page accordingly
     if (optionalLifecycleStage.isPresent()) {
       if (optionalLifecycleStage.get() == LifecycleStage.ACTIVE) {
         // ACTIVE lifecycle stage means the application was submitted. Redirect them to the review

--- a/server/app/views/applicant/ProgramCardsSectionParamsFactory.java
+++ b/server/app/views/applicant/ProgramCardsSectionParamsFactory.java
@@ -141,6 +141,7 @@ public final class ProgramCardsSectionParamsFactory {
             applicantRoutes,
             program.id(),
             program.adminName(),
+            program.isCommonIntakeForm(),
             programDatum.latestApplicationLifecycleStage(),
             applicantId,
             profile);
@@ -246,33 +247,43 @@ public final class ProgramCardsSectionParamsFactory {
       ApplicantRoutes applicantRoutes,
       Long programId,
       String programSlug,
+      boolean isCommonIntakeForm,
       Optional<LifecycleStage> optionalLifecycleStage,
       Optional<Long> applicantId,
       Optional<CiviFormProfile> profile) {
-    // Render the program overview page
-    String actionUrl = applicantRoutes.show(programSlug).url();
 
     boolean haveApplicant = profile.isPresent() && applicantId.isPresent();
 
-    if (!optionalLifecycleStage.isPresent() && haveApplicant) {
-      // Render the program overview page with applicant ID when applying as TI.
-      actionUrl = applicantRoutes.show(profile.get(), applicantId.get(), programSlug).url();
-    } else if (optionalLifecycleStage.isPresent()) {
+    // If it is an applicant's first time applying, render the program overview page
+    String actionUrl =
+        haveApplicant // TIs need to specify applicant ID.
+            ? applicantRoutes.show(profile.get(), applicantId.get(), programSlug).url()
+            : applicantRoutes.show(programSlug).url();
+
+    // If they have applied before, render the edit or review page accordingly
+    if (optionalLifecycleStage.isPresent()) {
       if (optionalLifecycleStage.get() == LifecycleStage.ACTIVE) {
         // ACTIVE lifecycle stage means the application was submitted. Redirect them to the review
-        // page. TIs need to specify applicant ID.
+        // page.
         actionUrl =
             haveApplicant
                 ? applicantRoutes.review(profile.get(), applicantId.get(), programId).url()
                 : applicantRoutes.review(programId).url();
       } else if (optionalLifecycleStage.get() == LifecycleStage.DRAFT) {
         // DRAFT lifecycle stage means they have started but not submitted an application. Redirect
-        // them to where they left off in the application. TIs need to specify applicant ID.
+        // them to where they left off in the application.
         actionUrl =
             haveApplicant
                 ? applicantRoutes.edit(profile.get(), applicantId.get(), programId).url()
                 : applicantRoutes.edit(programId).url();
       }
+      // If they are completing the common intake form for the first time, skip the program overview
+      // page
+    } else if (isCommonIntakeForm) {
+      actionUrl =
+          haveApplicant
+              ? applicantRoutes.edit(profile.get(), applicantId.get(), programId).url()
+              : applicantRoutes.edit(programId).url();
     }
 
     return actionUrl;

--- a/server/test/views/applicant/ProgramCardsSectionParamsFactoryTest.java
+++ b/server/test/views/applicant/ProgramCardsSectionParamsFactoryTest.java
@@ -82,9 +82,9 @@ public class ProgramCardsSectionParamsFactoryTest extends ResetPostgres {
             applicantRoutes,
             /* programId= */ 1L,
             /* programSlug= */ "fake-program",
-            /* lifeCycleStage= */ Optional
-                .empty(), // empty lifecycle stage means this is their first time filling out this
-            // application
+            /* isCommonIntakeForm= */ false,
+            // empty lifecycle stage means this is their first time filling out this application
+            /* lifeCycleStage= */ Optional.empty(),
             /* applicantId= */ Optional.empty(),
             /* profile= */ Optional.empty());
     assertThat(url).isEqualTo("/programs/fake-program");
@@ -98,9 +98,9 @@ public class ProgramCardsSectionParamsFactoryTest extends ResetPostgres {
             applicantRoutes,
             /* programId= */ 1L,
             /* programSlug= */ "fake-program",
-            /* lifeCycleStage= */ Optional
-                .empty(), // empty lifecycle stage means this is their first time filling out this
-            // application
+            /* isCommonIntakeForm= */ false,
+            // empty lifecycle stage means this is their first time filling out this application
+            /* lifeCycleStage= */ Optional.empty(),
             /* applicantId= */ Optional.of(1L),
             /* profile= */ Optional.of(testProfile));
     assertThat(url).isEqualTo("/applicants/1/programs/fake-program");
@@ -114,6 +114,7 @@ public class ProgramCardsSectionParamsFactoryTest extends ResetPostgres {
             applicantRoutes,
             /* programId= */ 1L,
             /* programSlug= */ "fake-program",
+            /* isCommonIntakeForm= */ false,
             Optional.of(
                 LifecycleStage.DRAFT), // draft lifecyle stage means they have an in progress draft
             /* applicantId= */ Optional.empty(),
@@ -129,6 +130,7 @@ public class ProgramCardsSectionParamsFactoryTest extends ResetPostgres {
             applicantRoutes,
             /* programId= */ 1L,
             /* programSlug= */ "fake-program",
+            /* isCommonIntakeForm= */ false,
             Optional.of(
                 LifecycleStage.DRAFT), // draft lifecyle stage means they have an in progress draft
             /* applicantId= */ Optional.of(1L),
@@ -144,6 +146,7 @@ public class ProgramCardsSectionParamsFactoryTest extends ResetPostgres {
             applicantRoutes,
             /* programId= */ 1L,
             /* programSlug= */ "fake-program",
+            /* isCommonIntakeForm= */ false,
             Optional.of(
                 LifecycleStage
                     .ACTIVE), // active lifecycle stage means they have submitted the application
@@ -160,12 +163,45 @@ public class ProgramCardsSectionParamsFactoryTest extends ResetPostgres {
             applicantRoutes,
             /* programId= */ 1L,
             /* programSlug= */ "fake-program",
+            /* isCommonIntakeForm= */ false,
             Optional.of(
                 LifecycleStage
                     .ACTIVE), // active lifecycle stage means they have submitted the application
             /* applicantId= */ Optional.of(1L),
             /* profile= */ Optional.of(testProfile));
     assertThat(url).isEqualTo("/applicants/1/programs/1/review");
+  }
+
+  @Test
+  public void getActionUrl_returnsEditUrlWhenCommonIntake() {
+    ApplicantRoutes applicantRoutes = new ApplicantRoutes();
+    String url =
+        ProgramCardsSectionParamsFactory.getActionUrl(
+            applicantRoutes,
+            /* programId= */ 1L,
+            /* programSlug= */ "fake-program",
+            /* isCommonIntakeForm= */ true,
+            // empty lifecycle stage means this is their first time filling out this application
+            /* lifeCycleStage= */ Optional.empty(),
+            /* applicantId= */ Optional.empty(),
+            /* profile= */ Optional.empty());
+    assertThat(url).isEqualTo("/programs/1/edit");
+  }
+
+  @Test
+  public void getActionUrl_returnsEditUrlWhenCommonIntakeWithApplicantIdWhenPresent() {
+    ApplicantRoutes applicantRoutes = new ApplicantRoutes();
+    String url =
+        ProgramCardsSectionParamsFactory.getActionUrl(
+            applicantRoutes,
+            /* programId= */ 1L,
+            /* programSlug= */ "fake-program",
+            /* isCommonIntakeForm= */ true,
+            // empty lifecycle stage means this is their first time filling out this application
+            /* lifeCycleStage= */ Optional.empty(),
+            /* applicantId= */ Optional.of(1L),
+            /* profile= */ Optional.of(testProfile));
+    assertThat(url).isEqualTo("/applicants/1/programs/1/edit");
   }
 
   private ProgramDefinition createProgramDefinition(


### PR DESCRIPTION
### Description

When applicants are applying to a common intake program, we want to skip the program overview page and go right into editing the application.

### Checklist

#### General

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [x] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [x] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`

### Instructions for manual testing

As an admin:
1. Create a common intake program and a regular program

As an applicant:
1. Click to apply to the common intake program -- should be taken directly into the application
2. Click to apply to the other program -- should be taken to the program overview page
3. Try out other scenarios like partially filling out the application (should be taken to where you left off) and submitting the application (should be taken to the review page)

As a TI:
1. Create a client and apply on behalf of them
2. Test out all the same steps as you did for the applicant above
3. The behavior should match that for the applicant and you should consistently see a banner telling you that you are applying on behalf of the client.

### Issue(s) this completes

Fixes #9058 
