### PR TITLE
Getting the swagger ui assets loading in deployed environments

### DIFF
--- a/prod.Dockerfile
+++ b/prod.Dockerfile
@@ -26,6 +26,7 @@ COPY "${PROJECT_NAME}" "${PROJECT_LOC}"
 RUN cd "${PROJECT_LOC}" && \
     npm install -g npm && \
     npm install && \
+    sbt addCustomAssets && \
     sbt update && \
     sbt dist && \
     unzip "${PROJECT_LOC}/target/universal/civiform-server-0.0.1.zip" -d / && \

--- a/server/build.sbt
+++ b/server/build.sbt
@@ -316,6 +316,32 @@ addCommandAlias(
   ";eval System.setProperty(\"config.file\", \"conf/application.dev-browser-tests.conf\");run"
 )
 
+// Define a custom command to add custom asset files. These are files that need to be
+// added to the `public` folder prior to the asset jar generation which occurs early
+// in the dist pipeline.
+//
+// During development webpack manages the files, but webpack doesn't run early
+// enough during the dist pipeline.
+val addCustomAssets = taskKey[Unit]("Add custom assets")
+addCustomAssets := {
+
+  // The swagger-ui-dist files already come minified. These are getting
+  // manually copied to the `public` folder instead of running through
+  // the webpack minifier/bundler because they cause webpack to fail with
+  // multiple errors. Doing it this way the files get put into `public`
+  // then the asset builder adds them to the internal assets jar file
+  // so they still get the url versioned hash prepended.
+  val sourceDir = baseDirectory.value / "node_modules" / "swagger-ui-dist"
+  val targetDir = baseDirectory.value / "public" / "swagger-ui"
+
+  if (!sourceDir.exists) {
+    throw new IllegalStateException(s"Source directory not found: $sourceDir")
+  }
+
+  IO.createDirectory(targetDir) // Create target directory if it doesn't exist
+  IO.copyDirectory(sourceDir, targetDir)
+}
+
 // scalaVersion is formatted as x.y.z, but we only want x.y in our path. This function
 // removes the .z component and returns the path to the generated source file directory.
 def generateSourcePath(scalaVersion: String): String = {


### PR DESCRIPTION
### Description

Due to the pipeline order of `sbt update` and `sbt dist` the prod image wasn't including the swagger ui web assets. The webpack step happens long after the internal asset jar bundling. This adds a custom sbt task that is called before we do other sbt commands to build the application for the prod image. This only needs to happen for the prod image and not other times sbt update happens which is why I'm not making `update` depend on the new task.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)

Related: #4946
