### PR TITLE
[SessionTimeout][part1]Introduce the session timeout configurations and feature flag

### DIFF
--- a/server/app/services/settings/SettingsManifest.java
+++ b/server/app/services/settings/SettingsManifest.java
@@ -822,11 +822,6 @@ public final class SettingsManifest extends AbstractSettingsManifest {
     return getInt("MAXIMUM_SESSION_DURATION_MINUTES");
   }
 
-  /** Enable session timeout based on inactivity and maximum duration. */
-  public boolean getSessionTimeoutEnabled() {
-    return getBool("SESSION_TIMEOUT_ENABLED");
-  }
-
   /**
    * The number of minutes of inactivity before we warn the user that their session will expire.
    * Default is 5.
@@ -1072,6 +1067,11 @@ public final class SettingsManifest extends AbstractSettingsManifest {
    */
   public boolean getNorthStarApplicantUi(RequestHeader request) {
     return getBool("NORTH_STAR_APPLICANT_UI", request);
+  }
+
+  /** Enable session timeout based on inactivity and maximum duration. */
+  public boolean getSessionTimeoutEnabled() {
+    return getBool("SESSION_TIMEOUT_ENABLED");
   }
 
   private static final ImmutableMap<String, SettingsSection> GENERATED_SECTIONS =
@@ -2200,7 +2200,13 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                           + " experience in Applicant flows",
                       /* isRequired= */ false,
                       SettingType.BOOLEAN,
-                      SettingMode.ADMIN_WRITEABLE))),
+                      SettingMode.ADMIN_WRITEABLE),
+                  SettingDescription.create(
+                      "SESSION_TIMEOUT_ENABLED",
+                      "Enable session timeout based on inactivity and maximum duration.",
+                      /* isRequired= */ false,
+                      SettingType.BOOLEAN,
+                      SettingMode.ADMIN_READABLE))),
           "Miscellaneous",
           SettingsSection.create(
               "Miscellaneous",
@@ -2323,12 +2329,6 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                           + " frontend to notify a user when their session is expired.",
                       /* isRequired= */ false,
                       SettingType.INT,
-                      SettingMode.ADMIN_READABLE),
-                  SettingDescription.create(
-                      "SESSION_TIMEOUT_ENABLED",
-                      "Enable session timeout based on inactivity and maximum duration.",
-                      /* isRequired= */ false,
-                      SettingType.BOOLEAN,
                       SettingMode.ADMIN_READABLE),
                   SettingDescription.create(
                       "SESSION_INACTIVITY_WARNING_MINUTES",

--- a/server/app/services/settings/SettingsManifest.java
+++ b/server/app/services/settings/SettingsManifest.java
@@ -822,6 +822,32 @@ public final class SettingsManifest extends AbstractSettingsManifest {
     return getInt("MAXIMUM_SESSION_DURATION_MINUTES");
   }
 
+  /** Enable session timeout based on inactivity and maximum duration. */
+  public boolean getSessionTimeoutEnabled() {
+    return getBool("SESSION_TIMEOUT_ENABLED");
+  }
+
+  /**
+   * The number of minutes of inactivity before we warn the user that their session will expire.
+   * Default is 5.
+   */
+  public Optional<Integer> getSessionInactivityWarningMinutes() {
+    return getInt("SESSION_INACTIVITY_WARNING_MINUTES");
+  }
+
+  /**
+   * The number of minutes before we hit the maximum session duration that we warn the user that
+   * their session will expire. Default is 10.
+   */
+  public Optional<Integer> getSessionMaxDurationWarningMinutes() {
+    return getInt("SESSION_MAX_DURATION_WARNING_MINUTES");
+  }
+
+  /** The number of minutes of inactivity before a session times out. Default is 30. */
+  public Optional<Integer> getSessionInactivityTimeoutMinutes() {
+    return getInt("SESSION_INACTIVITY_TIMEOUT_MINUTES");
+  }
+
   /**
    * If enabled, allows server Prometheus metrics to be retrieved via the '/metrics' URL path.  If
    * disabled, '/metrics' returns a 404.
@@ -2295,6 +2321,33 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                       "The amount of time, in minutes, that a session lasts. The default is 600"
                           + " minutes, or 10 hours. Note that there isn't yet messaging on the"
                           + " frontend to notify a user when their session is expired.",
+                      /* isRequired= */ false,
+                      SettingType.INT,
+                      SettingMode.ADMIN_READABLE),
+                  SettingDescription.create(
+                      "SESSION_TIMEOUT_ENABLED",
+                      "Enable session timeout based on inactivity and maximum duration.",
+                      /* isRequired= */ false,
+                      SettingType.BOOLEAN,
+                      SettingMode.ADMIN_READABLE),
+                  SettingDescription.create(
+                      "SESSION_INACTIVITY_WARNING_MINUTES",
+                      "The number of minutes of inactivity before we warn the user that their"
+                          + " session will expire. Default is 5.",
+                      /* isRequired= */ false,
+                      SettingType.INT,
+                      SettingMode.ADMIN_READABLE),
+                  SettingDescription.create(
+                      "SESSION_MAX_DURATION_WARNING_MINUTES",
+                      "The number of minutes before we hit the maximum session duration that we"
+                          + " warn the user that their session will expire. Default is 10.",
+                      /* isRequired= */ false,
+                      SettingType.INT,
+                      SettingMode.ADMIN_READABLE),
+                  SettingDescription.create(
+                      "SESSION_INACTIVITY_TIMEOUT_MINUTES",
+                      "The number of minutes of inactivity before a session times out. Default is"
+                          + " 30.",
                       /* isRequired= */ false,
                       SettingType.INT,
                       SettingMode.ADMIN_READABLE))));

