### PR TITLE
Update screen reader behavior for required fields

### DIFF
--- a/browser-test/src/applicant/northstar_program_overview.test.ts
+++ b/browser-test/src/applicant/northstar_program_overview.test.ts
@@ -61,7 +61,7 @@ test.describe('Applicant program overview', {tag: ['@northstar']}, () => {
         )
 
       await page
-        .getByRole('textbox', {name: 'Step 1 description *'})
+        .getByRole('textbox', {name: 'Step 1 description'})
         .fill(
           'This is the _application step_ with markdown\n' +
             'Autodetected link: https://www.example.com\n' +

--- a/browser-test/src/applicant/questions/northstar_date.test.ts
+++ b/browser-test/src/applicant/questions/northstar_date.test.ts
@@ -103,6 +103,15 @@ test.describe('Date question for applicant flow', {tag: ['@northstar']}, () => {
         programName,
         /* northStarEnabled= */ true,
       )
+      expect(
+        page.getByLabel('Day').getAttribute('aria-required'),
+      ).toBeTruthy()
+      expect(
+        page.getByLabel('Month').getAttribute('aria-required'),
+      ).toBeTruthy()
+      expect(
+        page.getByLabel('Year').getAttribute('aria-required'),
+      ).toBeTruthy()
 
       await validateAccessibility(page)
     })

--- a/browser-test/src/applicant/questions/northstar_date.test.ts
+++ b/browser-test/src/applicant/questions/northstar_date.test.ts
@@ -103,15 +103,11 @@ test.describe('Date question for applicant flow', {tag: ['@northstar']}, () => {
         programName,
         /* northStarEnabled= */ true,
       )
-      expect(
-        page.getByLabel('Day').getAttribute('aria-required'),
-      ).toBeTruthy()
+      expect(page.getByLabel('Day').getAttribute('aria-required')).toBeTruthy()
       expect(
         page.getByLabel('Month').getAttribute('aria-required'),
       ).toBeTruthy()
-      expect(
-        page.getByLabel('Year').getAttribute('aria-required'),
-      ).toBeTruthy()
+      expect(page.getByLabel('Year').getAttribute('aria-required')).toBeTruthy()
 
       await validateAccessibility(page)
     })

--- a/browser-test/src/applicant/questions/northstar_file.test.ts
+++ b/browser-test/src/applicant/questions/northstar_file.test.ts
@@ -232,6 +232,9 @@ test.describe('file upload applicant flow', {tag: ['@northstar']}, () => {
         /* northStarEnabled= */ true,
       )
 
+      expect(
+        page.getByLabel('Drag file here').getAttribute('aria-required'),
+      ).toBeTruthy()
       await validateAccessibility(page)
     })
 

--- a/browser-test/src/applicant/questions/northstar_name.test.ts
+++ b/browser-test/src/applicant/questions/northstar_name.test.ts
@@ -65,6 +65,12 @@ test.describe('name applicant flow', {tag: ['@northstar']}, () => {
         /* northStarEnabled= */ true,
       )
 
+      expect(
+        page.getByLabel('First name').getAttribute('aria-required'),
+      ).toBeTruthy()
+      expect(
+        page.getByLabel('Last name').getAttribute('aria-required'),
+      ).toBeTruthy()
       await validateAccessibility(page)
     })
 
@@ -77,7 +83,6 @@ test.describe('name applicant flow', {tag: ['@northstar']}, () => {
         /* northStarEnabled= */ true,
       )
       await applicantQuestions.answerNameQuestion('', '', '')
-
       await expectQuestionHasNoErrors(page)
     })
 

