### PR TITLE
Remove remaining uses of `TxScope.requiresNew()`

### DIFF
--- a/server/app/repository/QuestionRepository.java
+++ b/server/app/repository/QuestionRepository.java
@@ -82,7 +82,7 @@ public final class QuestionRepository {
   public QuestionModel createOrUpdateDraft(QuestionDefinition definition) {
     VersionModel draftVersion = versionRepositoryProvider.get().getDraftVersionOrCreate();
     try (Transaction transaction =
-        database.beginTransaction(TxScope.requiresNew().setIsolation(TxIsolation.SERIALIZABLE))) {
+        database.beginTransaction(TxScope.required().setIsolation(TxIsolation.SERIALIZABLE))) {
       Optional<QuestionModel> existingDraft =
           versionRepositoryProvider
               .get()


### PR DESCRIPTION
### Description

Remove remaining uses of `TxScope.requiresNew()` and replace them with `TxScope.required()`,  which is actually the behavior we want.

More details in #9643, but `.requiresNew()` is almost never the transaction isolation level we want, as it results in a separate, concurrent transaction whose changes are not visible to the outer transaction, rather than a nested "inner" transaction as one might expect.

Additionally, I verified all codepaths that call into these changes, and nothing expects the unusual behavior of `requiresNew()`.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [n/a] Created unit and/or browser tests which fail without the change (if possible)
- [n/a] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [n/a] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [n/a] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`

### Issue(s) this completes

Fixes #9643
