### PR TITLE
Cleaning up web first assertions

### DIFF
--- a/browser-test/.eslintrc.json
+++ b/browser-test/.eslintrc.json
@@ -20,8 +20,7 @@
     // easier to read.
     "playwright/no-nested-step": "off",
     "playwright/no-skipped-test": "off",
-    "playwright/no-wait-for-selector": "off",
-    "playwright/prefer-web-first-assertions": "off"
+    "playwright/no-wait-for-selector": "off"
   },
   "parserOptions": {
     "project": ["./src/tsconfig.json"]

--- a/browser-test/src/admin/admin_program_creation.test.ts
+++ b/browser-test/src/admin/admin_program_creation.test.ts
@@ -119,30 +119,24 @@ test.describe('program creation', () => {
     await test.step('navigate back to program edit page and confirm application step values show up', async () => {
       await adminProgramImage.clickBackButton()
       await adminPrograms.expectProgramEditPage(programName)
-      expect(
-        await page.getByRole('textbox', {name: 'Step 1 title'}).inputValue(),
-      ).toEqual(titleOne)
-      expect(
-        await page
-          .getByRole('textbox', {name: 'Step 1 description'})
-          .inputValue(),
-      ).toEqual(descriptionOne)
-      expect(
-        await page.getByRole('textbox', {name: 'Step 2 title'}).inputValue(),
-      ).toEqual(titleTwo)
-      expect(
-        await page
-          .getByRole('textbox', {name: 'Step 2 description'})
-          .inputValue(),
-      ).toEqual(descriptionTwo)
-      expect(
-        await page.getByRole('textbox', {name: 'Step 3 title'}).inputValue(),
-      ).toEqual(titleThree)
-      expect(
-        await page
-          .getByRole('textbox', {name: 'Step 3 description'})
-          .inputValue(),
-      ).toEqual(descriptionThree)
+      await expect(
+        page.getByRole('textbox', {name: 'Step 1 title'}),
+      ).toHaveValue(titleOne)
+      await expect(
+        page.getByRole('textbox', {name: 'Step 1 description'}),
+      ).toHaveValue(descriptionOne)
+      await expect(
+        page.getByRole('textbox', {name: 'Step 2 title'}),
+      ).toHaveValue(titleTwo)
+      await expect(
+        page.getByRole('textbox', {name: 'Step 2 description'}),
+      ).toHaveValue(descriptionTwo)
+      await expect(
+        page.getByRole('textbox', {name: 'Step 3 title'}),
+      ).toHaveValue(titleThree)
+      await expect(
+        page.getByRole('textbox', {name: 'Step 3 description'}),
+      ).toHaveValue(descriptionThree)
     })
   })
 
@@ -183,24 +177,27 @@ test.describe('program creation', () => {
     await test.step('navigate back to program edit page and confirm previously blank step is ignored', async () => {
       await adminProgramImage.clickBackButton()
       await adminPrograms.expectProgramEditPage(programName)
-      expect(await page.locator('#apply-step-1-title').inputValue()).toEqual(
-        titleOne,
-      )
-      expect(
-        await page.locator('#apply-step-1-description').inputValue(),
-      ).toEqual(descriptionOne)
+
+      await expect(
+        page.getByRole('textbox', {name: 'Step 1 title'}),
+      ).toHaveValue(titleOne)
+      await expect(
+        page.getByRole('textbox', {name: 'Step 1 description'}),
+      ).toHaveValue(descriptionOne)
       // values that were entered for step three now show up under step 2
-      expect(await page.locator('#apply-step-2-title').inputValue()).toEqual(
-        titleThree,
-      )
-      expect(
-        await page.locator('#apply-step-2-description').inputValue(),
-      ).toEqual(descriptionThree)
+      await expect(
+        page.getByRole('textbox', {name: 'Step 2 title'}),
+      ).toHaveValue(titleThree)
+      await expect(
+        page.getByRole('textbox', {name: 'Step 2 description'}),
+      ).toHaveValue(descriptionThree)
       // step three is blank
-      expect(await page.locator('#apply-step-3-title').inputValue()).toEqual('')
-      expect(
-        await page.locator('#apply-step-3-description').inputValue(),
-      ).toEqual('')
+      await expect(
+        page.getByRole('textbox', {name: 'Step 3 title'}),
+      ).toHaveValue('')
+      await expect(
+        page.getByRole('textbox', {name: 'Step 3 description'}),
+      ).toHaveValue('')
     })
   })
 

--- a/browser-test/src/admin/admin_program_migration.test.ts
+++ b/browser-test/src/admin/admin_program_migration.test.ts
@@ -639,8 +639,30 @@ test.describe('program migration', () => {
 
     await test.step('check programs are in draft', async () => {
       await adminPrograms.gotoAdminProgramsPage()
-      await adminPrograms.expectDraftProgram('Comprehensive Sample Program')
-      await adminPrograms.expectDraftProgram('Minimal Sample Program')
+
+      // This was calling {@link AdminPrograms#expectDraftProgram}. That was using
+      // page.isVisible method which would use the first result if more than one
+      // was found. Modern Playwright locataor behavior is more strict.
+      //
+      // This is getting the first result replicating it with a web first assertion,
+      // but long term this needs to be written in a way that better targets the
+      // card selector
+      await expect(
+        page
+          .locator(
+            adminPrograms.programCardSelector(
+              'Comprehensive Sample Program',
+              'Draft',
+            ),
+          )
+          .first(),
+      ).toBeVisible()
+
+      await expect(
+        page.locator(
+          adminPrograms.programCardSelector('Minimal Sample Program', 'Draft'),
+        ),
+      ).toBeVisible()
     })
 
     await test.step('publish programs', async () => {

--- a/browser-test/src/admin/admin_question_translation.test.ts
+++ b/browser-test/src/admin/admin_question_translation.test.ts
@@ -103,17 +103,11 @@ test.describe('Admin can manage question translations', () => {
     // View the question translations and check that the Spanish translations for question help text are gone.
     await adminQuestions.goToQuestionTranslationPage(questionName)
     await adminTranslations.selectLanguage('Spanish')
-    expect(await page.inputValue('text=Question text')).toContain(
+    await expect(page.getByRole('textbox', {name: 'Question text'})).toHaveText(
       'something different',
     )
-
-    // Fix me! ESLint: playwright/prefer-web-first-assertions
-    // Directly switching to the best practice method fails
-    // because of a locator stict mode violation. That is it
-    // returns multiple elements.
-    //
-    // Recommended prefer-web-first-assertions fix:
-    //   await expect(page.locator('text=Question help text')).toHaveText('')
-    expect(await page.inputValue('text=Question help text')).toEqual('')
+    await expect(
+      page.getByRole('textbox', {name: 'Question help text'}),
+    ).toHaveText('')
   })
 })

--- a/browser-test/src/applicant/northstar_applicant_application_index.test.ts
+++ b/browser-test/src/applicant/northstar_applicant_application_index.test.ts
@@ -79,7 +79,7 @@ test.describe('applicant program index page', {tag: ['@northstar']}, () => {
     await adminSettings.saveChanges()
     await logout(page)
 
-    expect(await page.getByText(/To get help with/).textContent()).toBeTruthy()
+    await expect(page.getByText(/To get help with/)).toBeVisible()
   })
 
   test('validate initial page load as guest user', async ({

--- a/browser-test/src/applicant/questions/number_input.test.ts
+++ b/browser-test/src/applicant/questions/number_input.test.ts
@@ -137,14 +137,7 @@ test.describe('Number question for applicant flow', () => {
       await applicantQuestions.answerNumberQuestion('33', 1)
       await applicantQuestions.clickNext()
 
-      // Fix me! ESLint: playwright/prefer-web-first-assertions
-      // Directly switching to the best practice method fails
-      // because of a locator stict mode violation. That is it
-      // returns multiple elements.
-      //
-      // Recommended prefer-web-first-assertions fix:
-      //   await expect(page.locator(numberInputError)).toBeVisible()
-      expect(await page.isHidden(numberInputError)).toEqual(false)
+      await expect(page.locator(numberInputError).nth(0)).toBeVisible()
     })
 
     test('with second invalid does not submit', async ({
@@ -156,14 +149,7 @@ test.describe('Number question for applicant flow', () => {
       await applicantQuestions.answerNumberQuestion('-5', 1)
       await applicantQuestions.clickNext()
 
-      // Fix me! ESLint: playwright/prefer-web-first-assertions
-      // Directly switching to the best practice method fails
-      // because of a locator stict mode violation. That is it
-      // returns multiple elements.
-      //
-      // Recommended prefer-web-first-assertions fix:
-      //   await expect(page.locator(numberInputError + ' >> nth=1')).toBeVisible()
-      expect(await page.isHidden(numberInputError + ' >> nth=1')).toEqual(false)
+      await expect(page.locator(numberInputError).nth(1)).toBeVisible()
     })
 
     test('has no accessiblity violations', async ({

--- a/browser-test/src/question_lifecycle.test.ts
+++ b/browser-test/src/question_lifecycle.test.ts
@@ -449,20 +449,12 @@ test.describe('normal question lifecycle', () => {
     await adminQuestions.expectAdminQuestionsPageWithUpdateSuccessToast()
     await adminQuestions.gotoQuestionEditPage(questionName)
 
-    // Fix me! ESLint: playwright/prefer-web-first-assertions
-    // Directly switching to the best practice method fails
-    // because of a locator stict mode violation. That is it
-    // returns multiple elements.
-    //
-    // Recommended prefer-web-first-assertions fix:
-    // await expect(page.locator(adminQuestions.selectorForExportOption(AdminQuestions.EXPORT_VALUE_OPTION))).toBeChecked()
-    expect(
-      await page.isChecked(
-        adminQuestions.selectorForExportOption(
-          AdminQuestions.EXPORT_VALUE_OPTION,
-        ),
-      ),
-    ).toBeTruthy()
+    await expect(
+      page.getByRole('radio', {
+        name: AdminQuestions.EXPORT_VALUE_OPTION,
+        exact: true,
+      }),
+    ).toBeChecked()
   })
 
   test('shows the "Remove from universal questions" confirmation modal in the right circumstances and navigation works', async ({

--- a/browser-test/src/support/admin_program_statuses.ts
+++ b/browser-test/src/support/admin_program_statuses.ts
@@ -1,6 +1,11 @@
 import {expect} from '@playwright/test'
 import {ElementHandle, Page} from 'playwright'
-import {dismissModal, waitForAnyModal, waitForPageJsLoad} from './wait'
+import {
+  dismissModal,
+  waitForAnyModal,
+  waitForAnyModalLocator,
+  waitForPageJsLoad,
+} from './wait'
 
 export class AdminProgramStatuses {
   private page!: Page
@@ -218,21 +223,19 @@ export class AdminProgramStatuses {
       this.programStatusItemSelector(statusName) + ' button:has-text("Edit")',
     )
 
-    const modal = await waitForAnyModal(this.page)
-    expect(await modal.innerText()).toContain('Edit this status')
+    const modal = await waitForAnyModalLocator(this.page)
+    await expect(modal).toContainText('Edit this status')
 
     // We perform selectors within the modal since using the typical
     // selectors will match multiple modals on the page.
-    const emailFieldHandle = (await modal.$(
-      'text="Email the applicant about the status change"',
-    ))!
-    const emailBody = await emailFieldHandle.inputValue()
+    const emailBody = modal.getByText(
+      'Email the applicant about the status change',
+    )
 
     // Close the modal prior to any assertions to avoid affecting
     // subsequent tests.
+    await expect(emailBody).toHaveValue(expectedEmailBody)
     await dismissModal(this.page)
-
-    expect(emailBody).toEqual(expectedEmailBody)
   }
 
   async emailTranslationWarningIsVisible(statusName: string): Promise<boolean> {

--- a/browser-test/src/support/admin_programs.ts
+++ b/browser-test/src/support/admin_programs.ts
@@ -119,10 +119,16 @@ export class AdminPrograms {
   }
 
   async expectAdminProgramsPage() {
-    expect(await this.page.innerText('h1')).toEqual('Program dashboard')
-    expect(await this.page.innerText('h2')).toEqual(
-      'Create, edit and publish programs in ' + TEST_CIVIC_ENTITY_SHORT_NAME,
-    )
+    await expect(
+      this.page.getByRole('heading', {name: 'Program dashboard'}),
+    ).toBeVisible()
+    await expect(
+      this.page.getByRole('heading', {
+        name:
+          'Create, edit and publish programs in ' +
+          TEST_CIVIC_ENTITY_SHORT_NAME,
+      }),
+    ).toBeVisible()
   }
 
   async expectProgramExist(programName: string, description: string) {
@@ -379,13 +385,9 @@ export class AdminPrograms {
   }
 
   async expectProgramDetailsSaveAndContinueButton() {
-    expect(await this.page.innerText('#program-update-button')).toEqual(
-      'Save and continue to next step',
-    )
-  }
-
-  async expectProgramDetailsSaveButton() {
-    expect(await this.page.innerText('#program-update-button')).toEqual('Save')
+    await expect(
+      this.page.getByRole('button', {name: 'Save and continue to next step'}),
+    ).toBeVisible()
   }
 
   async editProgram(
@@ -704,23 +706,21 @@ export class AdminPrograms {
   }
 
   async expectDraftProgram(programName: string) {
-    expect(
-      await this.page.isVisible(this.programCardSelector(programName, 'Draft')),
-    ).toBe(true)
+    await expect(
+      this.page.locator(this.programCardSelector(programName, 'Draft')),
+    ).toBeVisible()
   }
 
   async expectDoesNotHaveDraftProgram(programName: string) {
-    expect(
-      await this.page.isVisible(this.programCardSelector(programName, 'Draft')),
-    ).toBe(false)
+    await expect(
+      this.page.locator(this.programCardSelector(programName, 'Draft')),
+    ).toBeHidden()
   }
 
   async expectActiveProgram(programName: string) {
-    expect(
-      await this.page.isVisible(
-        this.programCardSelector(programName, 'Active'),
-      ),
-    ).toBe(true)
+    await expect(
+      this.page.locator(this.programCardSelector(programName, 'Active')),
+    ).toBeVisible()
   }
 
   async expectProgramEditPage(programName = '') {

--- a/browser-test/src/support/admin_questions.ts
+++ b/browser-test/src/support/admin_questions.ts
@@ -196,7 +196,10 @@ export class AdminQuestions {
     if (!exportOption) {
       throw new Error('A non-empty export option must be provided')
     }
-    await this.page.check(this.selectorForExportOption(exportOption))
+
+    await this.page
+      .getByRole('radio', {name: exportOption, exact: true})
+      .check()
   }
 
   async updateQuestionText(updateText: string) {
@@ -1375,28 +1378,13 @@ export class AdminQuestions {
     deleteEntityButtonText: string
     addEntityButtonText: string
   }) {
-    // Fix me! ESLint: playwright/prefer-web-first-assertions
-    // Directly switching to the best practice method fails
-    // because of a locator stict mode violation. That is it
-    // returns multiple elements.
-    //
-    // Recommended prefer-web-first-assertions fix:
-    // await expect(this.page.locator('.cf-entity-name-input label')).toHaveText(
-    //   entityNameInputLabelText,
-    // )
-    // await expect(this.page.locator('.cf-enumerator-delete-button')).toHaveText(
-    //   deleteEntityButtonText,
-    // )
-    // await expect(this.page.locator('#enumerator-field-add-button')).toHaveText(
-    //   addEntityButtonText,
-    // )
-    expect(await this.page.innerText('.cf-entity-name-input label')).toBe(
-      entityNameInputLabelText,
-    )
-    expect(await this.page.innerText('.cf-enumerator-delete-button')).toBe(
-      deleteEntityButtonText,
-    )
-    expect(await this.page.innerText('#enumerator-field-add-button')).toBe(
+    await expect(
+      this.page.locator('.cf-entity-name-input label:visible'),
+    ).toHaveText(entityNameInputLabelText)
+    await expect(
+      this.page.locator('.cf-enumerator-delete-button:visible'),
+    ).toHaveText(deleteEntityButtonText)
+    await expect(this.page.locator('#enumerator-field-add-button')).toHaveText(
       addEntityButtonText,
     )
   }

--- a/browser-test/src/support/admin_settings.ts
+++ b/browser-test/src/support/admin_settings.ts
@@ -44,12 +44,9 @@ export class AdminSettings {
   }
 
   async expectStringSetting(settingName: string, value: string) {
-    expect(
-      await this.page
-        .getByTestId(`string-${settingName}`)
-        .locator('input')
-        .inputValue(),
-    ).toBe(value)
+    await expect(
+      this.page.getByTestId(`string-${settingName}`).locator('input'),
+    ).toHaveValue(value)
   }
 
   async saveChanges(expectUpdated = true) {

--- a/browser-test/src/support/admin_translations.ts
+++ b/browser-test/src/support/admin_translations.ts
@@ -150,10 +150,9 @@ export class AdminTranslations {
   }
 
   async expectNoProgramStatusTranslations() {
-    // Fix me! ESLint: playwright/prefer-web-first-assertions
-    expect(await this.page.isVisible(':has-text("Application status: ")')).toBe(
-      false,
-    )
+    await expect(
+      this.page.locator(':has-text("Application status: ")'),
+    ).toBeHidden()
   }
 
   async expectNoApplicationSteps() {
@@ -196,14 +195,12 @@ export class AdminTranslations {
     configuredStatusText: string
     expectStatusText: string
   }) {
-    const statusTextValue = await this.page.inputValue(
-      this.statusNameFieldSelector(configuredStatusText),
-    )
-    expect(statusTextValue).toEqual(expectStatusText)
-    const isStatusEmailVisible = await this.page.isVisible(
-      this.statusEmailFieldSelector(configuredStatusText),
-    )
-    expect(isStatusEmailVisible).toBe(false)
+    await expect(
+      this.page.locator(this.statusNameFieldSelector(configuredStatusText)),
+    ).toHaveValue(expectStatusText)
+    await expect(
+      this.page.locator(this.statusEmailFieldSelector(configuredStatusText)),
+    ).toBeHidden()
   }
 
   /**

--- a/browser-test/src/support/ti_dashboard.ts
+++ b/browser-test/src/support/ti_dashboard.ts
@@ -177,9 +177,9 @@ export class TIDashboard {
   }
 
   async expectClientContainsProgramNames(programs: string[]) {
-    const cardContainer = this.page.locator('#card_applications')
-    const programsText = await cardContainer.innerText()
-    expect(programsText).toBe(programs.join(', '))
+    await expect(this.page.locator('#card_applications')).toHaveText(
+      programs.join(', '),
+    )
   }
 
   async searchByDateOfBirth(dobDay: string, dobMonth: string, dobYear: string) {

--- a/browser-test/src/trusted_intermediary.test.ts
+++ b/browser-test/src/trusted_intermediary.test.ts
@@ -1185,22 +1185,23 @@ test.describe('Trusted intermediaries', () => {
 
       await test.step('verify client info is pre-populated in the application after clicking continue', async () => {
         await applicantQuestions.clickContinue()
-        expect(await page.locator('input[type=date]').inputValue()).toEqual(
-          '2001-01-01',
-        )
-        expect(
-          await page.locator('.cf-name-first').locator('input').inputValue(),
-        ).toEqual('first')
-        expect(
-          await page.locator('.cf-name-middle').locator('input').inputValue(),
-        ).toEqual('middle')
-        expect(
-          await page.locator('.cf-name-last').locator('input').inputValue(),
-        ).toEqual('last')
-        expect(
-          await page.locator('.cf-phone-number').locator('input').inputValue(),
-        ).toEqual('(917) 867-5309')
-        expect(await page.locator('input[type=email]').inputValue()).toEqual(
+
+        await expect(
+          page.getByRole('textbox', {name: 'Date of birth'}),
+        ).toHaveValue('2001-01-01')
+        await expect(
+          page.getByRole('textbox', {name: 'First name'}),
+        ).toHaveValue('first')
+        await expect(
+          page.getByRole('textbox', {name: 'Middle name'}),
+        ).toHaveValue('middle')
+        await expect(
+          page.getByRole('textbox', {name: 'Last name'}),
+        ).toHaveValue('last')
+        await expect(
+          page.getByRole('textbox', {name: 'Phone number'}),
+        ).toHaveValue('(917) 867-5309')
+        await expect(page.getByRole('textbox', {name: 'Email'})).toHaveValue(
           'test@email.com',
         )
         await validateScreenshot(page, 'pai-program-application')


### PR DESCRIPTION
### Description

Updating old asserts that don't follow the web first assertion playwright recommendation. Enabled the check in eslint.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
