### PR TITLE
Wrapping two tests with isLocalDevEnvironment

### DIFF
--- a/browser-test/src/applicant/application_address_correction.test.ts
+++ b/browser-test/src/applicant/application_address_correction.test.ts
@@ -412,58 +412,105 @@ test.describe('address correction', () => {
       await enableFeatureFlag(page, 'esri_address_correction_enabled')
     })
 
-    test('can correct address single-block, single-address program', async ({
-      page,
-      applicantQuestions,
-    }) => {
-      await test.step('Answer address question', async () => {
-        await applicantQuestions.applyProgram(
-          singleBlockSingleAddressProgram,
-          /* northStarEnabled= */ true,
-        )
+    if (isLocalDevEnvironment()) {
+      test('can correct address single-block, single-address program', async ({
+        page,
+        applicantQuestions,
+      }) => {
+        await test.step('Answer address question', async () => {
+          await applicantQuestions.applyProgram(
+            singleBlockSingleAddressProgram,
+            /* northStarEnabled= */ true,
+          )
 
-        await applicantQuestions.expectTitle(
-          page,
-          'Address correction single-block, single-address program — 1 of 2',
-        )
+          await applicantQuestions.expectTitle(
+            page,
+            'Address correction single-block, single-address program — 1 of 2',
+          )
 
-        await applicantQuestions.answerAddressQuestion(
-          'Legit Address',
-          '',
-          'Redlands',
-          'CA',
-          '92373',
-        )
-        await applicantQuestions.clickContinue()
+          await applicantQuestions.answerAddressQuestion(
+            'Legit Address',
+            '',
+            'Redlands',
+            'CA',
+            '92373',
+          )
+          await applicantQuestions.clickContinue()
+        })
+
+        await test.step('Validate address correction page shown', async () => {
+          await applicantQuestions.expectVerifyAddressPage(true)
+
+          await validateScreenshot(
+            page,
+            'north-star-verify-address-with-suggestions',
+            /* fullPage= */ true,
+            /* mobileScreenshot= */ true,
+          )
+          await validateAccessibility(page)
+        })
+
+        await test.step('Confirm user can confirm address and submit', async () => {
+          await applicantQuestions.clickConfirmAddress()
+
+          await applicantQuestions.clickEdit()
+          await applicantQuestions.checkAddressQuestionValue(
+            'Address In Area',
+            '',
+            'Redlands',
+            'CA',
+            '92373',
+          )
+          await applicantQuestions.clickContinue()
+          await applicantQuestions.clickSubmitApplication()
+        })
       })
 
-      await test.step('Validate address correction page shown', async () => {
-        await applicantQuestions.expectVerifyAddressPage(true)
+      test('go back and edit does not save address selection', async ({
+        applicantQuestions,
+      }) => {
+        await test.step('Answer address question', async () => {
+          await applicantQuestions.applyProgram(
+            singleBlockSingleAddressProgram,
+            /* northStarEnabled= */ true,
+          )
 
-        await validateScreenshot(
-          page,
-          'north-star-verify-address-with-suggestions',
-          /* fullPage= */ true,
-          /* mobileScreenshot= */ true,
-        )
-        await validateAccessibility(page)
+          await applicantQuestions.answerAddressQuestion(
+            'Legit Address',
+            '',
+            'Redlands',
+            'CA',
+            '92373',
+          )
+          await applicantQuestions.clickContinue()
+        })
+
+        await test.step('Validate address correction page shown', async () => {
+          await applicantQuestions.expectVerifyAddressPage(true)
+        })
+
+        await test.step('Select suggestion, but click go back and edit should not save the suggestion', async () => {
+          await applicantQuestions.selectAddressSuggestion(
+            'Address With No Service Area Features',
+          )
+
+          await applicantQuestions.clickGoBackAndEdit()
+
+          await applicantQuestions.validateQuestionIsOnPage(
+            addressWithCorrectionText,
+          )
+
+          // Verify the original address (not the suggested address) is filled in on the block page
+          await applicantQuestions.checkAddressQuestionValue(
+            'Legit Address',
+            '',
+            'Redlands',
+            'CA',
+            '92373',
+          )
+        })
       })
-
-      await test.step('Confirm user can confirm address and submit', async () => {
-        await applicantQuestions.clickConfirmAddress()
-
-        await applicantQuestions.clickEdit()
-        await applicantQuestions.checkAddressQuestionValue(
-          'Address In Area',
-          '',
-          'Redlands',
-          'CA',
-          '92373',
-        )
-        await applicantQuestions.clickContinue()
-        await applicantQuestions.clickSubmitApplication()
-      })
-    })
+    }
 
     test('prompts user to edit if no suggestions are returned', async ({
       page,
@@ -501,51 +548,6 @@ test.describe('address correction', () => {
       await test.step('Confirm user can confirm address and submit', async () => {
         await applicantQuestions.clickConfirmAddress()
         await applicantQuestions.clickSubmitApplication()
-      })
-    })
-
-    test('go back and edit does not save address selection', async ({
-      applicantQuestions,
-    }) => {
-      await test.step('Answer address question', async () => {
-        await applicantQuestions.applyProgram(
-          singleBlockSingleAddressProgram,
-          /* northStarEnabled= */ true,
-        )
-
-        await applicantQuestions.answerAddressQuestion(
-          'Legit Address',
-          '',
-          'Redlands',
-          'CA',
-          '92373',
-        )
-        await applicantQuestions.clickContinue()
-      })
-
-      await test.step('Validate address correction page shown', async () => {
-        await applicantQuestions.expectVerifyAddressPage(true)
-      })
-
-      await test.step('Select suggestion, but click go back and edit should not save the suggestion', async () => {
-        await applicantQuestions.selectAddressSuggestion(
-          'Address With No Service Area Features',
-        )
-
-        await applicantQuestions.clickGoBackAndEdit()
-
-        await applicantQuestions.validateQuestionIsOnPage(
-          addressWithCorrectionText,
-        )
-
-        // Verify the original address (not the suggested address) is filled in on the block page
-        await applicantQuestions.checkAddressQuestionValue(
-          'Legit Address',
-          '',
-          'Redlands',
-          'CA',
-          '92373',
-        )
       })
     })
 


### PR DESCRIPTION
### Description

Wraps two tests in the `isLocalDevEnvironment` as they require the mock web services and only work in dev/ci.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
