### PR TITLE
Change htmx behavior to only reload part of the page on clearing filters

### DIFF
--- a/browser-test/src/applicant/northstar_applicant_application_index.test.ts
+++ b/browser-test/src/applicant/northstar_applicant_application_index.test.ts
@@ -609,6 +609,8 @@ test.describe('applicant program index page', {tag: ['@northstar']}, () => {
           page.getByRole('checkbox', {name: 'General'}),
         ).not.toBeChecked()
 
+        await expect(page.locator('#not-started-programs')).toBeVisible()
+
         await expect(
           page.locator(
             '#not-started-programs .usa-card-group .cf-application-card',

--- a/browser-test/src/applicant/northstar_applicant_application_index.test.ts
+++ b/browser-test/src/applicant/northstar_applicant_application_index.test.ts
@@ -609,12 +609,8 @@ test.describe('applicant program index page', {tag: ['@northstar']}, () => {
           page.getByRole('checkbox', {name: 'General'}),
         ).not.toBeChecked()
 
-        await expect(page.locator('#unfiltered-programs')).toBeVisible()
-
         await expect(
-          page.locator(
-            '#unfiltered-programs .usa-card-group .cf-application-card',
-          ),
+          page.locator('.usa-card-group .cf-application-card'),
         ).toHaveCount(4)
 
         await expect(

--- a/browser-test/src/applicant/northstar_applicant_application_index.test.ts
+++ b/browser-test/src/applicant/northstar_applicant_application_index.test.ts
@@ -610,7 +610,9 @@ test.describe('applicant program index page', {tag: ['@northstar']}, () => {
         ).not.toBeChecked()
 
         await expect(
-          page.locator('.usa-card-group .cf-application-card'),
+          page.locator(
+            '#not-started-programs .usa-card-group .cf-application-card',
+          ),
         ).toHaveCount(4)
 
         await expect(

--- a/server/app/views/applicant/FilteredProgramsTemplate.html
+++ b/server/app/views/applicant/FilteredProgramsTemplate.html
@@ -1,8 +1,10 @@
 <!--HTMX partial template for the filtered programs section of the landing page.-->
 
-<div
-  th:replace="~{applicant/ProgramCardsSectionFragment :: cardsSection(${recommendedSection})}"
-></div>
+<th:block th:if="${recommendedSection.isPresent()}">
+  <div
+    th:replace="~{applicant/ProgramCardsSectionFragment :: cardsSection(${recommendedSection.get()})}"
+  ></div>
+</th:block>
 <th:block th:if="${otherProgramsSection.isPresent()}">
   <div
     th:replace="~{applicant/ProgramCardsSectionFragment :: cardsSection(${otherProgramsSection.get()})}"

--- a/server/app/views/applicant/FilteredProgramsTemplate.html
+++ b/server/app/views/applicant/FilteredProgramsTemplate.html
@@ -2,11 +2,13 @@
 
 <th:block th:if="${recommendedSection.isPresent()}">
   <div
+    th:id="recommended-programs"
     th:replace="~{applicant/ProgramCardsSectionFragment :: cardsSection(${recommendedSection.get()})}"
   ></div>
 </th:block>
 <th:block th:if="${otherProgramsSection.isPresent()}">
   <div
+    th:id="not-started-programs"
     th:replace="~{applicant/ProgramCardsSectionFragment :: cardsSection(${otherProgramsSection.get()})}"
   ></div>
 </th:block>

--- a/server/app/views/applicant/NorthStarFilteredProgramsViewPartial.java
+++ b/server/app/views/applicant/NorthStarFilteredProgramsViewPartial.java
@@ -82,22 +82,22 @@ public class NorthStarFilteredProgramsViewPartial extends NorthStarBaseView {
             .collect(ImmutableList.toImmutableList());
 
     Optional<ProgramCardsSectionParamsFactory.ProgramSectionParams> recommendedSection =
-            Optional.empty();
-        if (!filteredPrograms.isEmpty()) {
-          recommendedSection =
-              Optional.of(
-                  programCardsSectionParamsFactory.getSection(
-                      request,
-                      messages,
-                      Optional.of(MessageKey.TITLE_RECOMMENDED_PROGRAMS_SECTION_V2),
-                      MessageKey.BUTTON_VIEW_AND_APPLY,
-                      filteredPrograms,
-                      /* preferredLocale= */ messages.lang().toLocale(),
-                      profile,
-                      applicantId,
-                      personalInfo,
-                      ProgramCardsSectionParamsFactory.SectionType.RECOMMENDED));
-        }
+        Optional.empty();
+    if (!filteredPrograms.isEmpty()) {
+      recommendedSection =
+          Optional.of(
+              programCardsSectionParamsFactory.getSection(
+                  request,
+                  messages,
+                  Optional.of(MessageKey.TITLE_RECOMMENDED_PROGRAMS_SECTION_V2),
+                  MessageKey.BUTTON_VIEW_AND_APPLY,
+                  filteredPrograms,
+                  /* preferredLocale= */ messages.lang().toLocale(),
+                  profile,
+                  applicantId,
+                  personalInfo,
+                  ProgramCardsSectionParamsFactory.SectionType.RECOMMENDED));
+    }
     Optional<ProgramCardsSectionParamsFactory.ProgramSectionParams> otherProgramsSection =
         Optional.empty();
 

--- a/server/app/views/applicant/NorthStarFilteredProgramsViewPartial.java
+++ b/server/app/views/applicant/NorthStarFilteredProgramsViewPartial.java
@@ -81,19 +81,23 @@ public class NorthStarFilteredProgramsViewPartial extends NorthStarBaseView {
             .filter(programData -> !filteredPrograms.contains(programData))
             .collect(ImmutableList.toImmutableList());
 
-    ProgramCardsSectionParamsFactory.ProgramSectionParams recommendedSection =
-        programCardsSectionParamsFactory.getSection(
-            request,
-            messages,
-            Optional.of(MessageKey.TITLE_RECOMMENDED_PROGRAMS_SECTION_V2),
-            MessageKey.BUTTON_VIEW_AND_APPLY,
-            filteredPrograms,
-            /* preferredLocale= */ messages.lang().toLocale(),
-            profile,
-            applicantId,
-            personalInfo,
-            ProgramCardsSectionParamsFactory.SectionType.RECOMMENDED);
-
+    Optional<ProgramCardsSectionParamsFactory.ProgramSectionParams> recommendedSection =
+            Optional.empty();
+        if (!filteredPrograms.isEmpty()) {
+          recommendedSection =
+              Optional.of(
+                  programCardsSectionParamsFactory.getSection(
+                      request,
+                      messages,
+                      Optional.of(MessageKey.TITLE_RECOMMENDED_PROGRAMS_SECTION_V2),
+                      MessageKey.BUTTON_VIEW_AND_APPLY,
+                      filteredPrograms,
+                      /* preferredLocale= */ messages.lang().toLocale(),
+                      profile,
+                      applicantId,
+                      personalInfo,
+                      ProgramCardsSectionParamsFactory.SectionType.RECOMMENDED));
+        }
     Optional<ProgramCardsSectionParamsFactory.ProgramSectionParams> otherProgramsSection =
         Optional.empty();
 
@@ -103,7 +107,9 @@ public class NorthStarFilteredProgramsViewPartial extends NorthStarBaseView {
               programCardsSectionParamsFactory.getSection(
                   request,
                   messages,
-                  Optional.of(MessageKey.TITLE_OTHER_PROGRAMS_SECTION_V2),
+                  recommendedSection.isEmpty()
+                      ? Optional.empty()
+                      : Optional.of(MessageKey.TITLE_OTHER_PROGRAMS_SECTION_V2),
                   MessageKey.BUTTON_VIEW_AND_APPLY,
                   otherPrograms,
                   /* preferredLocale= */ messages.lang().toLocale(),

--- a/server/app/views/applicant/NorthStarFilteredProgramsViewPartial.java
+++ b/server/app/views/applicant/NorthStarFilteredProgramsViewPartial.java
@@ -108,7 +108,7 @@ public class NorthStarFilteredProgramsViewPartial extends NorthStarBaseView {
                   request,
                   messages,
                   recommendedSection.isEmpty()
-                      ? Optional.empty()
+                      ? Optional.of(MessageKey.TITLE_PROGRAMS_SECTION_V2)
                       : Optional.of(MessageKey.TITLE_OTHER_PROGRAMS_SECTION_V2),
                   MessageKey.BUTTON_VIEW_AND_APPLY,
                   otherPrograms,
@@ -116,7 +116,9 @@ public class NorthStarFilteredProgramsViewPartial extends NorthStarBaseView {
                   profile,
                   applicantId,
                   personalInfo,
-                  ProgramCardsSectionParamsFactory.SectionType.DEFAULT));
+                  filteredPrograms.isEmpty()
+                      ? ProgramCardsSectionParamsFactory.SectionType.RECOMMENDED
+                      : ProgramCardsSectionParamsFactory.SectionType.DEFAULT));
     }
 
     context.setVariable("recommendedSection", recommendedSection);

--- a/server/app/views/applicant/NorthStarProgramIndexView.java
+++ b/server/app/views/applicant/NorthStarProgramIndexView.java
@@ -128,6 +128,7 @@ public class NorthStarProgramIndexView extends NorthStarBaseView {
     }
 
     // Used with hx-select to reload the Programs and services section and clear filters
+    // filter?
     String refreshUrl =
         applicantId.isPresent() && profile.isPresent()
             ? applicantRoutes.index(profile.get(), applicantId.get()).url()

--- a/server/app/views/applicant/NorthStarProgramIndexView.java
+++ b/server/app/views/applicant/NorthStarProgramIndexView.java
@@ -127,15 +127,6 @@ public class NorthStarProgramIndexView extends NorthStarBaseView {
                   ProgramCardsSectionParamsFactory.SectionType.UNFILTERED_PROGRAMS));
     }
 
-    // Used with hx-select to reload the Programs and services section and clear filters
-    // filter?
-    String refreshUrl =
-        applicantId.isPresent() && profile.isPresent()
-            ? applicantRoutes.index(profile.get(), applicantId.get()).url()
-            : controllers.applicant.routes.ApplicantProgramsController.indexWithoutApplicantId(
-                    ImmutableList.of())
-                .url();
-
     context.setVariable("myApplicationsSection", myApplicationsSection);
     context.setVariable("commonIntakeSection", intakeSection);
 
@@ -149,7 +140,6 @@ public class NorthStarProgramIndexView extends NorthStarBaseView {
     context.setVariable("isGuest", personalInfo.getType() == GUEST);
     context.setVariable("hasProfile", profile.isPresent());
     context.setVariable("categoryOptions", relevantCategories);
-    context.setVariable("refreshUrl", refreshUrl);
     context.setVariable("applicantId", applicantId);
 
     // Toasts

--- a/server/app/views/applicant/ProgramFiltersFragment.html
+++ b/server/app/views/applicant/ProgramFiltersFragment.html
@@ -56,9 +56,7 @@
             <button
               th:text="#{button.clearSelections}"
               id="clear-filters"
-              th:attr="hx-get=${refreshUrl}"
-              hx-select="#unfiltered-programs"
-              hx-target="#not-started-programs"
+              type="submit"
               class="usa-button usa-button--outline width-full"
             ></button>
           </li>


### PR DESCRIPTION
### Description

Currently in NS, when filters are applied, htmx is used to rerender part of the page to show filtered/unfiltered programs. This partial page is fetched through `/programs/hx/filter`. However, when clearing the filters, we currently fetch and rerender the whole page through `/programs`. 

We plan to update our content security policy to disallow inline styles (see https://github.com/civiform/civiform/issues/9980). However, this current behavior causes a CSP violation upon the page partially reloading when "Clear filters" is clicked, since htmx fetches and then attempts to parse the result for the whole page, which includes a `<style>` tag with a nonce in `<head>` and which fails to parse due to the new nonce not matching properly.

This change changes the "Clear filters" button to fetch just the partial filtered programs view so as to avoid refetching all of the html content of the page.

Fixes #10372

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [ ] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [x] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [x] Noted in the PR description which, if any, code in this PR was generated by AI.

#### User visible changes

- [ ] Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
  - [ ] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [ ] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Made equivalent changes in Thymeleaf for applicant-facing features and changes (or created an issue in the [Northstar epic](https://github.com/orgs/civiform/projects/1/views/94) to track that it's missing from Thymeleaf)
- [x] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order
- [ ] Manually tested with a screen reader if the feature is applicant-facing. See [screen reader testing](https://github.com/civiform/civiform/wiki/Testing#screen-reader-testing)

### Instructions for manual testing

Play around with adding/clearing filters in NS. Verify that the behavior remains the same, and when inspecting the network tab, clearing the filters should now result in a request to the filtering endpoint instead of /programs.

