### PR TITLE
Add a concurrency token to question update flows to prevent "stale tab" or "lost update" errors

### DIFF
--- a/server/app/controllers/FlashKey.java
+++ b/server/app/controllers/FlashKey.java
@@ -14,4 +14,5 @@ public final class FlashKey {
   public static String SHOW_FAST_FORWARDED_MESSAGE = "showFastForwardedMessage";
   public static String SUCCESS_BANNER = "success-banner";
   public static String DUPLICATE_SUBMISSION = "duplicate-submission";
+  public static String CONCURRENT_UPDATE = "concurrent-update";
 }

--- a/server/app/forms/translation/QuestionTranslationForm.java
+++ b/server/app/forms/translation/QuestionTranslationForm.java
@@ -1,6 +1,7 @@
 package forms.translation;
 
 import java.util.Locale;
+import java.util.UUID;
 import services.question.exceptions.UnsupportedQuestionTypeException;
 import services.question.types.QuestionDefinition;
 import services.question.types.QuestionDefinitionBuilder;
@@ -12,10 +13,13 @@ public class QuestionTranslationForm {
 
   private String questionText;
   private String questionHelpText;
+  private UUID concurrencyToken;
 
   public QuestionTranslationForm() {
     this.questionText = "";
     this.questionHelpText = "";
+    // If we don't get a token from the client, generate one so any updates fail.
+    this.concurrencyToken = UUID.randomUUID();
   }
 
   public final String getQuestionText() {
@@ -34,10 +38,15 @@ public class QuestionTranslationForm {
     this.questionHelpText = questionHelpText;
   }
 
+  public final void setConcurrencyToken(UUID concurrencyToken) {
+    this.concurrencyToken = concurrencyToken;
+  }
+
   public QuestionDefinitionBuilder builderWithUpdates(
       QuestionDefinition toUpdate, Locale updatedLocale) throws UnsupportedQuestionTypeException {
     QuestionDefinitionBuilder builder = new QuestionDefinitionBuilder(toUpdate);
     builder.updateQuestionText(updatedLocale, questionText);
+    builder.setConcurrencyToken(concurrencyToken);
     // Help text is optional
     if (!questionHelpText.isBlank()) {
       builder.updateQuestionHelpText(updatedLocale, questionHelpText);

--- a/server/app/models/ConcurrentUpdateException.java
+++ b/server/app/models/ConcurrentUpdateException.java
@@ -1,0 +1,7 @@
+package models;
+
+public class ConcurrentUpdateException extends RuntimeException {
+  ConcurrentUpdateException(String message) {
+    super(message);
+  }
+}

--- a/server/app/services/question/types/NullQuestionDefinitionConfig.java
+++ b/server/app/services/question/types/NullQuestionDefinitionConfig.java
@@ -5,6 +5,7 @@ import java.time.Instant;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.OptionalLong;
+import java.util.UUID;
 import services.LocalizedStrings;
 import services.question.PrimaryApplicantInfoTag;
 
@@ -64,6 +65,11 @@ public class NullQuestionDefinitionConfig extends QuestionDefinitionConfig {
 
   @Override
   Optional<Instant> lastModifiedTime() {
+    return Optional.empty();
+  }
+
+  @Override
+  Optional<UUID> concurrencyToken() {
     return Optional.empty();
   }
 
@@ -129,6 +135,11 @@ public class NullQuestionDefinitionConfig extends QuestionDefinitionConfig {
     @Override
     public QuestionDefinitionConfig.Builder setLastModifiedTime(
         Optional<Instant> lastModifiedTime) {
+      return this;
+    }
+
+    @Override
+    public QuestionDefinitionConfig.Builder setConcurrencyToken(UUID concurrencyToken) {
       return this;
     }
 

--- a/server/app/services/question/types/QuestionDefinition.java
+++ b/server/app/services/question/types/QuestionDefinition.java
@@ -19,6 +19,7 @@ import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Random;
+import java.util.UUID;
 import services.CiviFormError;
 import services.LocalizedStrings;
 import services.Path;
@@ -181,6 +182,11 @@ public abstract class QuestionDefinition {
   @JsonIgnore
   public final Optional<Instant> getLastModifiedTime() {
     return config.lastModifiedTime();
+  }
+
+  @JsonIgnore
+  public final Optional<UUID> getConcurrencyToken() {
+    return config.concurrencyToken();
   }
 
   // TODO(#6597): Persist the question name key to the database instead of just memoizing it
@@ -423,7 +429,8 @@ public abstract class QuestionDefinition {
           && getDescription().equals(o.getDescription())
           && getQuestionText().equals(o.getQuestionText())
           && getQuestionHelpText().equals(o.getQuestionHelpText())
-          && getValidationPredicates().equals(o.getValidationPredicates());
+          && getValidationPredicates().equals(o.getValidationPredicates())
+          && getConcurrencyToken().equals(o.getConcurrencyToken());
     }
     return false;
   }

--- a/server/app/services/question/types/QuestionDefinitionBuilder.java
+++ b/server/app/services/question/types/QuestionDefinitionBuilder.java
@@ -6,6 +6,7 @@ import java.time.Instant;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.OptionalLong;
+import java.util.UUID;
 import services.LocalizedStrings;
 import services.question.PrimaryApplicantInfoTag;
 import services.question.QuestionOption;
@@ -152,6 +153,11 @@ public final class QuestionDefinitionBuilder {
 
   public QuestionDefinitionBuilder setLastModifiedTime(Optional<Instant> lastModifiedTime) {
     builder.setLastModifiedTime(lastModifiedTime);
+    return this;
+  }
+
+  public QuestionDefinitionBuilder setConcurrencyToken(UUID concurrencyToken) {
+    builder.setConcurrencyToken(concurrencyToken);
     return this;
   }
 

--- a/server/app/services/question/types/QuestionDefinitionConfig.java
+++ b/server/app/services/question/types/QuestionDefinitionConfig.java
@@ -9,6 +9,7 @@ import com.google.common.collect.ImmutableSet;
 import java.time.Instant;
 import java.util.Optional;
 import java.util.OptionalLong;
+import java.util.UUID;
 import services.LocalizedStrings;
 import services.question.PrimaryApplicantInfoTag;
 
@@ -55,6 +56,9 @@ public abstract class QuestionDefinitionConfig {
 
   @JsonIgnore
   abstract Optional<Instant> lastModifiedTime();
+
+  @JsonIgnore
+  abstract Optional<UUID> concurrencyToken();
 
   @JsonProperty("universal")
   abstract boolean universal();
@@ -111,6 +115,8 @@ public abstract class QuestionDefinitionConfig {
     public abstract Builder setLastModifiedTime(Instant lastModifiedTime);
 
     public abstract Builder setLastModifiedTime(Optional<Instant> lastModifiedTime);
+
+    public abstract Builder setConcurrencyToken(UUID concurrencyToken);
 
     @JsonProperty("validationPredicates")
     public abstract Builder setValidationPredicates(

--- a/server/app/views/admin/questions/QuestionEditView.java
+++ b/server/app/views/admin/questions/QuestionEditView.java
@@ -138,11 +138,12 @@ public final class QuestionEditView extends BaseHtmlView {
         request, formContent, questionType, title, /* modal= */ Optional.empty());
   }
 
-  /** Render a fresh Edit Question Form. */
+  /** Render a fresh Edit Question Form with errors. */
   public Content renderEditQuestionForm(
       Request request,
       QuestionDefinition questionDefinition,
-      Optional<QuestionDefinition> maybeEnumerationQuestionDefinition)
+      Optional<QuestionDefinition> maybeEnumerationQuestionDefinition,
+      Optional<ToastMessage> message)
       throws InvalidQuestionTypeException {
     QuestionForm questionForm = QuestionFormBuilder.create(questionDefinition);
     return renderEditQuestionForm(
@@ -150,7 +151,7 @@ public final class QuestionEditView extends BaseHtmlView {
         questionDefinition.getId(),
         questionForm,
         maybeEnumerationQuestionDefinition,
-        Optional.empty());
+        message);
   }
 
   /** Render a Edit Question form with errors. */
@@ -384,6 +385,10 @@ public final class QuestionEditView extends BaseHtmlView {
                     .isHidden()
                     .withName(QuestionForm.REDIRECT_URL_PARAM)
                     .withValue(questionForm.getRedirectUrl()),
+                input()
+                    .isHidden()
+                    .withName("concurrencyToken")
+                    .withValue(questionForm.getConcurrencyToken()),
                 requiredFieldsExplanationContent());
     formTag.with(
         h2("Visible to applicants").withClasses("py-2", "mt-6", "font-semibold"),

--- a/server/app/views/admin/questions/QuestionTranslationView.java
+++ b/server/app/views/admin/questions/QuestionTranslationView.java
@@ -1,6 +1,7 @@
 package views.admin.questions;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static j2html.TagCreator.input;
 import static j2html.TagCreator.legend;
 import static j2html.TagCreator.span;
 
@@ -66,7 +67,12 @@ public final class QuestionTranslationView extends TranslationFormView {
         ImmutableList.<DomContent>builder()
             .add(
                 questionTextFields(
-                    question, locale, question.getQuestionText(), question.getQuestionHelpText()));
+                    question, locale, question.getQuestionText(), question.getQuestionHelpText()))
+            .add(
+                input()
+                    .isHidden()
+                    .withName("concurrencyToken")
+                    .withValue(question.getConcurrencyToken().map(String::valueOf).orElse("")));
     Optional<DomContent> questionTypeSpecificContent =
         getQuestionTypeSpecificContent(question, locale);
     if (questionTypeSpecificContent.isPresent()) {

--- a/server/conf/evolutions/default/84.sql
+++ b/server/conf/evolutions/default/84.sql
@@ -1,0 +1,6 @@
+# --- !Ups
+
+ALTER TABLE questions ADD COLUMN IF NOT EXISTS concurrency_token UUID NOT NULL DEFAULT gen_random_uuid();
+
+# --- !Downs
+ALTER TABLE questions DROP COLUMN IF EXISTS concurrency_token;

--- a/server/test/controllers/admin/AdminQuestionTranslationsControllerTest.java
+++ b/server/test/controllers/admin/AdminQuestionTranslationsControllerTest.java
@@ -12,6 +12,7 @@ import com.google.common.collect.ImmutableMap;
 import controllers.BadRequestException;
 import controllers.FlashKey;
 import java.util.Locale;
+import java.util.UUID;
 import models.QuestionModel;
 import models.VersionModel;
 import org.junit.Before;
@@ -100,7 +101,9 @@ public class AdminQuestionTranslationsControllerTest extends ResetPostgres {
                     "questionText",
                     "updated spanish question text",
                     "questionHelpText",
-                    "updated spanish help text"));
+                    "updated spanish help text",
+                    "concurrencyToken",
+                    question.getConcurrencyToken().toString()));
 
     Result result =
         controller.update(
@@ -132,7 +135,9 @@ public class AdminQuestionTranslationsControllerTest extends ResetPostgres {
                     "questionText",
                     "updated spanish question text",
                     "questionHelpText",
-                    "updated spanish question help text"));
+                    "updated spanish question help text",
+                    "concurrencyToken",
+                    question.getConcurrencyToken().toString()));
 
     Result result =
         controller.update(
@@ -159,6 +164,60 @@ public class AdminQuestionTranslationsControllerTest extends ResetPostgres {
             () -> controller.update(fakeRequest(), "non-existent question name", "es-US"))
         .hasMessage("No draft found for question: \"non-existent question name\"")
         .isInstanceOf(BadRequestException.class);
+  }
+
+  @Test
+  public void update_withMissingConcurrencyToken_redirectsToFreshForm() {
+    QuestionModel question = createDraftQuestionEnglishAndSpanish();
+
+    Http.RequestBuilder requestBuilder =
+        fakeRequestBuilder()
+            .bodyForm(
+                ImmutableMap.of(
+                    "questionText",
+                    "updated spanish question text",
+                    "questionHelpText",
+                    "updated spanish question help text"));
+
+    Result result =
+        controller.update(
+            requestBuilder.build(), question.getQuestionDefinition().getName(), "es-US");
+
+    assertThat(result.status()).isEqualTo(SEE_OTHER);
+    assertThat(result.flash().data()).containsKey(FlashKey.CONCURRENT_UPDATE);
+    assertThat(result.redirectLocation())
+        .hasValue(
+            routes.AdminQuestionTranslationsController.edit(
+                    question.getQuestionDefinition().getName(), "es-US")
+                .url());
+  }
+
+  @Test
+  public void update_withMismatchedConcurrencyToken_redirectsToFreshForm() {
+    QuestionModel question = createDraftQuestionEnglishAndSpanish();
+
+    Http.RequestBuilder requestBuilder =
+        fakeRequestBuilder()
+            .bodyForm(
+                ImmutableMap.of(
+                    "questionText",
+                    "updated spanish question text",
+                    "questionHelpText",
+                    "updated spanish question help text",
+                    "concurrencyToken",
+                    UUID.randomUUID().toString()));
+
+    Result result =
+        controller.update(
+            requestBuilder.build(), question.getQuestionDefinition().getName(), "es-US");
+
+    assertThat(result.status()).isEqualTo(SEE_OTHER);
+    assertThat(result.flash().data()).containsKey(FlashKey.CONCURRENT_UPDATE);
+    assertThat(result.redirectLocation())
+        .hasValue(
+            routes.AdminQuestionTranslationsController.edit(
+                    question.getQuestionDefinition().getName(), "es-US")
+                .url());
   }
 
   @Test

--- a/server/test/forms/AddressQuestionFormTest.java
+++ b/server/test/forms/AddressQuestionFormTest.java
@@ -3,6 +3,7 @@ package forms;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Locale;
+import java.util.UUID;
 import org.junit.Test;
 import services.LocalizedStrings;
 import services.question.types.AddressQuestionDefinition;
@@ -14,11 +15,13 @@ public class AddressQuestionFormTest {
 
   @Test
   public void getBuilder_returnsCompleteBuilder() throws Exception {
+    UUID initialToken = UUID.randomUUID();
     AddressQuestionForm form = new AddressQuestionForm();
     form.setQuestionName("name");
     form.setQuestionDescription("description");
     form.setQuestionText("What is the question text?");
     form.setQuestionHelpText("");
+    form.setConcurrencyToken(initialToken);
     form.setDisallowPoBox(true);
     QuestionDefinitionBuilder builder = form.getBuilder();
 
@@ -31,6 +34,7 @@ public class AddressQuestionFormTest {
                 .setQuestionHelpText(LocalizedStrings.empty())
                 .setValidationPredicates(
                     AddressQuestionDefinition.AddressValidationPredicates.create(true))
+                .setConcurrencyToken(initialToken)
                 .build());
 
     QuestionDefinition actual = builder.build();
@@ -47,6 +51,7 @@ public class AddressQuestionFormTest {
                 .setDescription("description")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
                 .setQuestionHelpText(LocalizedStrings.empty())
+                .setConcurrencyToken(UUID.randomUUID())
                 .build());
 
     AddressQuestionForm form = new AddressQuestionForm(originalQd);

--- a/server/test/forms/CheckboxQuestionFormTest.java
+++ b/server/test/forms/CheckboxQuestionFormTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import java.util.Locale;
+import java.util.UUID;
 import org.junit.Test;
 import services.LocalizedStrings;
 import services.question.QuestionOption;
@@ -17,6 +18,7 @@ public class CheckboxQuestionFormTest {
 
   @Test
   public void getBuilder_returnsCompleteBuilder() throws UnsupportedQuestionTypeException {
+    UUID initialToken = UUID.randomUUID();
     CheckboxQuestionForm form = new CheckboxQuestionForm();
     form.setQuestionName("name");
     form.setQuestionDescription("description");
@@ -26,6 +28,7 @@ public class CheckboxQuestionFormTest {
     form.setOptions(ImmutableList.of("cat", "dog", "rabbit"));
     form.setOptionAdminNames(ImmutableList.of("cat admin", "dog admin", "rabbit admin"));
     form.setOptionIds(ImmutableList.of(1L, 2L, 3L));
+    form.setConcurrencyToken(initialToken);
     QuestionDefinitionBuilder builder = form.getBuilder();
 
     QuestionDefinitionConfig config =
@@ -34,6 +37,7 @@ public class CheckboxQuestionFormTest {
             .setDescription("description")
             .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
             .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
+            .setConcurrencyToken(initialToken)
             .build();
 
     ImmutableList<QuestionOption> questionOptions =
@@ -56,6 +60,7 @@ public class CheckboxQuestionFormTest {
             .setDescription("description")
             .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
             .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
+            .setConcurrencyToken(UUID.randomUUID())
             .build();
 
     ImmutableList<QuestionOption> questionOptions =

--- a/server/test/forms/CurrencyQuestionFormTest.java
+++ b/server/test/forms/CurrencyQuestionFormTest.java
@@ -3,6 +3,7 @@ package forms;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Locale;
+import java.util.UUID;
 import org.junit.Test;
 import services.LocalizedStrings;
 import services.question.types.CurrencyQuestionDefinition;
@@ -14,11 +15,13 @@ public class CurrencyQuestionFormTest {
 
   @Test
   public void getBuilder_returnsCompleteBuilder() throws Exception {
+    UUID initialToken = UUID.randomUUID();
     CurrencyQuestionForm form = new CurrencyQuestionForm();
     form.setQuestionName("name");
     form.setQuestionDescription("description");
     form.setQuestionText("What is the question text?");
     form.setQuestionHelpText("");
+    form.setConcurrencyToken(initialToken);
     QuestionDefinitionBuilder builder = form.getBuilder();
 
     CurrencyQuestionDefinition expected =
@@ -28,6 +31,7 @@ public class CurrencyQuestionFormTest {
                 .setDescription("description")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
                 .setQuestionHelpText(LocalizedStrings.empty())
+                .setConcurrencyToken(initialToken)
                 .build());
 
     QuestionDefinition actual = builder.build();
@@ -44,6 +48,7 @@ public class CurrencyQuestionFormTest {
                 .setDescription("description")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
                 .setQuestionHelpText(LocalizedStrings.empty())
+                .setConcurrencyToken(UUID.randomUUID())
                 .build());
 
     CurrencyQuestionForm form = new CurrencyQuestionForm(originalQd);

--- a/server/test/forms/DropdownQuestionFormTest.java
+++ b/server/test/forms/DropdownQuestionFormTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import java.util.Locale;
+import java.util.UUID;
 import org.junit.Test;
 import services.LocalizedStrings;
 import services.question.QuestionOption;
@@ -17,11 +18,13 @@ public class DropdownQuestionFormTest {
 
   @Test
   public void getBuilder_returnsCompleteBuilder() throws UnsupportedQuestionTypeException {
+    UUID initialToken = UUID.randomUUID();
     DropdownQuestionForm form = new DropdownQuestionForm();
     form.setQuestionName("name");
     form.setQuestionDescription("description");
     form.setQuestionText("What is the question text?");
     form.setQuestionHelpText("help text");
+    form.setConcurrencyToken(initialToken);
     // Unique field
     form.setOptions(ImmutableList.of("cat", "dog", "rabbit"));
     form.setOptionAdminNames(ImmutableList.of("cat admin", "dog admin", "rabbit admin"));
@@ -34,6 +37,7 @@ public class DropdownQuestionFormTest {
             .setDescription("description")
             .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
             .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
+            .setConcurrencyToken(initialToken)
             .build();
 
     ImmutableList<QuestionOption> questionOptions =
@@ -56,6 +60,7 @@ public class DropdownQuestionFormTest {
             .setDescription("description")
             .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
             .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
+            .setConcurrencyToken(UUID.randomUUID())
             .build();
     ImmutableList<QuestionOption> questionOptions =
         ImmutableList.of(

--- a/server/test/forms/EnumeratorQuestionFormTest.java
+++ b/server/test/forms/EnumeratorQuestionFormTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Locale;
 import java.util.OptionalInt;
+import java.util.UUID;
 import org.junit.Test;
 import services.LocalizedStrings;
 import services.question.types.EnumeratorQuestionDefinition;
@@ -55,6 +56,17 @@ public class EnumeratorQuestionFormTest {
     assertThat(qd.getEntityType()).isEqualTo(LocalizedStrings.withDefaultValue(""));
     assertThat(qd.getMinEntities()).isEqualTo(OptionalInt.empty());
     assertThat(qd.getMaxEntities()).isEqualTo(OptionalInt.empty());
+  }
+
+  @Test
+  public void getBuilder_includesConcurrencyToken() throws Exception {
+    UUID initialToken = UUID.randomUUID();
+    EnumeratorQuestionForm form = new EnumeratorQuestionForm();
+    form.setConcurrencyToken(initialToken);
+
+    EnumeratorQuestionDefinition qd = (EnumeratorQuestionDefinition) form.getBuilder().build();
+
+    assertThat(qd.getConcurrencyToken()).hasValue(initialToken);
   }
 
   /** Returns a QuestionDefinitionConfig with minimal required fields set */

--- a/server/test/forms/FileUploadQuestionFormTest.java
+++ b/server/test/forms/FileUploadQuestionFormTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertThrows;
 
 import java.util.Locale;
 import java.util.OptionalInt;
+import java.util.UUID;
 import org.junit.Test;
 import services.LocalizedStrings;
 import services.question.types.FileUploadQuestionDefinition;
@@ -15,11 +16,13 @@ import services.question.types.QuestionDefinitionConfig;
 public class FileUploadQuestionFormTest {
   @Test
   public void getBuilder_returnsCompleteBuilder() throws Exception {
+    UUID initialToken = UUID.randomUUID();
     FileUploadQuestionForm form = new FileUploadQuestionForm();
     form.setQuestionName("file upload");
     form.setQuestionDescription("description");
     form.setQuestionText("What is the question text?");
     form.setQuestionHelpText("");
+    form.setConcurrencyToken(initialToken);
     form.setMaxFiles("4");
     QuestionDefinitionBuilder builder = form.getBuilder();
 
@@ -30,6 +33,7 @@ public class FileUploadQuestionFormTest {
                 .setDescription("description")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
                 .setQuestionHelpText(LocalizedStrings.empty())
+                .setConcurrencyToken(initialToken)
                 .setValidationPredicates(
                     FileUploadQuestionDefinition.FileUploadValidationPredicates.builder()
                         .setMaxFiles(OptionalInt.of(4))
@@ -50,6 +54,7 @@ public class FileUploadQuestionFormTest {
                 .setDescription("description")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
                 .setQuestionHelpText(LocalizedStrings.empty())
+                .setConcurrencyToken(UUID.randomUUID())
                 .setValidationPredicates(
                     FileUploadQuestionDefinition.FileUploadValidationPredicates.builder()
                         .setMaxFiles(OptionalInt.of(4))

--- a/server/test/forms/IdQuestionFormTest.java
+++ b/server/test/forms/IdQuestionFormTest.java
@@ -3,6 +3,7 @@ package forms;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Locale;
+import java.util.UUID;
 import org.junit.Test;
 import services.LocalizedStrings;
 import services.question.types.IdQuestionDefinition;
@@ -14,11 +15,13 @@ public class IdQuestionFormTest {
 
   @Test
   public void getBuilder_returnsCompleteBuilder() throws Exception {
+    UUID initialToken = UUID.randomUUID();
     IdQuestionForm form = new IdQuestionForm();
     form.setQuestionName("name");
     form.setQuestionDescription("description");
     form.setQuestionText("What is the question text?");
     form.setQuestionHelpText("");
+    form.setConcurrencyToken(initialToken);
     form.setMinLength("4");
     form.setMaxLength("6");
     QuestionDefinitionBuilder builder = form.getBuilder();
@@ -30,6 +33,7 @@ public class IdQuestionFormTest {
                 .setDescription("description")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
                 .setQuestionHelpText(LocalizedStrings.empty())
+                .setConcurrencyToken(initialToken)
                 .setValidationPredicates(IdQuestionDefinition.IdValidationPredicates.create(4, 6))
                 .build());
 
@@ -47,6 +51,7 @@ public class IdQuestionFormTest {
                 .setDescription("description")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
                 .setQuestionHelpText(LocalizedStrings.empty())
+                .setConcurrencyToken(UUID.randomUUID())
                 .setValidationPredicates(IdQuestionDefinition.IdValidationPredicates.create(4, 6))
                 .build());
 
@@ -60,11 +65,13 @@ public class IdQuestionFormTest {
 
   @Test
   public void getBuilder_emptyStringMinMax_noPredicateSet() throws Exception {
+    UUID initialToken = UUID.randomUUID();
     IdQuestionForm form = new IdQuestionForm();
     form.setQuestionName("name");
     form.setQuestionDescription("description");
     form.setQuestionText("What is the question text?");
     form.setQuestionHelpText("");
+    form.setConcurrencyToken(initialToken);
     form.setMinLength("");
     form.setMaxLength("");
     QuestionDefinitionBuilder builder = form.getBuilder();
@@ -76,6 +83,7 @@ public class IdQuestionFormTest {
                 .setDescription("description")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
                 .setQuestionHelpText(LocalizedStrings.empty())
+                .setConcurrencyToken(initialToken)
                 .build());
 
     QuestionDefinition actual = builder.build();

--- a/server/test/forms/MultiOptionQuestionFormTest.java
+++ b/server/test/forms/MultiOptionQuestionFormTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.google.common.collect.ImmutableList;
 import java.util.Locale;
 import java.util.OptionalLong;
+import java.util.UUID;
 import org.junit.Test;
 import services.LocalizedStrings;
 import services.question.QuestionOption;
@@ -19,11 +20,13 @@ public class MultiOptionQuestionFormTest {
 
   @Test
   public void getBuilder_returnsCompleteBuilder() throws Exception {
+    UUID initialToken = UUID.randomUUID();
     MultiOptionQuestionForm form = new CheckboxQuestionForm();
     form.setQuestionName("name");
     form.setQuestionDescription("description");
     form.setQuestionText("What is the question text?");
     form.setQuestionHelpText("help text");
+    form.setConcurrencyToken(initialToken);
     form.setMinChoicesRequired("1");
     form.setMaxChoicesAllowed("10");
     form.setOptions(ImmutableList.of("one", "two"));
@@ -37,6 +40,7 @@ public class MultiOptionQuestionFormTest {
             .setDescription("description")
             .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
             .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
+            .setConcurrencyToken(initialToken)
             .setValidationPredicates(MultiOptionValidationPredicates.create(1, 10))
             .build();
     MultiOptionQuestionDefinition expected =
@@ -60,6 +64,7 @@ public class MultiOptionQuestionFormTest {
             .setDescription("description")
             .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
             .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
+            .setConcurrencyToken(UUID.randomUUID())
             .setValidationPredicates(MultiOptionValidationPredicates.create(1, 10))
             .build();
     MultiOptionQuestionDefinition expectedQd =
@@ -84,6 +89,7 @@ public class MultiOptionQuestionFormTest {
             .setDescription("description")
             .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
             .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
+            .setConcurrencyToken(UUID.randomUUID())
             .setValidationPredicates(MultiOptionValidationPredicates.create(1, 10))
             .build();
     MultiOptionQuestionDefinition expectedQd =
@@ -105,11 +111,13 @@ public class MultiOptionQuestionFormTest {
 
   @Test
   public void getBuilder_emptyStringMinMax_noPredicateSet() throws Exception {
+    UUID initialToken = UUID.randomUUID();
     MultiOptionQuestionForm form = new CheckboxQuestionForm();
     form.setQuestionName("name");
     form.setQuestionDescription("description");
     form.setQuestionText("What is the question text?");
     form.setQuestionHelpText("help text");
+    form.setConcurrencyToken(initialToken);
     form.setMinChoicesRequired("");
     form.setMaxChoicesAllowed("");
     form.setOptions(ImmutableList.of("one", "two"));
@@ -123,6 +131,7 @@ public class MultiOptionQuestionFormTest {
             .setDescription("description")
             .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
             .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
+            .setConcurrencyToken(initialToken)
             .build();
     MultiOptionQuestionDefinition expected =
         new MultiOptionQuestionDefinition(

--- a/server/test/forms/NameQuestionFormTest.java
+++ b/server/test/forms/NameQuestionFormTest.java
@@ -3,6 +3,7 @@ package forms;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Locale;
+import java.util.UUID;
 import org.junit.Test;
 import services.LocalizedStrings;
 import services.question.types.NameQuestionDefinition;
@@ -13,11 +14,13 @@ import services.question.types.QuestionDefinitionConfig;
 public class NameQuestionFormTest {
   @Test
   public void getBuilder_returnsCompleteBuilder() throws Exception {
+    UUID initialToken = UUID.randomUUID();
     NameQuestionForm form = new NameQuestionForm();
     form.setQuestionName("name");
     form.setQuestionDescription("description");
     form.setQuestionText("What is the question text?");
     form.setQuestionHelpText("");
+    form.setConcurrencyToken(initialToken);
     QuestionDefinitionBuilder builder = form.getBuilder();
 
     NameQuestionDefinition expected =
@@ -27,6 +30,7 @@ public class NameQuestionFormTest {
                 .setDescription("description")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
                 .setQuestionHelpText(LocalizedStrings.empty())
+                .setConcurrencyToken(initialToken)
                 .build());
 
     QuestionDefinition actual = builder.build();
@@ -43,6 +47,7 @@ public class NameQuestionFormTest {
                 .setDescription("description")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
                 .setQuestionHelpText(LocalizedStrings.empty())
+                .setConcurrencyToken(UUID.randomUUID())
                 .build());
 
     NameQuestionForm form = new NameQuestionForm(originalQd);

--- a/server/test/forms/NumberQuestionFormTest.java
+++ b/server/test/forms/NumberQuestionFormTest.java
@@ -3,6 +3,7 @@ package forms;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Locale;
+import java.util.UUID;
 import org.junit.Test;
 import services.LocalizedStrings;
 import services.question.types.NumberQuestionDefinition;
@@ -14,11 +15,13 @@ public class NumberQuestionFormTest {
 
   @Test
   public void getBuilder_returnsCompleteBuilder() throws Exception {
+    UUID initialToken = UUID.randomUUID();
     NumberQuestionForm form = new NumberQuestionForm();
     form.setQuestionName("name");
     form.setQuestionDescription("description");
     form.setQuestionText("What is the question text?");
     form.setQuestionHelpText("");
+    form.setConcurrencyToken(initialToken);
     form.setMin("2");
     form.setMax("8");
     QuestionDefinitionBuilder builder = form.getBuilder();
@@ -30,6 +33,7 @@ public class NumberQuestionFormTest {
                 .setDescription("description")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
                 .setQuestionHelpText(LocalizedStrings.empty())
+                .setConcurrencyToken(initialToken)
                 .setValidationPredicates(
                     NumberQuestionDefinition.NumberValidationPredicates.create(2, 8))
                 .build());
@@ -48,6 +52,7 @@ public class NumberQuestionFormTest {
                 .setDescription("description")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
                 .setQuestionHelpText(LocalizedStrings.empty())
+                .setConcurrencyToken(UUID.randomUUID())
                 .setValidationPredicates(
                     NumberQuestionDefinition.NumberValidationPredicates.create(2, 8))
                 .build());
@@ -62,11 +67,13 @@ public class NumberQuestionFormTest {
 
   @Test
   public void getBuilder_emptyStringMinMax_noPredicateSet() throws Exception {
+    UUID initialToken = UUID.randomUUID();
     NumberQuestionForm form = new NumberQuestionForm();
     form.setQuestionName("name");
     form.setQuestionDescription("description");
     form.setQuestionText("What is the question text?");
     form.setQuestionHelpText("");
+    form.setConcurrencyToken(initialToken);
     form.setMin("");
     form.setMax("");
     QuestionDefinitionBuilder builder = form.getBuilder();
@@ -78,6 +85,7 @@ public class NumberQuestionFormTest {
                 .setDescription("description")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
                 .setQuestionHelpText(LocalizedStrings.empty())
+                .setConcurrencyToken(initialToken)
                 .build());
 
     QuestionDefinition actual = builder.build();

--- a/server/test/forms/PhoneQuestionFormTest.java
+++ b/server/test/forms/PhoneQuestionFormTest.java
@@ -3,6 +3,7 @@ package forms;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Locale;
+import java.util.UUID;
 import org.junit.Test;
 import services.LocalizedStrings;
 import services.question.types.PhoneQuestionDefinition;
@@ -13,11 +14,13 @@ import services.question.types.QuestionDefinitionConfig;
 public class PhoneQuestionFormTest {
   @Test
   public void getBuilder_returnsCompleteBuilder() throws Exception {
+    UUID initialToken = UUID.randomUUID();
     PhoneQuestionForm form = new PhoneQuestionForm();
     form.setQuestionName("name");
     form.setQuestionDescription("description");
     form.setQuestionText("What is your phone number?");
     form.setQuestionHelpText("");
+    form.setConcurrencyToken(initialToken);
     QuestionDefinitionBuilder builder = form.getBuilder();
 
     PhoneQuestionDefinition expected =
@@ -27,6 +30,7 @@ public class PhoneQuestionFormTest {
                 .setDescription("description")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is your phone number?"))
                 .setQuestionHelpText(LocalizedStrings.empty())
+                .setConcurrencyToken(initialToken)
                 .build());
 
     QuestionDefinition actual = builder.build();
@@ -43,6 +47,7 @@ public class PhoneQuestionFormTest {
                 .setDescription("description")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is your Phone Number?"))
                 .setQuestionHelpText(LocalizedStrings.empty())
+                .setConcurrencyToken(UUID.randomUUID())
                 .build());
 
     PhoneQuestionForm form = new PhoneQuestionForm(originalQd);

--- a/server/test/forms/QuestionFormTest.java
+++ b/server/test/forms/QuestionFormTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.common.collect.ImmutableSet;
+import java.util.UUID;
 import org.junit.Test;
 import services.question.PrimaryApplicantInfoTag;
 import services.question.exceptions.UnsupportedQuestionTypeException;
@@ -15,7 +16,7 @@ public class QuestionFormTest {
 
     @Override
     public QuestionType getQuestionType() {
-      return null;
+      return QuestionType.TEXT;
     }
   }
 
@@ -51,6 +52,36 @@ public class QuestionFormTest {
     TestQuestionForm form = new TestQuestionForm();
     form.setRedirectUrl("file://foo/bar");
     assertThatThrownBy(form::getRedirectUrl).hasMessageContaining("Invalid absolute URL.");
+  }
+
+  @Test
+  public void getConcurrencyToken_generatesUUIDWhenUnset() {
+    TestQuestionForm form = new TestQuestionForm();
+    assertThat(form.getConcurrencyToken()).isNotNull();
+  }
+
+  @Test
+  public void getConcurrencyToken_returnsBuilderWithGeneratedUUIDWhenUnset()
+      throws UnsupportedQuestionTypeException {
+    TestQuestionForm form = new TestQuestionForm();
+    assertThat(form.getBuilder().build().getConcurrencyToken()).isNotEmpty();
+  }
+
+  @Test
+  public void getConcurrencyToken_returnsSameUUIDWhenSet() {
+    UUID initialToken = UUID.randomUUID();
+    TestQuestionForm form = new TestQuestionForm();
+    form.setConcurrencyToken(initialToken);
+    assertThat(form.getConcurrencyToken()).isEqualTo(initialToken.toString());
+  }
+
+  @Test
+  public void getConcurrencyToken_returnsBuilderWithSameUUIDWhenSet()
+      throws UnsupportedQuestionTypeException {
+    UUID initialToken = UUID.randomUUID();
+    TestQuestionForm form = new TestQuestionForm();
+    form.setConcurrencyToken(initialToken);
+    assertThat(form.getBuilder().build().getConcurrencyToken()).hasValue(initialToken);
   }
 
   @Test

--- a/server/test/forms/RadioButtonQuestionFormTest.java
+++ b/server/test/forms/RadioButtonQuestionFormTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import java.util.Locale;
+import java.util.UUID;
 import org.junit.Test;
 import services.LocalizedStrings;
 import services.question.QuestionOption;
@@ -17,11 +18,13 @@ public class RadioButtonQuestionFormTest {
 
   @Test
   public void getBuilder_returnsCompleteBuilder() throws UnsupportedQuestionTypeException {
+    UUID initialToken = UUID.randomUUID();
     RadioButtonQuestionForm form = new RadioButtonQuestionForm();
     form.setQuestionName("name");
     form.setQuestionDescription("description");
     form.setQuestionText("What is the question text?");
     form.setQuestionHelpText("help text");
+    form.setConcurrencyToken(initialToken);
     // Unique field
     form.setOptions(ImmutableList.of("cat", "dog", "rabbit"));
     form.setOptionAdminNames(ImmutableList.of("cat admin", "dog admin", "rabbit admin"));
@@ -34,6 +37,7 @@ public class RadioButtonQuestionFormTest {
             .setDescription("description")
             .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
             .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
+            .setConcurrencyToken(initialToken)
             .build();
 
     ImmutableList<QuestionOption> questionOptions =
@@ -56,6 +60,7 @@ public class RadioButtonQuestionFormTest {
             .setDescription("description")
             .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
             .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
+            .setConcurrencyToken(UUID.randomUUID())
             .build();
 
     ImmutableList<QuestionOption> questionOptions =

--- a/server/test/forms/StaticContentQuestionFormTest.java
+++ b/server/test/forms/StaticContentQuestionFormTest.java
@@ -3,6 +3,7 @@ package forms;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Locale;
+import java.util.UUID;
 import org.junit.Test;
 import services.LocalizedStrings;
 import services.question.types.QuestionDefinition;
@@ -12,11 +13,13 @@ import services.question.types.StaticContentQuestionDefinition;
 public class StaticContentQuestionFormTest {
   @Test
   public void getBuilder_returnsCompleteBuilder() throws Exception {
+    UUID initialToken = UUID.randomUUID();
     StaticContentQuestionForm form = new StaticContentQuestionForm();
     form.setQuestionName("name");
     form.setQuestionDescription("description");
     form.setQuestionText("Some text. Not an actual question.");
     form.setQuestionHelpText("");
+    form.setConcurrencyToken(initialToken);
     QuestionDefinition actual = form.getBuilder().build();
 
     StaticContentQuestionDefinition expected =
@@ -27,6 +30,7 @@ public class StaticContentQuestionFormTest {
                 .setQuestionText(
                     LocalizedStrings.of(Locale.US, "Some text. Not an actual question."))
                 .setQuestionHelpText(LocalizedStrings.empty())
+                .setConcurrencyToken(initialToken)
                 .build());
 
     assertThat(actual).isEqualTo(expected);
@@ -42,6 +46,7 @@ public class StaticContentQuestionFormTest {
                 .setQuestionText(
                     LocalizedStrings.of(Locale.US, "Some text. Not an actual question."))
                 .setQuestionHelpText(LocalizedStrings.empty())
+                .setConcurrencyToken(UUID.randomUUID())
                 .build());
 
     StaticContentQuestionForm form = new StaticContentQuestionForm(originalQd);

--- a/server/test/forms/TextQuestionFormTest.java
+++ b/server/test/forms/TextQuestionFormTest.java
@@ -3,6 +3,7 @@ package forms;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Locale;
+import java.util.UUID;
 import org.junit.Test;
 import services.LocalizedStrings;
 import services.question.types.QuestionDefinition;
@@ -14,6 +15,7 @@ public class TextQuestionFormTest {
 
   @Test
   public void getBuilder_returnsCompleteBuilder() throws Exception {
+    UUID initialToken = UUID.randomUUID();
     TextQuestionForm form = new TextQuestionForm();
     form.setQuestionName("name");
     form.setQuestionDescription("description");
@@ -21,6 +23,7 @@ public class TextQuestionFormTest {
     form.setQuestionHelpText("");
     form.setMinLength("4");
     form.setMaxLength("6");
+    form.setConcurrencyToken(initialToken);
     QuestionDefinitionBuilder builder = form.getBuilder();
 
     TextQuestionDefinition expected =
@@ -32,6 +35,7 @@ public class TextQuestionFormTest {
                 .setQuestionHelpText(LocalizedStrings.empty())
                 .setValidationPredicates(
                     TextQuestionDefinition.TextValidationPredicates.create(4, 6))
+                .setConcurrencyToken(initialToken)
                 .build());
 
     QuestionDefinition actual = builder.build();
@@ -41,6 +45,7 @@ public class TextQuestionFormTest {
 
   @Test
   public void getBuilder_withQdConstructor_returnsCompleteBuilder() throws Exception {
+    UUID initialToken = UUID.randomUUID();
     TextQuestionDefinition originalQd =
         new TextQuestionDefinition(
             QuestionDefinitionConfig.builder()
@@ -50,6 +55,7 @@ public class TextQuestionFormTest {
                 .setQuestionHelpText(LocalizedStrings.empty())
                 .setValidationPredicates(
                     TextQuestionDefinition.TextValidationPredicates.create(4, 6))
+                .setConcurrencyToken(initialToken)
                 .build());
 
     TextQuestionForm form = new TextQuestionForm(originalQd);
@@ -62,6 +68,7 @@ public class TextQuestionFormTest {
 
   @Test
   public void getBuilder_emptyStringMinMax_noPredicateSet() throws Exception {
+    UUID initialToken = UUID.randomUUID();
     TextQuestionForm form = new TextQuestionForm();
     form.setQuestionName("name");
     form.setQuestionDescription("description");
@@ -69,6 +76,7 @@ public class TextQuestionFormTest {
     form.setQuestionHelpText("");
     form.setMinLength("");
     form.setMaxLength("");
+    form.setConcurrencyToken(initialToken);
     QuestionDefinitionBuilder builder = form.getBuilder();
 
     TextQuestionDefinition expected =
@@ -78,6 +86,7 @@ public class TextQuestionFormTest {
                 .setDescription("description")
                 .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
                 .setQuestionHelpText(LocalizedStrings.empty())
+                .setConcurrencyToken(initialToken)
                 .build());
 
     QuestionDefinition actual = builder.build();

--- a/server/test/forms/translation/QuestionTranslationFormTest.java
+++ b/server/test/forms/translation/QuestionTranslationFormTest.java
@@ -3,6 +3,7 @@ package forms.translation;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Locale;
+import java.util.UUID;
 import org.junit.Test;
 import services.LocalizedStrings;
 import services.question.types.QuestionDefinition;
@@ -64,5 +65,31 @@ public class QuestionTranslationFormTest {
 
     assertThat(updated.getQuestionText().get(Locale.CANADA)).isEqualTo("new locale");
     assertThat(updated.getQuestionHelpText()).isEqualTo(LocalizedStrings.empty());
+  }
+
+  @Test
+  public void builder_includesConcurrencyTokenWhenSet() throws Exception {
+    UUID initialToken = UUID.randomUUID();
+    QuestionDefinition question = questionBank.nameApplicantName().getQuestionDefinition();
+
+    QuestionTranslationForm form = new QuestionTranslationFormImpl();
+    form.setConcurrencyToken(initialToken);
+
+    QuestionDefinition updated =
+        form.builderWithUpdates(question, LocalizedStrings.DEFAULT_LOCALE).build();
+
+    assertThat(updated.getConcurrencyToken()).hasValue(initialToken);
+  }
+
+  @Test
+  public void builder_generatesConcurrencyTokenWhenUnset() throws Exception {
+    QuestionDefinition question = questionBank.nameApplicantName().getQuestionDefinition();
+
+    QuestionTranslationForm form = new QuestionTranslationFormImpl();
+
+    QuestionDefinition updated =
+        form.builderWithUpdates(question, LocalizedStrings.DEFAULT_LOCALE).build();
+
+    assertThat(updated.getConcurrencyToken()).isNotEmpty();
   }
 }

--- a/server/test/services/question/types/QuestionDefinitionTest.java
+++ b/server/test/services/question/types/QuestionDefinitionTest.java
@@ -7,6 +7,7 @@ import static org.assertj.core.api.Assertions.catchThrowable;
 import com.google.common.collect.ImmutableList;
 import java.util.Locale;
 import java.util.Optional;
+import java.util.UUID;
 import junitparams.JUnitParamsRunner;
 import org.junit.Before;
 import org.junit.Test;
@@ -126,6 +127,15 @@ public class QuestionDefinitionTest {
     QuestionDefinition differentDescription =
         builder.setDescription("Different description").build();
     assertThat(question.equals(differentDescription)).isFalse();
+  }
+
+  @Test
+  public void testEquality_differentConcurrencyTokenReturnsFalse()
+      throws UnsupportedQuestionTypeException {
+    QuestionDefinition question = builder.setConcurrencyToken(UUID.randomUUID()).build();
+    QuestionDefinition questionWithDifferentToken =
+        builder.setConcurrencyToken(UUID.randomUUID()).build();
+    assertThat(question.equals(questionWithDifferentToken)).isFalse();
   }
 
   @Test


### PR DESCRIPTION
### Description

Add a concurrency token to the question update flows to prevent "stale tab" or "lost update" errors.

See https://github.com/civiform/civiform/wiki/Concurrency-and-Transactions for more on concurrency tokens.

Details:
- If a `ConcurrentUpdateException` is thrown, we reload a fresh edit form without the user's changes. This is different than other errors, which reload the form with the admin's changes. This is so that the admin sees the concurrently made changes before making theirs.
- /archive, /restore, and /discard all operate on the version, not the question, so are out of scope for this change.
- If an update page is open in a browser during the server release, and then the user tries to submit, it behaves as if a concurrent update was made and reloads the page with a fresh form.
- The program import flows pull a question from the database to update, or create a new draft, so the token is already valid. (We should still wrap the program import logic in a transaction, though.)

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [x] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [x] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`

#### Database evolutions

Read the guidelines [here](https://github.com/civiform/civiform/wiki/Database#writing-database-evolutions)

- [x] Assigned two reviewers
- [x] Guarded against already existing resources using `IF NOT EXISTS` and `IF EXISTS`
- [x] Downs created to undo changes in Ups
- [x] Every comment in script should begin with -- and not # --- unless it denotes Ups or Downs. See [here](https://www.playframework.com/documentation/2.9.x/Evolutions) for details.
- [x] Tested both the Downs and the Ups scripts manually (When testing, include all comments from the evolution in your test script to ensure any syntax errors in the comments are caught.)
- [x] Data migrations aren't being done (please use a [Durable Job](https://github.com/civiform/civiform/wiki/Database#durable-jobs-for-data-updates) if doing a data migration)
- [x] Update the model documentation in our [wiki](https://github.com/civiform/civiform/wiki/Database) if necessary

### Instructions for manual testing

All update flows should work as expected.

To force concurrency issues, try opening two tabs, editing the question in both of them, and then submitting both of them. The second should fail.

### Issue(s) this completes

Fixes #10041 
