### PR TITLE
Update renovate to pin docker images to sha hashes

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -116,6 +116,17 @@
       "postUpdateOptions": ["comment"],
       "rebaseWhen": "always",
       "description": "Ensures GitHub Actions use commit hashes for security and include a version comment."
+    },
+    // Docker Images: Pin to SHA256 digests for security and consistency
+    {
+      "groupName": "Docker Images",
+      "matchManagers": ["docker-compose", "dockerfile"],
+      "pinDigests": true,
+      "commitMessagePrefix": "[Update Docker Images]: ",
+      "commitMessageExtra": "Pinned to latest digest",
+      "postUpdateOptions": ["comment"],
+      "rebaseWhen": "always",
+      "description": "Ensures Docker images use SHA256 digests for security and reproducibility."
     }
   ]
 }


### PR DESCRIPTION
### Description

I can't think of a reason not to pin docker tags as well.

Example of before/after
![image](https://github.com/user-attachments/assets/6f2c3fb1-c801-4418-9861-f3b74084c4f3)



### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
