### PR TITLE
[External Program Cards] Add feature flag

### DIFF
--- a/server/app/services/settings/SettingsManifest.java
+++ b/server/app/services/settings/SettingsManifest.java
@@ -2364,12 +2364,12 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                           SettingType.BOOLEAN,
                           SettingMode.ADMIN_WRITEABLE),
                       SettingDescription.create(
-                            "EXTERNAL_PROGRAM_CARDS_ENABLED",
-                            "(NOT FOR PRODUCTION USE) Enable showing external program cards on"
-                                + " North Star applicant UI.",
-                            /* isRequired= */ false,
-                            SettingType.BOOLEAN,
-                            SettingMode.ADMIN_WRITEABLE))))
+                          "EXTERNAL_PROGRAM_CARDS_ENABLED",
+                          "(NOT FOR PRODUCTION USE) Enable showing external program cards on North"
+                              + " Star applicant UI.",
+                          /* isRequired= */ false,
+                          SettingType.BOOLEAN,
+                          SettingMode.ADMIN_WRITEABLE))))
           .put(
               "Miscellaneous",
               SettingsSection.create(

--- a/server/app/services/settings/SettingsManifest.java
+++ b/server/app/services/settings/SettingsManifest.java
@@ -1109,6 +1109,11 @@ public final class SettingsManifest extends AbstractSettingsManifest {
     return getBool("CUSTOM_THEME_COLORS_ENABLED", request);
   }
 
+  /** (NOT FOR PRODUCTION USE) Enable showing external program cards on North Star applicant UI. */
+  public boolean getExternalProgramCardsEnabled(RequestHeader request) {
+    return getBool("EXTERNAL_PROGRAM_CARDS_ENABLED", request);
+  }
+
   private static final ImmutableMap<String, SettingsSection> GENERATED_SECTIONS =
       ImmutableMap.<String, SettingsSection>builder()
           .put(
@@ -2357,7 +2362,14 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                               + " applicant UI.",
                           /* isRequired= */ false,
                           SettingType.BOOLEAN,
-                          SettingMode.ADMIN_WRITEABLE))))
+                          SettingMode.ADMIN_WRITEABLE),
+                      SettingDescription.create(
+                            "EXTERNAL_PROGRAM_CARDS_ENABLED",
+                            "(NOT FOR PRODUCTION USE) Enable showing external program cards on"
+                                + " North Star applicant UI.",
+                            /* isRequired= */ false,
+                            SettingType.BOOLEAN,
+                            SettingMode.ADMIN_WRITEABLE))))
           .put(
               "Miscellaneous",
               SettingsSection.create(

--- a/server/conf/env-var-docs.json
+++ b/server/conf/env-var-docs.json
@@ -958,6 +958,12 @@
         "description": "(NOT FOR PRODUCTION USE) Enable using custom theme colors on North Star applicant UI.",
         "type": "bool",
         "required": false
+      },
+      "EXTERNAL_PROGRAM_CARDS_ENABLED": {
+        "mode": "ADMIN_WRITEABLE",
+        "description": "(NOT FOR PRODUCTION USE) Enable showing external program cards on North Star applicant UI.",
+        "type": "bool",
+        "required": false
       }
     }
   }

--- a/server/conf/helper/feature-flags.conf
+++ b/server/conf/helper/feature-flags.conf
@@ -85,3 +85,7 @@ customized_eligibility_message_enabled = ${?CUSTOMIZED_ELIGIBILITY_MESSAGE_ENABL
 # Custom theme colors
 custom_theme_colors_enabled = false
 custom_theme_colors_enabled = ${?CUSTOM_THEME_COLORS_ENABLED}
+
+# External program cards
+external_program_cards_enabled = false
+external_program_cards_enabled = ${?EXTERNAL_PROGRAM_CARDS_ENABLED}


### PR DESCRIPTION
### Description

Add feature flag that to gate the External Program Cards feature, which will allow admins to add external program which will be shown to the applicants on North Star UI.

### Checklist

#### General

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)

#### New Features

- [x] Add new FeatureFlag env vars to `server/conf/helper/feature-flags.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://github.com/civiform/civiform/wiki/Feature-Flags) <-- Next PRs
- [ ] Wrote browser tests with the feature flag off and on, etc. <-- Next PRs

### Issue(s) this completes

Part of #10062
