### PR TITLE
Remove show cf image tag on landing page

### DIFF
--- a/browser-test/src/footer.test.ts
+++ b/browser-test/src/footer.test.ts
@@ -1,10 +1,5 @@
 import {test, expect} from './support/civiform_fixtures'
-import {
-  enableFeatureFlag,
-  disableFeatureFlag,
-  validateAccessibility,
-  validateScreenshot,
-} from './support'
+import {validateAccessibility, validateScreenshot} from './support'
 
 test.describe('the footer', () => {
   test('does not have civiform version when feature flag is disabled', async ({
@@ -12,24 +7,11 @@ test.describe('the footer', () => {
   }) => {
     const footerLocator = page.locator('footer')
 
-    await disableFeatureFlag(page, 'show_civiform_image_tag_on_landing_page')
     await validateScreenshot(footerLocator, 'footer-no-version')
     await validateAccessibility(page)
 
     await test.step('Footer does not have version text', async () => {
       await expect(footerLocator).not.toContainText('CiviForm version:')
-    })
-  })
-
-  test('has civiform version when feature flag is enabled', async ({page}) => {
-    const footerLocator = page.locator('footer')
-
-    await enableFeatureFlag(page, 'show_civiform_image_tag_on_landing_page')
-    await validateScreenshot(footerLocator, 'footer-with-version')
-    await validateAccessibility(page)
-
-    await test.step('Footer does has version text', async () => {
-      await expect(footerLocator).toContainText('CiviForm version:')
     })
   })
 })

--- a/server/app/services/settings/SettingsManifest.java
+++ b/server/app/services/settings/SettingsManifest.java
@@ -787,18 +787,13 @@ public final class SettingsManifest extends AbstractSettingsManifest {
 
   /**
    * The tag of the docker image this server is running inside. Is added as a HTML meta tag with
-   * name 'civiform-build-tag'. If SHOW_CIVIFORM_IMAGE_TAG_ON_LANDING_PAGE is set to true, is also
-   * shown on the login page if CIVIFORM_VERSION is the empty string or set to 'latest'.
+   * name 'civiform-build-tag'.
    */
   public Optional<String> getCiviformImageTag() {
     return getString("CIVIFORM_IMAGE_TAG");
   }
 
-  /**
-   * The release version of CiviForm. For example: v1.18.0. If
-   * SHOW_CIVIFORM_IMAGE_TAG_ON_LANDING_PAGE is set to true, is also shown on the login page if it a
-   * value other than the empty string or 'latest'.
-   */
+  /** The release version of CiviForm. For example: v1.18.0. */
   public Optional<String> getCiviformVersion() {
     return getString("CIVIFORM_VERSION");
   }
@@ -957,14 +952,6 @@ public final class SettingsManifest extends AbstractSettingsManifest {
    */
   public boolean getAllowCiviformAdminAccessPrograms(RequestHeader request) {
     return getBool("ALLOW_CIVIFORM_ADMIN_ACCESS_PROGRAMS", request);
-  }
-
-  /**
-   * If enabled, the value of CIVIFORM_IMAGE_TAG will be shown on the login screen. Is disabled by
-   * default.
-   */
-  public boolean getShowCiviformImageTagOnLandingPage(RequestHeader request) {
-    return getBool("SHOW_CIVIFORM_IMAGE_TAG_ON_LANDING_PAGE", request);
   }
 
   /**
@@ -2173,13 +2160,6 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                           SettingType.BOOLEAN,
                           SettingMode.ADMIN_WRITEABLE),
                       SettingDescription.create(
-                          "SHOW_CIVIFORM_IMAGE_TAG_ON_LANDING_PAGE",
-                          "If enabled, the value of CIVIFORM_IMAGE_TAG will be shown on the login"
-                              + " screen. Is disabled by default.",
-                          /* isRequired= */ false,
-                          SettingType.BOOLEAN,
-                          SettingMode.ADMIN_WRITEABLE),
-                      SettingDescription.create(
                           "STAGING_ADD_NOINDEX_META_TAG",
                           "If this is a staging deployment and this variable is set to true, a"
                               + " [robots"
@@ -2406,19 +2386,13 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                       SettingDescription.create(
                           "CIVIFORM_IMAGE_TAG",
                           "The tag of the docker image this server is running inside. Is added as a"
-                              + " HTML meta tag with name 'civiform-build-tag'. If"
-                              + " SHOW_CIVIFORM_IMAGE_TAG_ON_LANDING_PAGE is set to true, is also"
-                              + " shown on the login page if CIVIFORM_VERSION is the empty string"
-                              + " or set to 'latest'.",
+                              + " HTML meta tag with name 'civiform-build-tag'.",
                           /* isRequired= */ false,
                           SettingType.STRING,
                           SettingMode.ADMIN_READABLE),
                       SettingDescription.create(
                           "CIVIFORM_VERSION",
-                          "The release version of CiviForm. For example: v1.18.0. If"
-                              + " SHOW_CIVIFORM_IMAGE_TAG_ON_LANDING_PAGE is set to true, is also"
-                              + " shown on the login page if it a value other than the empty string"
-                              + " or 'latest'.",
+                          "The release version of CiviForm. For example: v1.18.0.",
                           /* isRequired= */ false,
                           SettingType.STRING,
                           SettingMode.ADMIN_READABLE),

--- a/server/app/views/applicant/ApplicantLayout.java
+++ b/server/app/views/applicant/ApplicantLayout.java
@@ -81,7 +81,6 @@ public class ApplicantLayout extends BaseHtmlLayout {
   private final LanguageUtils languageUtils;
   private final LanguageSelector languageSelector;
   private final boolean isDevOrStaging;
-  private final DebugContent debugContent;
   private final PageNotProductionBanner pageNotProductionBanner;
   private String tiDashboardHref = getTiDashboardHref();
 
@@ -94,7 +93,6 @@ public class ApplicantLayout extends BaseHtmlLayout {
       LanguageUtils languageUtils,
       SettingsManifest settingsManifest,
       DeploymentType deploymentType,
-      DebugContent debugContent,
       AssetsFinder assetsFinder,
       PageNotProductionBanner pageNotProductionBanner) {
     super(viewUtils, settingsManifest, deploymentType, assetsFinder);
@@ -103,7 +101,6 @@ public class ApplicantLayout extends BaseHtmlLayout {
     this.languageSelector = checkNotNull(languageSelector);
     this.languageUtils = checkNotNull(languageUtils);
     this.isDevOrStaging = deploymentType.isDevOrStaging();
-    this.debugContent = debugContent;
     this.pageNotProductionBanner = checkNotNull(pageNotProductionBanner);
   }
 
@@ -175,10 +172,6 @@ public class ApplicantLayout extends BaseHtmlLayout {
         div()
             .withClasses("flex", "flex-col")
             .with(
-                div()
-                    .condWith(
-                        getSettingsManifest().getShowCiviformImageTagOnLandingPage(request),
-                        debugContent.civiformVersionDiv()),
                 div()
                     .with(
                         span(

--- a/server/app/views/dev/DebugContent.java
+++ b/server/app/views/dev/DebugContent.java
@@ -4,23 +4,11 @@ import static j2html.TagCreator.div;
 import static j2html.TagCreator.p;
 
 import auth.FakeAdminClient;
-import com.typesafe.config.Config;
 import j2html.tags.specialized.DivTag;
-import javax.inject.Inject;
 import views.BaseHtmlView;
 
 /** All frontend debug content that we show when running CiviForm in dev mode. */
 public final class DebugContent extends BaseHtmlView {
-
-  private final String civiformVersion;
-  private final String civiformImageTag;
-
-  @Inject
-  public DebugContent(Config config) {
-    this.civiformVersion = config.getString("civiform_version");
-    this.civiformImageTag = config.getString("civiform_image_tag");
-  }
-
   public static DivTag devTools() {
     return div()
         .withClasses("flex", "flex-col")
@@ -55,18 +43,5 @@ public final class DebugContent extends BaseHtmlView {
                 "additional-tools",
                 "Additional tools",
                 controllers.dev.routes.DevToolsController.index().url()));
-  }
-
-  public DivTag civiformVersionDiv() {
-    // civiformVersion is the version the deployer requests, like "latest" or
-    // "v1.18.0". civiformImageTag is set by bin/build-prod and is a string
-    // like "SNAPSHOT-3af8997-1678895722".
-    String version = civiformVersion;
-    if (civiformVersion.equals("") || civiformVersion.equals("latest")) {
-      version = civiformImageTag;
-    }
-    return div()
-        .with(p("CiviForm version: " + version).withClasses("text-gray-600", "mx-auto"))
-        .withClasses("flex", "flex-row");
   }
 }

--- a/server/conf/env-var-docs.json
+++ b/server/conf/env-var-docs.json
@@ -696,12 +696,12 @@
   },
   "CIVIFORM_IMAGE_TAG": {
     "mode": "ADMIN_READABLE",
-    "description": "The tag of the docker image this server is running inside. Is added as a HTML meta tag with name 'civiform-build-tag'. If SHOW_CIVIFORM_IMAGE_TAG_ON_LANDING_PAGE is set to true, is also shown on the login page if CIVIFORM_VERSION is the empty string or set to 'latest'.",
+    "description": "The tag of the docker image this server is running inside. Is added as a HTML meta tag with name 'civiform-build-tag'.",
     "type": "string"
   },
   "CIVIFORM_VERSION": {
     "mode": "ADMIN_READABLE",
-    "description": "The release version of CiviForm. For example: v1.18.0. If SHOW_CIVIFORM_IMAGE_TAG_ON_LANDING_PAGE is set to true, is also shown on the login page if it a value other than the empty string or 'latest'.",
+    "description": "The release version of CiviForm. For example: v1.18.0.",
     "type": "string"
   },
   "ALLOWED_IP_ADDRESSES_FOR_LOGOUT": {
@@ -830,11 +830,6 @@
       "ALLOW_CIVIFORM_ADMIN_ACCESS_PROGRAMS": {
         "mode": "ADMIN_WRITEABLE",
         "description": "If enabled, CiviForm Admins are able to see all applications for all programs. Is disabled by default.",
-        "type": "bool"
-      },
-      "SHOW_CIVIFORM_IMAGE_TAG_ON_LANDING_PAGE": {
-        "mode": "ADMIN_WRITEABLE",
-        "description": "If enabled, the value of CIVIFORM_IMAGE_TAG will be shown on the login screen. Is disabled by default.",
         "type": "bool"
       },
       "STAGING_ADD_NOINDEX_META_TAG": {

--- a/server/conf/helper/feature-flags.conf
+++ b/server/conf/helper/feature-flags.conf
@@ -9,9 +9,6 @@ civiform_image_tag = ${?CIVIFORM_IMAGE_TAG}
 allow_civiform_admin_access_programs = false
 allow_civiform_admin_access_programs = ${?ALLOW_CIVIFORM_ADMIN_ACCESS_PROGRAMS}
 
-show_civiform_image_tag_on_landing_page = false
-show_civiform_image_tag_on_landing_page = ${?SHOW_CIVIFORM_IMAGE_TAG_ON_LANDING_PAGE}
-
 # Staging deployment functionality toggles. These toggles only take effect for
 # staging deployments.
 staging_add_noindex_meta_tag = false


### PR DESCRIPTION
### Description

Removes the option to show the CiviForm release number on the applicant home page. 

If you have `SHOW_CIVIFORM_IMAGE_TAG_ON_LANDING_PAGE` set in your deployment config file please remove it.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)


Fixes #9939
