### PR TITLE
Set the unit tests compose to use the local oidc image

### DIFF
--- a/test-support/unit-test-docker-compose.yml
+++ b/test-support/unit-test-docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - ../init_postgres.sql:/docker-entrypoint-initdb.d/init_postgres.sql
 
   dev-oidc:
-    image: civiform/oidc-provider@sha256:2552ca9deb83498b57f2bd62015eb4a4c763d653e69a17a8c829a9a6e86ea372
+    image: civiform-oidc-provider
     restart: always
     expose:
       - 3390


### PR DESCRIPTION
### Description

This should have always been using the local tag the same way the rest of our images are used in compose files. Without this change we'll be constantly bombarded with renovate PRs to update the sha.


### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
