### PR TITLE
Use required() instead of requiresNew() when creating transaction in database seed tasks

### DIFF
--- a/server/app/controllers/dev/seeding/DevDatabaseSeedTask.java
+++ b/server/app/controllers/dev/seeding/DevDatabaseSeedTask.java
@@ -393,7 +393,7 @@ public final class DevDatabaseSeedTask {
 
   private void inSerializableTransaction(Runnable fn, int tryCount) {
     Transaction transaction =
-        database.beginTransaction(TxScope.requiresNew().setIsolation(TxIsolation.SERIALIZABLE));
+        database.beginTransaction(TxScope.required().setIsolation(TxIsolation.SERIALIZABLE));
 
     try {
       fn.run();

--- a/server/app/services/seeding/DatabaseSeedTask.java
+++ b/server/app/services/seeding/DatabaseSeedTask.java
@@ -191,7 +191,7 @@ public final class DatabaseSeedTask {
 
   private void inSerializableTransaction(Runnable fn, int tryCount) {
     Transaction transaction =
-        database.beginTransaction(TxScope.requiresNew().setIsolation(TxIsolation.SERIALIZABLE));
+        database.beginTransaction(TxScope.required().setIsolation(TxIsolation.SERIALIZABLE));
 
     try {
       fn.run();


### PR DESCRIPTION
### Description

Change dev and prod database seed tasks to use `TxScope.required()` instead of `TxScope.requiresNew()`.

This way, any changes are part of an outer transaction rather than in their own, separate, concurrent transaction.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [x] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [x] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`

### Issue(s) this completes

Part of #9643 
