### PR TITLE
[External Program Cards] Use ProgramType in ProgramCardsParam

### DIFF
--- a/server/app/views/applicant/ProgramCardsSectionFragment.html
+++ b/server/app/views/applicant/ProgramCardsSectionFragment.html
@@ -36,7 +36,7 @@
     <th:block th:each="card : ${section.cards()}">
       <!-- Standard cards and pre-screener card (after it is started) -->
       <li
-        th:replace="${card.isCommonIntakeForm} ? ~{applicant/ProgramCardsFragment :: submittedOrInProgressPreScreenerCard(${card})} : ~{applicant/ProgramCardsFragment :: card(${card}, ${sectionType} ?: 'DEFAULT')}"
+        th:replace="${card.programType().toString() == 'COMMON_INTAKE_FORM'} ? ~{applicant/ProgramCardsFragment :: submittedOrInProgressPreScreenerCard(${card})} : ~{applicant/ProgramCardsFragment :: card(${card}, ${sectionType} ?: 'DEFAULT')}"
       ></li>
     </th:block>
   </ul>

--- a/server/app/views/applicant/ProgramCardsSectionParamsFactory.java
+++ b/server/app/views/applicant/ProgramCardsSectionParamsFactory.java
@@ -22,6 +22,7 @@ import services.applicant.ApplicantPersonalInfo;
 import services.applicant.ApplicantService.ApplicantProgramData;
 import services.cloud.PublicStorageClient;
 import services.program.ProgramDefinition;
+import services.program.ProgramType;
 import views.ProgramImageUtils;
 import views.components.Modal;
 
@@ -140,7 +141,7 @@ public final class ProgramCardsSectionParamsFactory {
             applicantRoutes,
             program.id(),
             program.slug(),
-            program.isCommonIntakeForm(),
+            program.programType(),
             programDatum.latestApplicationLifecycleStage(),
             applicantId,
             profile);
