### PR TITLE
Configure Pinning GitHub Actions to Commit Hashes

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -105,6 +105,17 @@
         "tailwindcss"
       ],
       "allowedVersions": "<4.0.0"
+    },
+    // GitHub Actions: Pin to commit hashes and include a comment with the version
+    {
+      "groupName": "GitHub Actions",
+      "matchManagers": ["github-actions"],
+      "pinDigests": true,
+      "commitMessagePrefix": "[Update Github Actions]: ",
+      "commitMessageExtra": "Updated to latest release",
+      "postUpdateOptions": ["comment"],
+      "rebaseWhen": "always",
+      "description": "Ensures GitHub Actions use commit hashes for security and include a version comment."
     }
   ]
 }


### PR DESCRIPTION
### Description

Configure renovate to pin github actions to commit hashes instead of version tags.

This will do two things when renovate runs next.

1) Renovate will create a single PR that will update all tags to hashes for existing code. So we don't need to manually go change everything.

2) Renovate will continue to create PRs when github action versions change. 

Renovate will include the tag version as a comment so it's easier to determine what the version is.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)


### Issue(s) this completes

Fixes #10016
