### PR TITLE
Handle ConcurrentModificationException in MetricsController

### DIFF
--- a/server/app/controllers/monitoring/MetricsController.java
+++ b/server/app/controllers/monitoring/MetricsController.java
@@ -100,14 +100,13 @@ public final class MetricsController extends CiviFormController {
       TextFormat.write004(writer, collectorRegistry.metricFamilySamples());
       return ok(writer.toString()).as(TextFormat.CONTENT_TYPE_004);
     } catch (ConcurrentModificationException e) {
-      // This exception can often be reproduced if you start running the full browser test
-      // suite and then spam calling `/metrics` until it sometimes will throw.
+      // This exception can often be triggered if you start running the full browser test
+      // suite and then spam calling `/metrics`.
       //
       // Basically this state can happen when calling `database.metaInfo().collectMetrics()`
       // method and the metrics are either being updated or a lock can't be immediately gotten.
       //
-      // I'm trying to avoid using synchronize to force a lock on the database object as I'm
-      // concerned about adversely affecting performance.
+      // Avoid using synchronize to force a lock on the database object as it may adversely affecting performance.
       //
       // Since the `/metrics` endpoint is called very frequently any data from a failed call
       // gets rolled into the next successful call to `/metrics`.


### PR DESCRIPTION
### Description

Adds better error handling and a retry when trying to collect server metrics for Prometheus.

> This exception can often be reproduced if you start running the full browser test suite and then spam calling `/metrics` until it sometimes will throw.
> 
> Basically this state can happen when calling `database.metaInfo().collectMetrics()` method and the metrics are either being updated or a lock can't be immediately gotten.
> 
> I'm trying to avoid using synchronize to force a lock on the database object as I'm concerned about adversely affecting performance.
> 
> Since the `/metrics` endpoint is called very frequently any data from a failed call gets rolled into the next successful call to `/metrics`.


### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)

### Issue(s) this completes

Fixes #9640
