### PR TITLE
Attach error descriptions to form question inputs for screen readers

### DIFF
--- a/server/app/views/questiontypes/AddressQuestionFragment.html
+++ b/server/app/views/questiontypes/AddressQuestionFragment.html
@@ -18,7 +18,10 @@
 
       <!--/* Display errors for the entire question */-->
       <div
-        th:replace="~{questiontypes/QuestionBaseFragment :: validationErrors(${addressQuestion.getValidationErrors().get(question.getContextualizedPath())}, ${questionRendererParams})}"
+        th:replace="~{questiontypes/QuestionBaseFragment :: validationErrors(
+          ${addressQuestion.getValidationErrors().get(question.getContextualizedPath())},
+          ${questionRendererParams},
+          ${questionId})}"
       ></div>
     </div>
 
@@ -34,7 +37,7 @@
     >
       <th:block th:if="${showFieldErrorMessages}">
         <div
-          th:replace="~{questiontypes/QuestionBaseFragment :: validationErrors(${fieldErrors}, ${questionRendererParams})}"
+          th:replace="~{questiontypes/QuestionBaseFragment :: validationErrors(${fieldErrors}, ${questionRendererParams}, ${questionId})}"
         ></div>
       </th:block>
       <label class="usa-label" th:for="${inputId}">
@@ -53,6 +56,7 @@
         th:id="${inputId}"
         th:name="${streetPath}"
         th:value="${addressQuestion.getStreetValue().orElse('')}"
+        th:aria-describedby="${questionId} + '-description' + (${hasGroupErrors || hasFieldErrors} ? ' ' + ${questionId} + '-error' : '')"
         th:aria-invalid="${!addressQuestion.getValidationErrors().isEmpty()}"
         th:aria-required="${!question.isOptional()}"
         autocomplete="address-line1"
@@ -72,7 +76,7 @@
     >
       <th:block th:if="${showFieldErrorMessages}">
         <div
-          th:replace="~{questiontypes/QuestionBaseFragment :: validationErrors(${fieldErrors}, ${questionRendererParams})}"
+          th:replace="~{questiontypes/QuestionBaseFragment :: validationErrors(${fieldErrors}, ${questionRendererParams}, ${inputId})}"
         ></div>
       </th:block>
       <label
@@ -86,6 +90,7 @@
         th:id="${inputId}"
         th:name="${line2Path}"
         th:value="${addressQuestion.getLine2Value().orElse('')}"
+        th:aria-describedby="${hasFieldErrors} ? ${inputId} + '-error'"
         th:aria-invalid="${!addressQuestion.getValidationErrors().isEmpty()}"
         autocomplete="address-line2"
         th:autofocus="${questionRendererParams.autofocusFirstError() && !firstPathWithError.isEmpty() && firstPathWithError.get().equals(line2Path)}"
@@ -104,7 +109,7 @@
     >
       <th:block th:if="${showFieldErrorMessages}">
         <div
-          th:replace="~{questiontypes/QuestionBaseFragment :: validationErrors(${fieldErrors}, ${questionRendererParams})}"
+          th:replace="~{questiontypes/QuestionBaseFragment :: validationErrors(${fieldErrors}, ${questionRendererParams}, ${inputId})}"
         ></div>
       </th:block>
       <label class="usa-label" th:for="${inputId}">
@@ -123,6 +128,7 @@
         th:id="${inputId}"
         th:name="${cityPath}"
         th:value="${addressQuestion.getCityValue().orElse('')}"
+        th:aria-describedby="${hasFieldErrors} ? ${inputId} + '-error'"
         th:aria-invalid="${!addressQuestion.getValidationErrors().isEmpty()}"
         th:aria-required="${!question.isOptional()}"
         autocomplete="address-level2"
@@ -142,7 +148,7 @@
     >
       <th:block th:if="${showFieldErrorMessages}">
         <div
-          th:replace="~{questiontypes/QuestionBaseFragment :: validationErrors(${fieldErrors}, ${questionRendererParams})}"
+          th:replace="~{questiontypes/QuestionBaseFragment :: validationErrors(${fieldErrors}, ${questionRendererParams}, ${inputId})}"
         ></div>
       </th:block>
       <label class="usa-label" th:for="${inputId}">
@@ -160,6 +166,7 @@
         th:classappend="${hasFieldErrors ? 'usa-input--error' : ''}"
         th:id="${inputId}"
         th:name="${statePath}"
