### PR TITLE
Add structured JSON logging support for Google Cloud logging integration

### DIFF
--- a/server/build.sbt
+++ b/server/build.sbt
@@ -129,9 +129,6 @@ lazy val root = (project in file("."))
       "io.swagger.core.v3" % "swagger-core" % "2.2.28",
       "io.swagger.parser.v3" % "swagger-parser" % "2.1.25",
 
-      // GCP logback encoder
-      "com.google.cloud" % "google-cloud-logging-logback" % "0.131.11-alpha",
-
       // Logstash to write JSON formatted log lines with logback
       "net.logstash.logback" % "logstash-logback-encoder" % "7.4"
     ),

--- a/server/build.sbt
+++ b/server/build.sbt
@@ -130,7 +130,10 @@ lazy val root = (project in file("."))
       "io.swagger.parser.v3" % "swagger-parser" % "2.1.25",
 
       // GCP logback encoder
-      "com.google.cloud" % "google-cloud-logging-logback" % "0.131.11-alpha"
+      "com.google.cloud" % "google-cloud-logging-logback" % "0.131.11-alpha",
+
+      // Logstash to write JSON formatted log lines with logback
+      "net.logstash.logback" % "logstash-logback-encoder" % "7.4"
     ),
     javacOptions ++= {
       val defaultCompilerOptions = Seq(

--- a/server/build.sbt
+++ b/server/build.sbt
@@ -127,7 +127,10 @@ lazy val root = (project in file("."))
 
       // OpenAPI 3.x Dependencies
       "io.swagger.core.v3" % "swagger-core" % "2.2.28",
-      "io.swagger.parser.v3" % "swagger-parser" % "2.1.25"
+      "io.swagger.parser.v3" % "swagger-parser" % "2.1.25",
+
+      // GCP logback encoder
+      "com.google.cloud" % "google-cloud-logging-logback" % "0.131.11-alpha"
     ),
     javacOptions ++= {
       val defaultCompilerOptions = Seq(

--- a/server/conf/logback.xml
+++ b/server/conf/logback.xml
@@ -6,11 +6,18 @@
   <import class="ch.qos.logback.classic.AsyncAppender" />
   <import class="ch.qos.logback.core.FileAppender" />
   <import class="ch.qos.logback.core.ConsoleAppender" />
+  <import class="ch.qos.logback.classic.encoder.JsonEncoder" />
 
   <appender name="FILE" class="FileAppender">
     <file>${application.home:-.}/logs/application.log</file>
     <encoder class="PatternLayoutEncoder">
       <pattern>%date [%level] from %logger in %thread - %message%n%xException</pattern>
+    </encoder>
+  </appender>
+
+  <appender name="JSON" class="ConsoleAppender">
+    <encoder class="JsonEncoder">
+      <withFormattedMessage>true</withFormattedMessage>
     </encoder>
   </appender>
 
@@ -22,6 +29,10 @@
 
   <appender name="ASYNCFILE" class="AsyncAppender">
     <appender-ref ref="FILE" />
+  </appender>
+
+  <appender name="ASYNCJSON" class="AsyncAppender">
+    <appender-ref ref="JSON" />
   </appender>
 
   <appender name="ASYNCSTDOUT" class="AsyncAppender">
@@ -59,6 +70,6 @@
 
   <root level="WARN">
     <appender-ref ref="ASYNCFILE" />
-    <appender-ref ref="ASYNCSTDOUT" />
+    <appender-ref ref="${LOGBACK_CONSOLE_APPENDER:-ASYNCSTDOUT}" />
   </root>
 </configuration>

--- a/server/conf/logback.xml
+++ b/server/conf/logback.xml
@@ -6,7 +6,7 @@
   <import class="ch.qos.logback.classic.AsyncAppender" />
   <import class="ch.qos.logback.core.FileAppender" />
   <import class="ch.qos.logback.core.ConsoleAppender" />
-  <import class="ch.qos.logback.classic.encoder.JsonEncoder" />
+  <import class="com.google.cloud.logging.logback.LoggingAppender" />
 
   <appender name="FILE" class="FileAppender">
     <file>${application.home:-.}/logs/application.log</file>
@@ -15,11 +15,7 @@
     </encoder>
   </appender>
 
-  <appender name="JSON" class="ConsoleAppender">
-    <encoder class="JsonEncoder">
-      <withFormattedMessage>true</withFormattedMessage>
-    </encoder>
-  </appender>
+  <appender name="GOOGLECLOUD" class="LoggingAppender" />
 
   <appender name="STDOUT" class="ConsoleAppender">
     <encoder class="PatternLayoutEncoder">
@@ -31,8 +27,8 @@
     <appender-ref ref="FILE" />
   </appender>
 
-  <appender name="ASYNCJSON" class="AsyncAppender">
-    <appender-ref ref="JSON" />
+  <appender name="ASYNCGOOGLECLOUD" class="AsyncAppender">
+    <appender-ref ref="GOOGLECLOUD" />
   </appender>
 
   <appender name="ASYNCSTDOUT" class="AsyncAppender">
@@ -70,6 +66,6 @@
 
   <root level="WARN">
     <appender-ref ref="ASYNCFILE" />
-    <appender-ref ref="${LOGBACK_CONSOLE_APPENDER:-ASYNCSTDOUT}" />
+    <appender-ref ref="${LOGBACK_APPENDER:-ASYNCSTDOUT}" />
   </root>
 </configuration>

--- a/server/conf/logback.xml
+++ b/server/conf/logback.xml
@@ -15,7 +15,9 @@
     </encoder>
   </appender>
 
-  <appender name="GOOGLECLOUD" class="LoggingAppender" />
+  <appender name="GOOGLECLOUD" class="LoggingAppender">
+    <logName>civiform-logs</logName>
+  </appender>
 
   <appender name="STDOUT" class="ConsoleAppender">
     <encoder class="PatternLayoutEncoder">
@@ -64,7 +66,6 @@
   <logger name="io.ebean.TXN" level="OFF" />
 
   <root level="INFO">
-    <appender-ref ref="ASYNCFILE" />
     <appender-ref ref="GOOGLECLOUD" />
   </root>
 </configuration>

--- a/server/conf/logback.xml
+++ b/server/conf/logback.xml
@@ -66,6 +66,6 @@
 
   <root level="WARN">
     <appender-ref ref="ASYNCFILE" />
-    <appender-ref ref="${LOGBACK_APPENDER:-ASYNCSTDOUT}" />
+    <appender-ref ref="GOOGLECLOUD" />
   </root>
 </configuration>

--- a/server/conf/logback.xml
+++ b/server/conf/logback.xml
@@ -73,6 +73,13 @@
   <logger name="io.ebean.SQL" level="OFF" />
   <logger name="io.ebean.TXN" level="OFF" />
 
+  <!--
+    If the environment variable LOGBACK_CONSOLE_APPENDER is set, then it will used as the
+    appender for console logging.  If the environment variable is not set, then the ASYNCSTDOUT
+    appender wil be used.
+
+    This environment variable is used in GCP deployemnts to reference ASYNCJSON appender.
+  -->
   <root level="WARN">
     <appender-ref ref="ASYNCFILE" />
     <appender-ref ref="${LOGBACK_CONSOLE_APPENDER:-ASYNCSTDOUT}" />

--- a/server/conf/logback.xml
+++ b/server/conf/logback.xml
@@ -63,8 +63,7 @@
   <logger name="io.ebean.SQL" level="OFF" />
   <logger name="io.ebean.TXN" level="OFF" />
 
-
-  <root level="WARN">
+  <root level="INFO">
     <appender-ref ref="ASYNCFILE" />
     <appender-ref ref="GOOGLECLOUD" />
   </root>

--- a/server/conf/logback.xml
+++ b/server/conf/logback.xml
@@ -6,7 +6,8 @@
   <import class="ch.qos.logback.classic.AsyncAppender" />
   <import class="ch.qos.logback.core.FileAppender" />
   <import class="ch.qos.logback.core.ConsoleAppender" />
-  <import class="com.google.cloud.logging.logback.LoggingAppender" />
+  <import class="ch.qos.logback.classic.encoder.JsonEncoder" />
+  <import class="net.logstash.logback.encoder.LogstashEncoder" />
 
   <appender name="FILE" class="FileAppender">
     <file>${application.home:-.}/logs/application.log</file>
@@ -15,8 +16,13 @@
     </encoder>
   </appender>
 
-  <appender name="GOOGLECLOUD" class="LoggingAppender">
-    <logName>civiform-logs</logName>
+  <appender name="JSON" class="ConsoleAppender">
+    <encoder class="LogstashEncoder">
+      <fieldNames>
+        <timestamp>timestamp</timestamp>
+        <level>severity</level>
+      </fieldNames>
+    </encoder>
   </appender>
 
   <appender name="STDOUT" class="ConsoleAppender">
@@ -66,6 +72,6 @@
   <logger name="io.ebean.TXN" level="OFF" />
 
   <root level="INFO">
-    <appender-ref ref="GOOGLECLOUD" />
+    <appender-ref ref="JSON" />
   </root>
 </configuration>

--- a/server/conf/logback.xml
+++ b/server/conf/logback.xml
@@ -6,7 +6,6 @@
   <import class="ch.qos.logback.classic.AsyncAppender" />
   <import class="ch.qos.logback.core.FileAppender" />
   <import class="ch.qos.logback.core.ConsoleAppender" />
-  <import class="ch.qos.logback.classic.encoder.JsonEncoder" />
   <import class="net.logstash.logback.encoder.LogstashEncoder" />
 
   <appender name="FILE" class="FileAppender">
@@ -21,7 +20,10 @@
       <fieldNames>
         <timestamp>timestamp</timestamp>
         <level>severity</level>
+        <version>[ignore]</version>
+        <levelValue>[ignore]</levelValue>
       </fieldNames>
+      <includeContext>false</includeContext>
     </encoder>
   </appender>
 
@@ -35,8 +37,8 @@
     <appender-ref ref="FILE" />
   </appender>
 
-  <appender name="ASYNCGOOGLECLOUD" class="AsyncAppender">
-    <appender-ref ref="GOOGLECLOUD" />
+  <appender name="ASYNCJSON" class="AsyncAppender">
+    <appender-ref ref="JSON" />
   </appender>
 
   <appender name="ASYNCSTDOUT" class="AsyncAppender">
@@ -71,7 +73,8 @@
   <logger name="io.ebean.SQL" level="OFF" />
   <logger name="io.ebean.TXN" level="OFF" />
 
-  <root level="INFO">
-    <appender-ref ref="JSON" />
+  <root level="WARN">
+    <appender-ref ref="ASYNCFILE" />
+    <appender-ref ref="${LOGBACK_CONSOLE_APPENDER:-ASYNCSTDOUT}" />
   </root>
 </configuration>


### PR DESCRIPTION
### Description

Adds the following:

- Dependency on logstash-logback-encoder library in build.sbt
- Defines a new appender in logback configuration for JSON console output
- Optionally use the value of the environment variable LOGBACK_CONSOLE_APPENDER to determine which appender to use for console logging in logback.

By default if LOGBACK_CONSOLE_APPENDER  is undefined, it will use the ASYNCSTDOUT appender, which is the way the current logback configuration works.  (this means no changes to existing civiform deployments).

In the GCP deployments, LOGBACK_CONSOLE_APPENDER will be set to ASYNCJSON

Tested by running the dev server with LOGBACK_CONSOLE_APPENDER  set and unset.  The proper appenders were loaded and the server ran normally.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [X] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [X] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [X] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [X] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [X] Created unit and/or browser tests which fail without the change (if possible)
- [X] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [X] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [X] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`

