### PR TITLE
Avoid creating guest account for 404s

### DIFF
--- a/server/app/filters/CiviFormProfileFilter.java
+++ b/server/app/filters/CiviFormProfileFilter.java
@@ -39,8 +39,7 @@ public final class CiviFormProfileFilter extends Filter {
    *
    * <ul>
    *   <li>The request is for a user-facing route
-   *   <li>The request is not for a page that doesn't require a guest profile (eg. /programs,
-   *       /error)
+   *   <li>The request is not for the homepage (/ or /programs) or error page (/error)
    *   <li>The request is for a route that exists (won't result in a 404)
    *   <li>The request uses the `GET` or `HEAD` method (POST cannot be redirected back to the
    *       original URI)

--- a/server/app/filters/CiviFormProfileFilter.java
+++ b/server/app/filters/CiviFormProfileFilter.java
@@ -11,10 +11,12 @@ import controllers.routes;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
+import javax.inject.Provider;
 import org.apache.pekko.stream.Materializer;
 import play.mvc.Filter;
 import play.mvc.Http;
 import play.mvc.Result;
+import play.routing.Router;
 
 /**
  * Ensures that user-facing requests have a CiviFormProfile by redirecting to create a guest session
@@ -22,11 +24,14 @@ import play.mvc.Result;
  */
 public final class CiviFormProfileFilter extends Filter {
   private final ProfileUtils profileUtils;
+  private final Provider<Router> routerProvider;
 
   @Inject
-  public CiviFormProfileFilter(Materializer mat, ProfileUtils profileUtils) {
+  public CiviFormProfileFilter(
+      Materializer mat, ProfileUtils profileUtils, Provider<Router> routerProvider) {
     super(mat);
     this.profileUtils = checkNotNull(profileUtils);
+    this.routerProvider = checkNotNull(routerProvider);
   }
 
   /**
@@ -34,7 +39,9 @@ public final class CiviFormProfileFilter extends Filter {
    *
    * <ul>
    *   <li>The request is for a user-facing route
-   *   <li>The request is not for the homepage (/ or /programs)
+   *   <li>The request is not for a page that doesn't require a guest profile (eg. /programs,
+   *       /error)
+   *   <li>The request is for a route that exists (won't result in a 404)
    *   <li>The request uses the `GET` or `HEAD` method (POST cannot be redirected back to the
    *       original URI)
    *   <li>The session associated with the request does not contain a pac4j user profile
@@ -43,6 +50,7 @@ public final class CiviFormProfileFilter extends Filter {
   private boolean shouldRedirect(Http.RequestHeader requestHeader) {
     return NonUserRoutes.noneMatch(requestHeader)
         && OptionalProfileRoutes.noneMatch(requestHeader)
+        && routerProvider.get().route(requestHeader).isPresent()
         && !requestHeader.path().startsWith("/callback")
         // TODO(#8504) extend to all HTTP methods
         && (requestHeader.method().equals("GET") || requestHeader.method().equals("HEAD"))


### PR DESCRIPTION
### Description

This PR prevents creating guest accounts for bad routes by checking if the route exists in our `routes` before creating a guest account.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)

### Instructions for manual testing

1. Check the number of accounts currently in your local db (`select count(id) from accounts;`)
2. Without logging in, visit a bad route and see our 404 page
3. Check the number of accounts in your local db again and confirm it hasn't increased

### Issue(s) this completes

Fixes #10358 
