### PR TITLE
[Program Migration] Remove PROGRAM_MIGRATION_ENABLED feature flag

### DIFF
--- a/server/app/controllers/admin/AdminExportController.java
+++ b/server/app/controllers/admin/AdminExportController.java
@@ -64,10 +64,6 @@ public class AdminExportController extends CiviFormController {
 
   @Secure(authorizers = Authorizers.Labels.CIVIFORM_ADMIN)
   public Result index(Http.Request request, Long programId) {
-    if (!settingsManifest.getProgramMigrationEnabled()) {
-      return notFound("Program export is not enabled");
-    }
-
     ProgramDefinition program;
     try {
       program = programService.getFullProgramDefinition(programId);

--- a/server/app/controllers/admin/AdminExportController.java
+++ b/server/app/controllers/admin/AdminExportController.java
@@ -21,7 +21,6 @@ import services.program.ProgramService;
 import services.question.QuestionService;
 import services.question.exceptions.QuestionNotFoundException;
 import services.question.types.QuestionDefinition;
-import services.settings.SettingsManifest;
 import views.admin.migration.AdminExportView;
 import views.admin.migration.AdminProgramExportForm;
 
@@ -41,7 +40,6 @@ public class AdminExportController extends CiviFormController {
   private final ProgramMigrationService programMigrationService;
   private final ProgramService programService;
   private final QuestionService questionService;
-  private final SettingsManifest settingsManifest;
 
   @Inject
   public AdminExportController(
@@ -51,7 +49,6 @@ public class AdminExportController extends CiviFormController {
       ProgramMigrationService programMigrationService,
       ProgramService programService,
       QuestionService questionService,
-      SettingsManifest settingsManifest,
       VersionRepository versionRepository) {
     super(profileUtils, versionRepository);
     this.adminExportView = checkNotNull(adminExportView);
@@ -59,7 +56,6 @@ public class AdminExportController extends CiviFormController {
     this.programMigrationService = checkNotNull(programMigrationService);
     this.programService = checkNotNull(programService);
     this.questionService = checkNotNull(questionService);
-    this.settingsManifest = checkNotNull(settingsManifest);
   }
 
   @Secure(authorizers = Authorizers.Labels.CIVIFORM_ADMIN)

--- a/server/app/controllers/admin/AdminImportController.java
+++ b/server/app/controllers/admin/AdminImportController.java
@@ -98,9 +98,6 @@ public class AdminImportController extends CiviFormController {
 
   @Secure(authorizers = Authorizers.Labels.CIVIFORM_ADMIN)
   public Result index(Http.Request request) {
-    if (!settingsManifest.getProgramMigrationEnabled()) {
-      return notFound("Program import is not enabled");
-    }
     return ok(adminImportView.render(request));
   }
 
@@ -112,10 +109,6 @@ public class AdminImportController extends CiviFormController {
   @Secure(authorizers = Authorizers.Labels.CIVIFORM_ADMIN)
   @BodyParser.Of(LargeFormUrlEncodedBodyParser.class)
   public Result hxImportProgram(Http.Request request) {
-    if (!settingsManifest.getProgramMigrationEnabled()) {
-      return notFound("Program import is not enabled");
-    }
-
     Form<AdminProgramImportForm> form =
         formFactory
             .form(AdminProgramImportForm.class)
@@ -312,10 +305,6 @@ public class AdminImportController extends CiviFormController {
   @Secure(authorizers = Authorizers.Labels.CIVIFORM_ADMIN)
   @BodyParser.Of(LargeFormUrlEncodedBodyParser.class)
   public Result hxSaveProgram(Http.Request request) {
-    if (!settingsManifest.getProgramMigrationEnabled()) {
-      return notFound("Program import is not enabled");
-    }
-
     ErrorAnd<ProgramMigrationWrapper, String> deserializeResult = getDeserializeResult(request);
     if (deserializeResult.isError()) {
       return ok(

--- a/server/app/services/settings/SettingsManifest.java
+++ b/server/app/services/settings/SettingsManifest.java
@@ -1023,11 +1023,6 @@ public final class SettingsManifest extends AbstractSettingsManifest {
     return getBool("FASTFORWARD_ENABLED", request);
   }
 
-  /** Enables migrating programs between deployed environments */
-  public boolean getProgramMigrationEnabled() {
-    return getBool("PROGRAM_MIGRATION_ENABLED");
-  }
-
   /** When enabled, admins will be able to select many applications for status updates */
   public boolean getBulkStatusUpdateEnabled(RequestHeader request) {
     return getBool("BULK_STATUS_UPDATE_ENABLED", request);
@@ -2229,12 +2224,6 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                           /* isRequired= */ false,
                           SettingType.BOOLEAN,
                           SettingMode.ADMIN_WRITEABLE),
-                      SettingDescription.create(
-                          "PROGRAM_MIGRATION_ENABLED",
-                          "Enables migrating programs between deployed environments",
-                          /* isRequired= */ false,
-                          SettingType.BOOLEAN,
-                          SettingMode.ADMIN_READABLE),
                       SettingDescription.create(
                           "BULK_STATUS_UPDATE_ENABLED",
                           "When enabled, admins will be able to select many applications for status"

--- a/server/app/views/admin/programs/ProgramIndexView.java
+++ b/server/app/views/admin/programs/ProgramIndexView.java
@@ -124,34 +124,20 @@ public final class ProgramIndexView extends BaseHtmlView {
             .with(
                 h1(pageTitle),
                 div().withClass("flex-grow"),
-                demographicsCsvModal
-                    .getButton()
-                    .withClasses(ButtonStyles.OUTLINED_WHITE_WITH_ICON, "my-2"),
-                renderNewProgramButton(),
-                maybePublishModal.isPresent() ? maybePublishModal.get().getButton() : null);
-
-    if (settingsManifest.getProgramMigrationEnabled()) {
-      headerContent =
-          div()
-              .withClasses("flex", "items-center", "space-x-4", "mt-12")
-              .with(
-                  h1(pageTitle),
-                  div().withClass("flex-grow"),
-                  div()
-                      .with(
-                          div()
-                              .with(
-                                  demographicsCsvModal
-                                      .getButton()
-                                      .withClasses(ButtonStyles.OUTLINED_WHITE_WITH_ICON, "my-2"),
-                                  renderNewProgramButton(),
-                                  maybePublishModal.isPresent()
-                                      ? maybePublishModal.get().getButton()
-                                      : null)
-                              .withClasses("flex", "flex-row", "space-x-4"),
-                          renderImportProgramLink())
-                      .withClasses("flex", "flex-col", "items-end"));
-    }
+                div()
+                    .with(
+                        div()
+                            .with(
+                                demographicsCsvModal
+                                    .getButton()
+                                    .withClasses(ButtonStyles.OUTLINED_WHITE_WITH_ICON, "my-2"),
+                                renderNewProgramButton(),
+                                maybePublishModal.isPresent()
+                                    ? maybePublishModal.get().getButton()
+                                    : null)
+                            .withClasses("flex", "flex-row", "space-x-4"),
+                        renderImportProgramLink())
+                    .withClasses("flex", "flex-col", "items-end"));
 
     DivTag contentDiv =
         div()
@@ -534,9 +520,7 @@ public final class ProgramIndexView extends BaseHtmlView {
         draftRowExtraActions.add(maybeManageTranslationsLink.get());
       }
       draftRowExtraActions.add(renderEditStatusesLink(draftProgram.get()));
-      if (settingsManifest.getProgramMigrationEnabled()) {
-        draftRowExtraActions.add(renderExportProgramLink(draftProgram.get()));
-      }
+      draftRowExtraActions.add(renderExportProgramLink(draftProgram.get()));
 
       draftRow =
           Optional.of(
@@ -563,9 +547,7 @@ public final class ProgramIndexView extends BaseHtmlView {
       }
       activeRowActions.add(renderViewLink(activeProgram.get(), request));
       activeRowActions.add(renderShareLink(activeProgram.get()));
-      if (settingsManifest.getProgramMigrationEnabled()) {
-        activeRowExtraActions.add(renderExportProgramLink(activeProgram.get()));
-      }
+      activeRowExtraActions.add(renderExportProgramLink(activeProgram.get()));
 
       activeRow =
           Optional.of(

--- a/server/conf/env-var-docs.json
+++ b/server/conf/env-var-docs.json
@@ -882,11 +882,6 @@
         "description": "When enabled, existing draft applications will automatically be updated to use the latest version of a program when a newer version has been published.",
         "type": "bool"
       },
-      "PROGRAM_MIGRATION_ENABLED": {
-        "mode": "ADMIN_READABLE",
-        "description": "Enables migrating programs between deployed environments",
-        "type": "bool"
-      },
       "BULK_STATUS_UPDATE_ENABLED": {
         "mode": "ADMIN_WRITEABLE",
         "description": "When enabled, admins will be able to select many applications for status updates",

--- a/server/conf/helper/feature-flags.conf
+++ b/server/conf/helper/feature-flags.conf
@@ -50,9 +50,6 @@ north_star_applicant_ui = ${?NORTH_STAR_APPLICANT_UI}
 program_filtering_enabled = false
 program_filtering_enabled = ${?PROGRAM_FILTERING_ENABLED}
 
-# Program migration
-program_migration_enabled = true
-program_migration_enabled = ${?PROGRAM_MIGRATION_ENABLED}
 # Ensure no duplicate questions during program migration
 no_duplicate_questions_for_migration_enabled = false
 no_duplicate_questions_for_migration_enabled = ${?NO_DUPLICATE_QUESTIONS_FOR_MIGRATION_ENABLED}

--- a/server/test/controllers/admin/AdminExportControllerTest.java
+++ b/server/test/controllers/admin/AdminExportControllerTest.java
@@ -2,9 +2,7 @@ package controllers.admin;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 import static play.mvc.Http.Status.BAD_REQUEST;
-import static play.mvc.Http.Status.NOT_FOUND;
 import static play.mvc.Http.Status.OK;
 import static play.test.Helpers.contentAsString;
 import static support.FakeRequestBuilder.fakeRequest;
@@ -49,19 +47,7 @@ public class AdminExportControllerTest extends ResetPostgres {
   }
 
   @Test
-  public void index_migrationNotEnabled_notFound() {
-    when(mockSettingsManifest.getProgramMigrationEnabled()).thenReturn(false);
-
-    Result result = controller.index(fakeRequest(), 1L);
-
-    assertThat(result.status()).isEqualTo(NOT_FOUND);
-    assertThat(contentAsString(result)).contains("export is not enabled");
-  }
-
-  @Test
   public void index_migrationEnabled_ok_displaysJsonForTheSelectedProgram() {
-    when(mockSettingsManifest.getProgramMigrationEnabled()).thenReturn(true);
-
     String draftProgramA = "a-program-draft";
 
     ProgramModel draftProgram = ProgramBuilder.newDraftProgram(draftProgramA).build();
@@ -78,8 +64,6 @@ public class AdminExportControllerTest extends ResetPostgres {
 
   @Test
   public void index_invalidProgramId_badRequest() {
-    when(mockSettingsManifest.getProgramMigrationEnabled()).thenReturn(true);
-
     Result result = controller.index(fakeRequest(), Long.MAX_VALUE);
 
     assertThat(result.status()).isEqualTo(BAD_REQUEST);
@@ -88,7 +72,6 @@ public class AdminExportControllerTest extends ResetPostgres {
 
   @Test
   public void index_validProgram_rendersJsonPreview() {
-    when(mockSettingsManifest.getProgramMigrationEnabled()).thenReturn(true);
     ProgramModel activeProgram = ProgramBuilder.newActiveProgram("active-program-1").build();
 
     Result result = controller.index(fakeRequest(), activeProgram.id);
@@ -100,8 +83,6 @@ public class AdminExportControllerTest extends ResetPostgres {
 
   @Test
   public void index_removesProgramCategories() {
-    when(mockSettingsManifest.getProgramMigrationEnabled()).thenReturn(true);
-
     ImmutableMap<Locale, String> translations =
         ImmutableMap.of(
             Lang.forCode("en-US").toLocale(), "Health", Lang.forCode("es-US").toLocale(), "Salud");
@@ -120,7 +101,6 @@ public class AdminExportControllerTest extends ResetPostgres {
 
   @Test
   public void downloadJson_downloadsJson() {
-    when(mockSettingsManifest.getProgramMigrationEnabled()).thenReturn(true);
     String adminName = "fake-admin-name";
 
     Result result =

--- a/server/test/controllers/admin/AdminExportControllerTest.java
+++ b/server/test/controllers/admin/AdminExportControllerTest.java
@@ -1,7 +1,6 @@
 package controllers.admin;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
 import static play.mvc.Http.Status.BAD_REQUEST;
 import static play.mvc.Http.Status.OK;
 import static play.test.Helpers.contentAsString;
@@ -24,13 +23,11 @@ import repository.VersionRepository;
 import services.migration.ProgramMigrationService;
 import services.program.ProgramService;
 import services.question.QuestionService;
-import services.settings.SettingsManifest;
 import support.ProgramBuilder;
 import views.admin.migration.AdminExportView;
 
 public class AdminExportControllerTest extends ResetPostgres {
   private AdminExportController controller;
-  private final SettingsManifest mockSettingsManifest = mock(SettingsManifest.class);
 
   @Before
   public void setUp() {
@@ -42,7 +39,6 @@ public class AdminExportControllerTest extends ResetPostgres {
             instanceOf(ProgramMigrationService.class),
             instanceOf(ProgramService.class),
             instanceOf(QuestionService.class),
-            mockSettingsManifest,
             instanceOf(VersionRepository.class));
   }
 

--- a/server/test/controllers/admin/AdminImportControllerTest.java
+++ b/server/test/controllers/admin/AdminImportControllerTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static play.mvc.Http.Status.NOT_FOUND;
 import static play.mvc.Http.Status.OK;
 import static play.mvc.Http.Status.SEE_OTHER;
 import static play.test.Helpers.contentAsString;
@@ -65,18 +64,7 @@ public class AdminImportControllerTest extends ResetPostgres {
   }
 
   @Test
-  public void index_migrationNotEnabled_notFound() {
-    when(mockSettingsManifest.getProgramMigrationEnabled()).thenReturn(false);
-
-    Result result = controller.index(fakeRequest());
-
-    assertThat(result.status()).isEqualTo(NOT_FOUND);
-    assertThat(contentAsString(result)).contains("import is not enabled");
-  }
-
-  @Test
   public void index_migrationEnabled_ok() {
-    when(mockSettingsManifest.getProgramMigrationEnabled()).thenReturn(true);
     ProgramBuilder.newActiveProgram("active-program-1").build();
     ProgramBuilder.newActiveProgram("active-program-2").build();
     ProgramBuilder.newDraftProgram("draft-program").build();
@@ -88,19 +76,7 @@ public class AdminImportControllerTest extends ResetPostgres {
   }
 
   @Test
-  public void hxImportProgram_migrationNotEnabled_notFound() {
-    when(mockSettingsManifest.getProgramMigrationEnabled()).thenReturn(false);
-
-    Result result = controller.hxImportProgram(fakeRequest());
-
-    assertThat(result.status()).isEqualTo(NOT_FOUND);
-    assertThat(contentAsString(result)).contains("import is not enabled");
-  }
-
-  @Test
   public void hxImportProgram_noRequestBody_redirectsToIndex() {
-    when(mockSettingsManifest.getProgramMigrationEnabled()).thenReturn(true);
-
     Result result = controller.hxImportProgram(fakeRequest());
 
     assertThat(result.status()).isEqualTo(SEE_OTHER);
@@ -109,8 +85,6 @@ public class AdminImportControllerTest extends ResetPostgres {
 
   @Test
   public void hxImportProgram_malformattedJson_error() {
-    when(mockSettingsManifest.getProgramMigrationEnabled()).thenReturn(true);
-
     Result result =
         controller.hxImportProgram(
             fakeRequestBuilder()
@@ -125,7 +99,6 @@ public class AdminImportControllerTest extends ResetPostgres {
 
   @Test
   public void hxImportProgram_noDuplicatesEnabled_malformattedJson_error() {
-    when(mockSettingsManifest.getProgramMigrationEnabled()).thenReturn(true);
     when(mockSettingsManifest.getNoDuplicateQuestionsForMigrationEnabled(any())).thenReturn(true);
 
     Result result =
@@ -142,8 +115,6 @@ public class AdminImportControllerTest extends ResetPostgres {
 
   @Test
   public void hxImportProgram_noTopLevelProgramFieldInJson_error() {
-    when(mockSettingsManifest.getProgramMigrationEnabled()).thenReturn(true);
-
     Result result =
         controller.hxImportProgram(
             fakeRequestBuilder()
@@ -163,7 +134,6 @@ public class AdminImportControllerTest extends ResetPostgres {
 
   @Test
   public void hxImportProgram_noDuplicatesEnabled_noTopLevelProgramFieldInJson_error() {
-    when(mockSettingsManifest.getProgramMigrationEnabled()).thenReturn(true);
     when(mockSettingsManifest.getNoDuplicateQuestionsForMigrationEnabled(any())).thenReturn(true);
 
     Result result =
@@ -185,8 +155,6 @@ public class AdminImportControllerTest extends ResetPostgres {
 
   @Test
   public void hxImportProgram_notEnoughInfoToCreateProgramDef_error() {
-    when(mockSettingsManifest.getProgramMigrationEnabled()).thenReturn(true);
-
     Result result =
         controller.hxImportProgram(
             fakeRequestBuilder()
@@ -205,7 +173,6 @@ public class AdminImportControllerTest extends ResetPostgres {
 
   @Test
   public void hxImportProgram_noDuplicatesEnabled_notEnoughInfoToCreateProgramDef_error() {
-    when(mockSettingsManifest.getProgramMigrationEnabled()).thenReturn(true);
     when(mockSettingsManifest.getNoDuplicateQuestionsForMigrationEnabled(any())).thenReturn(true);
 
     Result result =
@@ -226,8 +193,6 @@ public class AdminImportControllerTest extends ResetPostgres {
 
   @Test
   public void hxImportProgram_programAlreadyExists_error() {
-    when(mockSettingsManifest.getProgramMigrationEnabled()).thenReturn(true);
-
     // save a program
     controller.hxSaveProgram(
         fakeRequestBuilder()
@@ -251,7 +216,6 @@ public class AdminImportControllerTest extends ResetPostgres {
 
   @Test
   public void hxImportProgram_noDuplicatesEnabled_programAlreadyExists_error() {
-    when(mockSettingsManifest.getProgramMigrationEnabled()).thenReturn(true);
     when(mockSettingsManifest.getNoDuplicateQuestionsForMigrationEnabled(any())).thenReturn(true);
 
     // save a program
@@ -277,8 +241,6 @@ public class AdminImportControllerTest extends ResetPostgres {
 
   @Test
   public void hxImportProgram_negativeBlockId_error() {
-    when(mockSettingsManifest.getProgramMigrationEnabled()).thenReturn(true);
-
     // attempt to import a program with a negative block id
     Result result =
         controller.hxImportProgram(
@@ -296,8 +258,6 @@ public class AdminImportControllerTest extends ResetPostgres {
 
   @Test
   public void hxImportProgram_handlesServerError() {
-    when(mockSettingsManifest.getProgramMigrationEnabled()).thenReturn(true);
-
     // attempt to import program with bad json - question id in block definition does not match
     // question id on question
     Result result =
@@ -315,8 +275,6 @@ public class AdminImportControllerTest extends ResetPostgres {
 
   @Test
   public void hxImportProgram_noDuplicatesNotEnabled_draftsExist_noError() {
-    when(mockSettingsManifest.getProgramMigrationEnabled()).thenReturn(true);
-
     // Create a draft program, so that there are unpublished programs
     ProgramBuilder.newDraftProgram("draft-program").build();
 
@@ -338,7 +296,6 @@ public class AdminImportControllerTest extends ResetPostgres {
 
   @Test
   public void hxImportProgram_noDuplicatesEnabled_draftProgramExists_error() {
-    when(mockSettingsManifest.getProgramMigrationEnabled()).thenReturn(true);
     when(mockSettingsManifest.getNoDuplicateQuestionsForMigrationEnabled(any())).thenReturn(true);
 
     // Create a draft program, so that there are unpublished programs
@@ -361,7 +318,6 @@ public class AdminImportControllerTest extends ResetPostgres {
 
   @Test
   public void hxImportProgram_noDuplicatesEnabled_draftQuestionExists_error() {
-    when(mockSettingsManifest.getProgramMigrationEnabled()).thenReturn(true);
     when(mockSettingsManifest.getNoDuplicateQuestionsForMigrationEnabled(any())).thenReturn(true);
 
     // Create a draft question, so there is an unpublished question
@@ -387,8 +343,6 @@ public class AdminImportControllerTest extends ResetPostgres {
 
   @Test
   public void hxImportProgram_jsonHasAllProgramInfo_resultHasProgramAndQuestionInfo() {
-    when(mockSettingsManifest.getProgramMigrationEnabled()).thenReturn(true);
-
     Result result =
         controller.hxImportProgram(
             fakeRequestBuilder()
@@ -406,7 +360,6 @@ public class AdminImportControllerTest extends ResetPostgres {
   @Test
   public void
       hxImportProgram_noDuplicatesEnabled_jsonHasAllProgramInfo_resultHasProgramAndQuestionInfo() {
-    when(mockSettingsManifest.getProgramMigrationEnabled()).thenReturn(true);
     when(mockSettingsManifest.getNoDuplicateQuestionsForMigrationEnabled(any())).thenReturn(true);
 
     Result result =
@@ -425,8 +378,6 @@ public class AdminImportControllerTest extends ResetPostgres {
 
   @Test
   public void hxImportProgram_showsWarningAndOverwritesQuestionAdminNamesIfTheyAlreadyExist() {
-    when(mockSettingsManifest.getProgramMigrationEnabled()).thenReturn(true);
-
     // save the program
     controller.hxSaveProgram(
         fakeRequestBuilder()
@@ -461,7 +412,6 @@ public class AdminImportControllerTest extends ResetPostgres {
   @Test
   public void
       hxImportProgram_noDuplicatesEnabled_showsWarningAndDoesNotOverwriteQuestionAdminNamesIfTheyAlreadyExist() {
-    when(mockSettingsManifest.getProgramMigrationEnabled()).thenReturn(true);
     when(mockSettingsManifest.getNoDuplicateQuestionsForMigrationEnabled(any())).thenReturn(true);
 
     // save the program
@@ -500,8 +450,6 @@ public class AdminImportControllerTest extends ResetPostgres {
 
   @Test
   public void hxSaveProgram_savesTheProgramWithoutQuestions() {
-    when(mockSettingsManifest.getProgramMigrationEnabled()).thenReturn(true);
-
     Result result =
         controller.hxSaveProgram(
             fakeRequestBuilder()
@@ -524,7 +472,6 @@ public class AdminImportControllerTest extends ResetPostgres {
 
   @Test
   public void hxSaveProgram_noDuplicatesEnabled_savesTheProgramWithoutQuestions() {
-    when(mockSettingsManifest.getProgramMigrationEnabled()).thenReturn(true);
     when(mockSettingsManifest.getNoDuplicateQuestionsForMigrationEnabled(any())).thenReturn(true);
 
     Result result =
@@ -549,8 +496,6 @@ public class AdminImportControllerTest extends ResetPostgres {
 
   @Test
   public void hxSaveProgram_savesTheProgramWithQuestions() {
-    when(mockSettingsManifest.getProgramMigrationEnabled()).thenReturn(true);
-
     Result result =
         controller.hxSaveProgram(
             fakeRequestBuilder()
@@ -583,7 +528,6 @@ public class AdminImportControllerTest extends ResetPostgres {
 
   @Test
   public void hxSaveProgram_noDuplicatesEnabled_savesTheProgramWithQuestions() {
-    when(mockSettingsManifest.getProgramMigrationEnabled()).thenReturn(true);
     when(mockSettingsManifest.getNoDuplicateQuestionsForMigrationEnabled(any())).thenReturn(true);
 
     Result result =
@@ -618,8 +562,6 @@ public class AdminImportControllerTest extends ResetPostgres {
 
   @Test
   public void hxSaveProgram_handlesNestEnumeratorQuestions() {
-    when(mockSettingsManifest.getProgramMigrationEnabled()).thenReturn(true);
-
     Result result =
         controller.hxSaveProgram(
             fakeRequestBuilder()
@@ -661,7 +603,6 @@ public class AdminImportControllerTest extends ResetPostgres {
 
   @Test
   public void hxSaveProgram_noDuplicatesEnabled_handlesNestEnumeratorQuestions() {
-    when(mockSettingsManifest.getProgramMigrationEnabled()).thenReturn(true);
     when(mockSettingsManifest.getNoDuplicateQuestionsForMigrationEnabled(any())).thenReturn(true);
 
     Result result =
@@ -706,8 +647,6 @@ public class AdminImportControllerTest extends ResetPostgres {
   @Test
   public void hxSaveProgram_savesUpdatedQuestionIdsOnPredicates()
       throws ProgramBlockDefinitionNotFoundException {
-    when(mockSettingsManifest.getProgramMigrationEnabled()).thenReturn(true);
-
     Result result =
         controller.hxSaveProgram(
             fakeRequestBuilder()
@@ -803,7 +742,6 @@ public class AdminImportControllerTest extends ResetPostgres {
   @Test
   public void hxSaveProgram_noDuplicatesEnabled_savesUpdatedQuestionIdsOnPredicates()
       throws ProgramBlockDefinitionNotFoundException {
-    when(mockSettingsManifest.getProgramMigrationEnabled()).thenReturn(true);
     when(mockSettingsManifest.getNoDuplicateQuestionsForMigrationEnabled(any())).thenReturn(true);
 
     Result result =
@@ -900,8 +838,6 @@ public class AdminImportControllerTest extends ResetPostgres {
 
   @Test
   public void hxSaveProgram_discardsPaiTagsOnImportedQuestions() {
-    when(mockSettingsManifest.getProgramMigrationEnabled()).thenReturn(true);
-
     Result result =
         controller.hxSaveProgram(
             fakeRequestBuilder()
@@ -924,7 +860,6 @@ public class AdminImportControllerTest extends ResetPostgres {
 
   @Test
   public void hxSaveProgram_noDuplicatesEnabled_discardsPaiTagsOnImportedQuestions() {
-    when(mockSettingsManifest.getProgramMigrationEnabled()).thenReturn(true);
     when(mockSettingsManifest.getNoDuplicateQuestionsForMigrationEnabled(any())).thenReturn(true);
 
     Result result =
@@ -949,8 +884,6 @@ public class AdminImportControllerTest extends ResetPostgres {
 
   @Test
   public void hxSaveProgram_preservesUniversalSettingOnImportedQuestions() {
-    when(mockSettingsManifest.getProgramMigrationEnabled()).thenReturn(true);
-
     Result result =
         controller.hxSaveProgram(
             fakeRequestBuilder()
@@ -975,7 +908,6 @@ public class AdminImportControllerTest extends ResetPostgres {
 
   @Test
   public void hxSaveProgram_noDuplicatesEnabled_preservesUniversalSettingOnImportedQuestions() {
-    when(mockSettingsManifest.getProgramMigrationEnabled()).thenReturn(true);
     when(mockSettingsManifest.getNoDuplicateQuestionsForMigrationEnabled(any())).thenReturn(true);
 
     Result result =
@@ -1002,8 +934,6 @@ public class AdminImportControllerTest extends ResetPostgres {
 
   @Test
   public void hxSaveProgram_addsAnEmptyStatus() {
-    when(mockSettingsManifest.getProgramMigrationEnabled()).thenReturn(true);
-
     controller.hxSaveProgram(
         fakeRequestBuilder()
             .method("POST")
@@ -1023,7 +953,6 @@ public class AdminImportControllerTest extends ResetPostgres {
 
   @Test
   public void hxSaveProgram_noDuplicatesEnabled_addsAnEmptyStatus() {
-    when(mockSettingsManifest.getProgramMigrationEnabled()).thenReturn(true);
     when(mockSettingsManifest.getNoDuplicateQuestionsForMigrationEnabled(any())).thenReturn(true);
 
     controller.hxSaveProgram(


### PR DESCRIPTION
### Description

`PROGRAM_MIGRATION_ENABLED` has been enabled by default for three months and is now able to be removed.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.

### Issue(s) this completes

Fixes #7088; #6783; #5034; #7087 
