### PR TITLE
Add missing = in inline param comments

### DIFF
--- a/browser-test/src/admin/admin_program_email_notifications.test.ts
+++ b/browser-test/src/admin/admin_program_email_notifications.test.ts
@@ -21,7 +21,7 @@ test.describe('program email notifications', () => {
         undefined,
         undefined,
         undefined,
-        /* submitNewProgram */ false,
+        /* submitNewProgram= */ false,
       )
       await adminPrograms.expectEmailNotificationPreferenceIsChecked(true)
     })

--- a/browser-test/src/applicant/application_version_fast_forward.test.ts
+++ b/browser-test/src/applicant/application_version_fast_forward.test.ts
@@ -1131,7 +1131,7 @@ class FastForwardCiviformAdminActor {
               (question) => <QuestionSpec>{name: question},
             ),
           },
-          /* editBlockScreenDetails */ false,
+          /* editBlockScreenDetails= */ false,
         )
       })
 

--- a/browser-test/src/applicant/northstar_application_version_fast_forward.test.ts
+++ b/browser-test/src/applicant/northstar_application_version_fast_forward.test.ts
@@ -1487,7 +1487,7 @@ class FastForwardCiviformAdminActor {
               (question) => <QuestionSpec>{name: question},
             ),
           },
-          /* editBlockScreenDetails */ false,
+          /* editBlockScreenDetails= */ false,
         )
       })
 

--- a/browser-test/src/applicant/northstar_ineligible.test.ts
+++ b/browser-test/src/applicant/northstar_ineligible.test.ts
@@ -228,7 +228,7 @@ test.describe('North Star Ineligible Page Tests', {tag: ['@northstar']}, () => {
       await applicantQuestions.clickApplyProgramButton(programName)
 
       // All questions have been answered
-      await applicantQuestions.expectReviewPage(/* northStarEnabled */ true)
+      await applicantQuestions.expectReviewPage(/* northStarEnabled= */ true)
 
       // Edit the block (there is only one block)
       await applicantQuestions.clickEdit()

--- a/server/app/services/applicant/ReadOnlyApplicantProgramService.java
+++ b/server/app/services/applicant/ReadOnlyApplicantProgramService.java
@@ -399,7 +399,7 @@ public final class ReadOnlyApplicantProgramService {
   public ImmutableList<AnswerData> getSummaryDataAllQuestions() {
     ImmutableList.Builder<AnswerData> builder = new ImmutableList.Builder<>();
     ImmutableList<Block> blocks = getBlocks((block) -> true);
-    addDataToBuilder(blocks, builder, /* showAnswerText */ true);
+    addDataToBuilder(blocks, builder, /* showAnswerText= */ true);
     return builder.build();
   }
 

--- a/server/app/services/question/QuestionService.java
+++ b/server/app/services/question/QuestionService.java
@@ -60,7 +60,7 @@ public final class QuestionService {
     ImmutableSet<CiviFormError> validationErrors = questionDefinition.validate();
 
     return transactionManager.executeInTransaction(
-        /* synchronousWork */ () -> {
+        /* synchronousWork= */ () -> {
           ImmutableSet<CiviFormError> conflictErrors = checkConflicts(questionDefinition);
           ImmutableSet<CiviFormError> errors =
               ImmutableSet.<CiviFormError>builder()
@@ -75,7 +75,7 @@ public final class QuestionService {
           questionRepository.insertQuestionSync(question);
           return ErrorAnd.of(question.getQuestionDefinition());
         },
-        /* onSerializationFailure */ () -> {
+        /* onSerializationFailure= */ () -> {
           return ErrorAnd.error(
               ImmutableSet.of(
                   CiviFormError.of(

--- a/server/app/views/admin/programs/ProgramAdministratorProgramListView.java
+++ b/server/app/views/admin/programs/ProgramAdministratorProgramListView.java
@@ -96,7 +96,7 @@ public final class ProgramAdministratorProgramListView extends BaseHtmlView {
                 /* untilDate= */ Optional.empty(),
                 /* applicationStatus= */ Optional.empty(),
                 /* selectedApplicationUri= */ Optional.empty(),
-                /* showDownloadModal */ Optional.empty(),
+                /* showDownloadModal= */ Optional.empty(),
                 /* message= */ Optional.empty())
             .url();
 

--- a/server/app/views/admin/programs/ProgramApplicationListView.java
+++ b/server/app/views/admin/programs/ProgramApplicationListView.java
@@ -130,7 +130,7 @@ public final class ProgramApplicationListView extends BaseHtmlView {
                             /* selectedApplicationUri= */ Optional.empty(),
                             /* showDownloadModal= */ Optional.empty(),
                             /* message= */ Optional.empty()),
-                    /* optionalMessages */ Optional.empty()))
+                    /* optionalMessages= */ Optional.empty()))
             .withClasses("mt-6", StyleUtils.responsiveLarge("mt-12"), "mb-16", "ml-6", "mr-2");
 
     DivTag applicationShowDiv =

--- a/server/app/views/admin/programs/ProgramApplicationTableView.java
+++ b/server/app/views/admin/programs/ProgramApplicationTableView.java
@@ -149,7 +149,7 @@ public class ProgramApplicationTableView extends BaseHtmlView {
                                     /* selectedApplicationUri= */ Optional.empty(),
                                     /* showDownloadModal= */ Optional.empty(),
                                     /* message= */ Optional.empty()),
-                            /* optionalMessages */ Optional.empty())));
+                            /* optionalMessages= */ Optional.empty())));
 
     HtmlBundle htmlBundle =
         layout

--- a/server/app/views/applicant/ApplicantProgramSummaryView.java
+++ b/server/app/views/applicant/ApplicantProgramSummaryView.java
@@ -190,7 +190,7 @@ public final class ApplicantProgramSummaryView extends BaseHtmlView {
                 .with(
                     TextFormatter.formatTextWithAriaLabel(
                         data.questionText(),
-                        /* preserveEmptyLines */ true,
+                        /* preserveEmptyLines= */ true,
                         !data.applicantQuestion().isOptional(),
                         messages
                             .at(MessageKey.LINK_OPENS_NEW_TAB_SR.getKeyName())

--- a/server/app/views/applicant/TrustedIntermediaryClientListView.java
+++ b/server/app/views/applicant/TrustedIntermediaryClientListView.java
@@ -394,7 +394,7 @@ public class TrustedIntermediaryClientListView extends TrustedIntermediaryDashbo
                 .withText(messages.at(MessageKey.BUTTON_VIEW_APPLICATIONS.getKeyName()))
                 .withHref(
                     controllers.applicant.routes.ApplicantProgramsController.indexWithApplicantId(
-                            newestApplicant.get().id, /* categories */ ImmutableList.of())
+                            newestApplicant.get().id, /* categories= */ ImmutableList.of())
                         .url()));
   }
 }

--- a/server/app/views/components/TextFormatter.java
+++ b/server/app/views/components/TextFormatter.java
@@ -79,7 +79,7 @@ public final class TextFormatter {
     String markdownText = formatTextToSanitizedHTML(text, false, false);
     PolicyFactory customPolicy =
         new HtmlPolicyBuilder().allowElements().allowAttributes("").globally().toFactory();
-    return customPolicy.sanitize(markdownText, /* listener */ null, /* context= */ null);
+    return customPolicy.sanitize(markdownText, /* listener= */ null, /* context= */ null);
   }
 
   static void setAriaLabelForLinks(String ariaLabelNewTabString) {


### PR DESCRIPTION
The = is necessary to trigger the param name mismatch linter


### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`

