### PR TITLE
Make the number of users configurable in the github action

### DIFF
--- a/.github/workflows/run_jmeter_test.yaml
+++ b/.github/workflows/run_jmeter_test.yaml
@@ -12,6 +12,10 @@ on:
         description: 'The url to run the load tests for. Defaults to staging-aws.civiform.dev'
         default: staging-aws.civiform.dev
 
+      num_users:
+        description: 'The number of users to run the tests with. Defaults to 10.'
+        default: '10'
+
       output_file_type:
         description: 'The type of the file to output. Defaults to jtl'
         type: choice
@@ -43,7 +47,7 @@ jobs:
         uses: QAInsights/PerfAction@d16221318a6d261b1546b9dec9c0bb1739e3d480 # v5.6.3
         with:
           test-plan-path: load-test/${{ github.event.inputs.test_to_run }}.jmx
-          args: -JciviformUrl=${{ github.event.inputs.civiform_url }}
+          args: -JciviformUrl=${{ github.event.inputs.civiform_url }} -Jusers=${{ github.event.inputs.num_users }}
           results-file: result.${{ github.event.inputs.output_file_type }}
       - name: Upload Results
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4


### PR DESCRIPTION
### Description

Add a param for number of users. Defaults to 10

Tested here: https://github.com/civiform/civiform/actions/runs/14542231643/job/40802248506

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.


### Issue(s) this completes

Meant to help with debugging https://github.com/civiform/civiform/issues/10330