--- a/server/app/services/settings/SettingsManifest.java
+++ b/server/app/services/settings/SettingsManifest.java
@@ -823,19 +823,19 @@ public final class SettingsManifest extends AbstractSettingsManifest {
   }
 
   /**
-   * The number of minutes of inactivity before we warn the user that their session will expire.
-   * Default is 5.
+   * How many minutes before the session inactivity timeout a user receives a warning that their
+   * session will expire. Default is 5.
    */
-  public Optional<Integer> getSessionInactivityWarningMinutes() {
-    return getInt("SESSION_INACTIVITY_WARNING_MINUTES");
+  public Optional<Integer> getSessionInactivityWarningThresholdMinutes() {
+    return getInt("SESSION_INACTIVITY_WARNING_THRESHOLD_MINUTES");
   }
 
   /**
-   * The number of minutes before we hit the maximum session duration that we warn the user that
+   * How many minutes before the maximum session duration timeout a user receives a warning that
    * their session will expire. Default is 10.
    */
-  public Optional<Integer> getSessionMaxDurationWarningMinutes() {
-    return getInt("SESSION_MAX_DURATION_WARNING_MINUTES");
+  public Optional<Integer> getSessionDurationWarningThresholdMinutes() {
+    return getInt("SESSION_DURATION_WARNING_THRESHOLD_MINUTES");
   }
 
   /** The number of minutes of inactivity before a session times out. Default is 30. */
@@ -2331,16 +2331,16 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                       SettingType.INT,
                       SettingMode.ADMIN_READABLE),
                   SettingDescription.create(
-                      "SESSION_INACTIVITY_WARNING_MINUTES",
-                      "The number of minutes of inactivity before we warn the user that their"
-                          + " session will expire. Default is 5.",
+                      "SESSION_INACTIVITY_WARNING_THRESHOLD_MINUTES",
+                      "How many minutes before the session inactivity timeout a user receives a"
+                          + " warning that their session will expire. Default is 5.",
                       /* isRequired= */ false,
                       SettingType.INT,
                       SettingMode.ADMIN_READABLE),
                   SettingDescription.create(
-                      "SESSION_MAX_DURATION_WARNING_MINUTES",
-                      "The number of minutes before we hit the maximum session duration that we"
-                          + " warn the user that their session will expire. Default is 10.",
+                      "SESSION_DURATION_WARNING_THRESHOLD_MINUTES",
+                      "How many minutes before the maximum session duration timeout a user receives"
+                          + " a warning that their session will expire. Default is 10.",
                       /* isRequired= */ false,
                       SettingType.INT,
                       SettingMode.ADMIN_READABLE),

--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -619,8 +619,8 @@ session_timeout_enabled = ${?SESSION_TIMEOUT_ENABLED}
 session_inactivity_timeout_minutes = 30
 session_inactivity_timeout_minutes = ${?SESSION_INACTIVITY_TIMEOUT_MINUTES}
 
-session_inactivity_warning_minutes = 5  # 5 minutes warning for inactivity
-session_inactivity_warning_minutes = ${?SESSION_INACTIVITY_WARNING_MINUTES}
+session_inactivity_warning_threshold_minutes = 5  # Warn the user 5 mins before session timeout due to inactivity
+session_inactivity_warning_threshold_minutes = ${?SESSION_INACTIVITY_WARNING_THRESHOLD_MINUTES}
 
-session_max_duration_warning_minutes = 10     # 10 minutes warning for total duration
-session_max_duration_warning_minutes = ${?SESSION_MAX_DURATION_WARNING_MINUTES}
+session_duration_warning_threshold_minutes = 10 # Warn the user 10 mins before the max session duration timeout
+session_duration_warning_threshold_minutes = ${?SESSION_DURATION_WARNING_THRESHOLD_MINUTES}

--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -611,3 +611,16 @@ file_upload_allowed_file_type_specifiers = ${?FILE_UPLOAD_ALLOWED_FILE_TYPE_SPEC
 # The number of minutes before a session expires
 maximum_session_duration_minutes = 600
 maximum_session_duration_minutes = ${?MAXIMUM_SESSION_DURATION_MINUTES}
+
+# Session timeout settings
+session_timeout_enabled = false
+session_timeout_enabled = ${?SESSION_TIMEOUT_ENABLED}
+
+session_inactivity_timeout_minutes = 30
+session_inactivity_timeout_minutes = ${?SESSION_INACTIVITY_TIMEOUT_MINUTES}
+
+session_inactivity_warning_minutes = 5  # 5 minutes warning for inactivity
+session_inactivity_warning_minutes = ${?SESSION_INACTIVITY_WARNING_MINUTES}
+
+session_max_duration_warning_minutes = 10     # 10 minutes warning for total duration
+session_max_duration_warning_minutes = ${?SESSION_MAX_DURATION_WARNING_MINUTES}

--- a/server/conf/application.dev.conf
+++ b/server/conf/application.dev.conf
@@ -66,3 +66,4 @@ bulk_status_update_enabled = true
 name_suffix_dropdown_enabled = true
 fastforward_enabled = true
 customized_eligibility_message_enabled = true
+session_timeout_enabled = false

--- a/server/conf/env-var-docs.json
+++ b/server/conf/env-var-docs.json
@@ -703,15 +703,15 @@
     "description": "The amount of time, in minutes, that a session lasts. The default is 600 minutes, or 10 hours. Note that there isn't yet messaging on the frontend to notify a user when their session is expired.",
     "type": "int"
   },
-  "SESSION_INACTIVITY_WARNING_MINUTES": {
+  "SESSION_INACTIVITY_WARNING_THRESHOLD_MINUTES": {
     "mode": "ADMIN_READABLE",
-    "description": "The number of minutes of inactivity before we warn the user that their session will expire. Default is 5.",
+    "description": "How many minutes before the session inactivity timeout a user receives a warning that their session will expire. Default is 5.",
     "type": "int",
     "required": false
   },
-  "SESSION_MAX_DURATION_WARNING_MINUTES": {
+  "SESSION_DURATION_WARNING_THRESHOLD_MINUTES": {
     "mode": "ADMIN_READABLE",
-    "description": "The number of minutes before we hit the maximum session duration that we warn the user that their session will expire. Default is 10.",
+    "description": "How many minutes before the maximum session duration timeout a user receives a warning that their session will expire. Default is 10.",
     "type": "int",
     "required": false
   },

--- a/server/conf/env-var-docs.json
+++ b/server/conf/env-var-docs.json
@@ -703,12 +703,6 @@
     "description": "The amount of time, in minutes, that a session lasts. The default is 600 minutes, or 10 hours. Note that there isn't yet messaging on the frontend to notify a user when their session is expired.",
     "type": "int"
   },
-  "SESSION_TIMEOUT_ENABLED": {
-    "mode": "ADMIN_READABLE",
-    "description": "Enable session timeout based on inactivity and maximum duration.",
-    "type": "bool",
-    "required": false
-  },
   "SESSION_INACTIVITY_WARNING_MINUTES": {
     "mode": "ADMIN_READABLE",
     "description": "The number of minutes of inactivity before we warn the user that their session will expire. Default is 5.",
@@ -909,6 +903,12 @@
         "mode": "ADMIN_WRITEABLE",
         "description": "(NOT FOR PRODUCTION USE) Enables showing new UI with an updated user experience in Applicant flows",
         "type": "bool"
+      },
+      "SESSION_TIMEOUT_ENABLED": {
+        "mode": "ADMIN_READABLE",
+        "description": "Enable session timeout based on inactivity and maximum duration.",
+        "type": "bool",
+        "required": false
       }
     }
   }

