### PR TITLE
Cleanup - AlertFragment

### DIFF
--- a/server/app/views/components/AlertFragment.html
+++ b/server/app/views/components/AlertFragment.html
@@ -14,27 +14,27 @@
     >
       <h2
         class="usa-alert__heading"
-        th:if="${hasTitle && headingLevel == 'H2'}"
+        th:if="${headingLevel == 'H2'}"
         th:text="${alertTitle}"
       ></h2>
       <h3
         class="usa-alert__heading"
-        th:if="${hasTitle && headingLevel == 'H3'}"
+        th:if="${headingLevel == 'H3'}"
         th:text="${alertTitle}"
       ></h3>
       <h4
         class="usa-alert__heading"
-        th:if="${hasTitle && headingLevel == 'H4'}"
+        th:if="${headingLevel == 'H4'}"
         th:text="${alertTitle}"
       ></h4>
       <h5
         class="usa-alert__heading"
-        th:if="${hasTitle && headingLevel == 'H5'}"
+        th:if="${headingLevel == 'H5'}"
         th:text="${alertTitle}"
       ></h5>
       <h6
         class="usa-alert__heading"
-        th:if="${hasTitle && headingLevel == 'H6'}"
+        th:if="${headingLevel == 'H6'}"
         th:text="${alertTitle}"
       ></h6>
     </th:block>

--- a/server/app/views/components/AlertFragment.html
+++ b/server/app/views/components/AlertFragment.html
@@ -1,6 +1,7 @@
 <div
   th:fragment="alert(alertSettings, headingLevel)"
   th:if="${alertSettings.title.isPresent() || alertSettings.isSlim}"
+  th:with="hasTitle=${alertSettings.title.isPresent()}"
   th:class="${'usa-alert usa-alert--' + alertSettings.alertType.name().toLowerCase()}"
   th:classappend="${alertSettings.isSlim ? 'usa-alert--slim' : ''}"
   aria-live="polite"
@@ -8,10 +9,10 @@
 >
   <div
     class="usa-alert__body"
-    th:if="${alertSettings.title.isPresent()}"
-    th:with="hasTitle=${alertSettings.title.isPresent()}
-      ,alertTitle=${alertSettings.title.get()}"
   >
+    <th:block th:if="${hasTitle}"
+              th:with="alertTitle=${alertSettings.title.get()}"
+    >
     <h2
       class="usa-alert__heading"
       th:if="${hasTitle && headingLevel == 'H2'}"
@@ -37,6 +38,7 @@
       th:if="${hasTitle && headingLevel == 'H6'}"
       th:text="${alertTitle}"
     ></h6>
+    </th:block>
 
     <div th:if="${alertSettings.unescapedDescription()} == true">
       <p

--- a/server/app/views/components/AlertFragment.html
+++ b/server/app/views/components/AlertFragment.html
@@ -6,31 +6,36 @@
   aria-live="polite"
   th:attr="role=${role != null ? role : 'alert'}"
 >
-  <div class="usa-alert__body">
+  <div
+    class="usa-alert__body"
+    th:if="${alertSettings.title.isPresent()}"
+    th:with="hasTitle=${alertSettings.title.isPresent()}
+      ,alertTitle=${alertSettings.title.get()}"
+  >
     <h2
       class="usa-alert__heading"
-      th:if="${alertSettings.title.isPresent() && headingLevel == 'H2'}"
-      th:text="${alertSettings.title.get()}"
+      th:if="${hasTitle && headingLevel == 'H2'}"
+      th:text="${alertTitle}"
     ></h2>
     <h3
       class="usa-alert__heading"
-      th:if="${alertSettings.title.isPresent() && headingLevel == 'H3'}"
-      th:text="${alertSettings.title.get()}"
+      th:if="${hasTitle && headingLevel == 'H3'}"
+      th:text="${alertTitle}"
     ></h3>
     <h4
       class="usa-alert__heading"
-      th:if="${alertSettings.title.isPresent() && headingLevel == 'H4'}"
-      th:text="${alertSettings.title.get()}"
+      th:if="${hasTitle && headingLevel == 'H4'}"
+      th:text="${alertTitle}"
     ></h4>
     <h5
       class="usa-alert__heading"
-      th:if="${alertSettings.title.isPresent() && headingLevel == 'H5'}"
-      th:text="${alertSettings.title.get()}"
+      th:if="${hasTitle && headingLevel == 'H5'}"
+      th:text="${alertTitle}"
     ></h5>
     <h6
       class="usa-alert__heading"
-      th:if="${alertSettings.title.isPresent() && headingLevel == 'H6'}"
-      th:text="${alertSettings.title.get()}"
+      th:if="${hasTitle && headingLevel == 'H6'}"
+      th:text="${alertTitle}"
     ></h6>
 
     <div th:if="${alertSettings.unescapedDescription()} == true">

--- a/server/app/views/components/AlertFragment.html
+++ b/server/app/views/components/AlertFragment.html
@@ -7,37 +7,36 @@
   aria-live="polite"
   th:attr="role=${role != null ? role : 'alert'}"
 >
-  <div
-    class="usa-alert__body"
-  >
-    <th:block th:if="${hasTitle}"
-              th:with="alertTitle=${alertSettings.title.get()}"
+  <div class="usa-alert__body">
+    <th:block
+      th:if="${hasTitle}"
+      th:with="alertTitle=${alertSettings.title.get()}"
     >
-    <h2
-      class="usa-alert__heading"
-      th:if="${hasTitle && headingLevel == 'H2'}"
-      th:text="${alertTitle}"
-    ></h2>
-    <h3
-      class="usa-alert__heading"
-      th:if="${hasTitle && headingLevel == 'H3'}"
-      th:text="${alertTitle}"
-    ></h3>
-    <h4
-      class="usa-alert__heading"
-      th:if="${hasTitle && headingLevel == 'H4'}"
-      th:text="${alertTitle}"
-    ></h4>
-    <h5
-      class="usa-alert__heading"
-      th:if="${hasTitle && headingLevel == 'H5'}"
-      th:text="${alertTitle}"
-    ></h5>
-    <h6
-      class="usa-alert__heading"
-      th:if="${hasTitle && headingLevel == 'H6'}"
-      th:text="${alertTitle}"
-    ></h6>
+      <h2
+        class="usa-alert__heading"
+        th:if="${hasTitle && headingLevel == 'H2'}"
+        th:text="${alertTitle}"
+      ></h2>
+      <h3
+        class="usa-alert__heading"
+        th:if="${hasTitle && headingLevel == 'H3'}"
+        th:text="${alertTitle}"
+      ></h3>
+      <h4
+        class="usa-alert__heading"
+        th:if="${hasTitle && headingLevel == 'H4'}"
+        th:text="${alertTitle}"
+      ></h4>
+      <h5
+        class="usa-alert__heading"
+        th:if="${hasTitle && headingLevel == 'H5'}"
+        th:text="${alertTitle}"
+      ></h5>
+      <h6
+        class="usa-alert__heading"
+        th:if="${hasTitle && headingLevel == 'H6'}"
+        th:text="${alertTitle}"
+      ></h6>
     </th:block>
 
     <div th:if="${alertSettings.unescapedDescription()} == true">


### PR DESCRIPTION
Move duplicate variable evaluations into th:with for readability and less errorprone
