### PR TITLE
Giving the button aria role to links that behave as buttons

### DIFF
--- a/server/app/views/NorthStarBaseView.java
+++ b/server/app/views/NorthStarBaseView.java
@@ -128,7 +128,7 @@ public abstract class NorthStarBaseView {
     // that will be embedded in the guest alert in the header.
     context.setVariable(
         "endSessionLinkHtml",
-        "<a id=\"logout-button\" class=\"usa-link\" href=\""
+        "<a id=\"logout-button\" class=\"usa-link\" role=\"button\" href=\""
             + logoutLink
             + "\">"
             + messages.at(MessageKey.END_YOUR_SESSION.getKeyName())

--- a/server/app/views/applicant/CreateAccountAlertFragment.html
+++ b/server/app/views/applicant/CreateAccountAlertFragment.html
@@ -19,6 +19,7 @@
       <div class="grid-col-auto">
         <a
           class="usa-button usa-button--inverse"
+          role="button"
           th:text="${createAccountLinkText}"
           id="create-account"
           th:href="${createAccountLink}"
@@ -31,6 +32,7 @@
     <p>
       <a
         class="usa-link"
+        role="button"
         href="javascript:void(0);"
         th:text="${loginLinkText}"
         th:href="${loginLink}"

--- a/server/app/views/applicant/ModalFragment.html
+++ b/server/app/views/applicant/ModalFragment.html
@@ -146,6 +146,7 @@
             <a
               class="usa-button usa-button--outline padding-105 text-center"
               data-close-modal
+              role="button"
               th:text="#{button.signIn}"
               th:href="${loginLink}"
             ></a>

--- a/server/app/views/applicant/NavigationFragment.html
+++ b/server/app/views/applicant/NavigationFragment.html
@@ -224,7 +224,6 @@
 
 <div th:fragment="showDebugTools">
   <a
-    type="button"
     class="usa-button usa-button--outline margin-right-0"
     id="debug-content-modal-button"
     href="#debug-content-modal"
@@ -247,7 +246,7 @@
 <th:block th:fragment="loginOrLogout">
   <th:block th:if="${isGuest}">
     <a
-      type="button"
+      role="button"
       class="usa-button usa-button--outline margin-right-0"
       th:text="#{button.login}"
       id="login-button"
@@ -258,7 +257,7 @@
 
   <th:block th:if="${!isGuest}">
     <a
-      type="button"
+      role="button"
       class="usa-button usa-button--outline margin-right-0"
       th:text="#{button.logout}"
       id="logout-button"
@@ -325,6 +324,7 @@
               class="mobile-lg:grid-col-6 desktop:grid-col-auto usa-footer__primary-content"
             >
               <a
+                role="button"
                 class="usa-footer__primary-link"
                 th:href="${adminLoginUrl}"
                 th:text="#{link.adminLogin}"


### PR DESCRIPTION
### Description

On iOS when using the VoiceOver screen reader, keyboard focus (blue outline) doesn't follow the VoiceOver cursor (black outline) to anchor tags.  However, keyboard focus does follow the cursor to buttons.  This PR assigns the button aria role to any anchor tags that act as buttons.  The button role should be used "when the user- action causes a change in either back-end or the front-end of the website." (see https://www.digitala11y.com/links-vs-buttons-a-perennial-problem/).  By doing this, we're solving the keyboard focus bug for those particular buttons.

However, some anchor tags in CiviForm need to keep the implicit link role because they function as links (they take the user to a new location within the page or to another page).  Since screen reader users often navigate by using the list of links in a page, if a link behaves like a link, it needs to keep that link role so that it will show up in the screen reader link list.  For those links, we will continue to have the problem on iOS of keyboard focus not syncing with the VoiceOver cursor.  However, this problem can be replicated on other reliable websites such as w3c.org and the USWDS site, as shown in #9911.  Therefore, this is expected VoiceOver behavior on iOS and we won't attempt to fix it.  

### Instructions for manual testing

1. Check out the `melanie-exygy/focus-links` branch.
2. Use these steps to open your local CF on your iPhone:  https://prowe214.medium.com/tip-how-to-view-localhost-web-apps-on-your-phone-ad6b2c883a7c
3. Turn VoiceOver on.
4. Swipe right to move from one interactive element to the next.  
5. When you get to the "Log in" button in the nav bar, the blue focus outline surrounds the element.

### Issue(s) this completes

Fixes #9911 
