### PR TITLE
[North Star] Use support email in footer

### DIFF
--- a/browser-test/src/applicant/northstar_footer.test.ts
+++ b/browser-test/src/applicant/northstar_footer.test.ts
@@ -1,6 +1,8 @@
-import {test} from '../support/civiform_fixtures'
+import {test, expect} from '../support/civiform_fixtures'
 import {
   enableFeatureFlag,
+  loginAsAdmin,
+  logout,
   validateAccessibility,
   validateScreenshot,
 } from '../support'
@@ -13,5 +15,25 @@ test.describe('North Star footer', {tag: ['@northstar']}, () => {
   test('renders footer', async ({page}) => {
     await validateScreenshot(page.locator('footer'), 'north-star-footer')
     await validateAccessibility(page)
+  })
+
+  test('Updating the support email updated the footer', async ({
+    page,
+    adminSettings,
+  }) => {
+    await loginAsAdmin(page)
+    await adminSettings.gotoAdminSettings()
+    await adminSettings.setStringSetting(
+      'SUPPORT_EMAIL_ADDRESS',
+      'test@email.com',
+    )
+    await adminSettings.saveChanges()
+    await logout(page)
+
+    await expect(
+      page.getByRole('link', {
+        name: 'test@email.com',
+      }),
+    ).toBeAttached()
   })
 })

--- a/server/app/views/NorthStarBaseView.java
+++ b/server/app/views/NorthStarBaseView.java
@@ -82,6 +82,7 @@ public abstract class NorthStarBaseView {
     context.setVariable("closeIcon", Icons.CLOSE);
     context.setVariable("httpsIcon", assetsFinder.path("Images/uswds/icon-https.svg"));
     context.setVariable("govIcon", assetsFinder.path("Images/uswds/icon-dot-gov.svg"));
+    context.setVariable("supportEmail", settingsManifest.getSupportEmailAddress(request).get());
 
     // Language selector params
     context.setVariable("preferredLanguage", languageUtils.getPreferredLanguage(request));

--- a/server/app/views/applicant/NavigationFragment.html
+++ b/server/app/views/applicant/NavigationFragment.html
@@ -309,9 +309,19 @@
             <div
               class="grid-col-auto mobile-lg:grid-col-12 desktop:grid-col-auto"
             >
+              <!--/* We construct the link inline instead of using a fragment
+                since ${supportEmail} won't be recognized when the fragment is
+                evaluated at insertion time */-->
               <div
                 class="usa-footer__contact-info expanding-div"
-                th:utext="#{footer.technicalSupport(~{this :: technicalSupportLink})}"
+                th:with="supportLink='<a class=\'usa-link\' '
+                  + 'href=\'mailto:' + ${supportEmail} + '\' '
+                  + 'target=\'_blank\' '
+                  + 'rel=\'noopener noreferrer\'>'
+                  + ${supportEmail}
+                  + '</a>'"
+                th:utext="#{footer.technicalSupport(${supportLink})}"
+                data-testid="supportEmail"
               ></div>
             </div>
           </div>
@@ -347,12 +357,3 @@
     th:replace="~{applicant/ApplicantBaseFragment :: pageFooterScripts}"
   ></div>
 </footer>
-
-<a
-  th:fragment="technicalSupportLink"
-  class="usa-link"
-  href="mailto:civiform-dev@exygy.com"
-  target="_blank"
-  rel="noopener noreferrer"
-  >civiform-dev@exygy.com</a
->


### PR DESCRIPTION
### Description

Use support email instead of a hardcoded email in the North Star footer

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)


#### User visible changes

- [x] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [x] Manually tested at 200% size
- [x] Manually tested with a screen reader if the feature is applicant-facing. See [screen reader testing](https://github.com/civiform/civiform/wiki/Testing#screen-reader-testing)

### Instructions for manual testing

1. As an Admin, go to settings and add a support email
2. As an Applicant, verify that new support email is used in the footer

### Issue(s) this completes

Fixes #9934