--- a/server/app/views/ViewUtils.java
+++ b/server/app/views/ViewUtils.java
@@ -242,7 +242,9 @@ public final class ViewUtils {
   }
 
   public static SpanTag requiredQuestionIndicator() {
-    return span(rawHtml("&nbsp;*")).withClasses("text-red-600", "font-semibold");
+    return span(rawHtml("&nbsp;*"))
+        .withClasses("text-red-600", "font-semibold")
+        .attr("aria-hidden", true);
   }
 
   /**

--- a/server/app/views/questiontypes/AddressQuestionFragment.html
+++ b/server/app/views/questiontypes/AddressQuestionFragment.html
@@ -151,7 +151,7 @@
         <span
           th:if="${!question.isOptional()}"
           class="usa-hint--required"
-          th:aria-label="#{content.required}"
+          th:aria-hidden="true"
         >
           *</span
         >

--- a/server/app/views/questiontypes/AddressQuestionFragment.html
+++ b/server/app/views/questiontypes/AddressQuestionFragment.html
@@ -40,7 +40,11 @@
       </th:block>
       <label class="usa-label" th:for="${inputId}">
         <span th:text="#{label.street}"></span>
-        <span th:if="${!question.isOptional()}" class="usa-hint--required">
+        <span
+          th:if="${!question.isOptional()}"
+          class="usa-hint--required"
+          th:aria-hidden="true"
+        >
           *</span
         >
       </label>
@@ -106,7 +110,11 @@
       </th:block>
       <label class="usa-label" th:for="${inputId}">
         <span th:text="#{label.city}"></span>
-        <span th:if="${!question.isOptional()}" class="usa-hint--required">
+        <span
+          th:if="${!question.isOptional()}"
+          class="usa-hint--required"
+          th:aria-hidden="true"
+        >
           *</span
         >
       </label>
@@ -140,7 +148,11 @@
       </th:block>
       <label class="usa-label" th:for="${inputId}">
         <span th:text="#{label.state}"></span>
-        <span th:if="${!question.isOptional()}" class="usa-hint--required">
+        <span
+          th:if="${!question.isOptional()}"
+          class="usa-hint--required"
+          th:aria-label="#{content.required}"
+        >
           *</span
         >
       </label>
@@ -181,7 +193,11 @@
       </th:block>
       <label class="usa-label" th:for="${inputId}">
         <span th:text="#{label.zipcode}"></span>
-        <span th:if="${!question.isOptional()}" class="usa-hint--required">
+        <span
+          th:if="${!question.isOptional()}"
+          class="usa-hint--required"
+          th:aria-hidden="true"
+        >
           *</span
         >
       </label>

--- a/server/app/views/questiontypes/DateQuestionFragment.html
+++ b/server/app/views/questiontypes/DateQuestionFragment.html
@@ -37,7 +37,11 @@
       >
         <label class="usa-label" th:for="${monthId}">
           <span th:text="#{label.month}"></span>
-          <span th:if="${!question.isOptional()}" class="usa-hint--required">
+          <span
+            th:if="${!question.isOptional()}"
+            class="usa-hint--required"
+            th:aria-hidden="true"
+          >
             *</span
           >
         </label>
@@ -121,7 +125,11 @@
       >
         <label class="usa-label" th:for="${dayId}">
           <span th:text="#{label.day}"></span>
-          <span th:if="${!question.isOptional()}" class="usa-hint--required">
+          <span
+            th:if="${!question.isOptional()}"
+            class="usa-hint--required"
+            th:aria-hidden="true"
+          >
             *</span
           >
         </label>
@@ -145,7 +153,11 @@
       >
         <label class="usa-label" th:for="${yearId}">
           <span th:text="#{label.year}"></span>
-          <span th:if="${!question.isOptional()}" class="usa-hint--required">
+          <span
+            th:if="${!question.isOptional()}"
+            class="usa-hint--required"
+            th:aria-hidden="true"
+          >
             *</span
           >
         </label>

--- a/server/app/views/questiontypes/DateQuestionFragment.html
+++ b/server/app/views/questiontypes/DateQuestionFragment.html
@@ -49,6 +49,7 @@
           th:with="value=${dateQuestion.getMonthValue().orElse('')}"
           th:aria-describedby="${questionId} + '-description'"
           th:autofocus="${questionRendererParams.autofocusFirstError()}"
+          th:aria-required="${!question.isOptional()}"
         >
           <option value th:text="#{placeholder.memorableDate}"></option>
           <option
@@ -134,6 +135,7 @@
           pattern="[0-9]*"
           inputmode="numeric"
           th:value="${dateQuestion.getDayValue().orElse('')}"
+          th:aria-required="${!question.isOptional()}"
         />
       </div>
       <!--/* Year input */-->
