### PR TITLE
Add /error path to optional profile routes 

### DIFF
--- a/server/app/filters/OptionalProfileRoutes.java
+++ b/server/app/filters/OptionalProfileRoutes.java
@@ -14,6 +14,7 @@ final class OptionalProfileRoutes {
           "/",
           "/programs",
           "/applicants/programs",
+          "/error",
           controllers.routes.SupportController.handleUnsupportedBrowser().url());
 
   public static boolean anyMatch(RequestHeader requestHeader) {


### PR DESCRIPTION
### Description

This is an attempt to fix the memory leak issues that were introduced on March 14th here:  https://github.com/civiform/civiform/pull/9973.  We are adding the `/error` path to the list of routes which will be excluded from guest profile creation.


