### PR TITLE
Disable OpenApi Validator Badge

### DIFF
--- a/server/app/views/docs/SchemaView.java
+++ b/server/app/views/docs/SchemaView.java
@@ -206,6 +206,7 @@ document.addEventListener('DOMContentLoaded', () => {
     SwaggerUIBundle({
         url: '%s',
         dom_id: '#%s',
+        validatorUrl: null,
         presets: [
             SwaggerUIBundle.presets.apis,
             SwaggerUIStandalonePreset


### PR DESCRIPTION
### Description

Disable the online OpenApi validator badge. The generator OpenApi yaml files are not accessible outside of the application so claims to be invalid. This wasn't noticeable on localhost as you can reach the validator website. Setting validatorUrl to null disables the check and the badge [per the docs](https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration).

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)