+        th:aria-describedby="${hasFieldErrors} ? ${inputId} + '-error'"
         th:aria-invalid="${!addressQuestion.getValidationErrors().isEmpty()}"
         th:aria-required="${!question.isOptional()}"
         autocomplete="address-level1"
@@ -187,7 +194,7 @@
     >
       <th:block th:if="${showFieldErrorMessages}">
         <div
-          th:replace="~{questiontypes/QuestionBaseFragment :: validationErrors(${fieldErrors}, ${questionRendererParams})}"
+          th:replace="~{questiontypes/QuestionBaseFragment :: validationErrors(${fieldErrors}, ${questionRendererParams}, ${inputId})}"
         ></div>
       </th:block>
       <label class="usa-label" th:for="${inputId}">
@@ -206,6 +213,7 @@
         th:id="${inputId}"
         th:name="${zipPath}"
         th:value="${addressQuestion.getZipValue().orElse('')}"
+        th:aria-describedby="${hasFieldErrors} ? ${inputId} + '-error'"
         th:aria-invalid="${!addressQuestion.getValidationErrors().isEmpty()}"
         th:aria-required="${!question.isOptional()}"
         autocomplete="postal-code"

--- a/server/app/views/questiontypes/CheckboxQuestionFragment.html
+++ b/server/app/views/questiontypes/CheckboxQuestionFragment.html
@@ -19,7 +19,7 @@
 
     <!--/* Display errors */-->
     <div
-      th:replace="~{questiontypes/QuestionBaseFragment :: validationErrors(${multiSelectQuestion.getValidationErrors().get(question.getContextualizedPath())}, ${questionRendererParams})}"
+      th:replace="~{questiontypes/QuestionBaseFragment :: validationErrors(${multiSelectQuestion.getValidationErrors().get(question.getContextualizedPath())}, ${questionRendererParams}, ${questionId})}"
     ></div>
 
     <!--/* Hidden input that we have checked to allow clearing data from a multi-select question */-->

--- a/server/app/views/questiontypes/CurrencyQuestionFragment.html
+++ b/server/app/views/questiontypes/CurrencyQuestionFragment.html
@@ -19,11 +19,11 @@
   <!--/* Display errors */-->
   <th:block th:if="${fieldErrors == null || fieldErrors.isEmpty()}">
     <div
-      th:replace="~{questiontypes/QuestionBaseFragment :: validationErrors(${questionErrors}, ${questionRendererParams})}"
+      th:replace="~{questiontypes/QuestionBaseFragment :: validationErrors(${questionErrors}, ${questionRendererParams}, ${questionId})}"
     ></div>
   </th:block>
   <div
-    th:replace="~{questiontypes/QuestionBaseFragment :: validationErrors(${fieldErrors}, ${questionRendererParams})}"
+    th:replace="~{questiontypes/QuestionBaseFragment :: validationErrors(${fieldErrors}, ${questionRendererParams}, ${questionId})}"
   ></div>
 
   <div
@@ -41,7 +41,7 @@
       th:id="${inputId}"
       th:name="${currencyQuestion.getCurrencyPath()}"
       th:value="${value}"
-      th:aria-describedby="${questionId} + '-description'"
+      th:aria-describedby="${questionId} + '-description' + (${hasErrors} ? ' ' + ${questionId} + '-error' : '')"
       th:aria-required="${!question.isOptional()}"
       th:aria-invalid="${hasErrors}"
       th:autofocus="${questionRendererParams.autofocusFirstError()}"

--- a/server/app/views/questiontypes/DateQuestionFragment.html
+++ b/server/app/views/questiontypes/DateQuestionFragment.html
@@ -20,13 +20,13 @@
     <!--/* Display errors */-->
     <th:block th:if="${fieldErrors == null || fieldErrors.isEmpty()}">
       <div
-        th:replace="~{questiontypes/QuestionBaseFragment :: validationErrors(${questionErrors}, ${questionRendererParams})}"
+        th:replace="~{questiontypes/QuestionBaseFragment :: validationErrors(${questionErrors}, ${questionRendererParams}, ${questionId})}"
       ></div>
     </th:block>
     <!--/* Display error messages for the shared date path. We actually use 3 different paths for
     inputs, but all errors are reported on the date path. */-->
     <div
