### PR TITLE
Remove aria-label from prescreener card buttons

### DIFF
--- a/server/app/views/applicant/ProgramCardsSectionFragment.html
+++ b/server/app/views/applicant/ProgramCardsSectionFragment.html
@@ -182,7 +182,6 @@
         th:href="${card.actionUrl()}"
         class="usa-button cf-apply-button"
         th:text="${card.actionText()}"
-        th:aria-label="#{button.viewAndApplySr(${card.title()})}"
       ></a>
     </div>
   </div>


### PR DESCRIPTION
### Description

Removing the aria-label will result in the screen reader reading the same text as what is on the button, vs. now the two are mismatched.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)

#### User visible changes

- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [x] Manually tested with a screen reader if the feature is applicant-facing. See [screen reader testing](https://github.com/civiform/civiform/wiki/Testing#screen-reader-testing)

### Instructions for manual testing

If instructions are needed for manual testing by reviewers, include them here.

### Issue(s) this completes

Fixes #9909
