### PR TITLE
Fix test for staging run

### DIFF
--- a/browser-test/src/admin/admin_settings.test.ts
+++ b/browser-test/src/admin/admin_settings.test.ts
@@ -59,6 +59,7 @@ test.describe('Managing system-wide settings', () => {
       await adminSettings.disableSetting('ALLOW_CIVIFORM_ADMIN_ACCESS_PROGRAMS')
       await adminSettings.saveChanges()
       await adminSettings.expectDisabled('ALLOW_CIVIFORM_ADMIN_ACCESS_PROGRAMS')
+
       await adminSettings.disableSetting('ALLOW_CIVIFORM_ADMIN_ACCESS_PROGRAMS')
       await adminSettings.saveChanges(/* expectUpdated= */ false)
     })

--- a/browser-test/src/admin/admin_settings.test.ts
+++ b/browser-test/src/admin/admin_settings.test.ts
@@ -58,9 +58,6 @@ test.describe('Managing system-wide settings', () => {
       await adminSettings.disableSetting('ALLOW_CIVIFORM_ADMIN_ACCESS_PROGRAMS')
       await adminSettings.saveChanges()
       await adminSettings.expectDisabled('ALLOW_CIVIFORM_ADMIN_ACCESS_PROGRAMS')
-
-      await adminSettings.disableSetting('ALLOW_CIVIFORM_ADMIN_ACCESS_PROGRAMS')
-      await adminSettings.saveChanges(/* expectUpdated= */ false)
     })
   })
 })

--- a/browser-test/src/admin/admin_settings.test.ts
+++ b/browser-test/src/admin/admin_settings.test.ts
@@ -1,5 +1,5 @@
 import {test} from '../support/civiform_fixtures'
