### PR TITLE
Update Transaction test to generate a real exception

### DIFF
--- a/server/test/repository/TransactionManagerTest.java
+++ b/server/test/repository/TransactionManagerTest.java
@@ -92,7 +92,6 @@ public class TransactionManagerTest extends ResetPostgres {
     Supplier<ErrorAnd<AccountModel, String>> modifyAccount =
         () -> {
           AccountModel outerAccount = accountRepo.lookupAccount(account.id).orElseThrow();
-          outerAccount.setEmailAddress("updated@test.com");
 
           // Update the account in a different Transaction (requiresNew)
           // before the current one finishes to trigger a serialization
@@ -105,6 +104,7 @@ public class TransactionManagerTest extends ResetPostgres {
             innerTransaction.commit();
           }
 
+          outerAccount.setEmailAddress("updated@test.com");
           outerAccount.save();
           return ErrorAnd.of(outerAccount);
         };

--- a/server/test/repository/TransactionManagerTest.java
+++ b/server/test/repository/TransactionManagerTest.java
@@ -90,17 +90,15 @@ public class TransactionManagerTest extends ResetPostgres {
 
     Supplier<ErrorAnd<AccountModel, String>> modifyAccount =
         () -> {
-          AccountModel outerAccount =
-            accountRepo.lookupAccount(account.id).orElseThrow();
+          AccountModel outerAccount = accountRepo.lookupAccount(account.id).orElseThrow();
           outerAccount.setEmailAddress("updated@test.com");
 
           // Update the account in a different Transaction (requiresNew)
           // before the current one finishes to trigger a serialization
           // exception in the outer transaction.
           try (Transaction innerTransaction =
-                 DB.beginTransaction(TxScope.requiresNew().setIsolation(TxIsolation.SERIALIZABLE))) {
-            AccountModel innerAccount =
-              accountRepo.lookupAccount(account.id).orElseThrow();
+              DB.beginTransaction(TxScope.requiresNew().setIsolation(TxIsolation.SERIALIZABLE))) {
+            AccountModel innerAccount = accountRepo.lookupAccount(account.id).orElseThrow();
             innerAccount.setEmailAddress("innerupdated@test.com");
             innerAccount.save();
             innerTransaction.commit();

--- a/server/test/repository/TransactionManagerTest.java
+++ b/server/test/repository/TransactionManagerTest.java
@@ -85,6 +85,7 @@ public class TransactionManagerTest extends ResetPostgres {
 
   @Test
   public void executeInTransaction_rollsBackTransactionSuccessfully() {
+    String innerEmail = "inneremail@test.com";
     AccountModel account = new AccountModel().setEmailAddress("initial@test.com");
     account.insert();
 
@@ -99,7 +100,7 @@ public class TransactionManagerTest extends ResetPostgres {
           try (Transaction innerTransaction =
               DB.beginTransaction(TxScope.requiresNew().setIsolation(TxIsolation.SERIALIZABLE))) {
             AccountModel innerAccount = accountRepo.lookupAccount(account.id).orElseThrow();
-            innerAccount.setEmailAddress("innerupdated@test.com");
+            innerAccount.setEmailAddress(innerEmail);
             innerAccount.save();
             innerTransaction.commit();
           }
@@ -116,7 +117,7 @@ public class TransactionManagerTest extends ResetPostgres {
 
     assertThat(result.hasResult()).isFalse();
     assertThat(result.isError()).isTrue();
-    assertThat(account.getEmailAddress()).isEqualTo("innerupdated@test.com");
+    assertThat(account.getEmailAddress()).isEqualTo(innerEmail);
   }
 
   /** Simulate when the work() supplier contains another transaction. */


### PR DESCRIPTION
### Description

Replaces an artificially created SerializableConflictException by forcing a race-condition that will cause the database to generate it.

This helps reinforce that the Transaction semantics work as we actually believe they do rather than as we mock/fake tests.


### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`

