### PR TITLE
Rename executeInTransaction() to execute()

### DIFF
--- a/server/app/repository/TransactionManager.java
+++ b/server/app/repository/TransactionManager.java
@@ -16,9 +16,10 @@ import org.slf4j.LoggerFactory;
  * A class for managing workflows that span multiple repositories, but should still be wrapped in a
  * transaction to prevent race conditions and data integrity errors.
  *
- * <p>Warning: This class does not work across Async calls, they will not see
- * the wrapping transaction due to transactions being stored thread-local.
- * <a href="https://github.com/civiform/civiform/wiki/Concurrency-and-Transactions#wrapping-logic-in-transactions">Details here</a>
+ * <p>Warning: This class does not work across Async calls, they will not see the wrapping
+ * transaction due to transactions being stored thread-local. <a
+ * href="https://github.com/civiform/civiform/wiki/Concurrency-and-Transactions#wrapping-logic-in-transactions">Details
+ * here</a>
  *
  * <p>See https://www.postgresql.org/docs/current/transaction-iso.html#XACT-SERIALIZABLE for details
  * on transactions.

--- a/server/app/repository/TransactionManager.java
+++ b/server/app/repository/TransactionManager.java
@@ -16,6 +16,10 @@ import org.slf4j.LoggerFactory;
  * A class for managing workflows that span multiple repositories, but should still be wrapped in a
  * transaction to prevent race conditions and data integrity errors.
  *
+ * <p>Warning: This class does not work across Async calls, they will not see
+ * the wrapping transaction due to transactions being stored thread-local.
+ * <a href="https://github.com/civiform/civiform/wiki/Concurrency-and-Transactions#wrapping-logic-in-transactions">Details here</a>
+ *
  * <p>See https://www.postgresql.org/docs/current/transaction-iso.html#XACT-SERIALIZABLE for details
  * on transactions.
  */
