### PR TITLE
Use correct value for program slug

### DIFF
--- a/server/app/views/applicant/ProgramCardsSectionParamsFactory.java
+++ b/server/app/views/applicant/ProgramCardsSectionParamsFactory.java
@@ -140,7 +140,7 @@ public final class ProgramCardsSectionParamsFactory {
         getActionUrl(
             applicantRoutes,
             program.id(),
-            program.adminName(),
+            program.slug(),
             program.isCommonIntakeForm(),
             programDatum.latestApplicationLifecycleStage(),
             applicantId,


### PR DESCRIPTION
### Description

This fixes a Northstar bug on the applicant program cards I came across by chance.

The adminName property was being use to build the url on the cards instead of the slug. In the past the adminName was pulled from the `programs.name` column, but was later changed to use the `programs.localized_name`. When creating new programs these days the adminName and the slug are the same thing, but programs created prior to this point might not be different. This causes the older programs to build a URL that doesn't work. Changing this to the slug as that is the correct value to be used in the URL.

Note, that even if the Civiform admin were to edit the program and change the program name it doesn't update the value in the `programs.name` column so it's not fixable from within the application. We should probably deprecate the `programs.name` column and phase it out.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
