### PR TITLE
[External Program Cards] Use ProgramType when adding programs on browser tests

### DIFF
--- a/browser-test/src/admin/admin_program_creation.test.ts
+++ b/browser-test/src/admin/admin_program_creation.test.ts
@@ -31,7 +31,7 @@ test.describe('program creation', () => {
       'https://usa.gov',
       ProgramVisibility.PUBLIC,
       'admin description',
-      /* isCommonIntake= */ false,
+      ProgramType.DEFAULT,
       'selectedTI',
       'confirmationMessage',
       Eligibility.IS_GATING,
@@ -60,7 +60,7 @@ test.describe('program creation', () => {
       'https://usa.gov',
       ProgramVisibility.DISABLED,
       'admin description',
-      /* isCommonIntake= */ false,
+      ProgramType.DEFAULT,
       'selectedTI',
       'confirmationMessage',
       Eligibility.IS_GATING,
@@ -103,7 +103,7 @@ test.describe('program creation', () => {
         'https://usa.gov',
         ProgramVisibility.PUBLIC,
         'admin description',
-        /* isCommonIntake= */ false,
+        ProgramType.DEFAULT,
         'selectedTI',
         'confirmationMessage',
         Eligibility.IS_GATING,
@@ -161,7 +161,7 @@ test.describe('program creation', () => {
         'https://usa.gov',
         ProgramVisibility.PUBLIC,
         'admin description',
-        /* isCommonIntake= */ false,
+        ProgramType.DEFAULT,
         'selectedTI',
         'confirmationMessage',
         Eligibility.IS_GATING,
@@ -217,7 +217,7 @@ test.describe('program creation', () => {
       'https://usa.gov',
       ProgramVisibility.PUBLIC,
       'admin description',
-      /* isCommonIntake= */ false,
+      ProgramType.DEFAULT,
       'selectedTI',
       'confirmationMessage',
       Eligibility.IS_GATING,
@@ -1071,7 +1071,7 @@ test.describe('program creation', () => {
       'https://usa.gov',
       ProgramVisibility.PUBLIC,
       'admin description',
-      /* isCommonIntake= */ true,
+      ProgramType.COMMON_INTAKE_FORM,
     )
 
     const programName = 'Apc program'
@@ -1122,7 +1122,7 @@ test.describe('program creation', () => {
       'https://usa.gov',
       ProgramVisibility.PUBLIC,
       'admin description',
-      /* isCommonIntake= */ false,
+      ProgramType.DEFAULT,
     )
 
     await adminPrograms.gotoEditDraftProgramPage('cif')
@@ -1142,7 +1142,7 @@ test.describe('program creation', () => {
       'https://usa.gov',
       ProgramVisibility.PUBLIC,
       'admin description',
-      /* isCommonIntake= */ true,
+      ProgramType.COMMON_INTAKE_FORM,
     )
 
     await adminPrograms.gotoEditDraftProgramPage('cif')
@@ -1219,7 +1219,7 @@ test.describe('program creation', () => {
           'https://usa.gov',
           ProgramVisibility.PUBLIC,
           'admin description',
-          /* isCommonIntake= */ false,
+          ProgramType.DEFAULT,
           'selectedTI',
           'confirmationMessage',
           Eligibility.IS_GATING,
@@ -1509,7 +1509,7 @@ test.describe('program creation', () => {
             /* externalLink= */ 'https://example.com',
             /* visibility= */ undefined,
             /* adminDescription= */ undefined,
-            /* isCommonIntake= */ false,
+            /* programType= */ ProgramType.DEFAULT,
             /* selectedTI= */ undefined,
             /* confirmationMessage= */ undefined,
             /* eligibility= */ undefined,

--- a/browser-test/src/admin/admin_program_list.test.ts
+++ b/browser-test/src/admin/admin_program_list.test.ts
@@ -6,7 +6,7 @@ import {
   loginAsAdmin,
   validateScreenshot,
 } from '../support'
-import {ProgramVisibility} from '../support/admin_programs'
+import {ProgramType, ProgramVisibility} from '../support/admin_programs'
 
 test.describe('Program list page.', () => {
   test('view draft program', async ({page, adminPrograms}) => {
@@ -249,7 +249,7 @@ test.describe('Program list page.', () => {
       'https://usa.gov',
       ProgramVisibility.PUBLIC,
       'admin description',
-      /* isCommonIntake= */ true,
+      ProgramType.COMMON_INTAKE_FORM,
     )
 
     await expectProgramListElements(adminPrograms, [programTwo, programOne])

--- a/browser-test/src/admin/admin_program_migration.test.ts
+++ b/browser-test/src/admin/admin_program_migration.test.ts
@@ -1,6 +1,6 @@
 import {expect, test} from '../support/civiform_fixtures'
 import {enableFeatureFlag, loginAsAdmin, validateScreenshot} from '../support'
-import {ProgramVisibility} from '../support/admin_programs'
+import {ProgramType, ProgramVisibility} from '../support/admin_programs'
 
 test.describe('program migration', () => {
   // These values should be kept in sync with USWDS Alert style classes in views/style/BaseStyles.java.
@@ -268,7 +268,7 @@ test.describe('program migration', () => {
         'https://usa.gov',
         ProgramVisibility.SELECT_TI,
         'admin description',
-        false,
+        ProgramType.DEFAULT,
         'groupOne',
       )
       await adminPrograms.gotoAdminProgramsPage()

--- a/browser-test/src/admin/admin_program_translation.test.ts
+++ b/browser-test/src/admin/admin_program_translation.test.ts
@@ -9,7 +9,7 @@ import {
   validateScreenshot,
   validateToastMessage,
 } from '../support'
-import {ProgramVisibility} from '../support/admin_programs'
+import {ProgramType, ProgramVisibility} from '../support/admin_programs'
 
 test.describe('Admin can manage program translations', () => {
   test('page layout screenshot', async ({
@@ -225,7 +225,7 @@ test.describe('Admin can manage program translations', () => {
         'https://www.example.com',
         ProgramVisibility.PUBLIC,
         'admin description',
-        /* isCommonIntake= */ true,
+        ProgramType.COMMON_INTAKE_FORM,
       )
     })
 
@@ -562,7 +562,7 @@ test.describe('Admin can manage program translations', () => {
           'https://www.example.com',
           ProgramVisibility.PUBLIC,
           'admin description',
-          /* isCommonIntake= */ true,
+          ProgramType.COMMON_INTAKE_FORM,
         )
       })
 

--- a/browser-test/src/admin/admin_program_visibility.test.ts
+++ b/browser-test/src/admin/admin_program_visibility.test.ts
@@ -10,7 +10,7 @@ import {
   waitForPageJsLoad,
 } from '../support'
 import {TEST_USER_DISPLAY_NAME} from '../support/config'
-import {ProgramVisibility} from '../support/admin_programs'
+import {ProgramType, ProgramVisibility} from '../support/admin_programs'
 
 test.describe('Validate program visibility is correct for applicants and TIs', () => {
   test('Create a new hidden program, verify applicants cannot see it on the home page', async ({
@@ -146,7 +146,7 @@ test.describe('Validate program visibility is correct for applicants and TIs', (
       'https://usa.gov',
       ProgramVisibility.SELECT_TI,
       'admin description',
-      /* isCommonIntake= */ false,
+      ProgramType.DEFAULT,
       'groupTwo',
     )
     await adminPrograms.publishAllDrafts()
@@ -226,7 +226,7 @@ test.describe('Validate program visibility is correct for applicants and TIs', (
       'https://usa.gov',
       ProgramVisibility.SELECT_TI,
       'admin description',
-      /* isCommonIntake= */ false,
+      ProgramType.DEFAULT,
       'groupTwo',
     )
     await adminPrograms.publishAllDrafts()

--- a/browser-test/src/admin/northstar_admin_program_image.test.ts
+++ b/browser-test/src/admin/northstar_admin_program_image.test.ts
@@ -7,7 +7,11 @@ import {
   validateToastMessage,
   validateToastHidden,
 } from '../support'
-import {Eligibility, ProgramVisibility} from '../support/admin_programs'
+import {
+  Eligibility,
+  ProgramType,
+  ProgramVisibility,
+} from '../support/admin_programs'
 
 test.describe('Admin can manage program image', {tag: ['@northstar']}, () => {
   test.beforeEach(async ({page}) => {
@@ -85,7 +89,7 @@ test.describe('Admin can manage program image', {tag: ['@northstar']}, () => {
           'https://usa.gov',
           ProgramVisibility.PUBLIC,
           'admin description',
-          /* isCommonIntake= */ false,
+          ProgramType.DEFAULT,
           'selectedTI',
           'confirmationMessage',
           Eligibility.IS_GATING,

--- a/browser-test/src/applicant/applicant_application_index.test.ts
+++ b/browser-test/src/applicant/applicant_application_index.test.ts
@@ -14,7 +14,7 @@ import {
   waitForPageJsLoad,
 } from '../support'
 import {Page} from 'playwright'
-import {ProgramVisibility} from '../support/admin_programs'
+import {ProgramType, ProgramVisibility} from '../support/admin_programs'
 import {BASE_URL} from '../support/config'
 
 test.describe('applicant program index page', () => {
@@ -285,7 +285,7 @@ test.describe('applicant program index page', () => {
         'https://usa.gov',
         ProgramVisibility.PUBLIC,
         'admin description',
-        /* isCommonIntake= */ true,
+        ProgramType.COMMON_INTAKE_FORM,
       )
       await adminPrograms.publishAllDrafts()
       await logout(page)
@@ -686,7 +686,7 @@ test.describe('applicant program index page with images', () => {
       'https://usa.gov',
       ProgramVisibility.PUBLIC,
       'admin description',
-      /* isCommonIntake= */ true,
+      ProgramType.COMMON_INTAKE_FORM,
     )
 
     // In Progress: Image

--- a/browser-test/src/applicant/navigation/application_navigation_common_intake.test.ts
+++ b/browser-test/src/applicant/navigation/application_navigation_common_intake.test.ts
@@ -9,7 +9,7 @@ import {
   validateScreenshot,
   waitForPageJsLoad,
 } from '../../support'
-import {ProgramVisibility} from '../../support/admin_programs'
+import {ProgramType, ProgramVisibility} from '../../support/admin_programs'
 
 test.describe('Applicant navigation flow', () => {
   test.describe('navigation with common intake', () => {
@@ -36,7 +36,7 @@ test.describe('Applicant navigation flow', () => {
           'https://usa.gov',
           ProgramVisibility.PUBLIC,
           'admin description',
-          /* isCommonIntake= */ true,
+          ProgramType.COMMON_INTAKE_FORM,
         )
 
         await adminPrograms.editProgramBlock(

--- a/browser-test/src/applicant/navigation/northstar_application_navigation_common_intake.test.ts
+++ b/browser-test/src/applicant/navigation/northstar_application_navigation_common_intake.test.ts
@@ -11,7 +11,7 @@ import {
   validateScreenshot,
   waitForPageJsLoad,
 } from '../../support'
-import {ProgramVisibility} from '../../support/admin_programs'
+import {ProgramType, ProgramVisibility} from '../../support/admin_programs'
 import {CardSectionName} from '../../support/applicant_program_list'
 
 test.describe('Applicant navigation flow', {tag: ['@northstar']}, () => {
@@ -43,7 +43,7 @@ test.describe('Applicant navigation flow', {tag: ['@northstar']}, () => {
           'https://usa.gov',
           ProgramVisibility.PUBLIC,
           'admin description',
-          /* isCommonIntake= */ true,
+          ProgramType.COMMON_INTAKE_FORM,
         )
 
         await adminPrograms.editProgramBlock(

--- a/browser-test/src/applicant/northstar_applicant_application_index.test.ts
+++ b/browser-test/src/applicant/northstar_applicant_application_index.test.ts
@@ -15,7 +15,7 @@ import {
   waitForPageJsLoad,
 } from '../support'
 import {Locator, Page} from 'playwright'
-import {ProgramVisibility} from '../support/admin_programs'
+import {ProgramType, ProgramVisibility} from '../support/admin_programs'
 import {BASE_URL} from '../support/config'
 
 test.describe('applicant program index page', {tag: ['@northstar']}, () => {
@@ -649,7 +649,7 @@ test.describe('applicant program index page', {tag: ['@northstar']}, () => {
         'https://usa.gov',
         ProgramVisibility.PUBLIC,
         'admin description',
-        /* isCommonIntake= */ true,
+        ProgramType.COMMON_INTAKE_FORM,
       )
 
       await adminPrograms.addProgramBlockUsingSpec(
@@ -1070,7 +1070,7 @@ test.describe(
           'https://usa.gov',
           ProgramVisibility.PUBLIC,
           'admin description',
-          /* isCommonIntake= */ true,
+          ProgramType.COMMON_INTAKE_FORM,
         )
 
         await adminPrograms.addProgram(programNameInProgressImage)

--- a/browser-test/src/applicant/northstar_common_intake_upsell.test.ts
+++ b/browser-test/src/applicant/northstar_common_intake_upsell.test.ts
@@ -10,7 +10,7 @@ import {
   loginAsTrustedIntermediary,
   waitForPageJsLoad,
 } from '../support'
-import {ProgramVisibility} from '../support/admin_programs'
+import {ProgramType, ProgramVisibility} from '../support/admin_programs'
 
 test.describe(
   'North Star Common Intake Upsell Tests',
@@ -30,7 +30,7 @@ test.describe(
           'https://usa.gov',
           ProgramVisibility.PUBLIC,
           'admin description',
-          /* isCommonIntake= */ true,
+          ProgramType.COMMON_INTAKE_FORM,
         )
         await adminPrograms.publishProgram(programName)
         await adminPrograms.expectActiveProgram(programName)

--- a/browser-test/src/support/admin_programs.ts
+++ b/browser-test/src/support/admin_programs.ts
@@ -195,7 +195,7 @@ export class AdminPrograms {
     externalLink = 'https://usa.gov',
     visibility = ProgramVisibility.PUBLIC,
     adminDescription = 'admin description',
-    isCommonIntake = false,
+    programType: ProgramType = ProgramType.DEFAULT,
     selectedTI = 'none',
     confirmationMessage = 'This is the _custom confirmation message_ with markdown\n' +
       '[This is a link](https://www.example.com)\n' +
@@ -238,9 +238,18 @@ export class AdminPrograms {
 
     await this.chooseEligibility(eligibility)
 
-    if (isCommonIntake && this.getCommonIntakeFormToggle != null) {
+    // Program type selector varies with the EXTERNAL_PROGRAM_CARDS feature.
+    // When enabled, form has program type options. Otherwise, form has a
+    // common intake checkbox.
+    const externalProgramsFeatureEnabled =
+      await this.getProgramTypeOption(programType).isVisible()
+    if (externalProgramsFeatureEnabled) {
+      await this.selectProgramType(programType)
+    } else if (programType === ProgramType.COMMON_INTAKE_FORM) {
       await this.clickCommonIntakeFormToggle()
-    } else {
+    }
+
+    if (programType === ProgramType.DEFAULT) {
       for (let i = 0; i < applicationSteps.length; i++) {
         const indexPlusOne = i + 1
         await this.page


### PR DESCRIPTION
### Description

Change `addProgram()` in browser-test/src/support/admin_programs.ts to use `ProgramType` instead of a `isCommonIntake boolean`. This is wanted to support the introduction of external programs of a program type.

No functionality or UI changed.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/helper/feature-flags.conf`
- [x] Conditioned new functionality on a [FeatureFlag](https://github.com/civiform/civiform/wiki/Feature-Flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.


### Issue(s) this completes

Part of #10183
