### PR TITLE
[a11y] add a categories group label to the category tags on a program card

### DIFF
--- a/server/app/services/MessageKey.java
+++ b/server/app/services/MessageKey.java
@@ -57,6 +57,7 @@ public enum MessageKey {
   ALERT_CLIENT_LIKELY_ELIGIBLE("alert.clientLikelyEligible"), // North Star only
   ALERT_CLIENT_LIKELY_INELIGIBLE("alert.clientLikelyIneligible"), // North Star only
   ALERT_SUBMITTED("alert.submitted"), // North Star only
+  ARIA_LABEL_CATEGORIES("ariaLabel.categories"), // North Star only
   ARIA_LABEL_EDIT("ariaLabel.edit"),
   ARIA_LABEL_ANSWER("ariaLabel.answer"),
   BANNER_ERROR_SAVING_APPLICATION("banner.errorSavingApplication"),

--- a/server/app/views/applicant/ProgramCardsSectionFragment.html
+++ b/server/app/views/applicant/ProgramCardsSectionFragment.html
@@ -73,6 +73,8 @@
     <!--*/ Program categories */-->
     <div class="usa-card__body">
       <div
+        role="group"
+        th:aria-label="#{ariaLabel.categories}"
         th:if="${sectionType != 'MY_APPLICATIONS' and !card.categories().isEmpty()}"
         class="display-flex flex-wrap margin-bottom-1 cf-flex-gap"
       >

--- a/server/conf/i18n/messages
+++ b/server/conf/i18n/messages
@@ -455,6 +455,10 @@ ariaLabel.answer=Answer {0}
 # An aria-label for screen readers that helps provide context for the associated edit link. The edit link is for a specific
 # question, so this might say "Edit What is your name?". The {0} variable is the question text.
 ariaLabel.edit=Edit {0}
+
+# An aria-label for screen readers that helps provide context for the category checkbox program filters.  
+ariaLabel.categories=Categories
+
 # Title for the summary of the pre-screener page
 title.commonIntakeSummary=Benefits pre-screener summary
 # Heading content at the top of the review page, where applicants can start answering questions.

--- a/server/conf/i18n/messages
+++ b/server/conf/i18n/messages
@@ -455,7 +455,6 @@ ariaLabel.answer=Answer {0}
 # An aria-label for screen readers that helps provide context for the associated edit link. The edit link is for a specific
 # question, so this might say "Edit What is your name?". The {0} variable is the question text.
 ariaLabel.edit=Edit {0}
-
 # Title for the summary of the pre-screener page
 title.commonIntakeSummary=Benefits pre-screener summary
 # Heading content at the top of the review page, where applicants can start answering questions.

--- a/server/conf/i18n/messages
+++ b/server/conf/i18n/messages
@@ -456,9 +456,6 @@ ariaLabel.answer=Answer {0}
 # question, so this might say "Edit What is your name?". The {0} variable is the question text.
 ariaLabel.edit=Edit {0}
 
-# An aria-label for screen readers that helps provide context for the category checkbox program filters.  
-ariaLabel.categories=Categories
-
 # Title for the summary of the pre-screener page
 title.commonIntakeSummary=Benefits pre-screener summary
 # Heading content at the top of the review page, where applicants can start answering questions.
@@ -995,6 +992,9 @@ category.tag.transportation=Transportation
 
 # A tag used to filter the list of programs down to those that are related to utilities.
 category.tag.utilities=Utilities
+
+# An aria-label for screen readers that helps provide context for the category tags.  
+ariaLabel.categories=Categories
 
 #------------------------------------------------------------------------------#
 #  Session timeout messages                                                    #


### PR DESCRIPTION
### Description

Adds a group around all the category tags in the program cards. Does this by
1. adding `role="group"` to the div
2. adding `aria-label="Categories"` to the div to be read out by the screen reader

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`

### Issue(s) this completes

Fixes #10120;
