### PR TITLE
Remove redundant word in Fast Forward feature flag description

### DIFF
--- a/server/app/services/settings/SettingsManifest.java
+++ b/server/app/services/settings/SettingsManifest.java
@@ -1009,7 +1009,7 @@ public final class SettingsManifest extends AbstractSettingsManifest {
   }
 
   /**
-   * When enabled, existing draft applications will be automatically be updated to use the latest
+   * When enabled, existing draft applications will automatically be updated to use the latest
    * version of a program when a newer version has been published.
    */
   public boolean getFastforwardEnabled(RequestHeader request) {
@@ -2163,7 +2163,7 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                           SettingMode.ADMIN_WRITEABLE),
                       SettingDescription.create(
                           "FASTFORWARD_ENABLED",
-                          "When enabled, existing draft applications will be automatically be"
+                          "When enabled, existing draft applications will automatically be"
                               + " updated to use the latest version of a program when a newer"
                               + " version has been published.",
                           /* isRequired= */ false,


### PR DESCRIPTION
Small update to remove a redundant work.