@@ -158,6 +160,7 @@
           pattern="[0-9]*"
           inputmode="numeric"
           th:value="${dateQuestion.getYearValue().orElse('')}"
+          th:aria-required="${!question.isOptional()}"
         />
       </div>
     </div>

--- a/server/app/views/questiontypes/FileUploadQuestionFragment.html
+++ b/server/app/views/questiontypes/FileUploadQuestionFragment.html
@@ -69,6 +69,7 @@
     th:accept="${fileUploadAllowedFileTypeSpecifiers}"
     th:data-file-limit-mb="${maxFileSizeMb}"
     th:disabled="${!fileUploadQuestion.canUploadFile()}"
+    th:aria-required="${!question.isOptional()}"
   />
 </div>
 

--- a/server/app/views/questiontypes/NameQuestionFragment.html
+++ b/server/app/views/questiontypes/NameQuestionFragment.html
@@ -76,7 +76,6 @@
       autocomplete="additional-name"
       th:value="${nameQuestion.getMiddleNameValue().orElse('')}"
       th:name="${nameQuestion.getMiddleNamePath()}"
-      th:aria-required="${!question.isOptional()}"
     />
   </div>
 

--- a/server/app/views/questiontypes/NameQuestionFragment.html
+++ b/server/app/views/questiontypes/NameQuestionFragment.html
@@ -37,7 +37,11 @@
     </th:block>
     <label class="usa-label" th:for="${firstNameId}">
       <span th:text="#{label.firstName}"></span>
-      <span th:if="${!question.isOptional()}" class="usa-hint--required">
+      <span
+        th:if="${!question.isOptional()}"
+        class="usa-hint--required"
+        th:aria-hidden="true"
+      >
         *</span
       >
     </label>
@@ -92,7 +96,11 @@
     </th:block>
     <label class="usa-label" th:for="${lastNameId}">
       <span th:text="#{label.lastName}"></span>
-      <span th:if="${!question.isOptional()}" class="usa-hint--required">
+      <span
+        th:if="${!question.isOptional()}"
+        class="usa-hint--required"
+        th:aria-hidden="true"
+      >
         *</span
       >
     </label>

--- a/server/app/views/questiontypes/NameQuestionFragment.html
+++ b/server/app/views/questiontypes/NameQuestionFragment.html
@@ -51,6 +51,7 @@
       th:value="${nameQuestion.getFirstNameValue().orElse('')}"
       th:name="${firstNamePath}"
       th:autofocus="${questionRendererParams.autofocusFirstError() && !firstPathWithError.isEmpty() && firstPathWithError.get().equals(firstNamePath)}"
+      th:aria-required="${!question.isOptional()}"
     />
   </div>
 
@@ -71,6 +72,7 @@
       autocomplete="additional-name"
       th:value="${nameQuestion.getMiddleNameValue().orElse('')}"
       th:name="${nameQuestion.getMiddleNamePath()}"
+      th:aria-required="${!question.isOptional()}"
     />
   </div>
 
@@ -104,6 +106,7 @@
       th:value="${nameQuestion.getLastNameValue().orElse('')}"
       th:name="${lastNamePath}"
       th:autofocus="${questionRendererParams.autofocusFirstError() && !firstPathWithError.isEmpty() && firstPathWithError.get().equals(lastNamePath)}"
