### PR TITLE
Making screen reader linear navigation outline visible on checkbox questions

### DIFF
--- a/server/app/assets/stylesheets/northstar/_uswds-theme-custom-styles.scss
+++ b/server/app/assets/stylesheets/northstar/_uswds-theme-custom-styles.scss
@@ -62,13 +62,24 @@ it is around the label */
  is styled to look like a checkbox.  This causes a problem with screen reader
  linear navigation because the screen reader navigation outline (different than focus outline)
  does not show.  These styles set that navigation outline around the label yet make it invisible
- when the screen reader linear navigation isn't being used. Only applies to category filter checkboxes for now.*/
-[id^='ns-check-category-'] {
+ when the screen reader linear navigation isn't being used.*/
+.usa-checkbox__input {
   @include u-left('auto');
+  opacity: 0;
+}
+
+// Category filters on applicant home page
+[id^='ns-check-category-'] {
   @include u-top(1);
   width: 95%;
   height: 85%;
-  opacity: 0;
+}
+
+// Checkbox question in the applicant form
+.cf-checkbox-question-input {
+  @include u-height('full');
+  @include u-width('full');
+  @include u-maxw('mobile-lg');
 }
 
 /*

--- a/server/app/views/questiontypes/CheckboxQuestionFragment.html
+++ b/server/app/views/questiontypes/CheckboxQuestionFragment.html
@@ -32,12 +32,12 @@
     />
     <!--/* Render each checkbox option */-->
     <div
-      class="usa-checkbox cf-multi-option-question-option"
+      class="usa-checkbox cf-multi-option-question-option position-relative"
       th:each="option,iterator: ${multiSelectQuestion.getOptions()}"
       th:with="inputId='checkbox-' + ${question.getContextualizedPath()} + '-' + ${option.id()},ariaLabelForNewTabs=#{link.opensNewTabSr}"
     >
       <input
-        class="usa-checkbox__input usa-checkbox__input--tile"
+        class="usa-checkbox__input usa-checkbox__input--tile cf-checkbox-question-input"
         th:id="${inputId}"
         th:value="${option.id()}"
         th:name="${multiSelectQuestion.getSelectionPathAsArray()}"


### PR DESCRIPTION
### Description

When the screen reader is on and the user is NOT navigating the checkboxes by using "Tab", but, rather, by using other form navigation controls which vary by screen reader, a navigation outline surrounds the element that the screen reader is currently reading. Note that this outline is not the focus outline. It is a different color and width, depending on the screen reader.

The USWDS checkbox component is a custom component. It shifts the native checkbox outside the viewport and uses its own customized element as the visible checkbox. Since the screen reader navigation outline is based on the native element, it is also outside the viewport and is missing from view.

This PR places the native checkbox input element around the custom one, but sets the opacity to 0 so that it is only visible during screen reader linear navigation. This PR fixes checkbox questions within the application form.  The program category checkboxes on the applicant homepage were fixed in #10182. 

### Instructions for manual testing

Since this would require access to the NVDA screen reader, I have provided a video here (using NVDA) in place of manual testing:

https://github.com/user-attachments/assets/57c1952a-59f8-43c3-84c5-a09df6b4dd1a

If instructions are needed for manual testing by reviewers, include them here.

### Issue(s) this completes

Fixes #9914 
