### PR TITLE
Add aria-invalid on text questions only when there are errors

### DIFF
--- a/server/app/views/questiontypes/TextQuestionFragment.html
+++ b/server/app/views/questiontypes/TextQuestionFragment.html
@@ -36,7 +36,7 @@
     th:value="${textQuestion.getTextValue().orElse('')}"
     th:aria-describedby="${questionId} + '-description' + (${hasErrors} ? ' ' + ${questionId} + '-error' : '')"
     th:aria-required="${!question.isOptional()}"
-    th:aria-invalid="${!hasErrors}"
+    th:aria-invalid="${hasErrors}"
     th:autofocus="${questionRendererParams.autofocusFirstError()}"
   />
 </div>


### PR DESCRIPTION
### Description

`aria-invalid` was being added to text questions when there were no errors, before the form was submitted.  This was likely a typo.  Now `aria-invalid` will only be added to the field when there are errors in the form field.

### Instructions for manual testing

1. As an admin, create a program with a text question.
2. As an applicant, apply to the program.
3. Turn a screen reader on.
4. Go to the empty text field.  
5. You should not hear "required, invalid text".
6. You should only hear "required text".

### Issue(s) this completes

Fixes #9734 
