### PR TITLE
Removing obsolete @types/dompurify stub

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -19,7 +19,6 @@
         "@tailwindcss/line-clamp": "0.4.4",
         "@tsconfig/recommended": "1.0.8",
         "@types/cleave.js": "1.4.12",
-        "@types/dompurify": "3.2.0",
         "@types/jest": "29.5.14",
         "@types/markdown-it": "14.1.2",
         "@typescript-eslint/eslint-plugin": "8.29.1",
@@ -1606,16 +1605,6 @@
       "dev": true,
       "dependencies": {
         "@types/react": "*"
-      }
-    },
-    "node_modules/@types/dompurify": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.2.0.tgz",
-      "integrity": "sha512-Fgg31wv9QbLDA0SpTOXO3MaxySc4DKGLi8sna4/Utjo4r3ZRPdCt4UQee8BWr+Q5z21yifghREPJGYaEOEIACg==",
-      "deprecated": "This is a stub types definition. dompurify provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "dependencies": {
-        "dompurify": "*"
       }
     },
     "node_modules/@types/eslint": {

--- a/server/package.json
+++ b/server/package.json
@@ -13,7 +13,6 @@
     "@tailwindcss/line-clamp": "0.4.4",
     "@tsconfig/recommended": "1.0.8",
     "@types/cleave.js": "1.4.12",
-    "@types/dompurify": "3.2.0",
     "@types/jest": "29.5.14",
     "@types/markdown-it": "14.1.2",
     "@typescript-eslint/eslint-plugin": "8.29.1",


### PR DESCRIPTION
### Description

Removes the @types/dompurify entry in the package.json file.

This package is deprecated and is only a stub in node.

https://www.npmjs.com/package/@types/dompurify


### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
