### PR TITLE
[North Star] Adding a link to skip to main content of the page

### DIFF
--- a/browser-test/src/applicant/northstar_applicant_application_index.test.ts
+++ b/browser-test/src/applicant/northstar_applicant_application_index.test.ts
@@ -14,7 +14,7 @@ import {
   selectApplicantLanguage,
   normalizeElements,
 } from '../support'
-import {Page} from 'playwright'
+import {Locator, Page} from 'playwright'
 import {ProgramVisibility} from '../support/admin_programs'
 import {BASE_URL} from '../support/config'
 
@@ -90,7 +90,25 @@ test.describe('applicant program index page', {tag: ['@northstar']}, () => {
     await applicantQuestions.expectTitle(page, 'Find programs')
   })
 
-  test('validate accessibility', async ({page}) => {
+  test('validate accessibility and validate skip link', async ({page}) => {
+    const skipLinkLocator: Locator = page.getByRole('link', {
+      name: 'Skip to main content',
+    })
+    await test.step('Tab and verify focus on skip link', async () => {
+      await page.keyboard.press('Tab')
+      await expect(skipLinkLocator).toBeFocused()
+      await expect(skipLinkLocator).toBeVisible()
+    })
+
+    await test.step('Click on skip link and skip to main content', async () => {
+      await skipLinkLocator.click()
+      await expect(page.locator('main')).toBeFocused()
+      await page.keyboard.press('Tab')
+      await expect(
+        page.getByRole('link', {name: 'View and apply'}).first(),
+      ).toBeFocused()
+    })
+
     await validateAccessibility(page)
   })
 

--- a/server/app/services/MessageKey.java
+++ b/server/app/services/MessageKey.java
@@ -288,6 +288,7 @@ public enum MessageKey {
   LINK_PROGRAM_DETAILS_SR("link.programDetailsSr"),
   LINK_REMOVE_FILE("link.removeFile"),
   LINK_SELECT_NEW_CLIENT("link.selectNewClient"),
+  LINK_SKIP_TO_MAIN_CONTENT("link.skipToMainContent"), // North Star only
   LINK_HOME("link.home"), // North Star only
   LINK_APPLICATION_FOR_PROGRAM("link.applicationForProgram"), // North Star
   // Only

--- a/server/app/views/applicant/AddressCorrectionBlockTemplate.html
+++ b/server/app/views/applicant/AddressCorrectionBlockTemplate.html
@@ -4,9 +4,10 @@
     th:replace="~{applicant/ApplicantBaseFragment :: pageHeaderScriptsAndLinks}"
   ></head>
   <body>
+    <div th:replace="~{applicant/ApplicantBaseFragment :: skipNav}"></div>
     <div th:replace="~{applicant/NavigationFragment :: pageHeader}"></div>
 
-    <main>
+    <main id="main-content" tabindex="-1">
       <div
         th:replace="~{applicant/TitleAndDescriptionFragment :: titleAndDescriptionFragment(${programTitle}, ${programShortDescription})}"
       ></div>

--- a/server/app/views/applicant/ApplicantBaseFragment.html
+++ b/server/app/views/applicant/ApplicantBaseFragment.html
@@ -5,7 +5,7 @@
   <meta name="civiform-build-tag" th:content="${civiformImageTag}" />
   <meta th:if="${addNoIndexMetaTag}" name="robots" content="noindex" />
   <!--/* Best practice: add ❤️ every time you touch this file :) */-->
-  <meta name="thanks" content="Thank you Bion ❤️❤️❤️" />
+  <meta name="thanks" content="Thank you Bion ❤️❤️❤️❤️" />
 
   <title th:text="${pageTitle}"></title>
 
@@ -90,3 +90,11 @@
 >
   <path th:attr="d=${icon.path}"></path>
 </svg>
+
+<th:block th:fragment="skipNav">
+  <a
+    class="usa-skipnav"
+    href="#main-content"
+    th:text="#{link.skipToMainContent}"
+  ></a>
+</th:block>

--- a/server/app/views/applicant/ApplicantCommonIntakeUpsellTemplate.html
+++ b/server/app/views/applicant/ApplicantCommonIntakeUpsellTemplate.html
@@ -4,8 +4,9 @@
     th:replace="~{applicant/ApplicantBaseFragment :: pageHeaderScriptsAndLinks}"
   ></head>
   <body>
+    <div th:replace="~{applicant/ApplicantBaseFragment :: skipNav}"></div>
     <div th:replace="~{applicant/NavigationFragment :: pageHeader}"></div>
-    <main>
+    <main id="main-content" tabindex="-1">
       <div
         th:replace="~{applicant/TitleAndDescriptionFragment :: titleAndDescriptionFragment(${programTitle}, ${programShortDescription})}"
       ></div>

--- a/server/app/views/applicant/ApplicantProgramBlockEditTemplate.html
+++ b/server/app/views/applicant/ApplicantProgramBlockEditTemplate.html
@@ -4,8 +4,9 @@
     th:replace="~{applicant/ApplicantBaseFragment :: pageHeaderScriptsAndLinks}"
   ></head>
   <body>
+    <div th:replace="~{applicant/ApplicantBaseFragment :: skipNav}"></div>
     <div th:replace="~{applicant/NavigationFragment :: pageHeader}"></div>
-    <main>
+    <main id="main-content" tabindex="-1">
       <div th:replace="~{components/ToastFragment :: blockEditToasts}"></div>
       <div
         th:replace="~{applicant/NavigationFragment :: adminPreviewBackButton(${goBackToAdminUrl})}"

--- a/server/app/views/applicant/ApplicantProgramFileUploadBlockEditTemplate.html
+++ b/server/app/views/applicant/ApplicantProgramFileUploadBlockEditTemplate.html
@@ -4,8 +4,11 @@
     th:replace="~{applicant/ApplicantBaseFragment :: pageHeaderScriptsAndLinks}"
   ></head>
   <body>
+    <div th:replace="~{applicant/ApplicantBaseFragment :: skipNav}"></div>
     <div th:replace="~{applicant/NavigationFragment :: pageHeader}"></div>
     <main
+      id="main-content"
+      tabindex="-1"
       role="main"
       th:with="question=${applicationParams.block().getQuestions().get(0)},
       questionParams=${questionRendererParams.get(question.getQuestionDefinition().getId())},

--- a/server/app/views/applicant/ApplicantProgramSummaryTemplate.html
+++ b/server/app/views/applicant/ApplicantProgramSummaryTemplate.html
@@ -4,8 +4,9 @@
     th:replace="~{applicant/ApplicantBaseFragment :: pageHeaderScriptsAndLinks}"
   ></head>
   <body>
+    <div th:replace="~{applicant/ApplicantBaseFragment :: skipNav}"></div>
     <div th:replace="~{applicant/NavigationFragment :: pageHeader}"></div>
-    <main>
+    <main id="main-content" tabindex="-1">
       <div
         th:replace="~{applicant/NavigationFragment :: adminPreviewBackButton(${goBackToAdminUrl})}"
       ></div>

--- a/server/app/views/applicant/ApplicantUpsellTemplate.html
+++ b/server/app/views/applicant/ApplicantUpsellTemplate.html
@@ -4,9 +4,10 @@
     th:replace="~{applicant/ApplicantBaseFragment :: pageHeaderScriptsAndLinks}"
   ></head>
   <body>
+    <div th:replace="~{applicant/ApplicantBaseFragment :: skipNav}"></div>
     <div th:replace="~{applicant/NavigationFragment :: pageHeader}"></div>
 
-    <main>
+    <main id="main-content" tabindex="-1">
       <div
         th:replace="~{applicant/TitleAndDescriptionFragment :: titleAndDescriptionFragment(${programTitle}, ${programShortDescription})}"
       ></div>

--- a/server/app/views/applicant/IneligibleTemplate.html
+++ b/server/app/views/applicant/IneligibleTemplate.html
@@ -4,8 +4,9 @@
     th:replace="~{applicant/ApplicantBaseFragment :: pageHeaderScriptsAndLinks}"
   ></head>
   <body>
+    <div th:replace="~{applicant/ApplicantBaseFragment :: skipNav}"></div>
     <div th:replace="~{applicant/NavigationFragment :: pageHeader}"></div>
-    <main>
+    <main id="main-content" tabindex="-1">
       <div
         th:replace="~{components/ToastFragment :: devOrStagingToast(${isDevOrStaging})}"
       ></div>

--- a/server/app/views/applicant/ProgramIndexTemplate.html
+++ b/server/app/views/applicant/ProgramIndexTemplate.html
@@ -33,8 +33,9 @@
     th:replace="~{applicant/ApplicantBaseFragment :: pageHeaderScriptsAndLinks}"
   ></head>
   <body>
+    <div th:replace="~{applicant/ApplicantBaseFragment :: skipNav}"></div>
     <div th:replace="~{applicant/NavigationFragment :: pageHeader}"></div>
-    <main>
+    <main id="main-content" tabindex="-1">
       <div th:replace="~{components/ToastFragment :: programIndexToasts}"></div>
       <div
         id="top-content"

--- a/server/app/views/applicant/ProgramOverviewTemplate.html
+++ b/server/app/views/applicant/ProgramOverviewTemplate.html
@@ -7,8 +7,9 @@
     th:replace="~{applicant/ApplicantBaseFragment :: pageHeaderScriptsAndLinks}"
   ></head>
   <body>
+    <div th:replace="~{applicant/ApplicantBaseFragment :: skipNav}"></div>
     <div th:replace="~{applicant/NavigationFragment :: pageHeader}"></div>
-    <main>
+    <main id="main-content" tabindex="-1">
       <div
         th:replace="~{applicant/TitleAndDescriptionFragment ::
           titleAndDescriptionFragment(

--- a/server/conf/i18n/messages
+++ b/server/conf/i18n/messages
@@ -73,6 +73,8 @@ label.primaryNavigation=Primary navigation
 label.agencyIdentifier=Agency identifier,
 # Aria-label for guest session alert
 label.guestSessionAlert=Guest session informational alert
+# Link to skip to the main content of the page
+link.skipToMainContent=Skip to main content
 
 #-------------------------------------------------------------#
 # LOGIN - contains text that for login page.                  #


### PR DESCRIPTION
### Description

Adding a skip link so that keyboard and screen reader users can skip to main content.  The link is the first focusable element on the page and is visible on keyboard focus only.  Once the user has clicked the link, clicking "Tab" will go to the first focusable element in the main content, rather than back up to the top of the page.

The skip link needs to be present on every applicant-facing page of the North Star.

### Instructions for manual testing

1. Turn the North Star flag on. 
2. From any applicant-facing page, press "Tab".
3. The "Skip to main content" link should become visible and should have focus.
4. Press "Enter".
5. Press "Tab".
6. Focus should be on the first interactive element of the main content of the page.
7. Refresh the page.
8. Turn the screen reader on.
9. Focus should go straight to the "Skip to main content link" and the link should be announced.
10. Click the link.
11. It should skip to main content and start reading there.

### Issue(s) this completes

Fixes #9916; Fixes #6067 
