### PR TITLE
[SessionTimeout][part6]Display session timeout warning and enforcement in frontend JS

### DIFF
--- a/server/app/assets/javascripts/admin_entry_point.ts
+++ b/server/app/assets/javascripts/admin_entry_point.ts
@@ -21,6 +21,7 @@ import * as devIcons from './dev_icons'
 import * as modal from './modal'
 import * as questionBank from './questionBank'
 import PreviewController, * as preview from './preview'
+import {SessionTimeoutHandler} from './session'
 import * as enumerator from './enumerator'
 import * as phoneNumber from './phone'
 import * as adminQuestionEdit from './admin_question_edit'
@@ -33,6 +34,7 @@ import htmx from './htmx'
 
 window.addEventListener('load', () => {
   initializeEverything()
+  SessionTimeoutHandler.init()
   htmx.on('htmx:afterSettle', () => {
     afterSettle()
   })

--- a/server/app/assets/javascripts/admin_entry_point.ts
+++ b/server/app/assets/javascripts/admin_entry_point.ts
@@ -34,7 +34,6 @@ import htmx from './htmx'
 
 window.addEventListener('load', () => {
   initializeEverything()
-  SessionTimeoutHandler.init()
   htmx.on('htmx:afterSettle', () => {
     afterSettle()
   })
@@ -69,6 +68,7 @@ function initializeEverything(): void {
   trustedIntermediaryController.init()
   fileUpload.init()
   azureUpload.init(AZURE_ADMIN_FILEUPLOAD_FORM_ID)
+  SessionTimeoutHandler.init()
 }
 
 function afterSettle(): void {

--- a/server/app/assets/javascripts/applicant_entry_point.ts
+++ b/server/app/assets/javascripts/applicant_entry_point.ts
@@ -17,6 +17,7 @@ import * as phoneNumber from './phone'
 import * as apiDocs from './api_docs'
 import * as trustedIntermediary from './trusted_intermediary'
 import * as htmx from './htmx'
+import {SessionTimeoutHandler} from './session'
 
 declare global {
   interface Window {
@@ -43,4 +44,5 @@ window.addEventListener('load', () => {
   // API docs are publicly visible, so we need the supporting scripts here.
   apiDocs.init()
   trustedIntermediary.init()
+  SessionTimeoutHandler.init()
 })

--- a/server/app/assets/javascripts/modal.ts
+++ b/server/app/assets/javascripts/modal.ts
@@ -104,3 +104,16 @@ export class ModalController {
 export function init() {
   new ModalController()
 }
+
+/**
+ * Hides the specified modal by adding the 'is-hidden' class.
+ * Updates visibility tracking flags when hiding a modal.
+ *
+ * @param modalType Type of modal to hide
+ */
+export function hideUswdsModal(modalType: string) {
+  const modal = document.getElementById(`${modalType}-modal`)
+  if (modal) {
+    modal.classList.add('is-hidden')
+  }
+}

--- a/server/app/assets/javascripts/session.test.ts
+++ b/server/app/assets/javascripts/session.test.ts
@@ -403,7 +403,7 @@ describe('SessionTimeoutHandler', () => {
 
     afterEach(() => {
       jest.useRealTimers()
-      document.cookie = `${SessionTimeoutHandler['COOKIE_NAME']}=; expires=Thu, 01 Jan 1970 00:00:00 GMT`
+      document.cookie = `${SessionTimeoutHandler['TIMEOUT_COOKIE_NAME']}=; expires=Thu, 01 Jan 1970 00:00:00 GMT`
     })
 
     it('immediately logs out if timeout is reached', () => {

--- a/server/app/assets/javascripts/session.test.ts
+++ b/server/app/assets/javascripts/session.test.ts
@@ -1,0 +1,392 @@
+import {jest, expect, describe, it, beforeEach, afterEach} from '@jest/globals'
+import {SessionTimeoutHandler} from './session'
+import {ToastController} from './toast'
+import {WarningType} from './session'
+
+type SessionTimeoutHandlerType = typeof SessionTimeoutHandler & {
+  logout: () => void
+  checkAndSetTimer: () => void
+  showWarning: (type: WarningType) => void
+  inactivityWarningShown: boolean
+  totalLengthWarningShown: boolean
+}
+
+describe('SessionTimeoutHandler', () => {
+  let container: HTMLElement
+  let inactivityModal: HTMLElement
+  let lengthModal: HTMLElement
+  let extendSessionForm: HTMLFormElement
+  let consoleSpy: ReturnType<typeof jest.spyOn>
+
+  beforeEach(() => {
+    // Set up DOM elements
+    container = document.createElement('div')
+    container.id = 'session-timeout-modals'
+    document.body.appendChild(container)
+
+    // Create inactivity warning modal with new structure
+    inactivityModal = document.createElement('div')
+    inactivityModal.id = 'session-inactivity-warning-modal'
+    inactivityModal.classList.add('is-hidden', 'usa-modal')
+    inactivityModal.setAttribute(
+      'data-modal-type',
+      'session-inactivity-warning',
+    )
+    container.appendChild(inactivityModal)
+
+    // Create extend session form
+    extendSessionForm = document.createElement('form')
+    extendSessionForm.id = 'extend-session-form'
+    extendSessionForm.setAttribute('hx-post', '/extend-session')
+    extendSessionForm.setAttribute('hx-target', 'this')
+    extendSessionForm.setAttribute('hx-swap', 'none')
+
+    // Add CSRF token input
+    const csrfInput = document.createElement('input')
+    csrfInput.setAttribute('name', 'csrfToken')
+    csrfInput.value = 'test-csrf-token'
+    extendSessionForm.appendChild(csrfInput)
+
+    // Create primary button (extend session)
+    const primaryButton = document.createElement('button')
+    primaryButton.textContent = 'Extend Session'
+    primaryButton.classList.add('usa-button')
+    primaryButton.setAttribute('data-modal-primary', '')
+    primaryButton.setAttribute('data-modal-type', 'session-inactivity-warning')
+    extendSessionForm.appendChild(primaryButton)
+
+    inactivityModal.appendChild(extendSessionForm)
+
+    // Create secondary button (cancel)
+    const secondaryButton = document.createElement('button')
+    secondaryButton.textContent = 'Cancel'
+    secondaryButton.classList.add('usa-button', 'usa-button--unstyled')
+    secondaryButton.setAttribute('data-modal-secondary', '')
+    secondaryButton.setAttribute(
+      'data-modal-type',
+      'session-inactivity-warning',
+    )
+    inactivityModal.appendChild(secondaryButton)
+
+    // Create close button
+    const closeButton = document.createElement('button')
+    closeButton.textContent = 'Close'
+    closeButton.classList.add('usa-button', 'usa-modal__close')
+    closeButton.setAttribute('data-close-modal', '')
+    closeButton.setAttribute('data-modal-type', 'session-inactivity-warning')
+    inactivityModal.appendChild(closeButton)
+
+    // Create session length warning modal
+    lengthModal = document.createElement('div')
+    lengthModal.id = 'session-length-warning-modal'
+    lengthModal.classList.add('is-hidden', 'usa-modal')
+    lengthModal.setAttribute('data-modal-type', 'session-length-warning')
+    container.appendChild(lengthModal)
+
+    // Create primary button (logout)
+    const logoutButton = document.createElement('button')
+    logoutButton.textContent = 'Logout'
+    logoutButton.classList.add('usa-button')
+    logoutButton.setAttribute('data-modal-primary', '')
+    logoutButton.setAttribute('data-modal-type', 'session-length-warning')
+    lengthModal.appendChild(logoutButton)
+
+    // Create secondary button (cancel)
+    const lengthCancelButton = document.createElement('button')
+    lengthCancelButton.textContent = 'Cancel'
+    lengthCancelButton.classList.add('usa-button', 'usa-button--unstyled')
+    lengthCancelButton.setAttribute('data-modal-secondary', '')
+    lengthCancelButton.setAttribute('data-modal-type', 'session-length-warning')
+    lengthModal.appendChild(lengthCancelButton)
+
+    // Add localized message elements
+    const messageContainer = document.createElement('div')
+    messageContainer.id = 'session-timeout-messages'
+    messageContainer.classList.add('is-hidden')
+
+    const successText = document.createElement('span')
+    successText.id = 'session-extended-success-text'
+    successText.textContent = 'Session successfully extended'
+    messageContainer.appendChild(successText)
+
+    const errorText = document.createElement('span')
+    errorText.id = 'session-extended-error-text'
+    errorText.textContent = 'Failed to extend session'
+    messageContainer.appendChild(errorText)
+
+    container.appendChild(messageContainer)
+
+    // Mock ToastController
+    jest.spyOn(ToastController, 'showToastMessage').mockImplementation(() => {})
+
+    // Mock console.error
+    consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+
+    // Mock window.location
+    Object.defineProperty(window, 'location', {
+      value: {href: ''},
+      writable: true,
+    })
+  })
+
+  afterEach(() => {
+    container.remove()
+
+    jest.clearAllMocks()
+
+    SessionTimeoutHandler['inactivityWarningShown'] = false
+    SessionTimeoutHandler['totalLengthWarningShown'] = false
+  })
+
+  describe('showWarning', () => {
+    it('shows inactivity warning modal', () => {
+      SessionTimeoutHandler['showWarning'](WarningType.INACTIVITY)
+
+      expect(inactivityModal.classList.contains('is-hidden')).toBe(false)
+
+      expect(SessionTimeoutHandler['inactivityWarningShown']).toBe(true)
+    })
+
+    it('shows total length warning modal', () => {
+      SessionTimeoutHandler['showWarning'](WarningType.TOTAL_LENGTH)
+
+      expect(lengthModal.classList.contains('is-hidden')).toBe(false)
+
+      expect(SessionTimeoutHandler['totalLengthWarningShown']).toBe(true)
+    })
+
+    it('does not show inactivity warning modal if already shown', () => {
+      SessionTimeoutHandler['inactivityWarningShown'] = true
+
+      inactivityModal.classList.add('is-hidden')
+
+      SessionTimeoutHandler['showWarning'](WarningType.INACTIVITY)
+
+      expect(inactivityModal.classList.contains('is-hidden')).toBe(true)
+    })
+
+    it('does not show total length warning modal if already shown', () => {
+      SessionTimeoutHandler['totalLengthWarningShown'] = true
+
+      lengthModal.classList.add('is-hidden')
+
+      SessionTimeoutHandler['showWarning'](WarningType.TOTAL_LENGTH)
+
+      expect(lengthModal.classList.contains('is-hidden')).toBe(true)
+    })
+
+    it('logs error if modal element is not found', () => {
+      inactivityModal.remove()
+
+      SessionTimeoutHandler['showWarning'](WarningType.INACTIVITY)
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        'Modal with ID session-inactivity-warning-modal not found',
+      )
+    })
+  })
+
+  describe('setupModalEventHandlers', () => {
+    it('handles successful session extension', () => {
+      SessionTimeoutHandler.init()
+
+      // Create a mock HTMX event
+      const successEvent = new CustomEvent('htmx:afterRequest', {
+        detail: {
+          xhr: {status: 200},
+          elt: extendSessionForm,
+        },
+      })
+
+      document.dispatchEvent(successEvent)
+
+      expect(inactivityModal.classList.contains('is-hidden')).toBe(true)
+
+      expect(SessionTimeoutHandler['inactivityWarningShown']).toBe(false)
+
+      expect(ToastController.showToastMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'session-extended-toast',
+          type: 'success',
+        }),
+      )
+    })
+
+    it('handles failed session extension', () => {
+      SessionTimeoutHandler.init()
+
+      // Create a mock HTMX event
+      const failEvent = new CustomEvent('htmx:afterRequest', {
+        detail: {
+          xhr: {status: 500},
+          elt: extendSessionForm,
+        },
+      })
+
+      document.dispatchEvent(failEvent)
+
+      expect(inactivityModal.classList.contains('is-hidden')).toBe(true)
+
+      expect(SessionTimeoutHandler['inactivityWarningShown']).toBe(false)
+
+      expect(ToastController.showToastMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'session-extend-error-toast',
+          type: 'error',
+        }),
+      )
+    })
+
+    it('handles logout button click', () => {
+      SessionTimeoutHandler.init()
+
+      const logoutButton = lengthModal.querySelector(
+        '[data-modal-primary][data-modal-type="session-length-warning"]',
+      ) as HTMLButtonElement
+      logoutButton?.click()
+
+      expect(window.location.href).toBe('/logout')
+    })
+
+    it('handles inactivity cancel button click', () => {
+      SessionTimeoutHandler.init()
+      SessionTimeoutHandler['inactivityWarningShown'] = true
+      inactivityModal.classList.remove('is-hidden')
+
+      const cancelButton = inactivityModal.querySelector(
+        '[data-modal-secondary][data-modal-type="session-inactivity-warning"]',
+      ) as HTMLButtonElement
+      cancelButton?.click()
+
+      expect(inactivityModal.classList.contains('is-hidden')).toBe(true)
+      expect(SessionTimeoutHandler['inactivityWarningShown']).toBe(false)
+    })
+
+    it('handles length cancel button click', () => {
+      SessionTimeoutHandler.init()
+      SessionTimeoutHandler['totalLengthWarningShown'] = true
+      lengthModal.classList.remove('is-hidden')
+
+      const cancelButton = lengthModal.querySelector(
+        '[data-modal-secondary][data-modal-type="session-length-warning"]',
+      ) as HTMLButtonElement
+      cancelButton?.click()
+
+      expect(lengthModal.classList.contains('is-hidden')).toBe(true)
+      expect(SessionTimeoutHandler['totalLengthWarningShown']).toBe(false)
+    })
+  })
+
+  describe('Modal Event Handlers', () => {
+    let originalLocation: Location
+
+    beforeEach(() => {
+      // Store original location
+      originalLocation = window.location
+
+      // Mock window.location
+      Object.defineProperty(window, 'location', {
+        configurable: true,
+        enumerable: true,
+        value: {href: ''},
+      })
+    })
+
+    afterEach(() => {
+      // Restore original location
+      Object.defineProperty(window, 'location', {
+        configurable: true,
+        enumerable: true,
+        value: originalLocation,
+      })
+    })
+
+    it('handles primary button click for inactivity warning', () => {
+      SessionTimeoutHandler.init()
+      const primaryButton = inactivityModal.querySelector(
+        '[data-modal-primary][data-modal-type="session-inactivity-warning"]',
+      ) as HTMLButtonElement
+      const requestSubmitSpy = jest.spyOn(extendSessionForm, 'requestSubmit')
+
+      primaryButton?.click()
+      expect(requestSubmitSpy).toHaveBeenCalled()
+    })
+
+    it('handles primary button click for session length warning', () => {
+      const logoutSpy = jest.spyOn(
+        SessionTimeoutHandler as SessionTimeoutHandlerType,
+        'logout',
+      )
+      SessionTimeoutHandler.init()
+
+      const primaryButton = lengthModal.querySelector(
+        '[data-modal-primary][data-modal-type="session-length-warning"]',
+      ) as HTMLButtonElement
+      primaryButton?.click()
+
+      expect(logoutSpy).toHaveBeenCalled()
+    })
+
+    it('handles secondary button click', () => {
+      SessionTimeoutHandler.init()
+      const secondaryButton = inactivityModal.querySelector(
+        '[data-modal-secondary][data-modal-type="session-inactivity-warning"]',
+      ) as HTMLButtonElement
+      secondaryButton?.click()
+
+      expect(inactivityModal.classList.contains('is-hidden')).toBe(true)
+      expect(SessionTimeoutHandler['inactivityWarningShown']).toBe(false)
+    })
+
+    it('handles close button click', () => {
+      SessionTimeoutHandler.init()
+      const closeButton = inactivityModal.querySelector(
+        '[data-close-modal][data-modal-type="session-inactivity-warning"]',
+      ) as HTMLButtonElement
+      closeButton?.click()
+
+      expect(inactivityModal.classList.contains('is-hidden')).toBe(true)
+      expect(SessionTimeoutHandler['inactivityWarningShown']).toBe(false)
+    })
+
+    it('shows localized success message on successful session extension', () => {
+      SessionTimeoutHandler.init()
+      const successEvent = new CustomEvent('htmx:afterRequest', {
+        detail: {
+          xhr: {status: 200},
+          elt: extendSessionForm,
+        },
+      })
+
+      document.dispatchEvent(successEvent)
+
+      expect(ToastController.showToastMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: 'Session successfully extended',
+          type: 'success',
+        }),
+      )
+    })
+
+    it('calls logout when handling timeout', () => {
+      const logoutSpy = jest.spyOn(
+        SessionTimeoutHandler as SessionTimeoutHandlerType,
+        'logout',
+      )
+      SessionTimeoutHandler.init()
+
+      const expiredTimeoutData = {
+        inactivityWarning: 0,
+        inactivityTimeout: 0,
+        totalWarning: 0,
+        totalTimeout: 0,
+        currentTime: 0,
+      }
+      document.cookie = `session_timeout_data=${btoa(JSON.stringify(expiredTimeoutData))}`
+
+      SessionTimeoutHandler['checkAndSetTimer']()
+
+      expect(logoutSpy).toHaveBeenCalled()
+    })
+  })
+})

--- a/server/app/assets/javascripts/session.test.ts
+++ b/server/app/assets/javascripts/session.test.ts
@@ -18,13 +18,10 @@ describe('SessionTimeoutHandler', () => {
   let extendSessionForm: HTMLFormElement
   let consoleSpy: ReturnType<typeof jest.spyOn>
 
-  beforeEach(() => {
-    // Set up DOM elements
-    container = document.createElement('div')
-    container.id = 'session-timeout-modals'
-    document.body.appendChild(container)
-
-    // Create inactivity warning modal with new structure
+  /**
+   * Create inactivity warning modal with new structure
+   */
+  function createInactivityModal() {
     inactivityModal = document.createElement('div')
     inactivityModal.id = 'session-inactivity-warning-modal'
     inactivityModal.classList.add('is-hidden', 'usa-modal')
@@ -32,74 +29,40 @@ describe('SessionTimeoutHandler', () => {
       'data-modal-type',
       'session-inactivity-warning',
     )
-    container.appendChild(inactivityModal)
 
-    // Create extend session form
+    createExtendSessionForm()
+    addSecondaryButton(inactivityModal, 'session-inactivity-warning')
+    addCloseButton(inactivityModal)
+    container.appendChild(inactivityModal)
+  }
+
+  /**
+   * Create extend session form
+   */
+  function createExtendSessionForm() {
     extendSessionForm = document.createElement('form')
     extendSessionForm.id = 'extend-session-form'
     extendSessionForm.setAttribute('hx-post', '/extend-session')
     extendSessionForm.setAttribute('hx-target', 'this')
     extendSessionForm.setAttribute('hx-swap', 'none')
-
-    // Add CSRF token input
-    const csrfInput = document.createElement('input')
-    csrfInput.setAttribute('name', 'csrfToken')
-    csrfInput.value = 'test-csrf-token'
-    extendSessionForm.appendChild(csrfInput)
-
-    // Create primary button (extend session)
-    const primaryButton = document.createElement('button')
-    primaryButton.textContent = 'Extend Session'
-    primaryButton.classList.add('usa-button')
-    primaryButton.setAttribute('data-modal-primary', '')
-    primaryButton.setAttribute('data-modal-type', 'session-inactivity-warning')
-    extendSessionForm.appendChild(primaryButton)
-
+    addCsrfToken()
+    addExtendSessionButton()
     inactivityModal.appendChild(extendSessionForm)
+  }
 
-    // Create secondary button (cancel)
-    const secondaryButton = document.createElement('button')
-    secondaryButton.textContent = 'Cancel'
-    secondaryButton.classList.add('usa-button', 'usa-button--unstyled')
-    secondaryButton.setAttribute('data-modal-secondary', '')
-    secondaryButton.setAttribute(
-      'data-modal-type',
-      'session-inactivity-warning',
-    )
-    inactivityModal.appendChild(secondaryButton)
+  /**
+   * Creates modal container that holds all session timeout related modals
+   */
+  function createModalContainer() {
+    container = document.createElement('div')
+    container.id = 'session-timeout-modals'
+    document.body.appendChild(container)
+  }
 
-    // Create close button
-    const closeButton = document.createElement('button')
-    closeButton.textContent = 'Close'
-    closeButton.classList.add('usa-button', 'usa-modal__close')
-    closeButton.setAttribute('data-close-modal', '')
-    closeButton.setAttribute('data-modal-type', 'session-inactivity-warning')
-    inactivityModal.appendChild(closeButton)
-
-    // Create session length warning modal
-    lengthModal = document.createElement('div')
-    lengthModal.id = 'session-length-warning-modal'
-    lengthModal.classList.add('is-hidden', 'usa-modal')
-    lengthModal.setAttribute('data-modal-type', 'session-length-warning')
-    container.appendChild(lengthModal)
-
-    // Create primary button (logout)
-    const logoutButton = document.createElement('button')
-    logoutButton.textContent = 'Logout'
-    logoutButton.classList.add('usa-button')
-    logoutButton.setAttribute('data-modal-primary', '')
-    logoutButton.setAttribute('data-modal-type', 'session-length-warning')
-    lengthModal.appendChild(logoutButton)
-
-    // Create secondary button (cancel)
-    const lengthCancelButton = document.createElement('button')
-    lengthCancelButton.textContent = 'Cancel'
-    lengthCancelButton.classList.add('usa-button', 'usa-button--unstyled')
-    lengthCancelButton.setAttribute('data-modal-secondary', '')
-    lengthCancelButton.setAttribute('data-modal-type', 'session-length-warning')
-    lengthModal.appendChild(lengthCancelButton)
-
-    // Add localized message elements
+  /**
+   * Creates localized message elements for session timeout notifications
+   */
+  function createMessageContainer() {
     const messageContainer = document.createElement('div')
     messageContainer.id = 'session-timeout-messages'
     messageContainer.classList.add('is-hidden')
@@ -113,9 +76,99 @@ describe('SessionTimeoutHandler', () => {
     errorText.id = 'session-extended-error-text'
     errorText.textContent = 'Failed to extend session'
     messageContainer.appendChild(errorText)
-
     container.appendChild(messageContainer)
+  }
 
+  /**
+   * Creates session length warning modal with buttons
+   */
+  function createLengthWarningModal() {
+    lengthModal = document.createElement('div')
+    lengthModal.id = 'session-length-warning-modal'
+    lengthModal.classList.add('is-hidden', 'usa-modal')
+    lengthModal.setAttribute('data-modal-type', 'session-length-warning')
+
+    // Create primary button (logout)
+    const logoutButton = document.createElement('button')
+    logoutButton.textContent = 'Logout'
+    logoutButton.classList.add('usa-button')
+    logoutButton.setAttribute('data-modal-primary', '')
+    logoutButton.setAttribute('data-modal-type', 'session-length-warning')
+    lengthModal.appendChild(logoutButton)
+
+    // Create secondary button (cancel)
+    const cancelButton = document.createElement('button')
+    cancelButton.textContent = 'Cancel'
+    cancelButton.classList.add('usa-button', 'usa-button--unstyled')
+    cancelButton.setAttribute('data-modal-secondary', '')
+    cancelButton.setAttribute('data-modal-type', 'session-length-warning')
+    lengthModal.appendChild(cancelButton)
+    container.appendChild(lengthModal)
+  }
+
+  /**
+   * Adds CSRF token input to a form
+   */
+  function addCsrfToken() {
+    const csrfInput = document.createElement('input')
+    csrfInput.setAttribute('name', 'csrfToken')
+    csrfInput.value = 'test-csrf-token'
+    extendSessionForm.appendChild(csrfInput)
+  }
+
+  /**
+   * Adds extend session button to a form
+   */
+  function addExtendSessionButton() {
+    const primaryButton = document.createElement('button')
+    primaryButton.textContent = 'Extend Session'
+    primaryButton.classList.add('usa-button')
+    primaryButton.setAttribute('data-modal-primary', '')
+    primaryButton.setAttribute('data-modal-type', 'session-inactivity-warning')
+    extendSessionForm.appendChild(primaryButton)
+  }
+
+  /**
+   * Adds secondary (cancel) button to a modal
+   * @param modal Modal element to add button to
+   * @param modalType Type of modal (for data attribute)
+   */
+  function addSecondaryButton(modal: HTMLElement, modalType: string) {
+    const button = document.createElement('button')
+    button.textContent = 'Cancel'
+    button.classList.add('usa-button', 'usa-button--unstyled')
+    button.setAttribute('data-modal-secondary', '')
+    button.setAttribute('data-modal-type', modalType)
+    modal.appendChild(button)
+  }
+
+  /**
+   * Adds close button to a modal
+   * @param modal Modal element to add button to
+   */
+  function addCloseButton(modal: HTMLElement) {
+    const closeButton = document.createElement('button')
+    closeButton.textContent = 'Close'
+    closeButton.classList.add('usa-button', 'usa-modal__close')
+    closeButton.setAttribute('data-close-modal', '')
+    closeButton.setAttribute('data-modal-type', 'session-inactivity-warning')
+    modal.appendChild(closeButton)
+  }
+
+  /**
+   * Sets up all DOM elements needed for testing
+   */
+  function setupDomElements() {
+    createModalContainer()
+    createInactivityModal()
+    createLengthWarningModal()
+    createMessageContainer()
+  }
+
+  /**
+   * Sets up all test mocks
+   */
+  function setupMocks() {
     // Mock ToastController
     jest.spyOn(ToastController, 'showToastMessage').mockImplementation(() => {})
 
@@ -127,6 +180,11 @@ describe('SessionTimeoutHandler', () => {
       value: {href: ''},
       writable: true,
     })
+  }
+
+  beforeEach(() => {
+    setupDomElements()
+    setupMocks()
   })
 
   afterEach(() => {

--- a/server/app/assets/javascripts/session.ts
+++ b/server/app/assets/javascripts/session.ts
@@ -1,0 +1,263 @@
+import {ToastController} from './toast'
+
+/**
+ * Represents session timeout data with timestamps for various timeout events.
+ * All timestamps are Unix timestamps in seconds.
+ */
+interface TimeoutData {
+  /** When to show the inactivity warning modal */
+  inactivityWarning: number
+  /** When to logout due to inactivity */
+  inactivityTimeout: number
+  /** When to show the total session length warning modal */
+  totalWarning: number
+  /** When to logout due to total session length */
+  totalTimeout: number
+  /** Server's current time when cookie was set - used for clock skew calculation */
+  currentTime: number
+}
+
+/**
+ * Types of warning modals that can be shown to the user.
+ */
+export enum WarningType {
+  /** Warning shown when user has been inactive */
+  INACTIVITY = 'inactivity',
+  /** Warning shown when total session length is approaching limit */
+  TOTAL_LENGTH = 'total_length',
+}
+
+/**
+ * Handles session timeout management including:
+ * - Reading timeout data from cookies
+ * - Showing warning modals before timeout
+ * - Handling session extension requests
+ * - Managing automatic logout
+ */
+export class SessionTimeoutHandler {
+  /** Name of cookie storing timeout data */
+  private static COOKIE_NAME = 'session_timeout_data'
+  /** How often to check timeout state (milliseconds) */
+  private static CHECK_INTERVAL = 2000 // 2 seconds
+  /** Tracks if inactivity warning is currently shown */
+  private static inactivityWarningShown = false
+  /** Tracks if total length warning is currently shown */
+  private static totalLengthWarningShown = false
+  /** Current active timeout timer */
+  private static timer: number | null = null
+
+  static init() {
+    void this.checkAndSetTimer()
+    this.setupModalEventHandlers()
+  }
+
+  /**
+   * Set up event handlers for the server-rendered modals.
+   */
+  private static setupModalEventHandlers() {
+    document.addEventListener('htmx:afterRequest', (event: Event) => {
+      const customEvent = event as CustomEvent
+      const detail = customEvent.detail as {
+        xhr: XMLHttpRequest
+        elt: HTMLElement
+      }
+      if (detail.elt.id !== 'extend-session-form') return
+
+      this.hideModal('session-inactivity-warning')
+      this.inactivityWarningShown = false
+
+      if (detail.xhr.status === 200) {
+        const successText =
+          document.getElementById('session-extended-success-text')
+            ?.textContent || 'Session successfully extended'
+        ToastController.showToastMessage({
+          id: 'session-extended-toast',
+          content: successText,
+          type: 'success',
+          duration: 3000,
+          canDismiss: true,
+          canIgnore: false,
+          condOnStorageKey: null,
+        })
+        this.checkAndSetTimer()
+      } else {
+        const errorText =
+          document.getElementById('session-extended-error-text')?.textContent ||
+          'Failed to extend session'
+        ToastController.showToastMessage({
+          id: 'session-extend-error-toast',
+          content: errorText,
+          type: 'error',
+          duration: 3000,
+          canDismiss: true,
+          canIgnore: false,
+          condOnStorageKey: null,
+        })
+      }
+    })
+
+    // Handle modal actions using event delegation
+    document.addEventListener('click', (event) => {
+      const target = event.target as HTMLElement
+      if (!target) return
+
+      const modalType = target.getAttribute('data-modal-type')
+      if (!modalType) return
+
+      if (target.hasAttribute('data-modal-primary')) {
+        if (modalType === 'session-inactivity-warning') {
+          // Handle extend session
+          const form = document.getElementById(
+            'extend-session-form',
+          ) as HTMLFormElement
+          form?.requestSubmit()
+        } else if (modalType === 'session-length-warning') {
+          this.logout()
+        }
+      } else if (
+        target.hasAttribute('data-modal-secondary') ||
+        target.hasAttribute('data-close-modal')
+      ) {
+        this.hideModal(modalType)
+        if (modalType === 'session-inactivity-warning') {
+          this.inactivityWarningShown = false
+        } else if (modalType === 'session-length-warning') {
+          this.totalLengthWarningShown = false
+        }
+        this.checkAndSetTimer()
+      }
+    })
+  }
+
+  private static hideModal(modalType: string) {
+    const modal = document.getElementById(`${modalType}-modal`)
+    if (modal) {
+      modal.classList.add('is-hidden')
+    }
+  }
+
+  private static getTimeoutData(): TimeoutData | null {
+    const cookieValue = this.getCookie(this.COOKIE_NAME)
+    if (!cookieValue) return null
+
+    try {
+      // Decode Base64 and parse JSON
+      const jsonString = atob(decodeURIComponent(cookieValue))
+      const data: unknown = JSON.parse(jsonString)
+      if (!this.isTimeoutData(data)) {
+        console.error('Invalid timeout data format')
+        return null
+      }
+      // Calculate clock skew between client and server
+      const clientNow = Math.floor(Date.now() / 1000)
+      const clockSkew = clientNow - data.currentTime
+      return {
+        inactivityWarning: data.inactivityWarning + clockSkew,
+        inactivityTimeout: data.inactivityTimeout + clockSkew,
+        totalWarning: data.totalWarning + clockSkew,
+        totalTimeout: data.totalTimeout + clockSkew,
+        currentTime: data.currentTime,
+      }
+    } catch (e) {
+      console.error('Failed to parse session timeout data:', e)
+      return null
+    }
+  }
+
+  private static isTimeoutData(data: unknown): data is TimeoutData {
+    if (!data || typeof data !== 'object') return false
+
+    const d = data as Record<string, unknown>
+
+    return (
+      typeof d.inactivityWarning === 'number' &&
+      typeof d.inactivityTimeout === 'number' &&
+      typeof d.totalWarning === 'number' &&
+      typeof d.totalTimeout === 'number' &&
+      typeof d.currentTime === 'number'
+    )
+  }
+
+  private static getCookie(name: string): string | null {
+    const value = `; ${document.cookie}`
+    const parts = value.split(`; ${name}=`)
+    if (parts.length === 2) {
+      return parts.pop()?.split(';').shift() || null
+    }
+    return null
+  }
+
+  private static checkAndSetTimer() {
+    const data = this.getTimeoutData()
+    if (!data) return
+
+    // Clear existing timer
+    if (this.timer) {
+      window.clearTimeout(this.timer)
+      this.timer = null
+    }
+
+    const now = Math.floor(Date.now() / 1000)
+
+    const timeouts = [
+      {time: data.inactivityWarning, type: WarningType.INACTIVITY},
+      {time: data.totalWarning, type: WarningType.TOTAL_LENGTH},
+      {time: data.inactivityTimeout, type: null},
+      {time: data.totalTimeout, type: null},
+    ].filter((t) => t.time > now)
+
+    // Sort by earliest time
+    timeouts.sort((a, b) => a.time - b.time)
+
+    if (timeouts.length === 0) {
+      this.handleTimeout()
+      return
+    }
+
+    const nextTimeout = timeouts[0]
+    const delay = (nextTimeout.time - now) * 1000
+
+    this.timer = window.setTimeout(() => {
+      if (nextTimeout.type) {
+        this.showWarning(nextTimeout.type)
+      } else {
+        void this.handleTimeout()
+      }
+    }, delay)
+  }
+
+  private static showWarning(type: WarningType) {
+    // Check if the warning is already shown to prevent duplicate dialogs
+    if (type === WarningType.INACTIVITY && this.inactivityWarningShown) return
+    if (type === WarningType.TOTAL_LENGTH && this.totalLengthWarningShown)
+      return
+    // Get the appropriate modal element
+    const modalId =
+      type === WarningType.INACTIVITY
+        ? 'session-inactivity-warning-modal'
+        : 'session-length-warning-modal'
+    const modal = document.getElementById(modalId)
+    if (!modal) {
+      console.error(`Modal with ID ${modalId} not found`)
+      return
+    }
+    // Show the modal by removing the hidden class
+    modal.classList.remove('is-hidden')
+    // Set the flag to indicate that the warning is shown
+    if (type === WarningType.INACTIVITY) {
+      this.inactivityWarningShown = true
+    } else {
+      this.totalLengthWarningShown = true
+    }
+    // Continue checking for other timeouts
+    this.checkAndSetTimer()
+  }
+
+  private static handleTimeout() {
+    this.logout()
+  }
+
+  private static logout() {
+    window.location.href = '/logout'
+  }
+}

--- a/server/app/assets/javascripts/session.ts
+++ b/server/app/assets/javascripts/session.ts
@@ -37,12 +37,14 @@ export enum WarningType {
 export class SessionTimeoutHandler {
   /** Name of cookie storing timeout data */
   private static COOKIE_NAME = 'session_timeout_data'
-  /** How often to check timeout state (milliseconds) */
-  private static CHECK_INTERVAL = 2000 // 2 seconds
   /** Tracks if inactivity warning is currently shown */
   private static inactivityWarningShown = false
   /** Tracks if total length warning is currently shown */
   private static totalLengthWarningShown = false
+  /** Tracks if inactivity warning has been shown at least once */
+  private static hasInactivityWarningBeenShown = false
+  /** Tracks if total length warning has been shown at least once */
+  private static hasTotalLengthWarningBeenShown = false
   /** Current active timeout timer */
   private static timer: number | null = null
 
@@ -52,9 +54,10 @@ export class SessionTimeoutHandler {
   }
 
   /**
-   * Set up event handlers for the server-rendered modals.
+   * Set up event handlers for the server-rendered modals and process the extend session form submission.
    */
   private static setupModalEventHandlers() {
+    // HTMX after-request handler for session extension
     document.addEventListener('htmx:afterRequest', (event: Event) => {
       const customEvent = event as CustomEvent
       const detail = customEvent.detail as {
@@ -66,6 +69,7 @@ export class SessionTimeoutHandler {
       this.hideModal('session-inactivity-warning')
       this.inactivityWarningShown = false
 
+      // Processes /extend-session form submissions
       if (detail.xhr.status === 200) {
         const successText =
           document.getElementById('session-extended-success-text')
@@ -96,7 +100,22 @@ export class SessionTimeoutHandler {
       }
     })
 
-    // Handle modal actions using event delegation
+    /**
+     * Handle modal button actions using event delegation:
+     * - Primary actions:
+     *   - For inactivity warning: Extends session by submitting form to /extend-session
+     *   - For total length warning: Initiates logout
+     * - Secondary/close actions:
+     *   - Hides the modal
+     *   - Resets warning visibility flags
+     *   - Rechecks timeout conditions
+     *
+     * Uses data attributes to identify buttons and their actions:
+     * - data-modal-type: Identifies which modal the button belongs to
+     * - data-modal-primary: Primary action button (extend/logout)
+     * - data-modal-secondary: Secondary action button (dismiss)
+     * - data-close-modal: Close button (X)
+     */
     document.addEventListener('click', (event) => {
       const target = event.target as HTMLElement
       if (!target) return
@@ -106,7 +125,7 @@ export class SessionTimeoutHandler {
 
       if (target.hasAttribute('data-modal-primary')) {
         if (modalType === 'session-inactivity-warning') {
-          // Handle extend session
+          // submit the extend session form to /extend-session endpoint.
           const form = document.getElementById(
             'extend-session-form',
           ) as HTMLFormElement
@@ -129,6 +148,12 @@ export class SessionTimeoutHandler {
     })
   }
 
+  /**
+   * Hides the specified modal by adding the 'is-hidden' class.
+   * Updates visibility tracking flags when hiding a modal.
+   *
+   * @param modalType Type of modal to hide ('session-inactivity-warning' or 'session-length-warning')
+   */
   private static hideModal(modalType: string) {
     const modal = document.getElementById(`${modalType}-modal`)
     if (modal) {
@@ -136,6 +161,9 @@ export class SessionTimeoutHandler {
     }
   }
 
+  /**
+   * Reads the session timeout data from the cookie.
+   */
   private static getTimeoutData(): TimeoutData | null {
     const cookieValue = this.getCookie(this.COOKIE_NAME)
     if (!cookieValue) return null
@@ -164,11 +192,22 @@ export class SessionTimeoutHandler {
     }
   }
 
+  /**
+   * Type predicate function to check if an unknown value is a TimeoutData object.
+   *
+   * @param data The value to check.
+   * @returns `true` if the value is a TimeoutData object, `false` otherwise.
+   */
   private static isTimeoutData(data: unknown): data is TimeoutData {
-    if (!data || typeof data !== 'object') return false
+    // Check if the data is falsy or not an object. If so, it cannot be TimeoutData.
+    if (!data || typeof data !== 'object') {
+      return false
+    }
 
+    // Treat the data as a Record to allow accessing properties.
     const d = data as Record<string, unknown>
 
+    // Check if all required properties exist and are of the correct type (number).
     return (
       typeof d.inactivityWarning === 'number' &&
       typeof d.inactivityTimeout === 'number' &&
@@ -178,15 +217,47 @@ export class SessionTimeoutHandler {
     )
   }
 
+  /**
+   * Retrieves the value of a cookie by its name.
+   *
+   * This function parses the `document.cookie` string to find the value
+   * associated with the given cookie name.
+   *
+   * @param name The name of the cookie to retrieve.
+   * @returns The string value of the cookie, or null if the cookie is not found.
+   */
   private static getCookie(name: string): string | null {
+    // Prefix the document cookie string with a semicolon and a space to handle case when our cookie is the first.
     const value = `; ${document.cookie}`
+
+    // Split the cookie string into an array of parts, using the cookie name as the delimiter.
+    // This assumes the cookie name is followed by an equals sign (=).
     const parts = value.split(`; ${name}=`)
+
+    // Check if the cookie was found. If parts.length is 2, it means the cookie name
+    // was found, and the array contains a part before and a part after the cookie name.
     if (parts.length === 2) {
+      // Extract the cookie value by taking the last element of the 'parts' array (the part after the cookie name),
+      // then splitting it by semicolons to separate the value from any subsequent cookie attributes
+      // (e.g., path, domain, etc.). Finally, take the first element (the actual value) and return it.
+      // If any of the split operations fail to return a value, return null.
       return parts.pop()?.split(';').shift() || null
     }
+
     return null
   }
 
+  /**
+   * Main timer management method that:
+   * 1. Checks for immediate timeout conditions and logs out if needed
+   * 2. Shows inactivity warning once if its time has passed and not shown before
+   * 3. Shows total length warning once if its time has passed and not shown before
+   * 4. Sets timer for next future event (warning or timeout)
+   *
+   * Warning dialogs are shown only once per session and only one dialog
+   * can be visible at a time. If a warning was previously shown, it won't
+   * be shown again even if its time passes again.
+   */
   private static checkAndSetTimer() {
     const data = this.getTimeoutData()
     if (!data) return
@@ -199,38 +270,96 @@ export class SessionTimeoutHandler {
 
     const now = Math.floor(Date.now() / 1000)
 
-    const timeouts = [
-      {time: data.inactivityWarning, type: WarningType.INACTIVITY},
-      {time: data.totalWarning, type: WarningType.TOTAL_LENGTH},
-      {time: data.inactivityTimeout, type: null},
-      {time: data.totalTimeout, type: null},
-    ].filter((t) => t.time > now)
-
-    // Sort by earliest time
-    timeouts.sort((a, b) => a.time - b.time)
-
-    if (timeouts.length === 0) {
+    // 1. If there is an inactivityTimeout or totalTimeout that has passed, just logout
+    if (data.inactivityTimeout <= now || data.totalTimeout <= now) {
       this.handleTimeout()
       return
     }
 
-    const nextTimeout = timeouts[0]
-    const delay = (nextTimeout.time - now) * 1000
+    // If a warning is already being shown, don't show another one
+    if (this.inactivityWarningShown || this.totalLengthWarningShown) {
+      return
+    }
 
-    this.timer = window.setTimeout(() => {
-      if (nextTimeout.type) {
-        this.showWarning(nextTimeout.type)
-      } else {
-        void this.handleTimeout()
-      }
-    }, delay)
+    // 2 & 3. Show warnings if they haven't been shown before and their time has passed
+    if (!this.hasInactivityWarningBeenShown && data.inactivityWarning <= now) {
+      this.showWarning(WarningType.INACTIVITY)
+      this.hasInactivityWarningBeenShown = true
+      return
+    }
+
+    if (!this.hasTotalLengthWarningBeenShown && data.totalWarning <= now) {
+      this.showWarning(WarningType.TOTAL_LENGTH)
+      this.hasTotalLengthWarningBeenShown = true
+      return
+    }
+
+    // Set timers for future events
+    const timeouts = []
+
+    // Only add inactivity warning if it hasn't been shown yet
+    if (!this.hasInactivityWarningBeenShown && data.inactivityWarning > now) {
+      timeouts.push({
+        time: data.inactivityWarning,
+        action: () => {
+          this.showWarning(WarningType.INACTIVITY)
+          this.hasInactivityWarningBeenShown = true
+        },
+      })
+    }
+
+    // Only add total length warning if it hasn't been shown yet
+    if (!this.hasTotalLengthWarningBeenShown && data.totalWarning > now) {
+      timeouts.push({
+        time: data.totalWarning,
+        action: () => {
+          this.showWarning(WarningType.TOTAL_LENGTH)
+          this.hasTotalLengthWarningBeenShown = true
+        },
+      })
+    }
+
+    // Always add timeout events
+    timeouts.push({
+      time: data.inactivityTimeout,
+      action: () => this.handleTimeout(),
+    })
+
+    timeouts.push({
+      time: data.totalTimeout,
+      action: () => this.handleTimeout(),
+    })
+
+    // Sort by earliest time
+    timeouts.sort((a, b) => a.time - b.time)
+
+    if (timeouts.length > 0) {
+      const nextTimeout = timeouts[0]
+      const delay = (nextTimeout.time - now) * 1000
+
+      this.timer = window.setTimeout(() => {
+        nextTimeout.action()
+
+        // Check for next timeout after handling this one
+        this.checkAndSetTimer()
+      }, delay)
+    }
   }
 
+  /**
+   * Shows a warning modal of specified type.
+   * Only shows the modal if:
+   * - No other warning is currently shown
+   * - The modal element exists in the DOM
+   *
+   * Updates visibility tracking flags when showing a modal.
+   *
+   * @param type Type of warning to show (inactivity or total length)
+   */
   private static showWarning(type: WarningType) {
-    // Check if the warning is already shown to prevent duplicate dialogs
-    if (type === WarningType.INACTIVITY && this.inactivityWarningShown) return
-    if (type === WarningType.TOTAL_LENGTH && this.totalLengthWarningShown)
-      return
+    // Check if any warning is already shown to prevent showing multiple dialogs
+    if (this.inactivityWarningShown || this.totalLengthWarningShown) return
+
     // Get the appropriate modal element
     const modalId =
       type === WarningType.INACTIVITY
@@ -249,14 +378,18 @@ export class SessionTimeoutHandler {
     } else {
       this.totalLengthWarningShown = true
     }
-    // Continue checking for other timeouts
-    this.checkAndSetTimer()
   }
 
+  /**
+   * Handles timeout conditions by calling logout.
+   */
   private static handleTimeout() {
     this.logout()
   }
 
+  /**
+   * Initiates logout.
+   */
   private static logout() {
     window.location.href = '/logout'
   }


### PR DESCRIPTION
### Description

Frontend code to read the session_timeout_data cookie and display warning message in a modal dialog or logout user if the session has timed out due to inactivity or total session length above a threshold. The session cookie is only set when session timeout feature is enabled and therefore the SessionTimeoutHandler initialization is not under feature flag. Browser tests are coming in the next PR.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [x] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`

#### User visible changes

- [ ] Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
  - [ ] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [ ] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Made equivalent changes in Thymeleaf for applicant-facing features and changes (or created an issue in the [Northstar epic](https://github.com/orgs/civiform/projects/1/views/94) to track that it's missing from Thymeleaf)
- [ ] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order
- [ ] Manually tested with a screen reader if the feature is applicant-facing. See [screen reader testing](https://github.com/civiform/civiform/wiki/Testing#screen-reader-testing)

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/helper/feature-flags.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://github.com/civiform/civiform/wiki/Feature-Flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Instructions for manual testing
- Configure the session timeouts in server configuration file(in applicantion.conf). To test session inactivity warning dialog, set the session_inactivity_timeout_minutes to 2 minutes and session_inactivity_warning_threshold_minutes to 1 minute. Set maximum_session_duration_minutes to 2 minutes and session_duration_warning_threshold_minutes to 1 minutes for session length warning dialog
- Log in as Admin
- Enable the session timeout in server settings(if not enabled in step 1).
- Visiting any page should now display and waiting for a minute would show a warning modal dialog.
- Logout as Admin
- Login as Applicant
- Any page visit should display the warning dialog.
- Now configure the session_inactivity_timeout_minutes to 1 minute
- Wait for 1 minute and you should be logged out automatically.
- Now configure the maximum_session_duration_minutes to 1 minute
- Wait for 1 minute and you should be logged out automatically.

### Issue(s) this completes
Fixes #<issue_number>; Fixes #<issue_number>...
