### PR TITLE
Allow empty strings when setting theme colors

### DIFF
--- a/browser-test/src/admin/admin_settings.test.ts
+++ b/browser-test/src/admin/admin_settings.test.ts
@@ -65,7 +65,7 @@ test.describe('Managing system-wide settings', () => {
     })
   })
 
-  test('Validates color contrast in theme settings', async ({
+  test('Validates theme settings', async ({
     adminSettings,
   }) => {
     await adminSettings.gotoAdminSettings()
@@ -109,6 +109,15 @@ test.describe('Managing system-wide settings', () => {
       await adminSettings.saveChanges(
         /* expectUpdated= */ false,
         /* expectError= */ true,
+      )
+    })
+
+    await test.step('can remove settings', async () => {
+      await adminSettings.setStringSetting('THEME_COLOR_PRIMARY', '')
+      await adminSettings.setStringSetting('THEME_COLOR_PRIMARY_DARK', '')
+      await adminSettings.saveChanges(
+        /* expectUpdated= */ true,
+        /* expectError= */ false,
       )
     })
   })

--- a/browser-test/src/admin/admin_settings.test.ts
+++ b/browser-test/src/admin/admin_settings.test.ts
@@ -65,9 +65,7 @@ test.describe('Managing system-wide settings', () => {
     })
   })
 
-  test('Validates theme settings', async ({
-    adminSettings,
-  }) => {
+  test('Validates theme settings', async ({adminSettings}) => {
     await adminSettings.gotoAdminSettings()
 
     await test.step('contrast ratio not met on primary color', async () => {

--- a/server/app/services/settings/SettingsManifest.java
+++ b/server/app/services/settings/SettingsManifest.java
@@ -1157,7 +1157,7 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                           /* isRequired= */ false,
                           SettingType.STRING,
                           SettingMode.ADMIN_WRITEABLE,
-                          Pattern.compile("^#(?:[0-9a-fA-F]{3}){1,2}$")),
+                          Pattern.compile("(^#(?:[0-9a-fA-F]{3}){1,2}$)?")),
                       SettingDescription.create(
                           "THEME_COLOR_PRIMARY_DARK",
                           "A darker version of your primary color can be applied to your website"
@@ -1166,7 +1166,7 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                           /* isRequired= */ false,
                           SettingType.STRING,
                           SettingMode.ADMIN_WRITEABLE,
-                          Pattern.compile("^#(?:[0-9a-fA-F]{3}){1,2}$")))))
+                          Pattern.compile("(^#(?:[0-9a-fA-F]{3}){1,2}$)?")))))
           .put(
               "External Services",
               SettingsSection.create(

--- a/server/app/services/settings/SettingsManifest.java
+++ b/server/app/services/settings/SettingsManifest.java
@@ -1157,7 +1157,7 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                           /* isRequired= */ false,
                           SettingType.STRING,
                           SettingMode.ADMIN_WRITEABLE,
-                          Pattern.compile("(^#(?:[0-9a-fA-F]{3}){1,2}$)?")),
+                          Pattern.compile("(^#(?:[0-9a-fA-F]{3}){1,2}$)|^$")),
                       SettingDescription.create(
                           "THEME_COLOR_PRIMARY_DARK",
                           "A darker version of your primary color can be applied to your website"
@@ -1166,7 +1166,7 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                           /* isRequired= */ false,
                           SettingType.STRING,
                           SettingMode.ADMIN_WRITEABLE,
-                          Pattern.compile("(^#(?:[0-9a-fA-F]{3}){1,2}$)?")))))
+                          Pattern.compile("(^#(?:[0-9a-fA-F]{3}){1,2}$)|^$")))))
           .put(
               "External Services",
               SettingsSection.create(

--- a/server/app/services/settings/SettingsService.java
+++ b/server/app/services/settings/SettingsService.java
@@ -195,7 +195,7 @@ public final class SettingsService {
                           || settingDescription.variableName().equals("THEME_COLOR_PRIMARY_DARK")) {
                         // Only allow admins to set theme colors that have a contrast ratio of 4.5:1
                         // with white, for accessibility reasons.
-                        if (!ColorUtil.contrastsWithWhite(newValue)) {
+                        if (!newValue.isEmpty() && !ColorUtil.contrastsWithWhite(newValue)) {
                           validationErrors.put(
                               settingDescription.variableName(),
                               SettingsGroupUpdateResult.UpdateError.create(

--- a/server/conf/env-var-docs.json
+++ b/server/conf/env-var-docs.json
@@ -40,22 +40,25 @@
         "mode": "ADMIN_WRITEABLE",
         "description": "A primary color is the color displayed most prominently across your website. Enter the hex code for this color. Not ready for production use.",
         "type": "string",
-        "regex": "^#(?:[0-9a-fA-F]{3}){1,2}$",
+        "regex": "(^#(?:[0-9a-fA-F]{3}){1,2}$)?",
         "regex_tests": [
           {"val": "#f12345", "should_match": true},
           {"val": "#c13", "should_match": true},
-          {"val": "cccccc", "should_match": false}
+          {"val": "cccccc", "should_match": false},
+          {"val": "", "should_match": true}
         ]
       },
       "THEME_COLOR_PRIMARY_DARK": {
         "mode": "ADMIN_WRITEABLE",
         "description": "A darker version of your primary color can be applied to your website for some purposes. Enter the hex code for this color. Not ready for production use.",
         "type": "string",
-        "regex": "^#(?:[0-9a-fA-F]{3}){1,2}$",
+        "required": false,
+        "regex": "(^#(?:[0-9a-fA-F]{3}){1,2}$)?",
         "regex_tests": [
           {"val": "#f12345", "should_match": true},
           {"val": "#c13", "should_match": true},
-          {"val": "cccccc", "should_match": false}
+          {"val": "cccccc", "should_match": false},
+          {"val": "", "should_match": true}
         ]
       }
     }

--- a/server/conf/env-var-docs.json
+++ b/server/conf/env-var-docs.json
@@ -40,7 +40,7 @@
         "mode": "ADMIN_WRITEABLE",
         "description": "A primary color is the color displayed most prominently across your website. Enter the hex code for this color. Not ready for production use.",
         "type": "string",
-        "regex": "(^#(?:[0-9a-fA-F]{3}){1,2}$)?",
+        "regex": "(^#(?:[0-9a-fA-F]{3}){1,2}$)|^$",
         "regex_tests": [
           {"val": "#f12345", "should_match": true},
           {"val": "#c13", "should_match": true},
@@ -53,7 +53,7 @@
         "description": "A darker version of your primary color can be applied to your website for some purposes. Enter the hex code for this color. Not ready for production use.",
         "type": "string",
         "required": false,
-        "regex": "(^#(?:[0-9a-fA-F]{3}){1,2}$)?",
+        "regex": "(^#(?:[0-9a-fA-F]{3}){1,2}$)|^$",
         "regex_tests": [
           {"val": "#f12345", "should_match": true},
           {"val": "#c13", "should_match": true},


### PR DESCRIPTION
### Description

Allow admins to remove theme color settings by saving an empty string. If the setting is empty, the site will revert back to the default color(s).

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [x] Noted in the PR description which, if any, code in this PR was generated by AI.

### Issue(s) this completes

Fixes #10423
