### PR TITLE
Do not use the constants defined in StorageServiceName in the SignedS3UploadRequest

### DIFF
--- a/server/app/services/cloud/aws/SignedS3UploadRequest.java
+++ b/server/app/services/cloud/aws/SignedS3UploadRequest.java
@@ -20,7 +20,6 @@ import java.time.format.DateTimeFormatter;
 import java.util.Optional;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
-import services.cloud.StorageServiceName;
 import services.cloud.StorageUploadRequest;
 import software.amazon.awssdk.utils.BinaryUtils;
 
@@ -36,6 +35,7 @@ import software.amazon.awssdk.utils.BinaryUtils;
 public abstract class SignedS3UploadRequest implements StorageUploadRequest {
 
   private static final long MB_TO_BYTES = 1L << 20;
+  private static final String S3_SERVICE_NAME = "s3";
 
   /** The name to use for the success action redirect in the policy JSON. */
   private static final String SUCCESS_ACTION_REDIRECT_NAME = "success_action_redirect";
@@ -64,7 +64,7 @@ public abstract class SignedS3UploadRequest implements StorageUploadRequest {
   public static Builder builder() {
     return new AutoValue_SignedS3UploadRequest.Builder()
         .setAlgorithm("AWS4-HMAC-SHA256")
-        .setServiceName(StorageServiceName.S3.getString());
+        .setServiceName(S3_SERVICE_NAME);
   }
 
   // -- Below should be included in the upload form.


### PR DESCRIPTION
### Description

The constants in StorageType are meant to be used to identify the type of storage that the deployment will use.  As such the values of these constants are arbitrary.

SignedS3UploadRequest always needs to set the serviceName field to 's3' regardless of wether the backend S3 service is GCP or AWS.  Therefore the constant being used to se that field should be private to the SignedS3UploadRequest class.

- Unit test already existed and passes.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [X] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [X] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [X] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [X] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [X] Created unit and/or browser tests which fail without the change (if possible)
- [X] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [X] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [x] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`


