### PR TITLE
Fix Infinite Redirect from IE User Agent

### DIFF
--- a/browser-test/src/unsupported_browser.test.ts
+++ b/browser-test/src/unsupported_browser.test.ts
@@ -1,0 +1,12 @@
+import {test, expect} from './support/civiform_fixtures'
+
+test.describe('unsupported browser', {tag: ['@parallel-candidate']}, () => {
+  test.use({
+    userAgent: 'Mozilla/5.0 (Windows NT 6.1; Trident/7.0; rv:11.0) like Gecko',
+  })
+
+  test('redirect ie user agent to page unsupported page', async ({page}) => {
+    await page.goto('/')
+    expect(page.url()).toContain('/support/unsupportedBrowser')
+  })
+})

--- a/server/app/filters/OptionalProfileRoutes.java
+++ b/server/app/filters/OptionalProfileRoutes.java
@@ -10,7 +10,11 @@ import play.mvc.Http.RequestHeader;
 final class OptionalProfileRoutes {
 
   public static ImmutableList<String> routes =
-      ImmutableList.of("/", "/programs", "/applicants/programs");
+      ImmutableList.of(
+          "/",
+          "/programs",
+          "/applicants/programs",
+          controllers.routes.SupportController.handleUnsupportedBrowser().url());
 
   public static boolean anyMatch(RequestHeader requestHeader) {
     String path = requestHeader.path();


### PR DESCRIPTION
### Description

When a browser user agent is detected to be that of Internet Explorer we redirect to the _unsupported browser page_. However it was discovered that this was in a redirect loop and never working. This was discovered in the logs from a demo site.

This will now not try to start a session for the unsupported browser page and let it load as expected.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)

Fixes #10222
