### PR TITLE
[SessionTimeout][part8] Increase gap between timeout events in browser test and handle context destruction.

### DIFF
--- a/server/conf/application.dev-browser-tests.conf
+++ b/server/conf/application.dev-browser-tests.conf
@@ -33,8 +33,8 @@ name_suffix_dropdown_enabled = true
 durable_jobs.poll_interval_seconds = 3600
 
 # Warn the user 10 mins before the inactivity timeout
-session_inactivity_warning_threshold_minutes = 10
-session_inactivity_timeout_minutes = 30
+session_inactivity_warning_threshold_minutes = 55
+session_inactivity_timeout_minutes = 60
  # Warn the user 35 mins before the max session duration timeout, 5 mins before inactivity timeout
-session_duration_warning_threshold_minutes = 35
-maximum_session_duration_minutes = 60
+session_duration_warning_threshold_minutes = 100
+maximum_session_duration_minutes = 120


### PR DESCRIPTION
### Description

These changes simply increase the time between the timeout events. The session timeout browser test currently test for 4 events to happen in this order: session inactivity warning, session length warning, inactivity timeout and then session length timeout. The test also rely on Playwright's clock API to advance time. The tests were flaking because the session length warning timestamp was too close to inactivity timeout and in traces, it can be seen that the timeout was processed right before the session length warning dialog was fully displayed. Also, when advancing the time to a timeout could sometime lead to user logout before we actually send the timechange event. This was result in an error where the page context is destroyed(due to navigation) at the time of sending timechange event. This change skip sending timechange event in this case.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`

### Instructions for manual testing

If instructions are needed for manual testing by reviewers, include them here.

### Issue(s) this completes

Fixes #<issue_number>; Fixes #<issue_number>...