@@ -24,8 +28,6 @@ public final class TransactionManager {
 
   /**
    * Run the supplied code in a {@link TxIsolation#SERIALIZABLE} transaction.
-   *
-   * <p>Warning: This has not been tested with a supplier that does work asynchronously.
    *
    * <p>Notes:
    *

--- a/server/app/repository/TransactionManager.java
+++ b/server/app/repository/TransactionManager.java
@@ -71,8 +71,7 @@ public final class TransactionManager {
    * @param onSerializationFailure {@link Supplier} to run in the event of a failure due to a
    *     conflict with a concurrent transaction
    */
-  public <T> T executeInTransaction(
-      Supplier<T> synchronousWork, Supplier<T> onSerializationFailure) {
+  public <T> T execute(Supplier<T> synchronousWork, Supplier<T> onSerializationFailure) {
     checkNotNull(synchronousWork);
     checkNotNull(onSerializationFailure);
     try {

--- a/server/app/services/question/QuestionService.java
+++ b/server/app/services/question/QuestionService.java
@@ -59,7 +59,7 @@ public final class QuestionService {
   public ErrorAnd<QuestionDefinition, CiviFormError> create(QuestionDefinition questionDefinition) {
     ImmutableSet<CiviFormError> validationErrors = questionDefinition.validate();
 
-    return transactionManager.executeInTransaction(
+    return transactionManager.execute(
         /* synchronousWork= */ () -> {
           ImmutableSet<CiviFormError> conflictErrors = checkConflicts(questionDefinition);
           ImmutableSet<CiviFormError> errors =

--- a/server/test/repository/TransactionManagerTest.java
+++ b/server/test/repository/TransactionManagerTest.java
@@ -135,7 +135,7 @@ public class TransactionManagerTest extends ResetPostgres {
   }
 
   @Test
-  public void execute_supplier_Successfully() {
+  public void execute_supplier_rollsBackTransactionSuccessfully() {
     String innerEmail = "inneremail@test.com";
     AccountModel account = new AccountModel().setEmailAddress("initial@test.com");
     account.insert();
@@ -249,7 +249,7 @@ public class TransactionManagerTest extends ResetPostgres {
 
   /** Simulate when the work() supplier contains another transaction. */
   @Test
-  public void execute_supplier_Fails() {
+  public void execute_supplier_transactionInsideSupplierRollsBackIfWrappedTransactionFails() {
     Supplier<String> work =
         () -> {
           try (Transaction innerTransaction =
@@ -273,7 +273,7 @@ public class TransactionManagerTest extends ResetPostgres {
 
   /** Simulate when we use the {@link TransactionManager} from inside another transaction. */
   @Test
-  public void executeInTransaction_workFails() {
+  public void execute_supplier_workInSupplierRollsBackIfOuterTransactionFails() {
     Supplier<String> work =
         () -> {
           new AccountModel().insert();
@@ -295,7 +295,7 @@ public class TransactionManagerTest extends ResetPostgres {
   }
 
   @Test
-  public void executeWithRequiresNewIsIndependent() {
+  public void execute_supplier_innerTransactionWithRequiresNewIsIndependent() {
     Supplier<String> work =
         () -> {
           // Check initial number of accounts in the outer transaction's snapshot

--- a/server/test/repository/TransactionManagerTest.java
+++ b/server/test/repository/TransactionManagerTest.java
@@ -83,7 +83,7 @@ public class TransactionManagerTest extends ResetPostgres {
 
   @SuppressWarnings("unchecked")
   @Test
-  public void execute_runsWorkSupplier() {
+  public void execute_supplier_runsWorkSupplier() {
     Supplier<String> mockWork = mock(Supplier.class);
     when(mockWork.get()).thenReturn("work");
     Supplier<String> mockOnFailure = mock(Supplier.class);
@@ -97,7 +97,7 @@ public class TransactionManagerTest extends ResetPostgres {
 
   @SuppressWarnings("unchecked")
   @Test
-  public void execute_runsFailureSupplier() {
+  public void execute_supplier_runsFailureSupplier() {
     Supplier<String> mockWork = mock(Supplier.class);
     when(mockWork.get())
         .thenThrow(
@@ -112,7 +112,7 @@ public class TransactionManagerTest extends ResetPostgres {
   }
 
   @Test
-  public void execute_modifiesEntitySuccessfully() {
+  public void execute_supplier_modifiesEntitySuccessfully() {
     AccountModel account = new AccountModel().setEmailAddress("initial@test.com");
     account.insert();
 
@@ -135,7 +135,7 @@ public class TransactionManagerTest extends ResetPostgres {
   }
 
   @Test
-  public void executeSuccessfully() {
+  public void execute_supplier_Successfully() {
     String innerEmail = "inneremail@test.com";
     AccountModel account = new AccountModel().setEmailAddress("initial@test.com");
     account.insert();
@@ -249,7 +249,7 @@ public class TransactionManagerTest extends ResetPostgres {
 
   /** Simulate when the work() supplier contains another transaction. */
   @Test
-  public void executeFails() {
+  public void execute_supplier_Fails() {
     Supplier<String> work =
         () -> {
           try (Transaction innerTransaction =

--- a/server/test/services/question/QuestionServiceTest.java
+++ b/server/test/services/question/QuestionServiceTest.java
@@ -79,7 +79,7 @@ public class QuestionServiceTest extends ResetPostgres {
   @Test
   public void create_handlesSerializationFailure() throws Exception {
     TransactionManager mockTransactionManager = mock(TransactionManager.class);
-    when(mockTransactionManager.executeInTransaction(any(), any()))
+    when(mockTransactionManager.execute(any(), any()))
         .then(
             invocation -> {
               Supplier<ErrorAnd<QuestionDefinition, CiviFormError>> onSerializationFailure =


### PR DESCRIPTION
### Description

`InTransaction` in the method name is redundant with the entire classes purpose and the implementation of all methods. The longer name creates less readable code.


### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [ ] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.
