### PR TITLE
[North Star a11y] add labeled by for question types

### DIFF
--- a/server/app/views/questiontypes/CheckboxQuestionFragment.html
+++ b/server/app/views/questiontypes/CheckboxQuestionFragment.html
@@ -7,7 +7,7 @@
   class="cf-question-checkbox cf-applicant-question-field"
   th:classappend="${hasErrors ? 'cf-question-field-with-error' : ''}"
   data-testid="questionRoot"
-  th:aria-labeledby="|${questionId}-title ${questionId}-description|"
+  th:aria-labelledby="|${questionId}-title ${questionId}-description|"
 >
   <fieldset class="usa-fieldset">
     <!--/* Title and Help Text */-->

--- a/server/app/views/questiontypes/CheckboxQuestionFragment.html
+++ b/server/app/views/questiontypes/CheckboxQuestionFragment.html
@@ -9,9 +9,7 @@
   data-testid="questionRoot"
   th:aria-labeledby="|${questionId}-title ${questionId}-description|"
 >
-  <fieldset
-    class="usa-fieldset"
-  >
+  <fieldset class="usa-fieldset">
     <!--/* Title and Help Text */-->
     <div
       th:replace="~{questiontypes/QuestionBaseFragment :: titleAndHelpTextMultipleInput(${question}, ${questionId})}"

--- a/server/app/views/questiontypes/CheckboxQuestionFragment.html
+++ b/server/app/views/questiontypes/CheckboxQuestionFragment.html
@@ -7,10 +7,10 @@
   class="cf-question-checkbox cf-applicant-question-field"
   th:classappend="${hasErrors ? 'cf-question-field-with-error' : ''}"
   data-testid="questionRoot"
+  th:aria-labeledby="|${questionId}-title ${questionId}-description|"
 >
   <fieldset
     class="usa-fieldset"
-    th:aria-describedby="${questionId} + '-description'"
   >
     <!--/* Title and Help Text */-->
     <div

--- a/server/app/views/questiontypes/EnumeratorQuestionFragment.html
+++ b/server/app/views/questiontypes/EnumeratorQuestionFragment.html
@@ -9,6 +9,7 @@
   class="cf-question-enumerator cf-applicant-question-field"
   th:classappend="${hasErrors ? 'cf-question-field-with-error' : ''}"
   data-testid="questionRoot"
+  th:aria-labeledby="|${questionId}-title ${questionId}-description|" 
 >
   <fieldset
     class="usa-fieldset"

--- a/server/app/views/questiontypes/EnumeratorQuestionFragment.html
+++ b/server/app/views/questiontypes/EnumeratorQuestionFragment.html
@@ -9,7 +9,7 @@
   class="cf-question-enumerator cf-applicant-question-field"
   th:classappend="${hasErrors ? 'cf-question-field-with-error' : ''}"
   data-testid="questionRoot"
-  th:aria-labeledby="|${questionId}-title ${questionId}-description|" 
+  th:aria-labeledby="|${questionId}-title ${questionId}-description|"
 >
   <fieldset
     class="usa-fieldset"

--- a/server/app/views/questiontypes/EnumeratorQuestionFragment.html
+++ b/server/app/views/questiontypes/EnumeratorQuestionFragment.html
@@ -9,7 +9,7 @@
   class="cf-question-enumerator cf-applicant-question-field"
   th:classappend="${hasErrors ? 'cf-question-field-with-error' : ''}"
   data-testid="questionRoot"
-  th:aria-labeledby="|${questionId}-title ${questionId}-description|"
+  th:aria-labelledby="|${questionId}-title ${questionId}-description|"
 >
   <fieldset
     class="usa-fieldset"

--- a/server/app/views/questiontypes/QuestionBaseFragment.html
+++ b/server/app/views/questiontypes/QuestionBaseFragment.html
@@ -16,7 +16,9 @@
   th:with="ariaLabelForNewTabs=#{link.opensNewTabSr}"
 >
   <!--/* Question title */-->
-  <legend class="usa-legend display-flex">
+  <legend 
+    th:id="${questionId} + '-title'"
+    class="usa-legend display-flex">
     <div th:replace="~{this :: titleContent(${question})}"></div>
   </legend>
 

--- a/server/app/views/questiontypes/QuestionBaseFragment.html
+++ b/server/app/views/questiontypes/QuestionBaseFragment.html
@@ -16,9 +16,7 @@
   th:with="ariaLabelForNewTabs=#{link.opensNewTabSr}"
 >
   <!--/* Question title */-->
-  <legend 
-    th:id="${questionId} + '-title'"
-    class="usa-legend display-flex">
+  <legend th:id="${questionId} + '-title'" class="usa-legend display-flex">
     <div th:replace="~{this :: titleContent(${question})}"></div>
   </legend>
 

--- a/server/app/views/questiontypes/RadioButtonQuestionFragment.html
+++ b/server/app/views/questiontypes/RadioButtonQuestionFragment.html
@@ -7,7 +7,8 @@
   class="cf-question-radio cf-applicant-question-field"
   th:classappend="${hasErrors ? 'cf-question-field-with-error' : ''}"
   data-testid="questionRoot"
->
+  th:aria-labeledby="|${questionId}-title ${questionId}-description|" 
+  >
   <fieldset
     class="usa-fieldset"
     th:aria-describedby="${questionId} + '-description'"

--- a/server/app/views/questiontypes/RadioButtonQuestionFragment.html
+++ b/server/app/views/questiontypes/RadioButtonQuestionFragment.html
@@ -7,7 +7,7 @@
   class="cf-question-radio cf-applicant-question-field"
   th:classappend="${hasErrors ? 'cf-question-field-with-error' : ''}"
   data-testid="questionRoot"
-  th:aria-labeledby="|${questionId}-title ${questionId}-description|"
+  th:aria-labelledby="|${questionId}-title ${questionId}-description|"
 >
   <fieldset
     class="usa-fieldset"

--- a/server/app/views/questiontypes/RadioButtonQuestionFragment.html
+++ b/server/app/views/questiontypes/RadioButtonQuestionFragment.html
@@ -7,8 +7,8 @@
   class="cf-question-radio cf-applicant-question-field"
   th:classappend="${hasErrors ? 'cf-question-field-with-error' : ''}"
   data-testid="questionRoot"
-  th:aria-labeledby="|${questionId}-title ${questionId}-description|" 
-  >
+  th:aria-labeledby="|${questionId}-title ${questionId}-description|"
+>
   <fieldset
     class="usa-fieldset"
     th:aria-describedby="${questionId} + '-description'"


### PR DESCRIPTION
### Description

Added an aria labeled by for enumerator, radio, and checkbox question types so that the title and description is read in voiceover when tabbing to the options.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [x] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [x] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [x] Noted in the PR description which, if any, code in this PR was generated by AI.

### Issue(s) this completes

Fixes #10219; 
