### PR TITLE
Getting a North Star test to pass on probers

### DIFF
--- a/browser-test/src/applicant/applicant_application_index.test.ts
+++ b/browser-test/src/applicant/applicant_application_index.test.ts
@@ -16,6 +16,7 @@ import {
 import {Page} from 'playwright'
 import {ProgramVisibility} from '../support/admin_programs'
 import {BASE_URL} from '../support/config'
+import {CardSectionName} from '../support/applicant_program_list'
 
 test.describe('applicant program index page', () => {
   const primaryProgramName = 'Application index primary program'
@@ -847,6 +848,7 @@ test.describe('applicant program index page', () => {
           page,
           adminPrograms,
           applicantQuestions,
+          applicantProgramList,
         }) => {
           await test.step('publish programs with categories', async () => {
             await adminPrograms.publishAllDrafts()
@@ -933,30 +935,28 @@ test.describe('applicant program index page', () => {
               'north-star-homepage-programs-filtered',
             )
 
-            await applicantQuestions.expectProgramsWithFilteringEnabled(
-              {
-                expectedProgramsInMyApplicationsSection: [primaryProgramName],
-                expectedProgramsInProgramsAndServicesSection: [],
-                expectedProgramsInRecommendedSection: [otherProgramName],
-                expectedProgramsInOtherProgramsSection: [
-                  'Minimal Sample Program',
-                  'Comprehensive Sample Program',
-                ],
-              },
-              /* filtersOn= */ true,
-              /* northStarEnabled= */ true,
-            )
-
-            // Check the program count in the section headings
             await expect(
-              page.getByRole('heading', {
-                name: 'Programs based on your selections (1)',
-              }),
+              applicantProgramList.getCardLocatorWithCount(
+                CardSectionName.Recommended,
+                1,
+                otherProgramName,
+              ),
             ).toBeVisible()
+
             await expect(
-              page.getByRole('heading', {
-                name: 'Other programs and services (2)',
-              }),
+              applicantProgramList.getCardLocatorWithCount(
+                CardSectionName.OtherPrograms,
+                2,
+                'Minimal Sample Program',
+              ),
+            ).toBeVisible()
+
+            await expect(
+              applicantProgramList.getCardLocatorWithCount(
+                CardSectionName.OtherPrograms,
+                2,
+                'Comprehensive Sample Program',
+              ),
             ).toBeVisible()
           })
 

--- a/browser-test/src/applicant/applicant_application_index.test.ts
+++ b/browser-test/src/applicant/applicant_application_index.test.ts
@@ -935,27 +935,29 @@ test.describe('applicant program index page', () => {
           })
 
           await test.step('Verify the contents of the Recommended and Other programs sections', async () => {
-            const notStartedSection = page.locator('#not-started-programs')
-            const recommendedSection = notStartedSection
-              .locator('.cf-application-program-section')
-              .first()
-            const othersSection = notStartedSection
-              .locator('.cf-application-program-section')
-              .last()
+            await applicantQuestions.expectProgramsWithFilteringEnabled(
+              {
+                expectedProgramsInMyApplicationsSection: [primaryProgramName],
+                expectedProgramsInProgramsAndServicesSection: [],
+                expectedProgramsInRecommendedSection: [otherProgramName],
+                expectedProgramsInOtherProgramsSection: [
+                  'Minimal Sample Program',
+                  'Comprehensive Sample Program',
+                ],
+              },
+              /* filtersOn= */ true,
+              /* northStarEnabled= */ true,
+            )
 
+            // Check the program count in the section headings
             await expect(
-              recommendedSection.getByRole('heading', {name: otherProgramName}),
-            ).toBeVisible()
-
-            await expect(
-              othersSection.getByRole('heading', {
-                name: 'Minimal Sample Program',
+              page.getByRole('heading', {
+                name: 'Programs based on your selections (1)',
               }),
             ).toBeVisible()
-
             await expect(
-              othersSection.getByRole('heading', {
-                name: 'Comprehensive Sample Program',
+              page.getByRole('heading', {
+                name: 'Other programs and services (2)',
               }),
             ).toBeVisible()
           })

--- a/browser-test/src/applicant/applicant_application_index.test.ts
+++ b/browser-test/src/applicant/applicant_application_index.test.ts
@@ -16,7 +16,6 @@ import {
 import {Page} from 'playwright'
 import {ProgramVisibility} from '../support/admin_programs'
 import {BASE_URL} from '../support/config'
-import {CardSectionName} from '../support/applicant_program_list'
 
 test.describe('applicant program index page', () => {
   const primaryProgramName = 'Application index primary program'
@@ -848,7 +847,6 @@ test.describe('applicant program index page', () => {
           page,
           adminPrograms,
           applicantQuestions,
-          applicantProgramList,
         }) => {
           await test.step('publish programs with categories', async () => {
             await adminPrograms.publishAllDrafts()
@@ -927,36 +925,38 @@ test.describe('applicant program index page', () => {
             )
           })
 
-          await test.step('Select a filter, click the filter submit button and see the Recommended and Other programs sections', async () => {
+          await test.step('Select a filter, click the filter submit button and validate screenshot', async () => {
             await applicantQuestions.filterProgramsByCategory('General')
 
             await validateScreenshot(
               page.locator('#programs-list'),
               'north-star-homepage-programs-filtered',
             )
+          })
+
+          await test.step('Verify the contents of the Recommended and Other programs sections', async () => {
+            const notStartedSection = page.locator('#not-started-programs')
+            const recommendedSection = notStartedSection
+              .locator('.cf-application-program-section')
+              .first()
+            const othersSection = notStartedSection
+              .locator('.cf-application-program-section')
+              .last()
 
             await expect(
-              applicantProgramList.getCardLocatorWithCount(
-                CardSectionName.Recommended,
-                1,
-                otherProgramName,
-              ),
+              recommendedSection.getByRole('heading', {name: otherProgramName}),
             ).toBeVisible()
 
             await expect(
-              applicantProgramList.getCardLocatorWithCount(
-                CardSectionName.OtherPrograms,
-                2,
-                'Minimal Sample Program',
-              ),
+              othersSection.getByRole('heading', {
+                name: 'Minimal Sample Program',
+              }),
             ).toBeVisible()
 
             await expect(
-              applicantProgramList.getCardLocatorWithCount(
-                CardSectionName.OtherPrograms,
-                2,
-                'Comprehensive Sample Program',
-              ),
+              othersSection.getByRole('heading', {
+                name: 'Comprehensive Sample Program',
+              }),
             ).toBeVisible()
           })
 

--- a/browser-test/src/support/applicant_program_list.ts
+++ b/browser-test/src/support/applicant_program_list.ts
@@ -22,6 +22,21 @@ export class ApplicantProgramList {
   }
 
   /**
+   * Get the card section locator for card sections where a count is displayed in the heading
+   * @param {CardSectionName} cardSectionName The heading for the section, without the count
+   * @param count The card count displayed in the heading
+   * @returns {Locator} Locator to the card section
+   */
+  getCardSectionLocatorWithCount(
+    cardSectionName: CardSectionName,
+    count: number,
+  ): Locator {
+    return this.page.getByRole('region', {
+      name: `${cardSectionName} (${count})`,
+    })
+  }
+
+  /**
    * Get the locator for program card heading in the desired section
    * @param {CardSectionName} cardSectionName to find
    * @param {String} programName to find
@@ -32,6 +47,25 @@ export class ApplicantProgramList {
     programName: string,
   ): Locator {
     return this.getCardSectionLocator(cardSectionName)
+      .getByRole('listitem')
+      .filter({
+        hasText: programName,
+      })
+  }
+
+  /**
+   * Get the locator for a program card in a section with a count in the section heading
+   * @param {CardSectionName} cardSectionName
+   * @param count The card count displayed in the section heading
+   * @param programName
+   * @returns {Locator} Locator for program card in the desired section
+   */
+  getCardLocatorWithCount(
+    cardSectionName: CardSectionName,
+    count: number,
+    programName: string,
+  ): Locator {
+    return this.getCardSectionLocatorWithCount(cardSectionName, count)
       .getByRole('listitem')
       .filter({
         hasText: programName,
@@ -153,6 +187,8 @@ export class ApplicantProgramList {
 export enum CardSectionName {
   MyApplications = 'My applications',
   ProgramsAndServices = 'Programs and services',
+  Recommended = 'Programs based on your selections',
+  OtherPrograms = 'Other programs and services',
 }
 
 /**

--- a/browser-test/src/support/applicant_program_list.ts
+++ b/browser-test/src/support/applicant_program_list.ts
@@ -22,21 +22,6 @@ export class ApplicantProgramList {
   }
 
   /**
-   * Get the card section locator for card sections where a count is displayed in the heading
-   * @param {CardSectionName} cardSectionName The heading for the section, without the count
-   * @param count The card count displayed in the heading
-   * @returns {Locator} Locator to the card section
-   */
-  getCardSectionLocatorWithCount(
-    cardSectionName: CardSectionName,
-    count: number,
-  ): Locator {
-    return this.page.getByRole('region', {
-      name: `${cardSectionName} (${count})`,
-    })
-  }
-
-  /**
    * Get the locator for program card heading in the desired section
    * @param {CardSectionName} cardSectionName to find
    * @param {String} programName to find
@@ -47,25 +32,6 @@ export class ApplicantProgramList {
     programName: string,
   ): Locator {
     return this.getCardSectionLocator(cardSectionName)
-      .getByRole('listitem')
-      .filter({
-        hasText: programName,
-      })
-  }
-
-  /**
-   * Get the locator for a program card in a section with a count in the section heading
-   * @param {CardSectionName} cardSectionName
-   * @param count The card count displayed in the section heading
-   * @param programName
-   * @returns {Locator} Locator for program card in the desired section
-   */
-  getCardLocatorWithCount(
-    cardSectionName: CardSectionName,
-    count: number,
-    programName: string,
-  ): Locator {
-    return this.getCardSectionLocatorWithCount(cardSectionName, count)
       .getByRole('listitem')
       .filter({
         hasText: programName,
@@ -187,8 +153,6 @@ export class ApplicantProgramList {
 export enum CardSectionName {
   MyApplications = 'My applications',
   ProgramsAndServices = 'Programs and services',
-  Recommended = 'Programs based on your selections',
-  OtherPrograms = 'Other programs and services',
 }
 
 /**

--- a/browser-test/src/support/applicant_questions.ts
+++ b/browser-test/src/support/applicant_questions.ts
@@ -1,7 +1,7 @@
 import {expect, Locator} from '@playwright/test'
 import {Page} from 'playwright'
 import {readFileSync, writeFileSync, unlinkSync} from 'fs'
-import {waitForAnyModal, waitForPageJsLoad} from './wait'
+import {waitForAnyModal, waitForPageJsLoad, waitForHtmxReady} from './wait'
 import {BASE_URL} from './config'
 import {
   ApplicantProgramList,
@@ -1199,6 +1199,7 @@ export class ApplicantQuestions {
     await this.page
       .getByRole('button', {name: 'Apply selections', exact: true})
       .click()
+    await waitForHtmxReady(this.page)
   }
 
   // On the North Star application summary page, find the block with the given name


### PR DESCRIPTION
### Description

An `applicant_application_index.test.ts` test was failing on probers. In different environments, Playwright was having trouble locating the Recommended and Other Programs `<section>` elements, possibly because they're rendered with HTMX.  The solution of using `first()` and `last()` was the only locator combination that worked in both the local/PR environment and in probers.

I added two helper functions to `applicant_program_list.ts` because these were working for probers, but I didn't end up using them because they didn't work locally and in the PR actions.  Leaving them in the PR because I think they could be useful in the future.

### Issue(s) this is part of:

Part of #9767
