### PR TITLE
Fix toDate API documentation

### DIFF
--- a/server/app/services/openapi/v2/Swagger2SchemaGenerator.java
+++ b/server/app/services/openapi/v2/Swagger2SchemaGenerator.java
@@ -111,9 +111,9 @@ public class Swagger2SchemaGenerator extends AbstractOpenApiSchemaGenerator
                                       .type(DefinitionType.STRING.toString())
                                       .description(
                                           "An ISO-8601 formatted date (i.e. YYYY-MM-DD). Limits"
-                                              + " results to applications submitted on or after the"
-                                              + " provided date, in the CiviForm instance's local"
-                                              + " time."))
+                                              + " results to applications submitted before the"
+                                              + " provided date, in the CiviForm instance's"
+                                              + " local time."))
                               .parameter(
                                   new QueryParameter()
                                       .name("pageSize")

--- a/server/app/services/openapi/v3/OpenApi3SchemaGenerator.java
+++ b/server/app/services/openapi/v3/OpenApi3SchemaGenerator.java
@@ -176,8 +176,8 @@ public class OpenApi3SchemaGenerator extends AbstractOpenApiSchemaGenerator
                                               .description(
                                                   "An ISO-8601 formatted date (i.e. YYYY-MM-DD)."
                                                       + " Limits results to applications submitted"
-                                                      + " on or after the provided date, in the"
-                                                      + " CiviForm instance's local time.")
+                                                      + " before the provided date, in the CiviForm"
+                                                      + " instance's local time.")
                                               .schema(new StringSchema()))
                                       .addParametersItem(
                                           new QueryParameter()

--- a/server/test/services/openapi/v2/Swagger2SchemaGeneratorTest.java
+++ b/server/test/services/openapi/v2/Swagger2SchemaGeneratorTest.java
@@ -111,8 +111,8 @@ paths:
       - name: "toDate"
         in: "query"
         description: "An ISO-8601 formatted date (i.e. YYYY-MM-DD). Limits results\\
-          \\ to applications submitted on or after the provided date, in the CiviForm\\
-          \\ instance's local time."
+          \\ to applications submitted before the provided date, in the CiviForm instance's\\
+          \\ local time."
         required: false
         type: "string"
       - name: "pageSize"
@@ -297,8 +297,8 @@ paths:
       - name: "toDate"
         in: "query"
         description: "An ISO-8601 formatted date (i.e. YYYY-MM-DD). Limits results\\
-          \\ to applications submitted on or after the provided date, in the CiviForm\\
-          \\ instance's local time."
+          \\ to applications submitted before the provided date, in the CiviForm instance's\\
+          \\ local time."
         required: false
         type: "string"
       - name: "pageSize"
@@ -836,8 +836,8 @@ paths:
       - name: "toDate"
         in: "query"
         description: "An ISO-8601 formatted date (i.e. YYYY-MM-DD). Limits results\\
-          \\ to applications submitted on or after the provided date, in the CiviForm\\
-          \\ instance's local time."
+          \\ to applications submitted before the provided date, in the CiviForm instance's\\
+          \\ local time."
         required: false
         type: "string"
       - name: "pageSize"

--- a/server/test/services/openapi/v3/OpenApi3SchemaGeneratorTest.java
+++ b/server/test/services/openapi/v3/OpenApi3SchemaGeneratorTest.java
@@ -106,8 +106,8 @@ paths:
       - name: toDate
         in: query
         description: "An ISO-8601 formatted date (i.e. YYYY-MM-DD). Limits results\\
-          \\ to applications submitted on or after the provided date, in the CiviForm\\
-          \\ instance's local time."
+          \\ to applications submitted before the provided date, in the CiviForm instance's\\
+          \\ local time."
         schema:
           type: string
       - name: pageSize
@@ -296,8 +296,8 @@ paths:
       - name: toDate
         in: query
         description: "An ISO-8601 formatted date (i.e. YYYY-MM-DD). Limits results\\
-          \\ to applications submitted on or after the provided date, in the CiviForm\\
-          \\ instance's local time."
+          \\ to applications submitted before the provided date, in the CiviForm instance's\\
+          \\ local time."
         schema:
           type: string
       - name: pageSize
@@ -839,8 +839,8 @@ paths:
       - name: toDate
         in: query
         description: "An ISO-8601 formatted date (i.e. YYYY-MM-DD). Limits results\\
-          \\ to applications submitted on or after the provided date, in the CiviForm\\
-          \\ instance's local time."
+          \\ to applications submitted before the provided date, in the CiviForm instance's\\
+          \\ local time."
         schema:
           type: string
       - name: pageSize


### PR DESCRIPTION
### Description

Fix `toDate` parameter in the API (both v2 and v3) to be "on or before the provided date" instead of "on or after the provided date"

### Issue(s) this completes

None