-import {enableFeatureFlag, loginAsAdmin, validateScreenshot} from '../support'
+import {disableFeatureFlag, loginAsAdmin, validateScreenshot} from '../support'
 
 test.describe('Managing system-wide settings', () => {
   test('Displays the settings page', async ({page, adminSettings}) => {
@@ -50,7 +50,7 @@ test.describe('Managing system-wide settings', () => {
     await adminSettings.gotoAdminSettings()
 
     await test.step('button check', async () => {
-      await enableFeatureFlag(page, 'allow_civiform_admin_access')
+      await disableFeatureFlag(page, 'allow_civiform_admin_access')
       await adminSettings.enableSetting('ALLOW_CIVIFORM_ADMIN_ACCESS_PROGRAMS')
       await adminSettings.saveChanges()
       await adminSettings.expectEnabled('ALLOW_CIVIFORM_ADMIN_ACCESS_PROGRAMS')

--- a/browser-test/src/admin/admin_settings.test.ts
+++ b/browser-test/src/admin/admin_settings.test.ts
@@ -4,6 +4,7 @@ import {disableFeatureFlag, loginAsAdmin, validateScreenshot} from '../support'
 test.describe('Managing system-wide settings', () => {
   test('Displays the settings page', async ({page, adminSettings}) => {
     await loginAsAdmin(page)
+    await disableFeatureFlag(page, 'allow_civiform_admin_access_programs')
 
     await test.step('Go to admin settings page and take screenshot', async () => {
       await page.setViewportSize({
@@ -51,7 +52,6 @@ test.describe('Managing system-wide settings', () => {
     await adminSettings.gotoAdminSettings()
 
     await test.step('button check', async () => {
-      await disableFeatureFlag(page, 'allow_civiform_admin_access_programs')
       await adminSettings.enableSetting('ALLOW_CIVIFORM_ADMIN_ACCESS_PROGRAMS')
       await adminSettings.saveChanges()
       await adminSettings.expectEnabled('ALLOW_CIVIFORM_ADMIN_ACCESS_PROGRAMS')

--- a/browser-test/src/admin/admin_settings.test.ts
+++ b/browser-test/src/admin/admin_settings.test.ts
@@ -1,5 +1,5 @@
 import {test} from '../support/civiform_fixtures'
-import {isLocalDevEnvironment, loginAsAdmin, validateScreenshot} from '../support'
+import {enableFeatureFlag, loginAsAdmin, validateScreenshot} from '../support'
 
 test.describe('Managing system-wide settings', () => {
   test('Displays the settings page', async ({page, adminSettings}) => {
@@ -44,23 +44,22 @@ test.describe('Managing system-wide settings', () => {
       )
     })
   })
-  if (isLocalDevEnvironment()) {
-    test('Updates settings on save', async ({page, adminSettings}) => {
-      await loginAsAdmin(page)
-  
-      await adminSettings.gotoAdminSettings()
-  
-      await test.step('button check', async () => {
-        await adminSettings.enableSetting('ALLOW_CIVIFORM_ADMIN_ACCESS_PROGRAMS')
-        await adminSettings.saveChanges()
-        await adminSettings.expectEnabled('ALLOW_CIVIFORM_ADMIN_ACCESS_PROGRAMS')
-  
-        await adminSettings.disableSetting('ALLOW_CIVIFORM_ADMIN_ACCESS_PROGRAMS')
-        await adminSettings.saveChanges()
-        await adminSettings.expectDisabled('ALLOW_CIVIFORM_ADMIN_ACCESS_PROGRAMS')
-        await adminSettings.disableSetting('ALLOW_CIVIFORM_ADMIN_ACCESS_PROGRAMS')
-        await adminSettings.saveChanges(/* expectUpdated= */ false)
-      })
+  test('Updates settings on save', async ({page, adminSettings}) => {
+    await loginAsAdmin(page)
+
+    await adminSettings.gotoAdminSettings()
+
+    await test.step('button check', async () => {
+      await enableFeatureFlag(page, 'allow_civiform_admin_access')
+      await adminSettings.enableSetting('ALLOW_CIVIFORM_ADMIN_ACCESS_PROGRAMS')
+      await adminSettings.saveChanges()
+      await adminSettings.expectEnabled('ALLOW_CIVIFORM_ADMIN_ACCESS_PROGRAMS')
+
+      await adminSettings.disableSetting('ALLOW_CIVIFORM_ADMIN_ACCESS_PROGRAMS')
+      await adminSettings.saveChanges()
+      await adminSettings.expectDisabled('ALLOW_CIVIFORM_ADMIN_ACCESS_PROGRAMS')
+      await adminSettings.disableSetting('ALLOW_CIVIFORM_ADMIN_ACCESS_PROGRAMS')
+      await adminSettings.saveChanges(/* expectUpdated= */ false)
     })
-  }
+  })
 })

--- a/browser-test/src/admin/admin_settings.test.ts
+++ b/browser-test/src/admin/admin_settings.test.ts
@@ -51,7 +51,7 @@ test.describe('Managing system-wide settings', () => {
     await adminSettings.gotoAdminSettings()
 
     await test.step('button check', async () => {
-      await disableFeatureFlag(page, 'allow_civiform_admin_access')
+      await disableFeatureFlag(page, 'allow_civiform_admin_access_programs')
       await adminSettings.enableSetting('ALLOW_CIVIFORM_ADMIN_ACCESS_PROGRAMS')
       await adminSettings.saveChanges()
       await adminSettings.expectEnabled('ALLOW_CIVIFORM_ADMIN_ACCESS_PROGRAMS')

--- a/browser-test/src/admin/admin_settings.test.ts
+++ b/browser-test/src/admin/admin_settings.test.ts
@@ -1,5 +1,5 @@
 import {test} from '../support/civiform_fixtures'
-import {loginAsAdmin, validateScreenshot} from '../support'
+import {isLocalDevEnvironment, loginAsAdmin, validateScreenshot} from '../support'
 
 test.describe('Managing system-wide settings', () => {
   test('Displays the settings page', async ({page, adminSettings}) => {
@@ -44,20 +44,23 @@ test.describe('Managing system-wide settings', () => {
       )
     })
   })
-
-  test('Updates settings on save', async ({page, adminSettings}) => {
-    await loginAsAdmin(page)
-
-    await adminSettings.gotoAdminSettings()
-
-    await test.step('button check', async () => {
-      await adminSettings.enableSetting('ALLOW_CIVIFORM_ADMIN_ACCESS_PROGRAMS')
-      await adminSettings.saveChanges()
-      await adminSettings.expectEnabled('ALLOW_CIVIFORM_ADMIN_ACCESS_PROGRAMS')
-
-      await adminSettings.disableSetting('ALLOW_CIVIFORM_ADMIN_ACCESS_PROGRAMS')
-      await adminSettings.saveChanges()
-      await adminSettings.expectDisabled('ALLOW_CIVIFORM_ADMIN_ACCESS_PROGRAMS')
+  if (isLocalDevEnvironment()) {
+    test('Updates settings on save', async ({page, adminSettings}) => {
+      await loginAsAdmin(page)
+  
+      await adminSettings.gotoAdminSettings()
+  
+      await test.step('button check', async () => {
+        await adminSettings.enableSetting('ALLOW_CIVIFORM_ADMIN_ACCESS_PROGRAMS')
+        await adminSettings.saveChanges()
+        await adminSettings.expectEnabled('ALLOW_CIVIFORM_ADMIN_ACCESS_PROGRAMS')
+  
+        await adminSettings.disableSetting('ALLOW_CIVIFORM_ADMIN_ACCESS_PROGRAMS')
+        await adminSettings.saveChanges()
+        await adminSettings.expectDisabled('ALLOW_CIVIFORM_ADMIN_ACCESS_PROGRAMS')
+        await adminSettings.disableSetting('ALLOW_CIVIFORM_ADMIN_ACCESS_PROGRAMS')
+        await adminSettings.saveChanges(/* expectUpdated= */ false)
+      })
     })
-  })
+  }
 })

--- a/browser-test/src/admin/admin_settings.test.ts
+++ b/browser-test/src/admin/admin_settings.test.ts
@@ -44,6 +44,7 @@ test.describe('Managing system-wide settings', () => {
       )
     })
   })
+
   test('Updates settings on save', async ({page, adminSettings}) => {
     await loginAsAdmin(page)
 


### PR DESCRIPTION
### Description

We were getting an error:

Expected substring: "Settings updated"
Received string:    "No changes to save"

This is because we staging has this flag defaulted to one value and local has it defaulted to another. https://github.com/civiform/civiform/pull/9956 is the PR that updated the flag we use in this test

Changing the feature flag value before the test to ensure it is always consistent


### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`

### Issue(s) this completes

Fixes #<issue_number>; Fixes #<issue_number>...
