### PR TITLE
Updating calls to waitForAnyModal

### DIFF
--- a/browser-test/src/admin/admin_program_creation.test.ts
+++ b/browser-test/src/admin/admin_program_creation.test.ts
@@ -11,7 +11,7 @@ import {
   FormField,
   ProgramVisibility,
 } from '../support/admin_programs'
-import {dismissModal, waitForAnyModal} from '../support/wait'
+import {dismissModal, waitForAnyModalLocator} from '../support/wait'
 import {Page} from 'playwright'
 
 test.describe('program creation', () => {
@@ -1088,8 +1088,9 @@ test.describe('program creation', () => {
     await page.fill('#program-external-link-input', 'https://example.com')
     await page.click('#program-update-button')
 
-    let modal = await waitForAnyModal(page)
-    expect(await modal.innerText()).toContain(`Confirm pre-screener change?`)
+    let modal = await waitForAnyModalLocator(page)
+    await expect(modal).toContainText('Confirm pre-screener change?')
+
     await validateScreenshot(
       page,
       'confirm-common-intake-change-modal',
@@ -1099,8 +1100,8 @@ test.describe('program creation', () => {
     // Modal gets re-rendered if needed.
     await dismissModal(page)
     await page.click('#program-update-button')
-    modal = await waitForAnyModal(page)
-    expect(await modal.innerText()).toContain(`Confirm pre-screener change?`)
+    modal = await waitForAnyModalLocator(page)
+    await expect(modal).toContainText('Confirm pre-screener change?')
 
     await page.click('#confirm-common-intake-change-button')
     await waitForPageJsLoad(page)

--- a/browser-test/src/admin/admin_program_statuses.test.ts
+++ b/browser-test/src/admin/admin_program_statuses.test.ts
@@ -5,7 +5,7 @@ import {
   validateScreenshot,
   validateToastMessage,
 } from '../support'
-import {waitForAnyModal} from '../support/wait'
+import {waitForAnyModalLocator} from '../support/wait'
 
 test.describe('modify program statuses', () => {
   test.beforeEach(async ({page}) => {
@@ -38,8 +38,8 @@ test.describe('modify program statuses', () => {
     test('renders create new status modal', async ({page}) => {
       await page.click('button:has-text("Create a new status")')
 
-      const modal = await waitForAnyModal(page)
-      expect(await modal.innerText()).toContain('Create a new status')
+      const modal = await waitForAnyModalLocator(page)
+      await expect(modal).toContainText('Create a new status')
       await validateScreenshot(page, 'create-new-status-modal')
     })
 
@@ -159,11 +159,10 @@ test.describe('modify program statuses', () => {
         expectEmailExists: false,
       })
       await adminProgramStatuses.expectStatusNotExists(secondStatusName)
-      const emailWarningVisible =
-        await adminProgramStatuses.emailTranslationWarningIsVisible(
-          'Updated status name',
-        )
-      expect(emailWarningVisible).toBe(false)
+      await adminProgramStatuses.expectEmailTranslationWarningVisibility(
+        'Updated status name',
+        false,
+      )
     })
 
     test('edits an existing status, configures email, and deletes the configured email', async ({
@@ -182,11 +181,11 @@ test.describe('modify program statuses', () => {
         statusName: firstStatusName,
         expectedEmailBody: 'An email body',
       })
-      const emailWarningVisible =
-        await adminProgramStatuses.emailTranslationWarningIsVisible(
-          firstStatusName,
-        )
-      expect(emailWarningVisible).toBe(true)
+
+      await adminProgramStatuses.expectEmailTranslationWarningVisibility(
+        firstStatusName,
+        true,
+      )
 
       // Edit the configured email.
       await adminProgramStatuses.editStatus(firstStatusName, {

--- a/browser-test/src/support/admin_questions.ts
+++ b/browser-test/src/support/admin_questions.ts
@@ -1,6 +1,11 @@
 import {expect} from '@playwright/test'
 import {ElementHandle, Page} from 'playwright'
-import {dismissModal, waitForAnyModal, waitForPageJsLoad} from './wait'
+import {
+  dismissModal,
+  waitForAnyModal,
+  waitForAnyModalLocator,
+  waitForPageJsLoad,
+} from './wait'
 
 type QuestionOption = {
   adminName: string
@@ -271,7 +276,9 @@ export class AdminQuestions {
     expect(programReferencesText).toContain(expectedProgramReferencesText)
   }
 
-  async clickOnProgramReferencesModal(questionName: string) {
+  async clickOnProgramReferencesModal(
+    questionName: string,
+  ): Promise<ElementHandle<HTMLElement>> {
     await this.page.click(
       this.selectProgramReferencesFromRow(questionName) + ' a',
     )
@@ -423,8 +430,8 @@ export class AdminQuestions {
       this.selectWithinQuestionTableRow(questionName, ':text("Archive")'),
     )
     if (expectModal) {
-      const modal = await waitForAnyModal(this.page)
-      expect(await modal.innerText()).toContain(
+      const modal = await waitForAnyModalLocator(this.page)
+      await expect(modal).toContainText(
         'This question cannot be archived since there are still programs using it',
       )
       await dismissModal(this.page)

--- a/browser-test/src/support/applicant_questions.ts
+++ b/browser-test/src/support/applicant_questions.ts
@@ -1,7 +1,11 @@
 import {expect, Locator} from '@playwright/test'
 import {Page} from 'playwright'
 import {readFileSync, writeFileSync, unlinkSync} from 'fs'
-import {waitForAnyModal, waitForPageJsLoad, waitForHtmxReady} from './wait'
+import {
+  waitForAnyModalLocator,
+  waitForPageJsLoad,
+  waitForHtmxReady,
+} from './wait'
 import {BASE_URL} from './config'
 import {
   ApplicantProgramList,
@@ -1132,11 +1136,11 @@ export class ApplicantQuestions {
       const modalContinueButton = 'Continue to review page without saving'
       const modalFixButton = 'Stay and fix your answers'
 
-      const modal = await waitForAnyModal(this.page)
-      const modalText = await modal.innerText()
-      expect(modalText).toContain(modalContent)
-      expect(modalText).toContain(modalContinueButton)
-      expect(modalText).toContain(modalFixButton)
+      const modal = await waitForAnyModalLocator(this.page)
+      await expect(modal).toBeVisible()
+      await expect(modal).toContainText(modalContent)
+      await expect(modal).toContainText(modalContinueButton)
+      await expect(modal).toContainText(modalFixButton)
     }
   }
 
@@ -1170,11 +1174,10 @@ export class ApplicantQuestions {
         'Continue to previous questions without saving'
       const modalFixButton = 'Stay and fix your answers'
 
-      const modal = await waitForAnyModal(this.page)
-      const modalText = await modal.innerText()
-      expect(modalText).toContain(modalTitle)
-      expect(modalText).toContain(modalContinueButton)
-      expect(modalText).toContain(modalFixButton)
+      const modal = await waitForAnyModalLocator(this.page)
+      await expect(modal).toContainText(modalTitle)
+      await expect(modal).toContainText(modalContinueButton)
+      await expect(modal).toContainText(modalFixButton)
     }
   }
 
@@ -1281,7 +1284,7 @@ export class ApplicantQuestions {
   }
 
   async expectLoginModal() {
-    const modal = await waitForAnyModal(this.page)
-    expect(await modal.innerText()).toContain(`Sign in`)
+    const modal = await waitForAnyModalLocator(this.page)
+    await expect(modal).toContainText('Sign in')
   }
 }


### PR DESCRIPTION
### Description

Migrating `waitForAnyModal` which uses deprecated `ElementHandle<T>` calls for `waitForAnyModalLocator` that uses the modern Playwright `Locator` object.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
