### PR TITLE
Link to program overview page from eligibility message

### DIFF
--- a/browser-test/src/applicant/northstar_ineligible.test.ts
+++ b/browser-test/src/applicant/northstar_ineligible.test.ts
@@ -216,6 +216,10 @@ test.describe('North Star Ineligible Page Tests', {tag: ['@northstar']}, () => {
       ).toBeVisible()
       await expect(page.getByText('Apply to another program')).toBeVisible()
       await expect(page.getByText('Edit my responses')).toBeVisible()
+      await expect(page.getByText('program details')).toHaveAttribute(
+        'href',
+        '/programs/pet-assistance-program',
+      )
 
       await page.click('#header-return-home')
       await tiDashboard.clickOnViewApplications()

--- a/browser-test/src/applicant/northstar_ineligible.test.ts
+++ b/browser-test/src/applicant/northstar_ineligible.test.ts
@@ -216,10 +216,8 @@ test.describe('North Star Ineligible Page Tests', {tag: ['@northstar']}, () => {
       ).toBeVisible()
       await expect(page.getByText('Apply to another program')).toBeVisible()
       await expect(page.getByText('Edit my responses')).toBeVisible()
-      await expect(page.getByText('program details')).toHaveAttribute(
-        'href',
-        '/programs/pet-assistance-program',
-      )
+      const href = await page.getByText('program details').getAttribute('href')
+      expect(href).toContain('/pet-assistance-program')
 
       await page.click('#header-return-home')
       await tiDashboard.clickOnViewApplications()

--- a/server/app/views/applicant/NorthStarApplicantIneligibleView.java
+++ b/server/app/views/applicant/NorthStarApplicantIneligibleView.java
@@ -95,7 +95,8 @@ public class NorthStarApplicantIneligibleView extends NorthStarBaseView {
 
     // Manually construct a hyperlink with a runtime href and localized string. The hyperlink will
     // be inserted into another localized string in the Thymeleaf template.
-    String linkHref = applicantRoutes.show(program.slug()).url();
+    String linkHref =
+        applicantRoutes.show(params.profile(), params.applicantId(), program.slug()).url();
     String linkText =
         params.messages().at(MessageKey.LINK_PROGRAM_DETAILS.getKeyName()).toLowerCase(Locale.ROOT);
     String linkHtml =

--- a/server/app/views/applicant/NorthStarApplicantIneligibleView.java
+++ b/server/app/views/applicant/NorthStarApplicantIneligibleView.java
@@ -95,10 +95,7 @@ public class NorthStarApplicantIneligibleView extends NorthStarBaseView {
 
     // Manually construct a hyperlink with a runtime href and localized string. The hyperlink will
     // be inserted into another localized string in the Thymeleaf template.
-    String linkHref =
-        program.externalLink().isEmpty()
-            ? applicantRoutes.show(params.profile(), params.applicantId(), program.slug()).url()
-            : program.externalLink();
+    String linkHref = applicantRoutes.show(program.slug()).url();
     String linkText =
         params.messages().at(MessageKey.LINK_PROGRAM_DETAILS.getKeyName()).toLowerCase(Locale.ROOT);
     String linkHtml =

--- a/server/app/views/applicant/NorthStarApplicantIneligibleView.java
+++ b/server/app/views/applicant/NorthStarApplicantIneligibleView.java
@@ -95,10 +95,9 @@ public class NorthStarApplicantIneligibleView extends NorthStarBaseView {
 
     // Manually construct a hyperlink with a runtime href and localized string. The hyperlink will
     // be inserted into another localized string in the Thymeleaf template.
-    // TODO: Update this to point to the new northstar details page.
     String linkHref =
         program.externalLink().isEmpty()
-            ? applicantRoutes.review(params.profile(), params.applicantId(), program.id()).url()
+            ? applicantRoutes.show(params.profile(), params.applicantId(), program.slug()).url()
             : program.externalLink();
     String linkText =
         params.messages().at(MessageKey.LINK_PROGRAM_DETAILS.getKeyName()).toLowerCase(Locale.ROOT);


### PR DESCRIPTION
### Description

In the hyperlink on the ineligible page in North Star UI, link to the program overview page instead of the external program URL.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)

### Instructions for manual testing

As an admin, create a program with a gating eligibility condition. As an applicant, apply to the program with an answer that does not meet the eligibility criteria. On the ineligible page, "program details" should link to the program overview page, whether or not an external program URL was set by the admin.

### Issue(s) this completes

Fixes #10117