-      th:replace="~{questiontypes/QuestionBaseFragment :: validationErrors(${fieldErrors}, ${questionRendererParams})}"
+      th:replace="~{questiontypes/QuestionBaseFragment :: validationErrors(${fieldErrors}, ${questionRendererParams}, ${questionId})}"
     ></div>
 
     <div class="usa-memorable-date">
@@ -51,7 +51,7 @@
           th:id="${monthId}"
           th:name="${dateQuestion.getMonthPath()}"
           th:with="value=${dateQuestion.getMonthValue().orElse('')}"
-          th:aria-describedby="${questionId} + '-description'"
+          th:aria-describedby="${questionId} + '-description' + (${hasErrors} ? ' ' + ${questionId} + '-error' : '')"
           th:autofocus="${questionRendererParams.autofocusFirstError()}"
           th:aria-required="${!question.isOptional()}"
         >
@@ -136,7 +136,7 @@
         <input
           class="usa-input"
           th:classappend="${hasErrors ? 'usa-input--error' : ''}"
-          th:aria-describedby="${questionId} + '-description'"
+          th:aria-describedby="${questionId} + '-description' + (${hasErrors} ? ' ' + ${questionId} + '-error' : '')"
           th:id="${dayId}"
           th:name="${dateQuestion.getDayPath()}"
           maxlength="2"
@@ -164,7 +164,7 @@
         <input
           class="usa-input"
           th:classappend="${hasErrors ? 'usa-input--error' : ''}"
-          th:aria-describedby="${questionId} + '-description'"
+          th:aria-describedby="${questionId} + '-description' + (${hasErrors} ? ' ' + ${questionId} + '-error' : '')"
           th:id="${yearId}"
           th:name="${dateQuestion.getYearPath()}"
           minlength="4"

--- a/server/app/views/questiontypes/DropdownQuestionFragment.html
+++ b/server/app/views/questiontypes/DropdownQuestionFragment.html
@@ -17,7 +17,7 @@
 
   <!--/* Display errors */-->
   <div
-    th:replace="~{questiontypes/QuestionBaseFragment :: validationErrors(${questionErrors}, ${questionRendererParams})}"
+    th:replace="~{questiontypes/QuestionBaseFragment :: validationErrors(${questionErrors}, ${questionRendererParams}, ${questionId})}"
   ></div>
 
   <select
@@ -27,7 +27,7 @@
     th:id="${inputId}"
     th:name="${singleSelectQuestion.getSelectionPath()}"
     th:aria-required="${!question.isOptional()}"
-    th:aria-describedby="${questionId} + '-description'"
+    th:aria-describedby="${questionId} + '-description' + (${hasErrors} ? ' ' + ${questionId} + '-error' : '')"
     th:autofocus="${questionRendererParams.autofocusFirstError()}"
   >
     <option

--- a/server/app/views/questiontypes/EmailQuestionFragment.html
+++ b/server/app/views/questiontypes/EmailQuestionFragment.html
@@ -17,7 +17,7 @@
 
   <!--/* Display errors */-->
   <div
-    th:replace="~{questiontypes/QuestionBaseFragment :: validationErrors(${questionErrors}, ${questionRendererParams})}"
+    th:replace="~{questiontypes/QuestionBaseFragment :: validationErrors(${questionErrors}, ${questionRendererParams}, ${questionId})}"
   ></div>
 
   <input
@@ -30,7 +30,7 @@
     th:id="${inputId}"
     th:name="${emailQuestion.getEmailPath()}"
     th:value="${emailQuestion.getEmailValue().orElse('')}"
-    th:aria-describedby="${questionId} + '-description'"
+    th:aria-describedby="${questionId} + '-description' + (${hasErrors} ? ' ' + ${questionId} + '-error' : '')"
     th:aria-required="${!question.isOptional()}"
     th:aria-invalid="${hasErrors}"
     th:autofocus="${questionRendererParams.autofocusFirstError()}"

--- a/server/app/views/questiontypes/EnumeratorQuestionFragment.html
+++ b/server/app/views/questiontypes/EnumeratorQuestionFragment.html
@@ -21,7 +21,7 @@
 
     <!--/* Display question level errors */-->
     <div
-      th:replace="~{questiontypes/QuestionBaseFragment :: validationErrors(${questionErrors}, ${questionRendererParams})}"
+      th:replace="~{questiontypes/QuestionBaseFragment :: validationErrors(${questionErrors}, ${questionRendererParams}, ${questionId})}"
     ></div>
 
     <div

