### PR TITLE
Prevent grouping docker/github actions in single PRs

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -106,25 +106,21 @@
       ],
       "allowedVersions": "<4.0.0"
     },
-    // GitHub Actions: Pin to commit hashes and include a comment with the version
     {
-      "groupName": "GitHub Actions",
+      // Using groupName null prevents all the GitHub Actions updates being done in a single commit
+      "groupName": null,
       "matchManagers": ["github-actions"],
       "pinDigests": true,
-      "commitMessagePrefix": "[Update Github Actions]: ",
-      "commitMessageExtra": "Updated to latest release",
-      "postUpdateOptions": ["comment"],
+      "commitMessageExtra": "to latest commit",
       "rebaseWhen": "always",
       "description": "Ensures GitHub Actions use commit hashes for security and include a version comment."
     },
-    // Docker Images: Pin to SHA256 digests for security and consistency
     {
-      "groupName": "Docker Images",
+      // Using groupName null prevents all the Docker updates being done in a single commit
+      "groupName": null,
       "matchManagers": ["docker-compose", "dockerfile"],
       "pinDigests": true,
-      "commitMessagePrefix": "[Update Docker Images]: ",
-      "commitMessageExtra": "Pinned to latest digest",
-      "postUpdateOptions": ["comment"],
+      "commitMessageExtra": "to latest commit",
       "rebaseWhen": "always",
       "description": "Ensures Docker images use SHA256 digests for security and reproducibility."
     }


### PR DESCRIPTION
### Description

The rules added to renovate to pin the GitHub Actions and Docker commit hashes ended up grouping all the detected changes into a single PR. This make it so each gets a separate PR, maintains pining to commit hash, and cleans up the PR title a bit.

Manually tested in a private test repository.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Performed manual testing
