### PR TITLE
Add note to monitor e2d test runs to on-call checklist

### DIFF
--- a/.github/ISSUE_TEMPLATE/oncall-rotation.md
+++ b/.github/ISSUE_TEMPLATE/oncall-rotation.md
@@ -36,7 +36,7 @@ Resources:
 
 - [ ] Create an Oncall issue for the next rotation, and assign to the next oncall
 - [ ] Check Security lists daily
-- [ ] Check #ci Slack channel daily to monitor failed pushes
+- [ ] Check #ci Slack channel daily to monitor failed pushes and e2e test runs
 - [ ] Check [needs triage bugs](https://github.com/civiform/civiform/issues?q=is%3Aopen+is%3Aissue+label%3Aneeds-triage) daily to ensure there aren't any P0s
 - [ ] Check for dependency updates
   - For any problematic dependency updates that break tests, add the "needs-triage" label so Exygy can prioritize fixing these issues.


### PR DESCRIPTION
### Description

Per our discussion in eng weekly, I'm adding a note to monitor our #eng-ci channel for failed end to end test runs.

#### General

- [ ] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [ ] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