--- a/server/app/views/questiontypes/FileUploadQuestionFragment.html
+++ b/server/app/views/questiontypes/FileUploadQuestionFragment.html
@@ -31,7 +31,7 @@
 
   <!--/* Display errors */-->
   <div
-    th:replace="~{questiontypes/QuestionBaseFragment :: validationErrors(${fileUploadQuestion.getValidationErrors().get(question.getContextualizedPath())}, ${questionRendererParams})}"
+    th:replace="~{questiontypes/QuestionBaseFragment :: validationErrors(${fileUploadQuestion.getValidationErrors().get(question.getContextualizedPath())}, ${questionRendererParams}, ${questionId})}"
   ></div>
 
   <!--/* Errors always rendered in the DOM and hidden, but shown by file_upload.ts when needed. */-->
@@ -65,7 +65,7 @@
     class="usa-file-input"
     type="file"
     name="file"
-    th:aria-describedby="${questionId} + '-description'"
+    th:aria-describedby="${questionId} + (${hasErrors} ? '-error' : '-description')"
     th:accept="${fileUploadAllowedFileTypeSpecifiers}"
     th:data-file-limit-mb="${maxFileSizeMb}"
     th:disabled="${!fileUploadQuestion.canUploadFile()}"

--- a/server/app/views/questiontypes/IdQuestionFragment.html
+++ b/server/app/views/questiontypes/IdQuestionFragment.html
@@ -19,11 +19,11 @@
   <!--/* Display errors */-->
   <th:block th:if="${fieldErrors == null || fieldErrors.isEmpty()}">
     <div
-      th:replace="~{questiontypes/QuestionBaseFragment :: validationErrors(${questionErrors}, ${questionRendererParams})}"
+      th:replace="~{questiontypes/QuestionBaseFragment :: validationErrors(${questionErrors}, ${questionRendererParams}, ${questionId})}"
     ></div>
   </th:block>
   <div
-    th:replace="~{questiontypes/QuestionBaseFragment :: validationErrors(${fieldErrors}, ${questionRendererParams})}"
+    th:replace="~{questiontypes/QuestionBaseFragment :: validationErrors(${fieldErrors}, ${questionRendererParams}, ${questionId})}"
   ></div>
 
   <input
@@ -34,7 +34,7 @@
     th:name="${idQuestion.getIdPath()}"
     th:value="${idQuestion.getIdValue().orElse('')}"
     maxlength="10000"
-    th:aria-describedby="${questionId} + '-description'"
+    th:aria-describedby="${questionId} + '-description' + (${hasErrors} ? ' ' + ${questionId} + '-error' : '')"
     th:aria-required="${!question.isOptional()}"
     th:aria-invalid="${hasErrors}"
     th:autofocus="${questionRendererParams.autofocusFirstError()}"

--- a/server/app/views/questiontypes/NameQuestionFragment.html
+++ b/server/app/views/questiontypes/NameQuestionFragment.html
@@ -17,7 +17,10 @@
     ></div>
 
     <div
-      th:replace="~{questiontypes/QuestionBaseFragment :: validationErrors(${nameQuestion.getValidationErrors().get(question.getContextualizedPath())}, ${questionRendererParams})}"
+      th:replace="~{questiontypes/QuestionBaseFragment :: validationErrors(
+      ${nameQuestion.getValidationErrors().get(question.getContextualizedPath())},
+      ${questionRendererParams},
+      ${questionId})}"
     ></div>
   </div>
 
@@ -32,7 +35,7 @@
   >
     <th:block th:if="${showFieldErrorMessages}">
       <div
-        th:replace="~{questiontypes/QuestionBaseFragment :: validationErrors(${nameQuestion.getValidationErrors().get(firstNamePath)}, ${questionRendererParams})}"
+        th:replace="~{questiontypes/QuestionBaseFragment :: validationErrors(${nameQuestion.getValidationErrors().get(firstNamePath)}, ${questionRendererParams}, ${questionId})}"
       ></div>
     </th:block>
     <label class="usa-label" th:for="${firstNameId}">
@@ -53,6 +56,7 @@
       th:id="${firstNameId}"
       autocomplete="given-name"
       th:value="${nameQuestion.getFirstNameValue().orElse('')}"