--- a/server/conf/env-var-docs.json
+++ b/server/conf/env-var-docs.json
@@ -703,6 +703,30 @@
     "description": "The amount of time, in minutes, that a session lasts. The default is 600 minutes, or 10 hours. Note that there isn't yet messaging on the frontend to notify a user when their session is expired.",
     "type": "int"
   },
+  "SESSION_TIMEOUT_ENABLED": {
+    "mode": "ADMIN_READABLE",
+    "description": "Enable session timeout based on inactivity and maximum duration.",
+    "type": "bool",
+    "required": false
+  },
+  "SESSION_INACTIVITY_WARNING_MINUTES": {
+    "mode": "ADMIN_READABLE",
+    "description": "The number of minutes of inactivity before we warn the user that their session will expire. Default is 5.",
+    "type": "int",
+    "required": false
+  },
+  "SESSION_MAX_DURATION_WARNING_MINUTES": {
+    "mode": "ADMIN_READABLE",
+    "description": "The number of minutes before we hit the maximum session duration that we warn the user that their session will expire. Default is 10.",
+    "type": "int",
+    "required": false
+  },
+  "SESSION_INACTIVITY_TIMEOUT_MINUTES": {
+    "mode": "ADMIN_READABLE",
+    "description": "The number of minutes of inactivity before a session times out. Default is 30.",
+    "type": "int",
+    "required": false
+  },
   "Observability": {
     "group_description": "Configuration options for CiviForm observability features.",
     "members": {


### PR DESCRIPTION
### Description

Introduce configurations for browser session timeouts and warning threshold. This is part 1 of browser session timeout work. The feature is by default turned off by default. Since the feature can be configured as on or off, I have not created an explicit feature flag. All subsequent changes will be guarded on the feature being on or off effectively serving as a feature flag.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).

#### New Features
- [ ] Add new FeatureFlag env vars to `server/conf/helper/feature-flags.conf`
- [x] Conditioned new functionality on a [FeatureFlag](https://github.com/civiform/civiform/wiki/Feature-Flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Instructions for manual testing
Login as admin and ensure that all the new server settings appears in the intended sections.

### Issue(s) this completes

Fixes #9820
