### PR TITLE
Adding aria-label to differentiate "Remove file" links and giving role of button

### DIFF
--- a/browser-test/src/applicant/questions/northstar_file.test.ts
+++ b/browser-test/src/applicant/questions/northstar_file.test.ts
@@ -706,45 +706,40 @@ test.describe('file upload applicant flow', {tag: ['@northstar']}, () => {
       )
     })
 
-    // TODO(9467): remove ".fixme" once https://github.com/civiform/civiform/issues/9467 is resolved
-    test.fixme(
-      'remove button has correct aria-labelled by',
-      async ({applicantQuestions, page}) => {
-        await applicantQuestions.applyProgram(
-          programName,
-          /* northStarEnabled= */ true,
-        )
+    test('remove button has correct aria-label', async ({
+      applicantQuestions,
+      page,
+    }) => {
+      await applicantQuestions.applyProgram(
+        programName,
+        /* northStarEnabled= */ true,
+      )
 
-        await applicantQuestions.answerFileUploadQuestionFromAssets(
-          'file-upload.png',
-        )
-        await applicantQuestions.answerFileUploadQuestionFromAssets(
-          'file-upload-second.png',
-        )
+      await applicantQuestions.answerFileUploadQuestionFromAssets(
+        'file-upload.png',
+      )
+      await applicantQuestions.answerFileUploadQuestionFromAssets(
+        'file-upload-second.png',
+      )
 
-        await expect(page.getByText('file-upload.png')).toBeVisible()
+      await expect(page.getByText('file-upload.png')).toBeVisible()
 
-        await expect(
-          page
-            .getByRole('list', {name: 'Uploaded files'})
-            .locator('li')
-            .filter({hasText: 'file-upload.png'})
-            .getByText('Remove File'),
-        ).toHaveAttribute('aria-labelledby', 'uploaded-file-1')
+      const fileListItem = page
+        .getByRole('list', {name: 'Uploaded files'})
+        .locator('li')
 
-        await expect(page.locator('#uploaded-file-2')).toContainText(
-          'file-upload-second.png',
-        )
+      await expect(
+        fileListItem
+          .filter({hasText: 'file-upload.png'})
+          .getByRole('button', {name: 'Remove file-upload.png file'}),
+      ).toBeVisible()
 
-        await expect(
-          page
-            .getByRole('list', {name: 'Uploaded files'})
-            .locator('li')
-            .filter({hasText: 'file-upload-second.png'})
-            .getByText('Remove File'),
-        ).toHaveAttribute('aria-labelledby', 'uploaded-file-2')
-      },
-    )
+      await expect(
+        fileListItem
+          .filter({hasText: 'file-upload-second.png'})
+          .getByRole('button', {name: 'Remove file-upload-second.png file'}),
+      ).toBeVisible()
+    })
 
     test('too large file error', async ({
       page,

--- a/server/app/services/MessageKey.java
+++ b/server/app/services/MessageKey.java
@@ -290,6 +290,7 @@ public enum MessageKey {
   LINK_PROGRAM_DETAILS("link.programDetails"),
   LINK_PROGRAM_DETAILS_SR("link.programDetailsSr"),
   LINK_REMOVE_FILE("link.removeFile"),
+  LINK_REMOVE_FILE_SR("link.removeFileSr"), // North Star only
   LINK_SELECT_NEW_CLIENT("link.selectNewClient"),
   LINK_SKIP_TO_MAIN_CONTENT("link.skipToMainContent"), // North Star only
   LINK_HOME("link.home"), // North Star only

--- a/server/app/views/applicant/ApplicantProgramFileUploadBlockEditTemplate.html
+++ b/server/app/views/applicant/ApplicantProgramFileUploadBlockEditTemplate.html
@@ -77,14 +77,17 @@
               >
                 <li
                   th:each="fileKey, iter: ${fileUploadQuestion.getFileKeyListValue().get()}"
+                  th:with="fileName=${fileUploadViewStrategy.getFileName(fileUploadQuestion.getFileNameForIndex(iter.index).get())}"
                   class="grid-row margin-y-1"
                 >
                   <span
-                    th:text="${fileUploadViewStrategy.getFileName(fileUploadQuestion.getFileNameForIndex(iter.index).get())}"
+                    th:text="${fileName}"
                     class="overflow-hidden grid-col flex-fill"
                   ></span>
                   <a
                     th:text="#{link.removeFile}"
+                    th:aria-label="#{link.removeFileSr(${fileName})}"
+                    role="button"
                     th:href="${applicationParams.applicantRoutes().removeFile(
                     applicationParams.profile(),
                     applicationParams.applicantId(),

--- a/server/conf/i18n/messages
+++ b/server/conf/i18n/messages
@@ -160,6 +160,8 @@ link.home=Home
 link.applicationForProgram=Application for {0}
 # Anchor which when clicked removes a file the user has previously uploaded.
 link.removeFile=Remove file
+# Screen reader text for anchor which when clicked removes a file the user has previously uploaded. {0} is the file name.
+link.removeFileSr=Remove {0} file
 # The title of a pop-up informing the user that they tried to go to the review page but there were errors in the information that they inputted
 modal.errorSaving.review.title=Questions on this page are not complete. Would you still like to leave and begin reviewing?
 # The title of a pop-up informing the user that they tried to go to the previous page but there were errors in the information that they inputted

--- a/server/conf/i18n/messages
+++ b/server/conf/i18n/messages
@@ -160,7 +160,7 @@ link.home=Home
 link.applicationForProgram=Application for {0}
 # Anchor which when clicked removes a file the user has previously uploaded.
 link.removeFile=Remove file
-# Screen reader text for anchor which when clicked removes a file the user has previously uploaded. {0} is the file name.
+# Screen reader text for a link which when clicked removes a file the user has previously uploaded. {0} is the file name.
 link.removeFileSr=Remove {0} file
 # The title of a pop-up informing the user that they tried to go to the review page but there were errors in the information that they inputted
 modal.errorSaving.review.title=Questions on this page are not complete. Would you still like to leave and begin reviewing?


### PR DESCRIPTION
### Description

On file upload questions, there is a "Remove file" link next to each uploaded file.  When multiple files are uploaded, this means the links have duplicated names.  A screen reader user would have no way of knowing which file they were removing.  This adds an aria label which includes the name of the file in the link label so that users can differentiate between links.  For example: "Remove puppy.jpg file".

Also, semantically these should be buttons, not links. The purpose of a link would be to take the user to a different location, whereas the purpose of a button is for the user to take action.  So, this PR gives the anchor tags the aria role of "button" so that screen readers will treat them as buttons.

### Instructions for manual testing

1. Create a program with a file upload question.
2. Turn the NS flag on.
3. Apply to the program.
4. When you get to the file upload question, upload a couple of files.
5. Turn the screen reader on.
6. Tab to the "Remove file" button.
7. It should be announced as a button and the screen reader should say "Remove 'filename' file".

### Issue(s) this completes

Fixes #9467 
