### PR TITLE
Check that tag exists and has a value

### DIFF
--- a/browser-test/src/northstar_meta_tags.test.ts
+++ b/browser-test/src/northstar_meta_tags.test.ts
@@ -8,8 +8,10 @@ test.describe('navigating to a deep link', {tag: ['@northstar']}, () => {
 
   test('has civiform build tag', async ({page, applicantQuestions}) => {
     await applicantQuestions.gotoApplicantHomePage()
-    await expect(
-      page.locator('meta[name="civiform-build-tag"]'),
-    ).toHaveAttribute('content', 'dev')
+
+    const metaTagLocator = page.locator('meta[name="civiform-build-tag"]')
+
+    await expect(metaTagLocator).toHaveAttribute('content')
+    expect(await metaTagLocator.getAttribute('content')).not.toBeNull()
   })
 })


### PR DESCRIPTION
### Description

This test was checking for an explicit value of `dev`. Changing to just verify the meta tag exists and has a value so it works in dev and against deployed instances.


### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