+      th:aria-describedby="${questionId} + '-description' + (${hasGroupErrors || hasFieldErrors} ? ' ' + ${questionId} + '-error' : '')"
       th:name="${firstNamePath}"
       th:autofocus="${questionRendererParams.autofocusFirstError() && !firstPathWithError.isEmpty() && firstPathWithError.get().equals(firstNamePath)}"
       th:aria-required="${!question.isOptional()}"
@@ -90,7 +94,7 @@
   >
     <th:block th:if="${showFieldErrorMessages}">
       <div
-        th:replace="~{questiontypes/QuestionBaseFragment :: validationErrors(${nameQuestion.getValidationErrors().get(lastNamePath)}, ${questionRendererParams})}"
+        th:replace="~{questiontypes/QuestionBaseFragment :: validationErrors(${nameQuestion.getValidationErrors().get(lastNamePath)}, ${questionRendererParams}, ${inputId})}"
       ></div>
     </th:block>
     <label class="usa-label" th:for="${lastNameId}">
@@ -111,6 +115,7 @@
       th:id="${lastNameId}"
       autocomplete="family-name"
       th:value="${nameQuestion.getLastNameValue().orElse('')}"
+      th:aria-describedby="${hasFieldErrors} ? ${inputId} + '-error'"
       th:name="${lastNamePath}"
       th:autofocus="${questionRendererParams.autofocusFirstError() && !firstPathWithError.isEmpty() && firstPathWithError.get().equals(lastNamePath)}"
       th:aria-required="${!question.isOptional()}"

--- a/server/app/views/questiontypes/NumberQuestionFragment.html
+++ b/server/app/views/questiontypes/NumberQuestionFragment.html
@@ -19,11 +19,11 @@
   <!--/* Display errors */-->
   <th:block th:if="${fieldErrors == null || fieldErrors.isEmpty()}">
     <div
-      th:replace="~{questiontypes/QuestionBaseFragment :: validationErrors(${questionErrors}, ${questionRendererParams})}"
+      th:replace="~{questiontypes/QuestionBaseFragment :: validationErrors(${questionErrors}, ${questionRendererParams}, ${questionId})}"
     ></div>
   </th:block>
   <div
-    th:replace="~{questiontypes/QuestionBaseFragment :: validationErrors(${fieldErrors}, ${questionRendererParams})}"
+    th:replace="~{questiontypes/QuestionBaseFragment :: validationErrors(${fieldErrors}, ${questionRendererParams}, ${questionId})}"
   ></div>
 
   <input
@@ -39,7 +39,7 @@
     th:value="${value}"
     th:min="${min}"
     th:max="${max}"
-    th:aria-describedby="${questionId} + '-description'"
+    th:aria-describedby="${questionId} + '-description' + (${hasErrors} ? ' ' + ${questionId} + '-error' : '')"
     th:aria-required="${!question.isOptional()}"
     th:aria-invalid="${hasErrors}"
     th:autofocus="${questionRendererParams.autofocusFirstError()}"

--- a/server/app/views/questiontypes/PhoneQuestionFragment.html
+++ b/server/app/views/questiontypes/PhoneQuestionFragment.html
@@ -19,11 +19,11 @@
   <!--/* Display errors */-->
   <th:block th:if="${fieldErrors == null || fieldErrors.isEmpty()}">
     <div
-      th:replace="~{questiontypes/QuestionBaseFragment :: validationErrors(${questionErrors}, ${questionRendererParams})}"
+      th:replace="~{questiontypes/QuestionBaseFragment :: validationErrors(${questionErrors}, ${questionRendererParams}, ${questionId})}"
     ></div>
   </th:block>
   <div
-    th:replace="~{questiontypes/QuestionBaseFragment :: validationErrors(${fieldErrors}, ${questionRendererParams})}"
+    th:replace="~{questiontypes/QuestionBaseFragment :: validationErrors(${fieldErrors}, ${questionRendererParams}, ${questionId})}"
   ></div>
 
   <div class="cf-phone-number">
@@ -37,7 +37,7 @@
       th:name="${phoneQuestion.getPhoneNumberPath()}"
       th:value="${phoneQuestion.getPhoneNumberValue().orElse('')}"
       placeholder="(xxx) xxx-xxxx"
