### PR TITLE
Fix extra ' in support email mailto and use ThymeLeaf href syntax

### DIFF
--- a/server/app/views/applicant/NavigationFragment.html
+++ b/server/app/views/applicant/NavigationFragment.html
@@ -340,9 +340,6 @@
             <div
               class="grid-col-auto mobile-lg:grid-col-12 desktop:grid-col-auto"
             >
-              <!--/* We construct the link inline instead of using a fragment
-                since ${supportEmail} won't be recognized when the fragment is
-                evaluated at insertion time */-->
               <a
                 th:href="@{mailto:{to}(to=${supportEmail})}"
                 class="usa-footer__contact-info usa-link"

--- a/server/app/views/applicant/NavigationFragment.html
+++ b/server/app/views/applicant/NavigationFragment.html
@@ -344,7 +344,7 @@
                 since ${supportEmail} won't be recognized when the fragment is
                 evaluated at insertion time */-->
               <a
-                th:href="'mailto:' + ${supportEmail} + '\' '"
+                th:href="@{mailto:{to}(to=${supportEmail})}"
                 class="usa-footer__contact-info usa-link"
                 rel="noopener noreferrer"
                 target="_blank"


### PR DESCRIPTION
### Description

The support email has an extra ' at the end which makes it not work, as well this changes the string composition to use ThymeLeaf's built in [href composition](https://www.thymeleaf.org/doc/articles/standardurlsyntax.html)

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