+      th:aria-required="${!question.isOptional()}"
     />
   </div>
 

--- a/server/test/views/components/TextFormatterTest.java
+++ b/server/test/views/components/TextFormatterTest.java
@@ -78,7 +78,7 @@ public class TextFormatterTest extends ResetPostgres {
     assertThat(content.get(0).render())
         .isEqualTo(
             "<p>Enter your full legal name.<span class=\"text-red-600"
-                + " font-semibold\">\u00a0*</span></p>\n");
+                + " font-semibold\" aria-hidden=\"true\">\u00a0*</span></p>\n");
   }
 
   @Test
@@ -91,7 +91,8 @@ public class TextFormatterTest extends ResetPostgres {
     String htmlContentWithUnorderedList = contentWithUnorderedList.get(0).render();
     assertThat(htmlContentWithUnorderedList)
         .isEqualTo(
-            "<p>Here is some text.<span class=\"text-red-600 font-semibold\"> *</span></p>\n"
+            "<p>Here is some text.<span class=\"text-red-600 font-semibold\" aria-hidden=\"true\">"
+                + " *</span></p>\n"
                 + "<ul class=\"list-disc mx-8\"><li>list item one</li><li>list item"
                 + " two</li></ul>\n");
 
@@ -103,7 +104,8 @@ public class TextFormatterTest extends ResetPostgres {
     String htmlContentWithOrderedList = contentWithOrderedList.get(0).render();
     assertThat(htmlContentWithOrderedList)
         .isEqualTo(
-            "<p>Here is some text.<span class=\"text-red-600 font-semibold\"> *</span></p>\n"
+            "<p>Here is some text.<span class=\"text-red-600 font-semibold\" aria-hidden=\"true\">"
+                + " *</span></p>\n"
                 + "<ol class=\"list-decimal mx-8\"><li>list item one</li><li>list item"
                 + " two</li></ol>\n");
   }
@@ -119,7 +121,8 @@ public class TextFormatterTest extends ResetPostgres {
     assertThat(htmlContentWithUnorderedList)
         .isEqualTo(
             "<ul class=\"list-disc mx-8\"><li>list item one</li><li>list item two</li><li>list item"
-                + " three<span class=\"text-red-600 font-semibold\"> *</span></li></ul>\n");
+                + " three<span class=\"text-red-600 font-semibold\" aria-hidden=\"true\">"
+                + " *</span></li></ul>\n");
 
     ImmutableList<DomContent> contentWithOrderedList =
         TextFormatter.formatText(
@@ -130,7 +133,8 @@ public class TextFormatterTest extends ResetPostgres {
     assertThat(htmlContentWithOrderedList)
         .isEqualTo(
             "<ol class=\"list-decimal mx-8\"><li>list item one</li><li>list item two</li><li>list"
-                + " item three<span class=\"text-red-600 font-semibold\"> *</span></li></ol>\n");
+                + " item three<span class=\"text-red-600 font-semibold\" aria-hidden=\"true\">"
+                + " *</span></li></ol>\n");
   }
 
   @Test


### PR DESCRIPTION
### Description

A few question types in North Star do not have an aria-required label set when the question is required. Adding the label so that the screen reader will recognize when the question is required.

Also hiding the required (*) from screen readers so that it does not get read as "star". The label will not have a required indication when read by a screen reader, but the input itself will. This change impacts both North Star and legacy UIs.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)

#### User visible changes

- [x] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [x] Manually tested with a screen reader if the feature is applicant-facing. See [screen reader testing](https://github.com/civiform/civiform/wiki/Testing#screen-reader-testing)

### Instructions for manual testing

Go to a program with required questions, and use a screen reader to read the elements on the page aloud. It would be best to test multiple types of questions. The screen reader should not read the asterisks aloud, but inputs with a label that have one should be labeled as "required" when read by the screen reader.

Test in both NS and legacy UIs.

### Issue(s) this completes

Fixes #9910
