### PR TITLE
Enable program filtering in dev

### DIFF
--- a/browser-test/src/applicant/applicant_application_index.test.ts
+++ b/browser-test/src/applicant/applicant_application_index.test.ts
@@ -12,6 +12,7 @@ import {
   validateScreenshot,
   selectApplicantLanguage,
   waitForPageJsLoad,
+  disableFeatureFlag,
 } from '../support'
 import {Page} from 'playwright'
 import {ProgramVisibility} from '../support/admin_programs'
@@ -26,6 +27,7 @@ test.describe('applicant program index page', () => {
 
   test.beforeEach(async ({page, adminPrograms, adminQuestions}) => {
     await loginAsAdmin(page)
+    await disableFeatureFlag(page, 'program_filtering_enabled')
 
     // Create a program with two questions on separate blocks so that an applicant can partially
     // complete an application.

--- a/server/conf/application.dev-browser-tests.conf
+++ b/server/conf/application.dev-browser-tests.conf
@@ -25,7 +25,7 @@ api_generated_docs_enabled = true
 version_cache_enabled=true
 program_cache_enabled=true
 question_cache_enabled=true
-program_filtering_enabled=false
+program_filtering_enabled=true
 name_suffix_dropdown_enabled = true
 
 # In the test environment we don't need to have the jobs running at the


### PR DESCRIPTION
### Description

Program filtering is enabled in staging, but not in dev which is causing some prober tests to fail. This PR enables program filtering in dev and updates the failing tests so they pass.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.
