### PR TITLE
Add backend options for duplicate handling

### DIFF
--- a/server/app/controllers/admin/ProgramMigrationWrapper.java
+++ b/server/app/controllers/admin/ProgramMigrationWrapper.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import services.program.ProgramDefinition;
 import services.question.types.QuestionDefinition;
 
@@ -44,12 +45,19 @@ public final class ProgramMigrationWrapper {
   @JsonInclude(JsonInclude.Include.NON_EMPTY)
   private ImmutableList<QuestionDefinition> questions;
 
+  /**
+   * A map of question admin names that already exist in the question bank to how that imported
+   * question should be handled during import.
+   */
+  private ImmutableMap<String, DuplicateQuestionHandlingOption> duplicateQuestionHandlingOptions;
+
   @JsonCreator
   public ProgramMigrationWrapper(
       @JsonProperty("program") ProgramDefinition program,
       @JsonProperty("questions") ImmutableList<QuestionDefinition> questions) {
     this.program = program;
     this.questions = questions;
+    this.duplicateQuestionHandlingOptions = ImmutableMap.of();
   }
 
   public ProgramDefinition getProgram() {
@@ -66,5 +74,27 @@ public final class ProgramMigrationWrapper {
 
   public void setQuestions(ImmutableList<QuestionDefinition> questions) {
     this.questions = questions;
+  }
+
+  public ImmutableMap<String, DuplicateQuestionHandlingOption>
+      getDuplicateQuestionHandlingOptions() {
+    return duplicateQuestionHandlingOptions;
+  }
+
+  public void setDuplicateQuestionHandlingOptions(
+      ImmutableMap<String, DuplicateQuestionHandlingOption> duplicateQuestionHandlingOptions) {
+    this.duplicateQuestionHandlingOptions = duplicateQuestionHandlingOptions;
+  }
+
+  /** Enum representing the options for handling duplicate questions during program import. */
+  public enum DuplicateQuestionHandlingOption {
+    /**
+     * Create a new question with the same definition as the imported one. A unique admin name is
+     * guaranteed.
+     */
+    CREATE_DUPLICATE,
+
+    /** Create a draft of the existing question with the imported definition. */
+    OVERWRITE_EXISTING,
   }
 }

--- a/server/app/views/admin/migration/AdminProgramImportForm.java
+++ b/server/app/views/admin/migration/AdminProgramImportForm.java
@@ -8,6 +8,8 @@ import com.google.common.collect.ImmutableList;
  */
 public final class AdminProgramImportForm {
   public static final String PROGRAM_JSON_FIELD = "programJson";
+  public static final String DUPLICATE_QUESTION_HANDLING_FIELD_PREFIX =
+      "duplicateQuestionHandling-";
   public static final ImmutableList<String> FIELD_NAMES = ImmutableList.of(PROGRAM_JSON_FIELD);
 
   private String programJson;


### PR DESCRIPTION
### Description

Creates the backend duplicate handling options for the new admin import flow (https://github.com/civiform/civiform/issues/10293 and https://github.com/civiform/civiform/issues/9628). This PR adds the [first two options](https://docs.google.com/document/d/1-3Xhm7MmH-DREzbwu_yKV9tU3VjcbHKmnq_Ea2qYkGQ/edit?tab=t.0) for handling duplicate imported questions. Wiring this to the UI/DB, and the third option will be forthcoming. No users should be currently impacted by this change, as it is predicated on UI components which are not present yet.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)