-      th:aria-describedby="${questionId} + '-description'"
+      th:aria-describedby="${questionId} + '-description' + (${hasErrors} ? ' ' + ${questionId} + '-error' : '')"
       th:aria-required="${!question.isOptional()}"
       th:aria-invalid="${hasErrors}"
       th:autofocus="${questionRendererParams.autofocusFirstError()}"

--- a/server/app/views/questiontypes/QuestionBaseFragment.html
+++ b/server/app/views/questiontypes/QuestionBaseFragment.html
@@ -1,9 +1,10 @@
 <th:block
-  th:fragment="validationErrors(validationErrors, questionRendererParams)"
+  th:fragment="validationErrors(validationErrors, questionRendererParams, questionId)"
 >
   <div
     th:each="error: ${validationErrors}"
     th:if="${questionRendererParams.shouldShowErrors()}"
+    th:id="${questionId} + '-error'"
     th:text="#{toast.errorMessageOutline(#{${error.key.getKeyName()}(${error.args})})}"
     class="cf-question-error-message cf-applicant-question-errors"
   ></div>

--- a/server/app/views/questiontypes/RadioButtonQuestionFragment.html
+++ b/server/app/views/questiontypes/RadioButtonQuestionFragment.html
@@ -19,7 +19,7 @@
 
     <!--/* Display errors */-->
     <div
-      th:replace="~{questiontypes/QuestionBaseFragment :: validationErrors(${singleSelectQuestion.getValidationErrors().get(question.getContextualizedPath())}, ${questionRendererParams})}"
+      th:replace="~{questiontypes/QuestionBaseFragment :: validationErrors(${singleSelectQuestion.getValidationErrors().get(question.getContextualizedPath())}, ${questionRendererParams}, ${questionId})}"
     ></div>
 
     <!--/* Render each radio button option */-->

--- a/server/app/views/questiontypes/TextQuestionFragment.html
+++ b/server/app/views/questiontypes/TextQuestionFragment.html
@@ -19,11 +19,11 @@
   <!--/* Display errors */-->
   <th:block th:if="${fieldErrors == null || fieldErrors.isEmpty()}">
     <div
-      th:replace="~{questiontypes/QuestionBaseFragment :: validationErrors(${questionErrors}, ${questionRendererParams})}"
+      th:replace="~{questiontypes/QuestionBaseFragment :: validationErrors(${questionErrors}, ${questionRendererParams}, ${questionId})}"
     ></div>
   </th:block>
   <div
-    th:replace="~{questiontypes/QuestionBaseFragment :: validationErrors(${fieldErrors}, ${questionRendererParams})}"
+    th:replace="~{questiontypes/QuestionBaseFragment :: validationErrors(${fieldErrors}, ${questionRendererParams}, ${questionId})}"
   ></div>
 
   <input
@@ -34,7 +34,7 @@
     th:id="${inputId}"
     th:name="${textQuestion.getTextPath()}"
     th:value="${textQuestion.getTextValue().orElse('')}"
-    th:aria-describedby="${questionId} + '-description'"
+    th:aria-describedby="${questionId} + '-description' + (${hasErrors} ? ' ' + ${questionId} + '-error' : '')"
     th:aria-required="${!question.isOptional()}"
     th:aria-invalid="${!hasErrors}"
     th:autofocus="${questionRendererParams.autofocusFirstError()}"


### PR DESCRIPTION
### Description

This PR attaches error text to questions in the application form with `aria-describedBy` so that when there are validation errors, the screen reader will read the error text.  For example, it will say "What is your phone number?  Error:  this question is required."  Hearing the error text helps users know what they did wrong.

The question description (help text) is still read before the error description so that users have even more information to complete the question.

Radio, checkbox and enumerator questions are left out of this PR because these have another bug which needs to be fixed first.  (I will create that bug and put a reference to it here).  The bug is that the label and help text aren't being read by the screen reader when there are errors. There is also another bug with group field questions (including address, name and date questions). When there is an error, the question label and help text aren’t read, only the field label is read.  These are separate problems and are not addressed in this PR.

### Instructions for manual testing

1. Start an application for the Comprehensive Sample Program.
2. Turn the screen reader on.
3. Create validation errors by either failing to fill out the questions or filling them out incorrectly.
4. Listen to what the screen reader says.
5. For group field questions (Name, Address), also try partially completing the question.

### Issue(s) this completes

Fixes #9730 
