### PR TITLE
Make IMPORT_DUPLICATE_HANDLING_OPTIONS_ENABLED writeable

### DIFF
--- a/server/app/services/settings/SettingsManifest.java
+++ b/server/app/services/settings/SettingsManifest.java
@@ -1093,8 +1093,8 @@ public final class SettingsManifest extends AbstractSettingsManifest {
    * importing/migrating programs: create a duplicate, use the existing question, or overwrite the
    * existing question.
    */
-  public boolean getImportDuplicateHandlingOptionsEnabled() {
-    return getBool("IMPORT_DUPLICATE_HANDLING_OPTIONS_ENABLED");
+  public boolean getImportDuplicateHandlingOptionsEnabled(RequestHeader request) {
+    return getBool("IMPORT_DUPLICATE_HANDLING_OPTIONS_ENABLED", request);
   }
 
   private static final ImmutableMap<String, SettingsSection> GENERATED_SECTIONS =
@@ -2332,7 +2332,7 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                               + " existing question, or overwrite the existing question.",
                           /* isRequired= */ false,
                           SettingType.BOOLEAN,
-                          SettingMode.ADMIN_READABLE))))
+                          SettingMode.ADMIN_WRITEABLE))))
           .put(
               "Miscellaneous",
               SettingsSection.create(

--- a/server/conf/env-var-docs.json
+++ b/server/conf/env-var-docs.json
@@ -946,7 +946,7 @@
         "required": false
       },
       "IMPORT_DUPLICATE_HANDLING_OPTIONS_ENABLED": {
-        "mode": "ADMIN_READABLE",
+        "mode": "ADMIN_WRITEABLE",
         "description": "(NOT FOR PRODUCTION USE) Enable options for handling duplicate questions when importing/migrating programs: create a duplicate, use the existing question, or overwrite the existing question.",
         "type": "bool",
         "required": false


### PR DESCRIPTION
### Description

Make the `IMPORT_DUPLICATE_HANDLING_OPTIONS_ENABLED` feature flag admin writeable for ease of writing browser tests. 

FF tracked in #10293 

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)