### PR TITLE
[North Star] Only use short description for admin when north star flag is on

### DIFF
--- a/browser-test/src/admin/admin_program_list.test.ts
+++ b/browser-test/src/admin/admin_program_list.test.ts
@@ -49,7 +49,11 @@ test.describe('Program list page.', () => {
     const programName = 'Program With Short Description'
     const programLongDescription =
       'A very very very very very very long description'
-    const programShortDescription = 'A very short description'
+    const programShortDescription =
+      'A short description with some __markdown__ and a [link](https://www.example.com)'
+    const programShortDescriptionWithoutMarkdown =
+      'A short description with some markdown and a link'
+
     await test.step('create new program', async () => {
       await loginAsAdmin(page)
       await adminPrograms.addProgram(
@@ -59,12 +63,28 @@ test.describe('Program list page.', () => {
       )
     })
 
-    await test.step('check that short description is shown', async () => {
+    await test.step('check that long description is shown when North Star flag is off', async () => {
       await adminPrograms.gotoAdminProgramsPage()
       const firstProgram = page.locator('.cf-admin-program-card').first()
       const firstProgramDesc = firstProgram.locator('.cf-program-description')
       await expect(
-        firstProgramDesc.getByText(programShortDescription),
+        firstProgramDesc.getByText(programLongDescription),
+      ).toBeVisible()
+      await expect(
+        firstProgramDesc.locator(
+          `text=${programShortDescriptionWithoutMarkdown}`,
+        ),
+      ).toHaveCount(0) // short description should not be shown
+    })
+
+    await enableFeatureFlag(page, 'north_star_applicant_ui')
+
+    await test.step('check that short description stripped of markdown is shown when North Star flag is on', async () => {
+      await adminPrograms.gotoAdminProgramsPage()
+      const firstProgram = page.locator('.cf-admin-program-card').first()
+      const firstProgramDesc = firstProgram.locator('.cf-program-description')
+      await expect(
+        firstProgramDesc.getByText(programShortDescriptionWithoutMarkdown),
       ).toBeVisible()
       await expect(
         firstProgramDesc.locator(`text=${programLongDescription}`),

--- a/server/app/views/admin/programs/ProgramAdministratorProgramListView.java
+++ b/server/app/views/admin/programs/ProgramAdministratorProgramListView.java
@@ -63,10 +63,7 @@ public final class ProgramAdministratorProgramListView extends BaseHtmlView {
                         .filter(program -> authorizedPrograms.contains(program.adminName()))
                         .map(p -> buildCardData(p, civiformProfile))
                         .sorted(ProgramCardFactory.programTypeThenLastModifiedThenNameComparator())
-                        .map(
-                            cardData ->
-                                programCardFactory.renderCard(
-                                    cardData, /* showCategories= */ false))));
+                        .map(cardData -> programCardFactory.renderCard(cardData, request))));
 
     HtmlBundle htmlBundle = layout.getBundle(request).setTitle(title).addMainContent(contentDiv);
     return layout.renderCentered(htmlBundle);

--- a/server/app/views/admin/programs/ProgramIndexView.java
+++ b/server/app/views/admin/programs/ProgramIndexView.java
@@ -196,11 +196,7 @@ public final class ProgramIndexView extends BaseHtmlView {
                                     publishSingleProgramModals,
                                     universalQuestionIds))
                         .sorted(ProgramCardFactory.programTypeThenLastModifiedThenNameComparator())
-                        .map(
-                            cardData ->
-                                programCardFactory.renderCard(
-                                    cardData,
-                                    settingsManifest.getProgramFilteringEnabled(request))))));
+                        .map(cardData -> programCardFactory.renderCard(cardData, request)))));
 
     HtmlBundle htmlBundle =
         layout


### PR DESCRIPTION
### Description

This is a little bug fix that conditions which description shows to admin based on if they've turned the north star flag on.

If the north star flag is off, the legacy program description (aka long description) shows in the admin view.

If the north star flag is on, the short program description shows with markdown stripped off of it.

### Checklist

#### General

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)

### Instructions for manual testing

1. Login as an admin and turn the north star flag off
2. Add a program with a long description and short description (include markdown)
3. View the program list page as an admin and see the long description on the program card
4. Turn the north star flag on
5. View the program list page as an admin and see the short description on the program card with markdown stripped out

### Issue(s) this completes

Fixes #9859 