### PR TITLE
[A11y] Fix navigation menu voiceover in mobile view

### DIFF
--- a/server/app/assets/stylesheets/northstar/_uswds-theme-custom-styles.scss
+++ b/server/app/assets/stylesheets/northstar/_uswds-theme-custom-styles.scss
@@ -279,6 +279,11 @@ it is around the label */
   }
 }
 
+// Styles the header to be vertically aligned
+.usa-header--basic .usa-nav-container {
+  align-items: center;
+}
+
 // Styles common to tablet and mobile
 @media (max-width: 63.9em) {
   // Hide the logo on mobile and tablet

--- a/server/app/views/applicant/NavigationFragment.html
+++ b/server/app/views/applicant/NavigationFragment.html
@@ -10,70 +10,68 @@
   <div class="usa-overlay"></div>
   <header class="usa-header usa-header--basic" role="banner">
     <div class="usa-nav-container">
-      <div class="display-flex flex-align-center grid-col-fill">
-        <div class="usa-navbar width-full">
-          <a
-            href="/"
-            class="usa-logo display-flex flex-align-center text-ink text-no-underline"
-            id="header-return-home"
-          >
-            <div class="padding-top-2 padding-bottom-2">
-              <img
-                th:src="${smallLogoUrl}"
-                class="height-8 cf-header-logo padding-right-2"
-                th:attr="alt=${civicEntityFullName + ' Logo'}"
-              />
-            </div>
-            <em class="usa-logo__text">
-              <!--/* This span is added only if the flag is enabled to hide the government name. In that case, we will hide the name on destop (when the logo appears) */-->
-              <span
-                class="cf-gov-name desktop:display-none"
-                th:if="${hideCivicEntityName}"
-                th:text="${civicEntityShortName}"
-              ></span>
-              <!--/* This span is added only if the flag to hide the government name is disabled */-->
-              <span
-                th:if="${!hideCivicEntityName}"
-                th:text="${civicEntityShortName}"
-              ></span>
-              <span>CiviForm</span>
-            </em>
-          </a>
-          <button
-            type="button"
-            class="usa-menu-btn"
-            th:text="#{header.menu}"
-          ></button>
-        </div>
-        <nav
-          th:aria-label="#{label.primaryNavigation}"
-          class="usa-nav grid-container"
-          role="navigation"
+      <div class="usa-navbar width-full">
+        <a
+          href="/"
+          class="usa-logo display-flex flex-align-center text-ink text-no-underline"
+          id="header-return-home"
         >
-          <button
-            type="button"
-            class="usa-nav__close"
-            th:aria-label="#{button.close}"
-          >
-            <svg
-              th:replace="~{applicant/ApplicantBaseFragment :: icon(${closeIcon})}"
-            ></svg>
-          </button>
-          <div class="display-flex grid-col-fill flex-column flex-align-end">
-            <div th:replace="~{this :: userName}"></div>
-            <div class="grid-row grid-gap-1">
-              <button
-                th:if="${showDebugTools}"
-                th:replace="~{this :: showDebugTools}"
-              ></button>
-              <div>
-                <button th:replace="~{this :: loginOrLogout}"></button>
-              </div>
-              <button th:replace="~{this :: languageSelector}"></button>
-            </div>
+          <div class="padding-top-2 padding-bottom-2">
+            <img
+              th:src="${smallLogoUrl}"
+              class="height-8 cf-header-logo padding-right-2"
+              th:attr="alt=${civicEntityFullName + ' Logo'}"
+            />
           </div>
-        </nav>
+          <em class="usa-logo__text">
+            <!--/* This span is added only if the flag is enabled to hide the government name. In that case, we will hide the name on destop (when the logo appears) */-->
+            <span
+              class="cf-gov-name desktop:display-none"
+              th:if="${hideCivicEntityName}"
+              th:text="${civicEntityShortName}"
+            ></span>
+            <!--/* This span is added only if the flag to hide the government name is disabled */-->
+            <span
+              th:if="${!hideCivicEntityName}"
+              th:text="${civicEntityShortName}"
+            ></span>
+            <span>CiviForm</span>
+          </em>
+        </a>
+        <button
+          type="button"
+          class="usa-menu-btn"
+          th:text="#{header.menu}"
+        ></button>
       </div>
+      <nav
+        th:aria-label="#{label.primaryNavigation}"
+        class="usa-nav grid-container"
+        role="navigation"
+      >
+        <button
+          type="button"
+          class="usa-nav__close"
+          th:aria-label="#{button.close}"
+        >
+          <svg
+            th:replace="~{applicant/ApplicantBaseFragment :: icon(${closeIcon})}"
+          ></svg>
+        </button>
+        <div class="display-flex grid-col-fill flex-column flex-align-end">
+          <div th:replace="~{this :: userName}"></div>
+          <div class="grid-row grid-gap-1">
+            <button
+              th:if="${showDebugTools}"
+              th:replace="~{this :: showDebugTools}"
+            ></button>
+            <div>
+              <button th:replace="~{this :: loginOrLogout}"></button>
+            </div>
+            <button th:replace="~{this :: languageSelector}"></button>
+          </div>
+        </div>
+      </nav>
     </div>
   </header>
   <div th:replace="~{this :: guestSessionAlert}"></div>


### PR DESCRIPTION
### Description

On iOS voiceover, the menu options are being skipped. I _think_ this is due to some unneeded formatting that I removed in this pr.

Before: 
https://github.com/user-attachments/assets/fc74c50f-b0da-4e22-bd28-c77954a54221

After:
https://github.com/user-attachments/assets/94f920f2-4665-44d7-91ef-e91408e26790

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`

#### User visible changes

- [ ] Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
  - [ ] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [ ] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Made equivalent changes in Thymeleaf for applicant-facing features and changes (or created an issue in the [Northstar epic](https://github.com/orgs/civiform/projects/1/views/94) to track that it's missing from Thymeleaf)
- [x] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [ ] Manually tested at 200% size
- [x] Manually evaluated tab order
- [x] Manually tested with a screen reader if the feature is applicant-facing. See [screen reader testing](https://github.com/civiform/civiform/wiki/Testing#screen-reader-testing)