@@ -160,10 +161,10 @@ public final class ProgramCardsSectionParamsFactory {
         .setBody(description)
         .setActionUrl(actionUrl)
         .setIsGuest(isGuest)
-        .setIsCommonIntakeForm(program.isCommonIntakeForm())
         .setCategories(categoriesBuilder.build())
         .setActionText(messages.at(buttonText.getKeyName()))
-        .setProgramId(program.id());
+        .setProgramId(program.id())
+        .setProgramType(program.programType());
 
     if (isGuest) {
       cardBuilder.setLoginModalId("login-dialog-" + program.id());
@@ -228,7 +229,7 @@ public final class ProgramCardsSectionParamsFactory {
       ApplicantRoutes applicantRoutes,
       Long programId,
       String programSlug,
-      boolean isCommonIntakeForm,
+      ProgramType programType,
       Optional<LifecycleStage> optionalLifecycleStage,
       Optional<Long> applicantId,
       Optional<CiviFormProfile> profile) {
@@ -261,7 +262,7 @@ public final class ProgramCardsSectionParamsFactory {
       }
       // If they are completing the common intake form for the first time, skip the program overview
       // page
-    } else if (isCommonIntakeForm) {
+    } else if (programType.equals(ProgramType.COMMON_INTAKE_FORM)) {
       actionUrl =
           haveApplicant
               ? applicantRoutes.edit(profile.get(), applicantId.get(), programId).url()
@@ -344,8 +345,6 @@ public final class ProgramCardsSectionParamsFactory {
 
     public abstract boolean isGuest();
 
-    public abstract boolean isCommonIntakeForm();
-
     public abstract Optional<String> loginModalId();
 
     public abstract Optional<Boolean> eligible();
@@ -371,6 +370,8 @@ public final class ProgramCardsSectionParamsFactory {
 
     public abstract long programId();
 
+    public abstract ProgramType programType();
+
     public static Builder builder() {
       return new AutoValue_ProgramCardsSectionParamsFactory_ProgramCardParams.Builder();
     }
@@ -388,8 +389,6 @@ public final class ProgramCardsSectionParamsFactory {
       public abstract Builder setActionUrl(String actionUrl);
 
       public abstract Builder setIsGuest(Boolean isGuest);
-
-      public abstract Builder setIsCommonIntakeForm(Boolean isCommonIntakeForm);
 
       public abstract Builder setLoginModalId(String loginModalId);
 
@@ -412,6 +411,8 @@ public final class ProgramCardsSectionParamsFactory {
       public abstract Builder setCategories(ImmutableList<String> categories);
 
       public abstract Builder setProgramId(long id);
+
+      public abstract Builder setProgramType(ProgramType programType);
 
       public abstract ProgramCardParams build();
     }

--- a/server/test/views/applicant/ProgramCardsSectionParamsFactoryTest.java
+++ b/server/test/views/applicant/ProgramCardsSectionParamsFactoryTest.java
@@ -13,6 +13,7 @@ import models.LifecycleStage;
 import org.junit.Before;
 import org.junit.Test;
 import repository.ResetPostgres;
+import services.program.ProgramType;
 
 public class ProgramCardsSectionParamsFactoryTest extends ResetPostgres {
   private CiviFormProfile testProfile;
@@ -36,7 +37,7 @@ public class ProgramCardsSectionParamsFactoryTest extends ResetPostgres {
             applicantRoutes,
             /* programId= */ 1L,
             /* programSlug= */ "fake-program",
-            /* isCommonIntakeForm= */ false,
+            ProgramType.DEFAULT,
             // empty lifecycle stage means this is their first time filling out this application
             /* lifeCycleStage= */ Optional.empty(),
             /* applicantId= */ Optional.empty(),
@@ -52,7 +53,7 @@ public class ProgramCardsSectionParamsFactoryTest extends ResetPostgres {
             applicantRoutes,
             /* programId= */ 1L,
             /* programSlug= */ "fake-program",
-            /* isCommonIntakeForm= */ false,
+            ProgramType.DEFAULT,
             // empty lifecycle stage means this is their first time filling out this application
             /* lifeCycleStage= */ Optional.empty(),
             /* applicantId= */ Optional.of(1L),
@@ -68,7 +69,7 @@ public class ProgramCardsSectionParamsFactoryTest extends ResetPostgres {
             applicantRoutes,
             /* programId= */ 1L,
             /* programSlug= */ "fake-program",
-            /* isCommonIntakeForm= */ false,
+            ProgramType.DEFAULT,
             Optional.of(
                 LifecycleStage.DRAFT), // draft lifecyle stage means they have an in progress draft
             /* applicantId= */ Optional.empty(),
@@ -84,7 +85,7 @@ public class ProgramCardsSectionParamsFactoryTest extends ResetPostgres {
             applicantRoutes,
             /* programId= */ 1L,
             /* programSlug= */ "fake-program",
-            /* isCommonIntakeForm= */ false,
+            ProgramType.DEFAULT,
             Optional.of(
                 LifecycleStage.DRAFT), // draft lifecyle stage means they have an in progress draft
             /* applicantId= */ Optional.of(1L),
@@ -100,7 +101,7 @@ public class ProgramCardsSectionParamsFactoryTest extends ResetPostgres {
             applicantRoutes,
             /* programId= */ 1L,
             /* programSlug= */ "fake-program",
-            /* isCommonIntakeForm= */ false,
+            ProgramType.DEFAULT,
             Optional.of(
                 LifecycleStage
                     .ACTIVE), // active lifecycle stage means they have submitted the application
@@ -117,7 +118,7 @@ public class ProgramCardsSectionParamsFactoryTest extends ResetPostgres {
             applicantRoutes,
             /* programId= */ 1L,
             /* programSlug= */ "fake-program",
-            /* isCommonIntakeForm= */ false,
+            ProgramType.DEFAULT,
             Optional.of(
                 LifecycleStage
                     .ACTIVE), // active lifecycle stage means they have submitted the application
@@ -134,7 +135,7 @@ public class ProgramCardsSectionParamsFactoryTest extends ResetPostgres {
             applicantRoutes,
             /* programId= */ 1L,
             /* programSlug= */ "fake-program",
-            /* isCommonIntakeForm= */ true,
+            ProgramType.COMMON_INTAKE_FORM,
             // empty lifecycle stage means this is their first time filling out this application
             /* lifeCycleStage= */ Optional.empty(),
             /* applicantId= */ Optional.empty(),
@@ -150,7 +151,7 @@ public class ProgramCardsSectionParamsFactoryTest extends ResetPostgres {
             applicantRoutes,
             /* programId= */ 1L,
             /* programSlug= */ "fake-program",
-            /* isCommonIntakeForm= */ true,
+            ProgramType.COMMON_INTAKE_FORM,
             // empty lifecycle stage means this is their first time filling out this application
             /* lifeCycleStage= */ Optional.empty(),
             /* applicantId= */ Optional.of(1L),


### PR DESCRIPTION
### Description

Use `programType` instead of `isCommonIntake` in `ProgramCardParams`. This will allow for an easier introduction of  external program cards

No functionality or UI changed.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

### Issue(s) this completes

Part of #10184
