### PR TITLE
[North Star] use uswds styling in language selector

### DIFF
--- a/browser-test/src/admin/admin_program_translation.test.ts
+++ b/browser-test/src/admin/admin_program_translation.test.ts
@@ -5,6 +5,7 @@ import {
   logout,
   loginAsTestUser,
   selectApplicantLanguage,
+  selectApplicantLanguageNorthstar,
   validateScreenshot,
   validateToastMessage,
 } from '../support'
@@ -532,7 +533,7 @@ test.describe('Admin can manage program translations', () => {
       await test.step('Publish and verify in the applicant experience', async () => {
         await adminPrograms.publishProgram(programName)
         await logout(page)
-        await selectApplicantLanguage(page, 'Español')
+        await selectApplicantLanguageNorthstar(page, 'es-US')
         await applicantQuestions.clickApplyProgramButton('Spanish name')
         await applicantProgramOverview.startApplicationFromTranslatedProgramOverviewPage(
           'Descripción general del programa', // translated page title

--- a/browser-test/src/applicant/northstar_applicant_application_index.test.ts
+++ b/browser-test/src/applicant/northstar_applicant_application_index.test.ts
@@ -11,7 +11,7 @@ import {
   validateAccessibility,
   validateScreenshot,
   seedProgramsAndCategories,
-  selectApplicantLanguage,
+  selectApplicantLanguageNorthstar,
   normalizeElements,
 } from '../support'
 import {Locator, Page} from 'playwright'
@@ -130,7 +130,7 @@ test.describe('applicant program index page', {tag: ['@northstar']}, () => {
     applicantQuestions,
   }) => {
     await applicantQuestions.gotoApplicantHomePage()
-    await selectApplicantLanguage(page, 'Español')
+    await selectApplicantLanguageNorthstar(page, 'es-US')
     expect(await page.textContent('html')).not.toContain('End session')
     expect(await page.textContent('html')).not.toContain("You're a guest user")
   })

--- a/browser-test/src/applicant/northstar_applicant_question_translation.test.ts
+++ b/browser-test/src/applicant/northstar_applicant_question_translation.test.ts
@@ -3,7 +3,7 @@ import {
   enableFeatureFlag,
   loginAsAdmin,
   logout,
-  selectApplicantLanguage,
+  selectApplicantLanguageNorthstar,
   validateScreenshot,
 } from '../support'
 
@@ -46,7 +46,7 @@ test.describe('Admin can manage translations', {tag: ['@northstar']}, () => {
     await logout(page)
 
     // Go to the home page and select Spanish as the language
-    await selectApplicantLanguage(page, 'Español')
+    await selectApplicantLanguageNorthstar(page, 'es-US')
     await applicantQuestions.validateHeader('es-US')
 
     await applicantQuestions.applyProgram(
@@ -61,7 +61,7 @@ test.describe('Admin can manage translations', {tag: ['@northstar']}, () => {
     )
 
     // TODO(#9203): When the bug is fixed, we don't need to select Español again.
-    await selectApplicantLanguage(page, 'Español')
+    await selectApplicantLanguageNorthstar(page, 'es-US')
     await applicantQuestions.validateHeader('es-US')
 
     expect(await page.innerText('.cf-applicant-question-text')).toContain(
@@ -108,7 +108,7 @@ test.describe('Admin can manage translations', {tag: ['@northstar']}, () => {
       programName,
       /* northStarEnabled= */ true,
     )
-    await selectApplicantLanguage(page, 'Español')
+    await selectApplicantLanguageNorthstar(page, 'es-US')
     await applicantQuestions.validateHeader('es-US')
 
     await validateScreenshot(
@@ -159,7 +159,7 @@ test.describe('Admin can manage translations', {tag: ['@northstar']}, () => {
       programName,
       /* northStarEnabled= */ true,
     )
-    await selectApplicantLanguage(page, 'Español')
+    await selectApplicantLanguageNorthstar(page, 'es-US')
 
     expect(await page.innerText('main form')).toContain('uno')
     expect(await page.innerText('main form')).toContain('dos')
@@ -198,7 +198,7 @@ test.describe('Admin can manage translations', {tag: ['@northstar']}, () => {
       programName,
       /* northStarEnabled= */ true,
     )
-    await selectApplicantLanguage(page, 'Español')
+    await selectApplicantLanguageNorthstar(page, 'es-US')
 
     expect(await page.innerText('main form')).toContain('miembro de la familia')
   })

--- a/browser-test/src/support/index.ts
+++ b/browser-test/src/support/index.ts
@@ -240,6 +240,19 @@ export const selectApplicantLanguage = async (page: Page, language: string) => {
   })
 }
 
+export const selectApplicantLanguageNorthstar = async (
+  page: Page,
+  languageCode: string,
+) => {
+  await test.step('Set applicant language from header dropdown', async () => {
+    await page.click('#select-language-menu')
+
+    await page.click(`#select-language-${languageCode}`)
+
+    await waitForPageJsLoad(page)
+  })
+}
+
 export const seedProgramsAndCategories = async (page: Page) => {
   await test.step('Seed programs', async () => {
     await page.goto('/dev/seed')

--- a/server/app/assets/stylesheets/northstar/_uswds-theme-custom-styles.scss
+++ b/server/app/assets/stylesheets/northstar/_uswds-theme-custom-styles.scss
@@ -447,3 +447,28 @@ main {
 .cf-wrap-anywhere {
   overflow-wrap: anywhere;
 }
+
+// Custom styling to make the usa-language component work with buttons rather than anchors
+.usa-language__submenu-item {
+  &:focus {
+    outline-offset: units('neg-05');
+  }
+
+  &:hover {
+    color: color('white');
+    text-decoration: underline;
+    cursor: pointer;
+  }
+
+  button {
+    all: unset;
+    color: color('white');
+    display: block;
+    line-height: line-height($theme-navigation-font-family, 3);
+    padding: 0;
+    padding: units(1);
+    text-decoration: none;
+    display: block;
+    width: 100%;
+  }
+}

--- a/server/app/views/applicant/NavigationFragment.html
+++ b/server/app/views/applicant/NavigationFragment.html
@@ -277,6 +277,7 @@
     <ul class="usa-language__primary usa-accordion">
       <li class="usa-language__primary-item">
         <button
+          id="select-language-menu"
           type="button"
           class="usa-button usa-language__link"
           role="button"
@@ -295,6 +296,7 @@
             class="usa-language__submenu-item"
           >
             <button
+              th:id="|select-language-${language.key.code()}|"
               name="locale"
               type="submit"
               th:value="${language.key.code()}"

--- a/server/app/views/applicant/NavigationFragment.html
+++ b/server/app/views/applicant/NavigationFragment.html
@@ -281,7 +281,7 @@
           type="button"
           class="usa-button usa-language__link"
           role="button"
-          aria-expanded="true"
+          aria-expanded="false"
           aria-controls="select-language"
           th:text="#{button.languages}"
         ></button>

--- a/server/app/views/applicant/NavigationFragment.html
+++ b/server/app/views/applicant/NavigationFragment.html
@@ -286,12 +286,10 @@
         ></button>
         <ul
           th:aria-label="#{label.languageSr}"
-          k
           id="select-language"
           class="usa-language__submenu"
           hidden="true"
         >
-          k
           <li
             th:each="language: ${enabledLanguages}"
             class="usa-language__submenu-item"

--- a/server/app/views/applicant/NavigationFragment.html
+++ b/server/app/views/applicant/NavigationFragment.html
@@ -274,20 +274,38 @@
     <input hidden th:value="${csrfToken}" name="csrfToken" />
     <input hidden th:value="${requestUri}" name="redirectLink" />
 
-    <select
-      name="locale"
-      th:aria-label="#{label.languageSr}"
-      class="usa-button margin-right-0"
-      id="select-language"
-    >
-      <option th:text="#{button.languages}"></option>
-      <option
-        class="usa-language__submenu-item"
-        th:each="language: ${enabledLanguages}"
-        th:value="${language.key.code()}"
-        th:text="${language.value}"
-      ></option>
-    </select>
+    <ul class="usa-language__primary usa-accordion">
+      <li class="usa-language__primary-item">
+        <button
+          type="button"
+          class="usa-button usa-language__link"
+          role="button"
+          aria-expanded="true"
+          aria-controls="select-language"
+          th:text="#{button.languages}"
+        ></button>
+        <ul
+          th:aria-label="#{label.languageSr}"
+          k
+          id="select-language"
+          class="usa-language__submenu"
+          hidden="true"
+        >
+          k
+          <li
+            th:each="language: ${enabledLanguages}"
+            class="usa-language__submenu-item"
+          >
+            <button
+              name="locale"
+              type="submit"
+              th:value="${language.key.code()}"
+              th:text="${language.value}"
+            ></button>
+          </li>
+        </ul>
+      </li>
+    </ul>
   </form>
 </div>
 


### PR DESCRIPTION
### Description

Updates the language selector to use the same styling as the USWDS language selector.

Had to do some custom styling because the USWDS component expects the dropdown to have anchor tags and we need to use buttons.

NOTE: found an accessibility bug on mobile view but it's unrelated to a pr - if you are testing on an actual device, it won't tab into the menu

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)

#### User visible changes

- [x] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [x] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [x] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [x] Manually tested at 200% size
- [x] Manually evaluated tab order
- [x] Manually tested with a screen reader if the feature is applicant-facing. See [screen reader testing](https://github.com/civiform/civiform/wiki/Testing#screen-reader-testing)

### Issue(s) this completes

Fixes #9918; 