### PR TITLE
Fix test for staging run take 2

### DIFF
--- a/browser-test/src/admin/admin_settings.test.ts
+++ b/browser-test/src/admin/admin_settings.test.ts
@@ -2,10 +2,12 @@ import {test} from '../support/civiform_fixtures'
 import {disableFeatureFlag, loginAsAdmin, validateScreenshot} from '../support'
 
 test.describe('Managing system-wide settings', () => {
-  test('Displays the settings page', async ({page, adminSettings}) => {
+  test.beforeEach(async ({page}) => {
     await loginAsAdmin(page)
     await disableFeatureFlag(page, 'allow_civiform_admin_access_programs')
+  })
 
+  test('Displays the settings page', async ({page, adminSettings}) => {
     await test.step('Go to admin settings page and take screenshot', async () => {
       await page.setViewportSize({
         width: 1280,
@@ -46,9 +48,7 @@ test.describe('Managing system-wide settings', () => {
     })
   })
 
-  test('Updates settings on save', async ({page, adminSettings}) => {
-    await loginAsAdmin(page)
-
+  test('Updates settings on save', async ({adminSettings}) => {
     await adminSettings.gotoAdminSettings()
 
     await test.step('button check', async () => {


### PR DESCRIPTION
### Description

Another test is failing in the same test class as before (see https://github.com/civiform/civiform/pull/10133). This PR updates that test file to disable the feature flag before each test.

#### General

- [ ] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [ ] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
