### PR TITLE
Add JAVA_TOOL_OPTIONS env var

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -128,4 +128,5 @@ services:
       - WHITELABEL_CIVIC_ENTITY_FULL_NAME
       - FAVICON_URL
       - DISABLE_ERRORPRONE=${DISABLE_ERRORPRONE:-false}
+      - JAVA_TOOL_OPTIONS
     entrypoint: /bin/bash

--- a/env-var-docs/check_vars_documented.py
+++ b/env-var-docs/check_vars_documented.py
@@ -78,6 +78,10 @@ def main():
     errors = False
     msg = "CiviForm environment variables are not correctly documented. See https://github.com/civiform/civiform/blob/main/env-var-docs/README.md for information. Issues:\n"
 
+    # This should not be set in application.conf as it is for the JVM, not CiviForm itself,
+    # so ignore checking on this particular variable
+    documented_vars.pop('JAVA_TOOL_OPTIONS', '')
+
     for name, var in documented_vars.items():
         if var.mode == env_var_docs.parser.Mode.ADMIN_READABLE:
             try:

--- a/env-var-docs/check_vars_documented.py
+++ b/env-var-docs/check_vars_documented.py
@@ -78,10 +78,6 @@ def main():
     errors = False
     msg = "CiviForm environment variables are not correctly documented. See https://github.com/civiform/civiform/blob/main/env-var-docs/README.md for information. Issues:\n"
 
-    # This should not be set in application.conf as it is for the JVM, not CiviForm itself,
-    # so ignore checking on this particular variable
-    documented_vars.pop('JAVA_TOOL_OPTIONS', '')
-
     for name, var in documented_vars.items():
         if var.mode == env_var_docs.parser.Mode.ADMIN_READABLE:
             try:

--- a/server/app/services/settings/SettingsManifest.java
+++ b/server/app/services/settings/SettingsManifest.java
@@ -823,6 +823,14 @@ public final class SettingsManifest extends AbstractSettingsManifest {
   }
 
   /**
+   * Any list of options to pass to the JVM when starting the server. For example, to set the heap
+   * size, "-Xms2G -Xmx2g"
+   */
+  public Optional<String> getJavaToolOptions() {
+    return getString("JAVA_TOOL_OPTIONS");
+  }
+
+  /**
    * If enabled, allows server Prometheus metrics to be retrieved via the '/metrics' URL path.  If
    * disabled, '/metrics' returns a 404.
    */
@@ -2297,5 +2305,12 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                           + " frontend to notify a user when their session is expired.",
                       /* isRequired= */ false,
                       SettingType.INT,
+                      SettingMode.ADMIN_READABLE),
+                  SettingDescription.create(
+                      "JAVA_TOOL_OPTIONS",
+                      "Any list of options to pass to the JVM when starting the server. For"
+                          + " example, to set the heap size, \"-Xms2G -Xmx2g\"",
+                      /* isRequired= */ false,
+                      SettingType.STRING,
                       SettingMode.ADMIN_READABLE))));
 }

--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -611,3 +611,8 @@ file_upload_allowed_file_type_specifiers = ${?FILE_UPLOAD_ALLOWED_FILE_TYPE_SPEC
 # The number of minutes before a session expires
 maximum_session_duration_minutes = 600
 maximum_session_duration_minutes = ${?MAXIMUM_SESSION_DURATION_MINUTES}
+
+# This is not actually used by CiviForm but rather the JVM itself. It is
+# only exposed here in order to show the value on the Settings page.
+java_tool_options = ''
+java_tool_options = ${?JAVA_TOOL_OPTIONS}

--- a/server/conf/env-var-docs.json
+++ b/server/conf/env-var-docs.json
@@ -703,6 +703,11 @@
     "description": "The amount of time, in minutes, that a session lasts. The default is 600 minutes, or 10 hours. Note that there isn't yet messaging on the frontend to notify a user when their session is expired.",
     "type": "int"
   },
+  "JAVA_TOOL_OPTIONS": {
+    "mode": "ADMIN_READABLE",
+    "description": "Any list of options to pass to the JVM when starting the server. For example, to set the heap size, \"-Xms2G -Xmx2g\"",
+    "type": "string"
+  },
   "Observability": {
     "group_description": "Configuration options for CiviForm observability features.",
     "members": {

--- a/server/conf/env-var-docs.json
+++ b/server/conf/env-var-docs.json
@@ -705,7 +705,7 @@
   },
   "JAVA_TOOL_OPTIONS": {
     "mode": "ADMIN_READABLE",
-    "description": "Any list of options to pass to the JVM when starting the server. For example, to set the heap size, \"-Xms2G -Xmx2g\"",
+    "description": "Any list of options to pass to the JVM when starting the server. For example, to set the heap size, \"-Xms2G -Xmx2G\"",
     "type": "string"
   },
   "Observability": {


### PR DESCRIPTION
This allows us to add options passed to the JVM in case we need to do so in a live environment, such as setting the heap size.  See https://docs.oracle.com/en/java/javase/17/troubleshoot/environment-variables-and-system-properties.html for details on how this works.

Example:
`export JAVA_TOOL_OPTIONS="-Xmx2G -Xms2G"`

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [x] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`

### Instructions for manual testing

I built a dev image called `DEV-e6a6b59-java_tool_options` to test this.  When deploying with the above example in your config.sh, the log for the deployment shows `Picked up JAVA_TOOL_OPTIONS: -Xmx2G -Xms2G`.  You can also try hammering the server with massive exports to try to fill up the heap.  If you manage this, you should observe the memory usage on the container approaching 50% (I believe the VM it runs on has 4GB, so usually you'll only see it fill up to 25%).
