### PR TITLE
Redirect to home page when applicants/:applicantId/programs/:programName has an invalid programName

### DIFF
--- a/server/app/controllers/applicant/ApplicantProgramsController.java
+++ b/server/app/controllers/applicant/ApplicantProgramsController.java
@@ -211,9 +211,15 @@ public final class ApplicantProgramsController extends CiviFormController {
   @Secure
   public CompletionStage<Result> showWithApplicantId(
       Request request, long applicantId, String programName) {
-    CiviFormProfile profile = profileUtils.currentUserProfile(request);
-    return programSlugHandler.showProgramWithApplicantId(
-        this, request, programName, applicantId, profile);
+    if (StringUtils.isNumeric(programName)) {
+      // We no longer support (or provide) links to numeric program ID (See issue #8599), redirect
+      // to home.
+      return CompletableFuture.completedFuture(redirectToHome());
+    } else {
+      CiviFormProfile profile = profileUtils.currentUserProfile(request);
+      return programSlugHandler.showProgramWithApplicantId(
+          this, request, programName, applicantId, profile);
+    }
   }
 
   @Secure

--- a/server/test/controllers/applicant/ApplicantProgramsControllerTest.java
+++ b/server/test/controllers/applicant/ApplicantProgramsControllerTest.java
@@ -296,6 +296,14 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
   }
 
   @Test
+  public void showWithApplicantId_withProgramIdRedirects() {
+    Result result =
+        controller.showWithApplicantId(fakeRequest(), 1, "123").toCompletableFuture().join();
+    assertThat(result.status()).isEqualTo(SEE_OTHER);
+    assertThat(result.redirectLocation()).hasValue("/");
+  }
+
+  @Test
   public void showWithApplicantId_withStringProgramParam_redirectsToReview() {
     ProgramModel program = resourceCreator().insertActiveProgram("program");
 


### PR DESCRIPTION
### Description

In https://github.com/civiform/civiform/pull/8701/files, we added validation that the programName is not an ID for the `show` endpoint, which gets called from /programs/:programParam, but we didn't handle the `showWithApplicantId` case

For more context:

There are two identical endpoints:
- [/programs/:programParam](https://github.com/civiform/civiform/blob/main/server/conf/routes#L192) 
  - calls [controllers.applicant.ApplicantProgramsController.show](https://github.com/civiform/civiform/blob/94d06b451ee15e5674690662c6e24b66a1ca44e3/server/app/controllers/applicant/ApplicantProgramsController.java#L201), which then calls [showWithApplicantId](https://github.com/civiform/civiform/blob/main/server/app/controllers/applicant/ProgramSlugHandler.java#L96)
- [/applicants/:applicantId/programs/:programName](https://github.com/civiform/civiform/blob/main/server/conf/routes#L203)
  - calls [controllers.applicant.ApplicantProgramsController.showWithApplicantId](https://github.com/civiform/civiform/blob/main/server/app/controllers/applicant/ProgramSlugHandler.java#L96)

We've removed references to the application ID in URLs, so the second one should only be called with legacy links. Arkansas noticed several not found errors that matched the second URL schema, but with the programName as an ID
![Not Found 404 (1)](https://github.com/user-attachments/assets/d07cf50a-bf61-4544-9a48-392a93565264)

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [ ] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [ ] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

### Instructions for manual testing

Tested with: http://localhost:9000/applications/1/programs/1 and confirmed that before this gave an error `java.lang.RuntimeException: services.program.ProgramNotFoundException: Program not found for slug: 1` and now it redirects to the home page.


### Issue(s) this completes

Fixes https://github.com/civiform/civiform/issues/8599