### PR TITLE
Duplicate-Options Feature Flag

### DIFF
--- a/server/app/services/settings/SettingsManifest.java
+++ b/server/app/services/settings/SettingsManifest.java
@@ -1088,6 +1088,15 @@ public final class SettingsManifest extends AbstractSettingsManifest {
     return getBool("EXTERNAL_PROGRAM_CARDS_ENABLED", request);
   }
 
+  /**
+   * (NOT FOR PRODUCTION USE) Enable options for handling duplicate questions when
+   * importing/migrating programs: create a duplicate, use the existing question, or overwrite the
+   * existing question.
+   */
+  public boolean getImportDuplicateHandlingOptionsEnabled() {
+    return getBool("IMPORT_DUPLICATE_HANDLING_OPTIONS_ENABLED");
+  }
+
   private static final ImmutableMap<String, SettingsSection> GENERATED_SECTIONS =
       ImmutableMap.<String, SettingsSection>builder()
           .put(
@@ -2315,7 +2324,15 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                               + " Star applicant UI.",
                           /* isRequired= */ false,
                           SettingType.BOOLEAN,
-                          SettingMode.ADMIN_WRITEABLE))))
+                          SettingMode.ADMIN_WRITEABLE),
+                      SettingDescription.create(
+                          "IMPORT_DUPLICATE_HANDLING_OPTIONS_ENABLED",
+                          "(NOT FOR PRODUCTION USE) Enable options for handling duplicate questions"
+                              + " when importing/migrating programs: create a duplicate, use the"
+                              + " existing question, or overwrite the existing question.",
+                          /* isRequired= */ false,
+                          SettingType.BOOLEAN,
+                          SettingMode.ADMIN_READABLE))))
           .put(
               "Miscellaneous",
               SettingsSection.create(

--- a/server/conf/env-var-docs.json
+++ b/server/conf/env-var-docs.json
@@ -944,6 +944,12 @@
         "description": "(NOT FOR PRODUCTION USE) Enable showing external program cards on North Star applicant UI.",
         "type": "bool",
         "required": false
+      },
+      "IMPORT_DUPLICATE_HANDLING_OPTIONS_ENABLED": {
+        "mode": "ADMIN_READABLE",
+        "description": "(NOT FOR PRODUCTION USE) Enable options for handling duplicate questions when importing/migrating programs: create a duplicate, use the existing question, or overwrite the existing question.",
+        "type": "bool",
+        "required": false
       }
     }
   }

--- a/server/conf/helper/feature-flags.conf
+++ b/server/conf/helper/feature-flags.conf
@@ -74,3 +74,7 @@ custom_theme_colors_enabled = ${?CUSTOM_THEME_COLORS_ENABLED}
 # External program cards
 external_program_cards_enabled = false
 external_program_cards_enabled = ${?EXTERNAL_PROGRAM_CARDS_ENABLED}
+
+# Allow admins to choose how to handle duplicate questions during program import/migration
+import_duplicate_handling_options_enabled = false
+import_duplicate_handling_options_enabled = ${?IMPORT_DUPLICATE_HANDLING_OPTIONS_ENABLED}


### PR DESCRIPTION
### Description

Adding feature flag for [giving admins options of how to handle duplicate questions during import](https://docs.google.com/document/d/1-3Xhm7MmH-DREzbwu_yKV9tU3VjcbHKmnq_Ea2qYkGQ/edit?tab=t.0)

This feature flag is tracked in #10293 

## Release notes

Adding a feature flag that guard a new feature to allow admins to select how they want to handle duplicate questions when importing a new program via JSON: create a duplicate question, use the existing question, or overwrite the existing question's configuration.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).