### PR TITLE
Fixing North Star upsell test on probers

### DIFF
--- a/browser-test/bin/wait_for_server_start_and_run_tests.sh
+++ b/browser-test/bin/wait_for_server_start_and_run_tests.sh
@@ -9,11 +9,11 @@ DEADLINE=$(($START_TIME + 500))
 # Defaults civiform:9000 when running from within docker.
 export BASE_URL="${BASE_URL:-http://civiform:9000}"
 
-export TEST_USER_AUTH_STRATEGY=fake-oidc
-export TEST_USER_LOGIN=testuser
-export TEST_USER_PASSWORD=anotsecretpassword
+export TEST_USER_AUTH_STRATEGY="${TEST_USER_AUTH_STRATEGY:-fake-oidc}"
+export TEST_USER_LOGIN="${TEST_USER_LOGIN:-testuser}"
+export TEST_USER_PASSWORD="${TEST_USER_PASSWORD:-anotsecretpassword}"
 # The display name returned by test_oidc_provider.js is <username>@example.com.
-export TEST_USER_DISPLAY_NAME=testuser@example.com
+export TEST_USER_DISPLAY_NAME="${TEST_USER_DISPLAY_NAME:-testuser@example.com}"
 
 if ! output="$(node -v)"; then
   echo output

--- a/browser-test/src/applicant/applicant_application_index.test.ts
+++ b/browser-test/src/applicant/applicant_application_index.test.ts
@@ -12,6 +12,7 @@ import {
   validateScreenshot,
   seedProgramsAndCategories,
   selectApplicantLanguage,
+  normalizeElements,
 } from '../support'
 import {Page} from 'playwright'
 import {ProgramVisibility} from '../support/admin_programs'
@@ -698,6 +699,7 @@ test.describe('applicant program index page', () => {
             page,
             'program-index-page-submitted-northstar',
           )
+          await normalizeElements(page)
           await expect(page.getByText('Submitted on 1/1/30')).toBeVisible()
         })
 

--- a/browser-test/src/applicant/northstar_upsell.test.ts
+++ b/browser-test/src/applicant/northstar_upsell.test.ts
@@ -4,6 +4,7 @@ import {
   disableFeatureFlag,
   loginAsAdmin,
   loginAsTestUser,
+  testUserDisplayName,
   logout,
   validateScreenshot,
   validateAccessibility,
@@ -21,6 +22,8 @@ test.describe('Upsell tests', {tag: ['@northstar']}, () => {
   const relatedProgramName = 'Related program'
 
   test.beforeEach(async ({page, adminPrograms}) => {
+    await enableFeatureFlag(page, 'north_star_applicant_ui')
+
     await loginAsAdmin(page)
 
     await test.step('Setup: Publish program as admin', async () => {
@@ -53,7 +56,6 @@ test.describe('Upsell tests', {tag: ['@northstar']}, () => {
 
     await loginAsTestUser(page)
 
-    await enableFeatureFlag(page, 'north_star_applicant_ui')
     await enableFeatureFlag(page, 'application_exportable')
     await enableFeatureFlag(
       page,
@@ -96,7 +98,7 @@ test.describe('Upsell tests', {tag: ['@northstar']}, () => {
       await page.waitForURL('**/programs')
       // Expect the user is still logged in
       await expect(page.getByRole('banner')).toContainText(
-        'Logged in as testuser@example.com',
+        `Logged in as ${testUserDisplayName()}`,
       )
     })
   })
@@ -112,7 +114,6 @@ test.describe('Upsell tests', {tag: ['@northstar']}, () => {
     await createRelatedProgram(page, adminPrograms)
     await loginAsTestUser(page)
 
-    await enableFeatureFlag(page, 'north_star_applicant_ui')
     await enableFeatureFlag(page, 'application_exportable')
     await disableFeatureFlag(
       page,
@@ -142,7 +143,6 @@ test.describe('Upsell tests', {tag: ['@northstar']}, () => {
     // This test will only validate that the download link is no longer visible.
     await loginAsTestUser(page)
 
-    await enableFeatureFlag(page, 'north_star_applicant_ui')
     await disableFeatureFlag(page, 'application_exportable')
 
     await test.step('Submit application', async () => {
@@ -164,7 +164,6 @@ test.describe('Upsell tests', {tag: ['@northstar']}, () => {
     applicantQuestions,
     applicantProgramOverview,
   }) => {
-    await enableFeatureFlag(page, 'north_star_applicant_ui')
     await enableFeatureFlag(page, 'application_exportable')
 
     await test.step('Submit application', async () => {
@@ -207,7 +206,6 @@ test.describe('Upsell tests', {tag: ['@northstar']}, () => {
     applicantProgramOverview,
   }) => {
     // This test will only validate that the download link is no longer visible.
-    await enableFeatureFlag(page, 'north_star_applicant_ui')
     await disableFeatureFlag(page, 'application_exportable')
 
     await test.step('Submit application', async () => {
@@ -229,8 +227,6 @@ test.describe('Upsell tests', {tag: ['@northstar']}, () => {
     applicantQuestions,
     applicantProgramOverview,
   }) => {
-    await enableFeatureFlag(page, 'north_star_applicant_ui')
-
     await test.step('Submit application', async () => {
       await applicantQuestions.clickApplyProgramButton(programName)
       await applicantProgramOverview.startApplicationFromProgramOverviewPage(
@@ -261,8 +257,6 @@ test.describe('Upsell tests', {tag: ['@northstar']}, () => {
     await createRelatedProgram(page, adminPrograms)
 
     await loginAsTestUser(page)
-
-    await enableFeatureFlag(page, 'north_star_applicant_ui')
 
     await test.step('Submit application', async () => {
       await applicantQuestions.clickApplyProgramButton(programName)


### PR DESCRIPTION
### Description

Fixing North Star upsell test on probers.  It was using a hard-coded test user name.  Also fixing another in `applicant_application_index.test.ts`, which needed to call `normalizeElements` for the date.

Also, updating `bin/wait_for_server_start_and_run_tests.sh` so that it'll take those additional args rather than hard-coding them.

### Issue(s) this is part of

Part of #9767 
