### PR TITLE
Increase allowed payload size when saving program translations

### DIFF
--- a/server/app/controllers/admin/AdminProgramTranslationsController.java
+++ b/server/app/controllers/admin/AdminProgramTranslationsController.java
@@ -13,7 +13,9 @@ import java.util.Locale;
 import java.util.Optional;
 import javax.inject.Inject;
 import org.pac4j.play.java.Secure;
+import parsers.LargeFormUrlEncodedBodyParser;
 import play.data.FormFactory;
+import play.mvc.BodyParser;
 import play.mvc.Http;
 import play.mvc.Result;
 import repository.VersionRepository;
@@ -128,6 +130,11 @@ public class AdminProgramTranslationsController extends CiviFormController {
    *     same {@link ProgramTranslationView} with error messages
    */
   @Secure(authorizers = Authorizers.Labels.CIVIFORM_ADMIN)
+  // Adding our custom large body parser. The introduction of the eligibility message
+  // translations has resulted in the occasional exception if the program has a large
+  // number of them. This is a band-aid to allow them to be saved right now, the
+  // ultimate solution is to redesign this form
+  @BodyParser.Of(LargeFormUrlEncodedBodyParser.class)
   public Result update(Http.Request request, String programName, String locale)
       throws ProgramNotFoundException {
     ProgramDefinition program = getDraftProgramDefinition(programName);


### PR DESCRIPTION
### Description

Increase allowed payload size when saving program translations.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)


### Issue(s) this completes

Fixes #9992
