### PR TITLE
[North Star] Use only short description in program cards

### DIFF
--- a/server/app/views/applicant/ProgramCardsSectionParamsFactory.java
+++ b/server/app/views/applicant/ProgramCardsSectionParamsFactory.java
@@ -14,7 +14,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 import models.LifecycleStage;
-import org.apache.commons.lang3.StringUtils;
 import play.i18n.Messages;
 import play.mvc.Http.Request;
 import services.DateConverter;
@@ -25,7 +24,6 @@ import services.cloud.PublicStorageClient;
 import services.program.ProgramDefinition;
 import views.ProgramImageUtils;
 import views.components.Modal;
-import views.components.TextFormatter;
 
 /**
  * Factory for creating parameter info for applicant program card sections.
@@ -154,7 +152,7 @@ public final class ProgramCardsSectionParamsFactory {
             .map(c -> c.getLocalizedName().getOrDefault(preferredLocale))
             .collect(ImmutableList.toImmutableList()));
 
-    String description = selectAndFormatDescription(program, preferredLocale);
+    String description = program.localizedShortDescription().getOrDefault(preferredLocale);
 
     cardBuilder
         .setTitle(program.localizedName().getOrDefault(preferredLocale))
@@ -217,24 +215,6 @@ public final class ProgramCardsSectionParamsFactory {
     }
 
     return cardBuilder.build();
-  }
-
-  /**
-   * Use the short description if present, otherwise use the long description with all markdown
-   * removed and truncated to 100 characters.
-   */
-  static String selectAndFormatDescription(ProgramDefinition program, Locale preferredLocale) {
-    String description = program.localizedShortDescription().getOrDefault(preferredLocale);
-
-    if (description.isEmpty()) {
-      description = program.localizedDescription().getOrDefault(preferredLocale);
-      // Add a space before any new line characters so when markdown is stripped off the words
-      // aren't smooshed together
-      description = String.join("&nbsp;\n", description.split("\n"));
-      description = StringUtils.abbreviate(TextFormatter.removeMarkdown(description), 100);
-    }
-
-    return description;
   }
 
   /**

--- a/server/test/views/applicant/ProgramCardsSectionParamsFactoryTest.java
+++ b/server/test/views/applicant/ProgramCardsSectionParamsFactoryTest.java
@@ -10,7 +10,6 @@ import auth.ProfileFactory;
 import auth.ProgramAcls;
 import com.google.common.collect.ImmutableList;
 import controllers.applicant.ApplicantRoutes;
-import java.util.Locale;
 import java.util.Optional;
 import models.DisplayMode;
 import models.LifecycleStage;
@@ -33,45 +32,6 @@ public class ProgramCardsSectionParamsFactoryTest extends ResetPostgres {
     when(testProfile.getProfileData()).thenReturn(testProfileData);
     when(testProfileData.containsAttribute(ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME))
         .thenReturn(false);
-  }
-
-  @Test
-  public void selectAndFormatDescription_usesShortDescriptionWhenPresent() {
-    ProgramDefinition program = createProgramDefinition("short description", "long description");
-    String description =
-        ProgramCardsSectionParamsFactory.selectAndFormatDescription(program, Locale.getDefault());
-
-    assertThat(description).isEqualTo("short description");
-  }
-
-  @Test
-  public void selectAndFormatDescription_usesLongDescriptionWhenShortDescriptionIsBlank() {
-    ProgramDefinition program = createProgramDefinition("", "long description");
-    String description =
-        ProgramCardsSectionParamsFactory.selectAndFormatDescription(program, Locale.getDefault());
-
-    assertThat(description).isEqualTo("long description\n");
-  }
-
-  @Test
-  public void selectAndFormatDescription_truncatesAndRemovesMarkdownFromLongDescription() {
-    ProgramDefinition program =
-        createProgramDefinition(
-            "",
-            "Here is a very long description with some markdown.\n"
-                + "Here we have a [link](https://www.example.com) and some __bold text__.\n"
-                + "Here we have a list:\n"
-                + "- one\n"
-                + "- two\n"
-                + "- three\n"
-                + "And some more text to make sure this is realllllllllyyyyyy long.");
-    String description =
-        ProgramCardsSectionParamsFactory.selectAndFormatDescription(program, Locale.getDefault());
-
-    assertThat(description)
-        .isEqualTo(
-            "Here is a very long description with some markdown. Here we have a link and some bold"
-                + " text. Here ...");
   }
 
   @Test


### PR DESCRIPTION
### Description

Program cards used the long description when short description is non existent. However, since we want to encourage admins to add a short description and make this consistent, we are taking out the long description as backup for short description in the program card. This aligns with #9719

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)

#### User visible changes

- [x] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [x] Manually tested at 200% size
- [x] Manually tested with a screen reader if the feature is applicant-facing. See [screen reader testing](https://github.com/civiform/civiform/wiki/Testing#screen-reader-testing)

### Issue(s) this completes

Fixes #9798

