### PR TITLE
Fix Apache CSV deprecation warnings

### DIFF
--- a/server/test/services/export/CsvExporterServiceTest.java
+++ b/server/test/services/export/CsvExporterServiceTest.java
@@ -44,7 +44,7 @@ import services.question.types.TextQuestionDefinition;
 
 public class CsvExporterServiceTest extends AbstractExporterTest {
 
-  private static final CSVFormat DEFAULT_FORMAT = CSVFormat.DEFAULT.builder().setHeader().build();
+  private static final CSVFormat DEFAULT_FORMAT = CSVFormat.DEFAULT.builder().setHeader().get();
   private static final String SECRET_SALT = "super secret";
   private static final String BASE_URL = String.format("http://localhost:%d", testServerPort());
   private static final ImmutableList<String> metadataHeaders =

--- a/server/test/services/reporting/ReportingServiceTest.java
+++ b/server/test/services/reporting/ReportingServiceTest.java
@@ -48,7 +48,7 @@ public class ReportingServiceTest extends ResetPostgres {
 
     var parser =
         CSVParser.parse(
-            service.applicationCountsByMonthCsv(), CSVFormat.DEFAULT.builder().setHeader().build());
+            service.applicationCountsByMonthCsv(), CSVFormat.DEFAULT.builder().setHeader().get());
 
     assertThat(parser.getHeaderNames())
         .containsExactly(
@@ -68,8 +68,7 @@ public class ReportingServiceTest extends ResetPostgres {
 
     parser =
         CSVParser.parse(
-            service.applicationCountsByProgramCsv(),
-            CSVFormat.DEFAULT.builder().setHeader().build());
+            service.applicationCountsByProgramCsv(), CSVFormat.DEFAULT.builder().setHeader().get());
     assertThat(parser.getHeaderNames())
         .containsExactly(
             "Program",
@@ -89,7 +88,7 @@ public class ReportingServiceTest extends ResetPostgres {
     parser =
         CSVParser.parse(
             service.applicationsToProgramByMonthCsv("Fake Program B"),
-            CSVFormat.DEFAULT.builder().setHeader().build());
+            CSVFormat.DEFAULT.builder().setHeader().get());
     assertThat(parser.getHeaderNames())
         .containsExactly(
             "Month",


### PR DESCRIPTION
### Description

Fixes deprecation warnings in apache csv library. The `build` method is now `get`.
