### PR TITLE
Rename message keys and file names from "common intake" to "pre-screener"

### DIFF
--- a/browser-test/src/support/admin_programs.ts
+++ b/browser-test/src/support/admin_programs.ts
@@ -1603,16 +1603,6 @@ export class AdminPrograms {
     await this.page.waitForLoadState()
   }
 
-  /**
-   *
-   * @deprecated prefer using {@link getPreScreenerFormToggle} instead.
-   */
-  getCommonIntakeFormToggle() {
-    return this.page.getByRole('checkbox', {
-      name: 'Set program as pre-screener',
-    })
-  }
-
   getPreScreenerFormToggle() {
     return this.page.getByRole('checkbox', {
       name: 'Set program as pre-screener',
@@ -1691,19 +1681,6 @@ export class AdminPrograms {
         break
     }
     await this.page.locator('label[for="' + programId + '"]').click()
-  }
-
-  /**
-   * @todo (#10363): Migrate callers to use selectProgramType(programType) once
-   * EXTERNAL_PROGRAM_CARDS is enabled by default.
-   * @deprecated prefer using {@link clickPreScreenerFormToggle} instead.
-   */
-  async clickCommonIntakeFormToggle() {
-    // Note: We click on the label instead of directly interacting with the checkbox
-    // because USWDS styling hides the actual checkbox input and styles the label to
-    // look like a checkbox. The actual input element is visually hidden or positioned
-    // off-screen, making it inaccessible to Playwright's direct interactions.
-    await this.page.locator('label[for="common-intake-checkbox"]').click()
   }
 
   // TODO(#10363): Migrate callers to use selectProgramType(programType) once

--- a/browser-test/src/support/admin_programs.ts
+++ b/browser-test/src/support/admin_programs.ts
@@ -1603,6 +1603,16 @@ export class AdminPrograms {
     await this.page.waitForLoadState()
   }
 
+  /**
+   * 
+   * @deprecated prefer using {@link getPreScreenerFormToggle} instead.
+   */
+  getCommonIntakeFormToggle() {
+    return this.page.getByRole('checkbox', {
+      name: 'Set program as pre-screener',
+    })
+  }
+
   getPreScreenerFormToggle() {
     return this.page.getByRole('checkbox', {
       name: 'Set program as pre-screener',
@@ -1673,11 +1683,27 @@ export class AdminPrograms {
       case ProgramType.PRE_SCREENER:
         programId = 'common-intake-program-option'
         break
+      case ProgramType.PRE_SCREENER_FORM:
+        programId = 'common-intake-program-option'
+        break
       case ProgramType.EXTERNAL:
         programId = 'external-program-option'
         break
     }
     await this.page.locator('label[for="' + programId + '"]').click()
+  }
+
+  /**
+   * @todo (#10363): Migrate callers to use selectProgramType(programType) once
+   * EXTERNAL_PROGRAM_CARDS is enabled by default.
+   * @deprecated prefer using {@link clickPreScreenerFormToggle} instead.
+   */
+  async clickCommonIntakeFormToggle() {
+    // Note: We click on the label instead of directly interacting with the checkbox
+    // because USWDS styling hides the actual checkbox input and styles the label to
+    // look like a checkbox. The actual input element is visually hidden or positioned
+    // off-screen, making it inaccessible to Playwright's direct interactions.
+    await this.page.locator('label[for="common-intake-checkbox"]').click()
   }
 
   // TODO(#10363): Migrate callers to use selectProgramType(programType) once

--- a/browser-test/src/support/admin_programs.ts
+++ b/browser-test/src/support/admin_programs.ts
@@ -1604,7 +1604,7 @@ export class AdminPrograms {
   }
 
   /**
-   * 
+   *
    * @deprecated prefer using {@link getPreScreenerFormToggle} instead.
    */
   getCommonIntakeFormToggle() {

--- a/browser-test/src/support/admin_programs.ts
+++ b/browser-test/src/support/admin_programs.ts
@@ -1673,9 +1673,6 @@ export class AdminPrograms {
       case ProgramType.PRE_SCREENER:
         programId = 'common-intake-program-option'
         break
-      case ProgramType.PRE_SCREENER_FORM:
-        programId = 'common-intake-program-option'
-        break
       case ProgramType.EXTERNAL:
         programId = 'external-program-option'
         break

--- a/browser-test/src/support/applicant_questions.ts
+++ b/browser-test/src/support/applicant_questions.ts
@@ -537,10 +537,36 @@ export class ApplicantQuestions {
     }
   }
 
+  /**
+   * @deprecated prefer using {@link expectPreScreenerForm} instead
+   * 
+   * @param commonIntakeFormName 
+   */
+  async expectCommonIntakeForm(commonIntakeFormName: string) {
+    const commonIntakeFormSectionNames =
+      await this.programNamesForSection('Get Started')
+    expect(commonIntakeFormSectionNames).toEqual([commonIntakeFormName])
+  }
+
   async expectPreScreenerForm(preScreenerFormName: string) {
     const preScreenerFormSectionNames =
-      await this.programNamesForSection('Find services')
+      await this.programNamesForSection('Get Started')
     expect(preScreenerFormSectionNames).toEqual([preScreenerFormName])
+  }
+
+  /**
+   * 
+   * @param commonIntakeFormName 
+   * @deprecated prefer using {@link expectPreScreenerFormNorthstar} instead
+   */
+  async expectCommonIntakeFormNorthstar(commonIntakeFormName: string) {
+    const sectionLocator = this.page.locator('[aria-label="Get Started"]')
+
+    const programTitlesLocator = sectionLocator.locator(
+      '.cf-application-card-title',
+    )
+
+    await expect(programTitlesLocator).toHaveText(preScreenerFormName)
   }
 
   async expectPreScreenerFormNorthstar(preScreenerFormName: string) {
@@ -824,10 +850,62 @@ export class ApplicantQuestions {
     }
   }
 
+  /**
+   * @deprecated prefer using {@link expectPreScreenerReviewPage} instead
+   */
+  async expectCommonIntakeReviewPage() {
+    expect(await this.page.innerText('h2')).toContain(
+      'Benefits pre-screener summary',
+    )
+  }
+
   async expectPreScreenerReviewPage() {
     expect(await this.page.innerText('h2')).toContain(
       'Benefits pre-screener summary',
     )
+  }
+
+  /**
+   * @deprecated prefer using {@link expectPreScreenerConfirmationPage} instead
+   * 
+   * @param wantUpsell 
+   * @param wantTrustedIntermediary 
+   * @param wantEligiblePrograms 
+   */
+  async expectCommonIntakeConfirmationPage(
+    wantUpsell: boolean,
+    wantTrustedIntermediary: boolean,
+    wantEligiblePrograms: string[],
+  ) {
+    if (wantTrustedIntermediary) {
+      expect(await this.page.innerText('h1')).toContain(
+        'Programs your client may qualify for',
+      )
+    } else {
+      expect(await this.page.innerText('h1')).toContain(
+        'Programs you may qualify for',
+      )
+    }
+
+    const upsellLocator = this.page.locator(
+      ':text("Create an account or sign in"):visible',
+    )
+    if (wantUpsell) {
+      expect(await upsellLocator.count()).toEqual(1)
+    } else {
+      expect(await upsellLocator.count()).toEqual(0)
+    }
+
+    const programLocator = this.page.locator(
+      '.cf-applicant-cif-eligible-program-name',
+    )
+    if (wantEligiblePrograms.length == 0) {
+      expect(await programLocator.count()).toEqual(0)
+    } else {
+      expect(await programLocator.count()).toEqual(wantEligiblePrograms.length)
+      const allProgramTitles = await programLocator.allTextContents()
+      expect(allProgramTitles.sort()).toEqual(wantEligiblePrograms.sort())
+    }
   }
 
   async expectPreScreenerConfirmationPage(
@@ -857,6 +935,52 @@ export class ApplicantQuestions {
     const programLocator = this.page.locator(
       '.cf-applicant-cif-eligible-program-name',
     )
+    if (wantEligiblePrograms.length == 0) {
+      expect(await programLocator.count()).toEqual(0)
+    } else {
+      expect(await programLocator.count()).toEqual(wantEligiblePrograms.length)
+      const allProgramTitles = await programLocator.allTextContents()
+      expect(allProgramTitles.sort()).toEqual(wantEligiblePrograms.sort())
+    }
+  }
+
+  /**
+   * @deprecated prefer using {@link expectPreScreenerConfirmationPageNorthStar} instead
+   * 
+   * @param wantUpsell 
+   * @param wantTrustedIntermediary 
+   * @param wantEligiblePrograms 
+   */
+  async expectCommonIntakeConfirmationPageNorthStar(
+    wantUpsell: boolean,
+    wantTrustedIntermediary: boolean,
+    wantEligiblePrograms: string[],
+  ) {
+    if (wantTrustedIntermediary) {
+      await expect(
+        this.page.getByRole('heading', {
+          name: 'Programs your client may qualify for',
+        }),
+      ).toBeVisible()
+    } else {
+      await expect(
+        this.page.getByRole('heading', {name: 'Programs you may qualify for'}),
+      ).toBeVisible()
+    }
+
+    const createAccountHeading = this.page.getByRole('heading', {
+      name: 'To access your application later, create an account',
+    })
+    if (wantUpsell) {
+      await expect(createAccountHeading).toBeVisible()
+    } else {
+      await expect(createAccountHeading).toBeHidden()
+    }
+
+    const programLocator = this.page.locator(
+      '.cf-applicant-cif-eligible-program-name',
+    )
+
     if (wantEligiblePrograms.length == 0) {
       expect(await programLocator.count()).toEqual(0)
     } else {

--- a/browser-test/src/support/applicant_questions.ts
+++ b/browser-test/src/support/applicant_questions.ts
@@ -539,8 +539,8 @@ export class ApplicantQuestions {
 
   /**
    * @deprecated prefer using {@link expectPreScreenerForm} instead
-   * 
-   * @param commonIntakeFormName 
+   *
+   * @param commonIntakeFormName
    */
   async expectCommonIntakeForm(commonIntakeFormName: string) {
     const commonIntakeFormSectionNames =
@@ -555,8 +555,8 @@ export class ApplicantQuestions {
   }
 
   /**
-   * 
-   * @param commonIntakeFormName 
+   *
+   * @param commonIntakeFormName
    * @deprecated prefer using {@link expectPreScreenerFormNorthstar} instead
    */
   async expectCommonIntakeFormNorthstar(commonIntakeFormName: string) {
@@ -867,10 +867,10 @@ export class ApplicantQuestions {
 
   /**
    * @deprecated prefer using {@link expectPreScreenerConfirmationPage} instead
-   * 
-   * @param wantUpsell 
-   * @param wantTrustedIntermediary 
-   * @param wantEligiblePrograms 
+   *
+   * @param wantUpsell
+   * @param wantTrustedIntermediary
+   * @param wantEligiblePrograms
    */
   async expectCommonIntakeConfirmationPage(
     wantUpsell: boolean,
@@ -946,10 +946,10 @@ export class ApplicantQuestions {
 
   /**
    * @deprecated prefer using {@link expectPreScreenerConfirmationPageNorthStar} instead
-   * 
-   * @param wantUpsell 
-   * @param wantTrustedIntermediary 
-   * @param wantEligiblePrograms 
+   *
+   * @param wantUpsell
+   * @param wantTrustedIntermediary
+   * @param wantEligiblePrograms
    */
   async expectCommonIntakeConfirmationPageNorthStar(
     wantUpsell: boolean,

--- a/browser-test/src/support/applicant_questions.ts
+++ b/browser-test/src/support/applicant_questions.ts
@@ -537,17 +537,6 @@ export class ApplicantQuestions {
     }
   }
 
-  /**
-   * @deprecated prefer using {@link expectPreScreenerForm} instead
-   *
-   * @param commonIntakeFormName
-   */
-  async expectCommonIntakeForm(commonIntakeFormName: string) {
-    const commonIntakeFormSectionNames =
-      await this.programNamesForSection('Get Started')
-    expect(commonIntakeFormSectionNames).toEqual([commonIntakeFormName])
-  }
-
   async expectPreScreenerForm(preScreenerFormName: string) {
     const preScreenerFormSectionNames =
       await this.programNamesForSection('Get Started')
@@ -850,62 +839,10 @@ export class ApplicantQuestions {
     }
   }
 
-  /**
-   * @deprecated prefer using {@link expectPreScreenerReviewPage} instead
-   */
-  async expectCommonIntakeReviewPage() {
-    expect(await this.page.innerText('h2')).toContain(
-      'Benefits pre-screener summary',
-    )
-  }
-
   async expectPreScreenerReviewPage() {
     expect(await this.page.innerText('h2')).toContain(
       'Benefits pre-screener summary',
     )
-  }
-
-  /**
-   * @deprecated prefer using {@link expectPreScreenerConfirmationPage} instead
-   *
-   * @param wantUpsell
-   * @param wantTrustedIntermediary
-   * @param wantEligiblePrograms
-   */
-  async expectCommonIntakeConfirmationPage(
-    wantUpsell: boolean,
-    wantTrustedIntermediary: boolean,
-    wantEligiblePrograms: string[],
-  ) {
-    if (wantTrustedIntermediary) {
-      expect(await this.page.innerText('h1')).toContain(
-        'Programs your client may qualify for',
-      )
-    } else {
-      expect(await this.page.innerText('h1')).toContain(
-        'Programs you may qualify for',
-      )
-    }
-
-    const upsellLocator = this.page.locator(
-      ':text("Create an account or sign in"):visible',
-    )
-    if (wantUpsell) {
-      expect(await upsellLocator.count()).toEqual(1)
-    } else {
-      expect(await upsellLocator.count()).toEqual(0)
-    }
-
-    const programLocator = this.page.locator(
-      '.cf-applicant-cif-eligible-program-name',
-    )
-    if (wantEligiblePrograms.length == 0) {
-      expect(await programLocator.count()).toEqual(0)
-    } else {
-      expect(await programLocator.count()).toEqual(wantEligiblePrograms.length)
-      const allProgramTitles = await programLocator.allTextContents()
-      expect(allProgramTitles.sort()).toEqual(wantEligiblePrograms.sort())
-    }
   }
 
   async expectPreScreenerConfirmationPage(
@@ -935,52 +872,6 @@ export class ApplicantQuestions {
     const programLocator = this.page.locator(
       '.cf-applicant-cif-eligible-program-name',
     )
-    if (wantEligiblePrograms.length == 0) {
-      expect(await programLocator.count()).toEqual(0)
-    } else {
-      expect(await programLocator.count()).toEqual(wantEligiblePrograms.length)
-      const allProgramTitles = await programLocator.allTextContents()
-      expect(allProgramTitles.sort()).toEqual(wantEligiblePrograms.sort())
-    }
-  }
-
-  /**
-   * @deprecated prefer using {@link expectPreScreenerConfirmationPageNorthStar} instead
-   *
-   * @param wantUpsell
-   * @param wantTrustedIntermediary
-   * @param wantEligiblePrograms
-   */
-  async expectCommonIntakeConfirmationPageNorthStar(
-    wantUpsell: boolean,
-    wantTrustedIntermediary: boolean,
-    wantEligiblePrograms: string[],
-  ) {
-    if (wantTrustedIntermediary) {
-      await expect(
-        this.page.getByRole('heading', {
-          name: 'Programs your client may qualify for',
-        }),
-      ).toBeVisible()
-    } else {
-      await expect(
-        this.page.getByRole('heading', {name: 'Programs you may qualify for'}),
-      ).toBeVisible()
-    }
-
-    const createAccountHeading = this.page.getByRole('heading', {
-      name: 'To access your application later, create an account',
-    })
-    if (wantUpsell) {
-      await expect(createAccountHeading).toBeVisible()
-    } else {
-      await expect(createAccountHeading).toBeHidden()
-    }
-
-    const programLocator = this.page.locator(
-      '.cf-applicant-cif-eligible-program-name',
-    )
-
     if (wantEligiblePrograms.length == 0) {
       expect(await programLocator.count()).toEqual(0)
     } else {

--- a/browser-test/src/support/applicant_questions.ts
+++ b/browser-test/src/support/applicant_questions.ts
@@ -539,23 +539,8 @@ export class ApplicantQuestions {
 
   async expectPreScreenerForm(preScreenerFormName: string) {
     const preScreenerFormSectionNames =
-      await this.programNamesForSection('Get Started')
+      await this.programNamesForSection('Find services')
     expect(preScreenerFormSectionNames).toEqual([preScreenerFormName])
-  }
-
-  /**
-   *
-   * @param commonIntakeFormName
-   * @deprecated prefer using {@link expectPreScreenerFormNorthstar} instead
-   */
-  async expectCommonIntakeFormNorthstar(commonIntakeFormName: string) {
-    const sectionLocator = this.page.locator('[aria-label="Get Started"]')
-
-    const programTitlesLocator = sectionLocator.locator(
-      '.cf-application-card-title',
-    )
-
-    await expect(programTitlesLocator).toHaveText(preScreenerFormName)
   }
 
   async expectPreScreenerFormNorthstar(preScreenerFormName: string) {

--- a/server/app/controllers/applicant/UpsellController.java
+++ b/server/app/controllers/applicant/UpsellController.java
@@ -35,9 +35,9 @@ import services.program.ProgramDefinition;
 import services.program.ProgramNotFoundException;
 import services.program.ProgramService;
 import services.settings.SettingsManifest;
-import views.applicant.ApplicantCommonIntakeUpsellCreateAccountView;
+import views.applicant.ApplicantPreScreenerUpsellCreateAccountView;
 import views.applicant.ApplicantUpsellCreateAccountView;
-import views.applicant.NorthStarApplicantCommonIntakeUpsellView;
+import views.applicant.NorthStarApplicantPreScreenerUpsellView;
 import views.applicant.NorthStarApplicantUpsellView;
 import views.applicant.UpsellParams;
 import views.components.ToastMessage;
@@ -50,9 +50,9 @@ public final class UpsellController extends CiviFormController {
   private final ApplicationService applicationService;
   private final ProgramService programService;
   private final ApplicantUpsellCreateAccountView upsellView;
-  private final ApplicantCommonIntakeUpsellCreateAccountView cifUpsellView;
+  private final ApplicantPreScreenerUpsellCreateAccountView cifUpsellView;
   private final NorthStarApplicantUpsellView northStarUpsellView;
-  private final NorthStarApplicantCommonIntakeUpsellView northStarCommonIntakeUpsellView;
+  private final NorthStarApplicantPreScreenerUpsellView northStarPreScreenerUpsellView;
   private final MessagesApi messagesApi;
   private final PdfExporterService pdfExporterService;
   private final SettingsManifest settingsManifest;
@@ -66,9 +66,9 @@ public final class UpsellController extends CiviFormController {
       ProfileUtils profileUtils,
       ProgramService programService,
       ApplicantUpsellCreateAccountView upsellView,
-      ApplicantCommonIntakeUpsellCreateAccountView cifUpsellView,
+      ApplicantPreScreenerUpsellCreateAccountView cifUpsellView,
       NorthStarApplicantUpsellView northStarApplicantUpsellView,
-      NorthStarApplicantCommonIntakeUpsellView northStarApplicantCommonIntakeUpsellView,
+      NorthStarApplicantPreScreenerUpsellView northStarApplicantPreScreenerUpsellView,
       MessagesApi messagesApi,
       PdfExporterService pdfExporterService,
       SettingsManifest settingsManifest,
@@ -82,7 +82,7 @@ public final class UpsellController extends CiviFormController {
     this.upsellView = checkNotNull(upsellView);
     this.cifUpsellView = checkNotNull(cifUpsellView);
     this.northStarUpsellView = checkNotNull(northStarApplicantUpsellView);
-    this.northStarCommonIntakeUpsellView = checkNotNull(northStarApplicantCommonIntakeUpsellView);
+    this.northStarPreScreenerUpsellView = checkNotNull(northStarApplicantPreScreenerUpsellView);
     this.messagesApi = checkNotNull(messagesApi);
     this.pdfExporterService = checkNotNull(pdfExporterService);
     this.settingsManifest = checkNotNull(settingsManifest);
@@ -184,7 +184,7 @@ public final class UpsellController extends CiviFormController {
                       paramsBuilder
                           .setEligiblePrograms(maybeEligiblePrograms.orElseGet(ImmutableList::of))
                           .build();
-                  return ok(northStarCommonIntakeUpsellView.render(upsellParams))
+                  return ok(northStarPreScreenerUpsellView.render(upsellParams))
                       .as(Http.MimeTypes.HTML);
                 } else {
                   UpsellParams upsellParams =

--- a/server/app/services/MessageKey.java
+++ b/server/app/services/MessageKey.java
@@ -88,7 +88,7 @@ public enum MessageKey {
   BUTTON_CLOSE("button.close"),
   BUTTON_CONTINUE("button.continue"),
   BUTTON_CONTINUE_SR("button.continueSr"),
-  BUTTON_CONTINUE_COMMON_INTAKE_SR("button.continueCommonIntakeSr"),
+  BUTTON_CONTINUE_PRE_SCREENER_SR("button.continuePreScreenerSr"),
   BUTTON_CONTINUE_EDITING("button.continueEditing"),
   BUTTON_CONTINUE_WITHOUT_AN_ACCOUNT("button.continueWithoutAnAccount"),
   BUTTON_CREATE_ACCOUNT("button.createAccount"),
@@ -97,7 +97,7 @@ public enum MessageKey {
   BUTTON_DOWNLOAD_PDF("button.downloadPdf"),
   BUTTON_EDIT("button.edit"),
   BUTTON_EDIT_SR("button.editSr"),
-  BUTTON_EDIT_COMMON_INTAKE_SR("button.editCommonIntakeSr"),
+  BUTTON_EDIT_PRE_SCREENER_SR("button.editPreScreenerSr"),
   BUTTON_EXIT_APPLICATION("button.exitApplication"),
   BUTTON_GO_BACK("button.goBack"),
   BUTTON_GO_BACK_AND_EDIT("button.goBackAndEdit"),
@@ -127,7 +127,7 @@ public enum MessageKey {
   BUTTON_START_SURVEY("button.startSurvey"),
   BUTTON_START_APP("button.startApp"),
   BUTTON_CONTINUE_TO_APPLICATION("button.continueToApplication"),
-  BUTTON_START_HERE_COMMON_INTAKE_SR("button.startHereCommonIntakeSr"),
+  BUTTON_START_HERE_PRE_SCREENER_SR("button.startHerePreScreenerSr"),
   BUTTON_SUBMIT("button.submit"),
   BUTTON_SUBMIT_APPLICATION("button.submitApplication"), // North Star only
   BUTTON_UNTRANSLATED_SUBMIT("button.untranslatedSubmit"),
@@ -153,15 +153,15 @@ public enum MessageKey {
   CONTENT_CONFIRMED("content.confirmed"),
   CONTENT_DOES_NOT_QUALIFY("content.doesNotQualify"),
   CONTENT_DISABLED_PROGRAM_INFO("content.disabledProgramInfo"),
-  CONTENT_COMMON_INTAKE_CONFIRMATION("content.commonIntakeConfirmation"),
-  CONTENT_COMMON_INTAKE_CONFIRMATION_V2("content.commonIntakeConfirmation.v2"), // North Star only
-  CONTENT_COMMON_INTAKE_CONFIRMATION_TI("content.commonIntakeConfirmationTi"),
-  CONTENT_COMMON_INTAKE_CONFIRMATION_TI_V2(
-      "content.commonIntakeConfirmationTi.v2"), // North Star only
-  CONTENT_COMMON_INTAKE_NO_MATCHING_PROGRAMS("content.commonIntakeNoMatchingPrograms"),
-  CONTENT_COMMON_INTAKE_NO_MATCHING_PROGRAMS_TI("content.commonIntakeNoMatchingProgramsTi"),
-  CONTENT_COMMON_INTAKE_NO_MATCHING_PROGRAMS_NEXT_STEP(
-      "content.commonIntakeNoMatchingProgramsNextStep"),
+  CONTENT_PRE_SCREENER_CONFIRMATION("content.preScreenerConfirmation"),
+  CONTENT_PRE_SCREENER_CONFIRMATION_V2("content.preScreenerConfirmation.v2"), // North Star only
+  CONTENT_PRE_SCREENER_CONFIRMATION_TI("content.preScreenerConfirmationTi"),
+  CONTENT_PRE_SCREENER_CONFIRMATION_TI_V2(
+      "content.preScreenerConfirmationTi.v2"), // North Star only
+  CONTENT_PRE_SCREENER_NO_MATCHING_PROGRAMS("content.preScreenerNoMatchingPrograms"),
+  CONTENT_PRE_SCREENER_NO_MATCHING_PROGRAMS_TI("content.preScreenerNoMatchingProgramsTi"),
+  CONTENT_PRE_SCREENER_NO_MATCHING_PROGRAMS_NEXT_STEP(
+      "content.preScreenerNoMatchingProgramsNextStep"),
   CONTENT_OTHER_PROGRAMS_TO_APPLY_FOR("content.otherProgramsToApplyFor"),
   CONTENT_ELIGIBILITY_CRITERIA("content.eligibilityCriteria"),
   CONTENT_ELIGIBILITY_CRITERIA_V2("content.eligibilityCriteria.v2"), // North Star only
@@ -383,14 +383,14 @@ public enum MessageKey {
   TITLE_ALL_CLIENTS("title.allClients"),
   TITLE_ALL_PROGRAMS_SECTION("title.allProgramsSection"),
   TITLE_APPLICATION_CONFIRMATION("title.applicationConfirmation"),
-  TITLE_COMMON_INTAKE_CONFIRMATION("title.commonIntakeConfirmation"),
-  TITLE_COMMON_INTAKE_CONFIRMATION_TI("title.commonIntakeConfirmationTi"),
+  TITLE_PRE_SCREENER_CONFIRMATION("title.preScreenerConfirmation"),
+  TITLE_PRE_SCREENER_CONFIRMATION_TI("title.preScreenerConfirmationTi"),
   TITLE_CREATE_CLIENT("title.createClient"),
   TITLE_APPLICATION_NOT_ELIGIBLE("title.applicantNotEligible"),
   TITLE_APPLICATION_NOT_ELIGIBLE_TI("title.applicantNotEligibleTi"),
   TITLE_AVAILABLE_PROGRAMS_SECTION("title.availableProgramsSection"), // North Star only
   TITLE_BENEFITS_FINDER_SECTION_V2("title.benefitsFinderSection.v2"),
-  TITLE_COMMON_INTAKE_SUMMARY("title.commonIntakeSummary"),
+  TITLE_PRE_SCREENER_SUMMARY("title.preScreenerSummary"),
   TITLE_CREATE_AN_ACCOUNT("title.createAnAccount"),
   TITLE_DISPLAY_ALL_CLIENTS("title.displayingAllClients"),
   TITLE_DISPLAY_MULTI_CLIENTS("title.displayingMultiClients"),

--- a/server/app/views/applicant/ApplicantPreScreenerUpsellCreateAccountView.java
+++ b/server/app/views/applicant/ApplicantPreScreenerUpsellCreateAccountView.java
@@ -34,14 +34,14 @@ import views.components.Modal;
 import views.components.ToastMessage;
 import views.style.ReferenceClasses;
 
-/** Renders a confirmation page after application submission, for the common intake form. */
-public final class ApplicantCommonIntakeUpsellCreateAccountView extends ApplicantUpsellView {
+/** Renders a confirmation page after application submission, for the pre-screener form. */
+public final class ApplicantPreScreenerUpsellCreateAccountView extends ApplicantUpsellView {
 
   private final ApplicantLayout layout;
   private final SettingsManifest settingsManifest;
 
   @Inject
-  public ApplicantCommonIntakeUpsellCreateAccountView(
+  public ApplicantPreScreenerUpsellCreateAccountView(
       ApplicantLayout layout, SettingsManifest settingsManifest) {
     this.layout = checkNotNull(layout);
     this.settingsManifest = checkNotNull(settingsManifest);
@@ -99,8 +99,8 @@ public final class ApplicantCommonIntakeUpsellCreateAccountView extends Applican
 
     String title =
         profile.isTrustedIntermediary()
-            ? messages.at(MessageKey.TITLE_COMMON_INTAKE_CONFIRMATION_TI.getKeyName())
-            : messages.at(MessageKey.TITLE_COMMON_INTAKE_CONFIRMATION.getKeyName());
+            ? messages.at(MessageKey.TITLE_PRE_SCREENER_CONFIRMATION_TI.getKeyName())
+            : messages.at(MessageKey.TITLE_PRE_SCREENER_CONFIRMATION.getKeyName());
     var content =
         createMainContent(
             title,
@@ -150,15 +150,15 @@ public final class ApplicantCommonIntakeUpsellCreateAccountView extends Applican
           p(isTrustedIntermediary
                   ? rawHtml(
                       messages.at(
-                          MessageKey.CONTENT_COMMON_INTAKE_NO_MATCHING_PROGRAMS_TI.getKeyName(),
+                          MessageKey.CONTENT_PRE_SCREENER_NO_MATCHING_PROGRAMS_TI.getKeyName(),
                           moreLink))
                   : rawHtml(
                       messages.at(
-                          MessageKey.CONTENT_COMMON_INTAKE_NO_MATCHING_PROGRAMS.getKeyName(),
+                          MessageKey.CONTENT_PRE_SCREENER_NO_MATCHING_PROGRAMS.getKeyName(),
                           moreLink)))
               .withClasses("mb-4"),
           p(messages.at(
-                  MessageKey.CONTENT_COMMON_INTAKE_NO_MATCHING_PROGRAMS_NEXT_STEP.getKeyName()))
+                  MessageKey.CONTENT_PRE_SCREENER_NO_MATCHING_PROGRAMS_NEXT_STEP.getKeyName()))
               .withClasses("mb-4"));
     }
 
@@ -180,8 +180,8 @@ public final class ApplicantCommonIntakeUpsellCreateAccountView extends Applican
                             .withClasses("mb-4")))),
         section(
             p(isTrustedIntermediary
-                    ? messages.at(MessageKey.CONTENT_COMMON_INTAKE_CONFIRMATION_TI.getKeyName())
-                    : messages.at(MessageKey.CONTENT_COMMON_INTAKE_CONFIRMATION.getKeyName()))
+                    ? messages.at(MessageKey.CONTENT_PRE_SCREENER_CONFIRMATION_TI.getKeyName())
+                    : messages.at(MessageKey.CONTENT_PRE_SCREENER_CONFIRMATION.getKeyName()))
                 .withClasses("mb-4")));
   }
 }

--- a/server/app/views/applicant/ApplicantPreScreenerUpsellTemplate.html
+++ b/server/app/views/applicant/ApplicantPreScreenerUpsellTemplate.html
@@ -23,8 +23,8 @@
               <h2>
                 <th:block
                   th:text="${isTrustedIntermediary} ?
-                  #{title.commonIntakeConfirmationTi} :
-                  #{title.commonIntakeConfirmation}"
+                  #{title.preScreenerConfirmationTi} :
+                  #{title.preScreenerConfirmation}"
                 ></th:block>
               </h2>
 
@@ -32,8 +32,8 @@
                 <!-- utext is necessary to insert a hyperlink into a localized string. -->
                 <p
                   th:utext="${isTrustedIntermediary} ?
-                  #{content.commonIntakeNoMatchingProgramsTi(${moreResourcesLinkHtml})} :
-                  #{content.commonIntakeNoMatchingPrograms(${moreResourcesLinkHtml})}"
+                  #{content.preScreenerNoMatchingProgramsTi(${moreResourcesLinkHtml})} :
+                  #{content.preScreenerNoMatchingPrograms(${moreResourcesLinkHtml})}"
                 ></p>
               </div>
 
@@ -43,8 +43,8 @@
               >
                 <p
                   th:text="${isTrustedIntermediary} ?
-                    #{content.commonIntakeConfirmationTi.v2} :
-                    #{content.commonIntakeConfirmation.v2}"
+                    #{content.preScreenerConfirmationTi.v2} :
+                    #{content.preScreenerConfirmation.v2}"
                   class="content"
                 ></p>
 

--- a/server/app/views/applicant/ApplicantProgramSummaryView.java
+++ b/server/app/views/applicant/ApplicantProgramSummaryView.java
@@ -139,7 +139,7 @@ public final class ApplicantProgramSummaryView extends BaseHtmlView {
 
     String pageTitle =
         params.programType().equals(ProgramType.COMMON_INTAKE_FORM)
-            ? messages.at(MessageKey.TITLE_COMMON_INTAKE_SUMMARY.getKeyName())
+            ? messages.at(MessageKey.TITLE_PRE_SCREENER_SUMMARY.getKeyName())
             : messages.at(MessageKey.TITLE_PROGRAM_SUMMARY.getKeyName());
     bundle.setTitle(String.format("%s — %s", pageTitle, params.programTitle()));
     Optional<DivTag> maybeBackToAdminViewButton =

--- a/server/app/views/applicant/NorthStarApplicantPreScreenerUpsellView.java
+++ b/server/app/views/applicant/NorthStarApplicantPreScreenerUpsellView.java
@@ -14,10 +14,10 @@ import services.MessageKey;
 import services.settings.SettingsManifest;
 import views.NorthStarBaseView;
 
-public class NorthStarApplicantCommonIntakeUpsellView extends NorthStarBaseView {
+public class NorthStarApplicantPreScreenerUpsellView extends NorthStarBaseView {
 
   @Inject
-  NorthStarApplicantCommonIntakeUpsellView(
+  NorthStarApplicantPreScreenerUpsellView(
       TemplateEngine templateEngine,
       ThymeleafModule.PlayThymeleafContextFactory playThymeleafContextFactory,
       AssetsFinder assetsFinder,
@@ -92,7 +92,7 @@ public class NorthStarApplicantCommonIntakeUpsellView extends NorthStarBaseView 
 
       context.setVariable("bannerMessage", params.bannerMessage());
     }
-    return templateEngine.process("applicant/ApplicantCommonIntakeUpsellTemplate", context);
+    return templateEngine.process("applicant/ApplicantPreScreenerUpsellTemplate", context);
   }
 
   /* Provides syntactic sugar for displaying user-facing program information in HTML. */

--- a/server/app/views/applicant/NorthStarApplicantProgramSummaryView.java
+++ b/server/app/views/applicant/NorthStarApplicantProgramSummaryView.java
@@ -57,7 +57,7 @@ public final class NorthStarApplicantProgramSummaryView extends NorthStarBaseVie
     // Create a string such as "Program appplication summary - Pet Assistance Program"
     String summarySubstring =
         params.programType().equals(ProgramType.COMMON_INTAKE_FORM)
-            ? params.messages().at(MessageKey.TITLE_COMMON_INTAKE_SUMMARY.getKeyName())
+            ? params.messages().at(MessageKey.TITLE_PRE_SCREENER_SUMMARY.getKeyName())
             : params.messages().at(MessageKey.TITLE_PROGRAM_SUMMARY.getKeyName());
     String pageTitle = String.format("%s — %s", summarySubstring, params.programTitle());
     context.setVariable("pageTitle", pageTitle);

--- a/server/app/views/applicant/ProgramCardsSectionParamsFactory.java
+++ b/server/app/views/applicant/ProgramCardsSectionParamsFactory.java
@@ -269,7 +269,7 @@ public final class ProgramCardsSectionParamsFactory {
                 ? applicantRoutes.edit(profile.get(), applicantId.get(), programId).url()
                 : applicantRoutes.edit(programId).url();
       }
-      // If they are completing the common intake form for the first time, skip the program overview
+      // If they are completing the pre-screener form for the first time, skip the program overview
       // page
     } else if (programType.equals(ProgramType.COMMON_INTAKE_FORM)) {
       actionUrl =

--- a/server/app/views/applicant/ProgramIndexTemplate.html
+++ b/server/app/views/applicant/ProgramIndexTemplate.html
@@ -22,7 +22,7 @@
     Auth provider, for logging in.
 
   commonIntakeSection: Optional<ProgramSectionParams>
-    An optional which contains the common intake section, if there is one.
+    An optional which contains the pre-screener section, if there is one.
 
   applicantId: Optional<Long>
     Id of the applicant whose data is requested to be accessed

--- a/server/app/views/applicant/ProgramIndexView.java
+++ b/server/app/views/applicant/ProgramIndexView.java
@@ -543,16 +543,16 @@ public final class ProgramIndexView extends BaseHtmlView {
     Optional<LifecycleStage> commonIntakeFormApplicationStatus =
         relevantPrograms.commonIntakeForm().get().latestApplicationLifecycleStage();
     MessageKey buttonText = MessageKey.BUTTON_START_HERE;
-    MessageKey buttonScreenReaderText = MessageKey.BUTTON_START_HERE_COMMON_INTAKE_SR;
+    MessageKey buttonScreenReaderText = MessageKey.BUTTON_START_HERE_PRE_SCREENER_SR;
     if (commonIntakeFormApplicationStatus.isPresent()) {
       switch (commonIntakeFormApplicationStatus.get()) {
         case ACTIVE:
           buttonText = MessageKey.BUTTON_EDIT;
-          buttonScreenReaderText = MessageKey.BUTTON_EDIT_COMMON_INTAKE_SR;
+          buttonScreenReaderText = MessageKey.BUTTON_EDIT_PRE_SCREENER_SR;
           break;
         case DRAFT:
           buttonText = MessageKey.BUTTON_CONTINUE;
-          buttonScreenReaderText = MessageKey.BUTTON_CONTINUE_COMMON_INTAKE_SR;
+          buttonScreenReaderText = MessageKey.BUTTON_CONTINUE_PRE_SCREENER_SR;
           break;
         default:
           // Leave button text as is.

--- a/server/conf/i18n/messages
+++ b/server/conf/i18n/messages
@@ -218,11 +218,11 @@ button.viewInNewWindow=View in new window
 # The text for the button that allows a guest to bypass the login prompt modal.
 button.continueToApplication=Continue to application
 # The screen reader text for a button an applicant clicks to start filling out a pre-screener form.
-button.startHereCommonIntakeSr=Start here by filling out {0}
+button.startHerePreScreenerSr=Start here by filling out {0}
 # The screen reader text for a button an applicant clicks to edit their responses to a pre-screener form.
-button.editCommonIntakeSr=Edit submitted information for {0}
+button.editPreScreenerSr=Edit submitted information for {0}
 # The screen reader text for a button an applicant clicks to continue filling out a pre-screener form.
-button.continueCommonIntakeSr=Continue filling out {0}
+button.continuePreScreenerSr=Continue filling out {0}
 # Text describing the date the application was last submitted.
 content.submittedDate=Submitted {0}
 # Text for applicants to understand the section is for finding programs
@@ -468,7 +468,7 @@ ariaLabel.answer=Answer {0}
 # question, so this might say "Edit What is your name?". The {0} variable is the question text.
 ariaLabel.edit=Edit {0}
 # Title for the summary of the pre-screener page
-title.commonIntakeSummary=Benefits pre-screener summary
+title.preScreenerSummary=Benefits pre-screener summary
 # Heading content at the top of the review page, where applicants can start answering questions.
 title.getStarted=Let''s get started.
 title.programSummary=Program application summary
@@ -609,23 +609,23 @@ content.generalLoginModalPrompt=You are not logged in to an account. Without an 
 content.initialLoginModalPrompt=Before you continue, log in to your {0} account or create an account. You''ll be able to apply for multiple programs without having to enter the same information again. You can also edit applications and check your application statuses.
 # A button for continuing to apply to other programs without an account.
 button.continueWithoutAnAccount=Continue without an account
-title.commonIntakeConfirmation=Programs you may qualify for
-# Title on the page after a trusted intermediary has successfully filled out the common intake form.
-title.commonIntakeConfirmationTi=Programs your client may qualify for
+title.preScreenerConfirmation=Programs you may qualify for
+# Title on the page after a trusted intermediary has successfully filled out the pre-screener form.
+title.preScreenerConfirmationTi=Programs your client may qualify for
 # A message explaining that the applicant may be eligible for the following list of programs, and that they need to apply to them.
-content.commonIntakeConfirmation=You may be able to enroll in these programs if you apply through the online application by clicking ''Apply to programs''.
+content.preScreenerConfirmation=You may be able to enroll in these programs if you apply through the online application by clicking ''Apply to programs''.
 # A message explaining that the applicant may be eligible for the following list of programs.
-content.commonIntakeConfirmation.v2=Based on your responses, you may qualify for the following programs:
+content.preScreenerConfirmation.v2=Based on your responses, you may qualify for the following programs:
 # A message explaining that the trusted intermediary's client may be eligible for the following list of programs, and that they need to apply to them.
-content.commonIntakeConfirmationTi=Your client may be able to enroll in these programs if you apply through the online application by clicking ''Apply to programs''.
+content.preScreenerConfirmationTi=Your client may be able to enroll in these programs if you apply through the online application by clicking ''Apply to programs''.
 # A message explaining that the trusted intermediary's client may be eligible for the following list of programs.
-content.commonIntakeConfirmationTi.v2=Based on your responses, your client may qualify for the following programs:
+content.preScreenerConfirmationTi.v2=Based on your responses, your client may qualify for the following programs:
 # A message explaining that there were no programs the applicant is currently eligible for. The {0} parameter is a link to another website, where the text is the name of that site. It may read "Access Arkansas", for example.
-content.commonIntakeNoMatchingPrograms=The pre-screener could not find programs you may qualify for at this time. However, you may apply for programs at any time, by clicking ''Apply to programs''. Or to view additional programs you can visit {0}
+content.preScreenerNoMatchingPrograms=The pre-screener could not find programs you may qualify for at this time. However, you may apply for programs at any time, by clicking ''Apply to programs''. Or to view additional programs you can visit {0}
 # A message explaining that there were no programs the trusted intermediary's client is currently eligible for. The {0} parameter is a link to another website, where the text is the name of that site. It may read "Access Arkansas", for example.
-content.commonIntakeNoMatchingProgramsTi=The pre-screener could not find programs your client may qualify for at this time. However, you may apply for programs at any time, by clicking ''Apply to programs''. Or to view additional programs you can visit {0}
+content.preScreenerNoMatchingProgramsTi=The pre-screener could not find programs your client may qualify for at this time. However, you may apply for programs at any time, by clicking ''Apply to programs''. Or to view additional programs you can visit {0}
 # A message explaining a second option when there are no eligible programs, which is to edit your responses.
-content.commonIntakeNoMatchingProgramsNextStep=You can also return to the previous page to edit your responses.
+content.preScreenerNoMatchingProgramsNextStep=You can also return to the previous page to edit your responses.
 # A header above a list of other programs the applicant might be interested in applying to.
 content.otherProgramsToApplyFor=Other programs you might be interested in
 # Button on the "Application Submitted" page. Clicking it downloads the user's application.

--- a/server/conf/i18n/messages.am
+++ b/server/conf/i18n/messages.am
@@ -214,11 +214,11 @@ button.viewAndApplySr=በ{0} ላይ አሳይ እና ተግብር
 # The text for the button that allows a guest to bypass the login prompt modal.
 button.continueToApplication=ወደ ማመልከቻ ይቀጥሉ
 # The screen reader text for a button an applicant clicks to start filling out a pre-screener form.
-button.startHereCommonIntakeSr={0}ን በመሙላት እዚህ ይጀምሩ
+button.startHerePreScreenerSr={0}ን በመሙላት እዚህ ይጀምሩ
 # The screen reader text for a button an applicant clicks to edit their responses to a pre-screener form.
-button.editCommonIntakeSr=ለ{0} የገባ መረጃን ያርትዑ
+button.editPreScreenerSr=ለ{0} የገባ መረጃን ያርትዑ
 # The screen reader text for a button an applicant clicks to continue filling out a pre-screener form.
-button.continueCommonIntakeSr={0}ን መሙላት ይቀጥሉ
+button.continuePreScreenerSr={0}ን መሙላት ይቀጥሉ
 # Text describing the date the application was last submitted.
 content.submittedDate={0} ገብቷል
 # Text for applicants to understand the section is for finding programs
@@ -460,7 +460,7 @@ ariaLabel.answer=መልስ {0}
 # question, so this might say "Edit What is your name?". The {0} variable is the question text.
 ariaLabel.edit={0}ን አርትዕ
 # Title for the summary of the pre-screener page
-title.commonIntakeSummary=የጥቅማጥቅሞች ቅድመ-ማጣሪያ ማጠቃለያ
+title.preScreenerSummary=የጥቅማጥቅሞች ቅድመ-ማጣሪያ ማጠቃለያ
 # Heading content at the top of the review page, where applicants can start answering questions.
 title.getStarted=እንጀምር።
 title.programSummary=የፕሮግራም ማመልከቻ ማጠቃለያ
@@ -601,23 +601,23 @@ content.generalLoginModalPrompt=እርስዎ ወደ መለያ አልገቡም።
 content.initialLoginModalPrompt=ከመቀጠልዎ በፊት ወደ {0} መለያዎ ይግቡ ወይም መለያ ይፍጠሩ። ተመሳሳዩን መረጃ እንደገና ሳያስገቡ ለብዙ ፕሮግራሞች ማመልከት ይችላሉ። እንዲሁም ማመልከቻዎችን ማርትዕ እና የማመልከቻ ሁኔታዎችዎን መፈተሽ ይችላሉ።
 # A button for continuing to apply to other programs without an account.
 button.continueWithoutAnAccount=ያለ መለያ ቀጥል
-title.commonIntakeConfirmation=እርስዎ ብቁ ሊሆኑ የሚችሉባቸው ፕሮግራሞች
-# Title on the page after a trusted intermediary has successfully filled out the common intake form.
-title.commonIntakeConfirmationTi=ደንበኛዎ ብቁ ሊሆኑ የሚችሉባቸው ፕሮግራሞች
+title.preScreenerConfirmation=እርስዎ ብቁ ሊሆኑ የሚችሉባቸው ፕሮግራሞች
+# Title on the page after a trusted intermediary has successfully filled out the pre-screener form.
+title.preScreenerConfirmationTi=ደንበኛዎ ብቁ ሊሆኑ የሚችሉባቸው ፕሮግራሞች
 # A message explaining that the applicant may be eligible for the following list of programs, and that they need to apply to them.
-content.commonIntakeConfirmation=እርስዎ «ለፕሮግራሞች አመልክት» የሚለውን ጠቅ በማድረግ በመስመር ላይ ማመልከቻው በኩል ካመለከቱ በእነዚህ ፕሮግራሞች ውስጥ መመዝገብ ይችሉ ይሆናል።
+content.preScreenerConfirmation=እርስዎ «ለፕሮግራሞች አመልክት» የሚለውን ጠቅ በማድረግ በመስመር ላይ ማመልከቻው በኩል ካመለከቱ በእነዚህ ፕሮግራሞች ውስጥ መመዝገብ ይችሉ ይሆናል።
 # A message explaining that the applicant may be eligible for the following list of programs.
-content.commonIntakeConfirmation.v2=በምላሾችዎ ላይ በመመስረት ለሚከተሉት ፕሮግራሞች ብቁ ሊሆኑ ይችላሉ፦
+content.preScreenerConfirmation.v2=በምላሾችዎ ላይ በመመስረት ለሚከተሉት ፕሮግራሞች ብቁ ሊሆኑ ይችላሉ፦
 # A message explaining that the trusted intermediary's client may be eligible for the following list of programs, and that they need to apply to them.
-content.commonIntakeConfirmationTi=እርስዎ «ለፕሮግራሞች አመልክት» የሚለውን ጠቅ በማድረግ በመስመር ላይ ማመልከቻው በኩል ካመለከቱ ደንበኛዎ በእነዚህ ፕሮግራሞች ውስጥ መመዝገብ ይችሉ ይሆናል።
+content.preScreenerConfirmationTi=እርስዎ «ለፕሮግራሞች አመልክት» የሚለውን ጠቅ በማድረግ በመስመር ላይ ማመልከቻው በኩል ካመለከቱ ደንበኛዎ በእነዚህ ፕሮግራሞች ውስጥ መመዝገብ ይችሉ ይሆናል።
 # A message explaining that the trusted intermediary's client may be eligible for the following list of programs.
-content.commonIntakeConfirmationTi.v2=በምላሾችዎ ላይ በመመስረት ደንበኛዎ ለሚከተሉት ፕሮግራሞች ብቁ ሊሆኑ ይችላሉ፦
+content.preScreenerConfirmationTi.v2=በምላሾችዎ ላይ በመመስረት ደንበኛዎ ለሚከተሉት ፕሮግራሞች ብቁ ሊሆኑ ይችላሉ፦
 # A message explaining that there were no programs the applicant is currently eligible for. The {0} parameter is a link to another website, where the text is the name of that site. It may read "Access Arkansas", for example.
-content.commonIntakeNoMatchingPrograms=ቅድመ-ማጣሪያው እርስዎ በዚህ ጊዜ ብቁ ሊሆኑ የሚችሉባቸውን ፕሮግራሞች ማግኘት አልቻለም። ሆኖም፣ «ለፕሮግራሞች አመልክት» የሚለውን ጠቅ በማድረግ በማንኛውም ጊዜ ለፕሮግራሞች ማመልከት ይችላሉ። ወይም ተጨማሪ ፕሮግራሞችን ለመመልከት {0}ን መጎብኘት ይችላሉ
+content.preScreenerNoMatchingPrograms=ቅድመ-ማጣሪያው እርስዎ በዚህ ጊዜ ብቁ ሊሆኑ የሚችሉባቸውን ፕሮግራሞች ማግኘት አልቻለም። ሆኖም፣ «ለፕሮግራሞች አመልክት» የሚለውን ጠቅ በማድረግ በማንኛውም ጊዜ ለፕሮግራሞች ማመልከት ይችላሉ። ወይም ተጨማሪ ፕሮግራሞችን ለመመልከት {0}ን መጎብኘት ይችላሉ
 # A message explaining that there were no programs the trusted intermediary's client is currently eligible for. The {0} parameter is a link to another website, where the text is the name of that site. It may read "Access Arkansas", for example.
-content.commonIntakeNoMatchingProgramsTi=ቅድመ-ማጣሪያው ደንበኛዎ በዚህ ጊዜ ብቁ ሊሆኑ የሚችሉባቸውን ፕሮግራሞች ማግኘት አልቻለም። ሆኖም፣ «ለፕሮግራሞች አመልክት» የሚለውን ጠቅ በማድረግ በማንኛውም ጊዜ ለፕሮግራሞች ማመልከት ይችላሉ። ወይም ተጨማሪ ፕሮግራሞችን ለመመልከት {0}ን መጎብኘት ይችላሉ
+content.preScreenerNoMatchingProgramsTi=ቅድመ-ማጣሪያው ደንበኛዎ በዚህ ጊዜ ብቁ ሊሆኑ የሚችሉባቸውን ፕሮግራሞች ማግኘት አልቻለም። ሆኖም፣ «ለፕሮግራሞች አመልክት» የሚለውን ጠቅ በማድረግ በማንኛውም ጊዜ ለፕሮግራሞች ማመልከት ይችላሉ። ወይም ተጨማሪ ፕሮግራሞችን ለመመልከት {0}ን መጎብኘት ይችላሉ
 # A message explaining a second option when there are no eligible programs, which is to edit your responses.
-content.commonIntakeNoMatchingProgramsNextStep=እንዲሁም የእርስዎን ምላሾች ለማርትዕ ወደ ቀዳሚው ገጽ መመለስ ይችላሉ።
+content.preScreenerNoMatchingProgramsNextStep=እንዲሁም የእርስዎን ምላሾች ለማርትዕ ወደ ቀዳሚው ገጽ መመለስ ይችላሉ።
 # A header above a list of other programs the applicant might be interested in applying to.
 content.otherProgramsToApplyFor=ሊወዷቸው የሚችሏቸው ሌሎች ፕሮግራሞች
 # Button on the "Application Submitted" page. Clicking it downloads the user's application.

--- a/server/conf/i18n/messages.ar
+++ b/server/conf/i18n/messages.ar
@@ -214,11 +214,11 @@ button.viewAndApplySr=عرض طلب الانضمام وإرساله إلى "{0}"
 # The text for the button that allows a guest to bypass the login prompt modal.
 button.continueToApplication=المتابعة إلى الطلب
 # The screen reader text for a button an applicant clicks to start filling out a pre-screener form.
-button.startHereCommonIntakeSr=البدء هنا من خلال ملء {0}
+button.startHerePreScreenerSr=البدء هنا من خلال ملء {0}
 # The screen reader text for a button an applicant clicks to edit their responses to a pre-screener form.
-button.editCommonIntakeSr=تعديل المعلومات المُرسلة إلى {0}
+button.editPreScreenerSr=تعديل المعلومات المُرسلة إلى {0}
 # The screen reader text for a button an applicant clicks to continue filling out a pre-screener form.
-button.continueCommonIntakeSr=متابعة ملء {0}
+button.continuePreScreenerSr=متابعة ملء {0}
 # Text describing the date the application was last submitted.
 content.submittedDate=تم إرسال الطلب في ‎{0}
 # Text for applicants to understand the section is for finding programs
@@ -460,7 +460,7 @@ ariaLabel.answer=يُرجى الإجابة عن السؤال "{0}"
 # question, so this might say "Edit What is your name?". The {0} variable is the question text.
 ariaLabel.edit=يُرجى تعديل الإجابة عن السؤال "{0}"
 # Title for the summary of the pre-screener page
-title.commonIntakeSummary=ملخص مزايا برنامج الفحص المُسبق للطلبات
+title.preScreenerSummary=ملخص مزايا برنامج الفحص المُسبق للطلبات
 # Heading content at the top of the review page, where applicants can start answering questions.
 title.getStarted=لنبدأ بالإجابة عن الأسئلة.
 title.programSummary=ملخّص طلب البرنامج
@@ -601,23 +601,23 @@ content.generalLoginModalPrompt=لم يتم تسجيل الدخول إلى حس�
 content.initialLoginModalPrompt=قبل المتابعة، يُرجى تسجيل الدخول إلى حسابك على "{0}" أو إنشاء حساب جديد. سيتيح لك ذلك إرسال طلبات للانضمام إلى عدة برامج بدون الحاجة إلى إدخال المعلومات نفسها مرة أخرى. يمكنك أيضًا تعديل الطلبات والاطّلاع على حالتها.
 # A button for continuing to apply to other programs without an account.
 button.continueWithoutAnAccount=المتابعة بدون حساب
-title.commonIntakeConfirmation=برامج قد يكون حسابك مؤهلاً للانضمام إليها
-# Title on the page after a trusted intermediary has successfully filled out the common intake form.
-title.commonIntakeConfirmationTi=برامج قد يكون عميلك مؤهلاً للانضمام إليها
+title.preScreenerConfirmation=برامج قد يكون حسابك مؤهلاً للانضمام إليها
+# Title on the page after a trusted intermediary has successfully filled out the pre-screener form.
+title.preScreenerConfirmationTi=برامج قد يكون عميلك مؤهلاً للانضمام إليها
 # A message explaining that the applicant may be eligible for the following list of programs, and that they need to apply to them.
-content.commonIntakeConfirmation=قد يكون بإمكانك التسجيل في هذه البرامج من خلال إرسال طلب على الإنترنت بالنقر على "إرسال طلبات للانضمام إلى البرامج".
+content.preScreenerConfirmation=قد يكون بإمكانك التسجيل في هذه البرامج من خلال إرسال طلب على الإنترنت بالنقر على "إرسال طلبات للانضمام إلى البرامج".
 # A message explaining that the applicant may be eligible for the following list of programs.
-content.commonIntakeConfirmation.v2=بناءً على ردودك، قد يكون حسابك مؤهلاً للانضمام إلى البرامج التالية:
+content.preScreenerConfirmation.v2=بناءً على ردودك، قد يكون حسابك مؤهلاً للانضمام إلى البرامج التالية:
 # A message explaining that the trusted intermediary's client may be eligible for the following list of programs, and that they need to apply to them.
-content.commonIntakeConfirmationTi=قد يكون بإمكان عميلك التسجيل في هذه البرامج إذا أرسلت طلبًا على الإنترنت بالنقر على "إرسال طلبات للانضمام إلى البرامج".
+content.preScreenerConfirmationTi=قد يكون بإمكان عميلك التسجيل في هذه البرامج إذا أرسلت طلبًا على الإنترنت بالنقر على "إرسال طلبات للانضمام إلى البرامج".
 # A message explaining that the trusted intermediary's client may be eligible for the following list of programs.
-content.commonIntakeConfirmationTi.v2=بناءً على ردودك، قد يكون حساب عميلك مؤهلاً للانضمام إلى البرامج التالية:
+content.preScreenerConfirmationTi.v2=بناءً على ردودك، قد يكون حساب عميلك مؤهلاً للانضمام إلى البرامج التالية:
 # A message explaining that there were no programs the applicant is currently eligible for. The {0} parameter is a link to another website, where the text is the name of that site. It may read "Access Arkansas", for example.
-content.commonIntakeNoMatchingPrograms=لم يتمكن الفحص المُسبق للطلبات من العثور على برامج قد يكون حسابك مؤهلاً للانضمام إليها حاليًا. ومع ذلك، قد يكون بإمكانك إرسال طلبات في أي وقت بالنقر على "إرسال طلبات للانضمام إلى البرامج"، أو الاطّلاع على برامج إضافية من خلال الانتقال إلى {0}.
+content.preScreenerNoMatchingPrograms=لم يتمكن الفحص المُسبق للطلبات من العثور على برامج قد يكون حسابك مؤهلاً للانضمام إليها حاليًا. ومع ذلك، قد يكون بإمكانك إرسال طلبات في أي وقت بالنقر على "إرسال طلبات للانضمام إلى البرامج"، أو الاطّلاع على برامج إضافية من خلال الانتقال إلى {0}.
 # A message explaining that there were no programs the trusted intermediary's client is currently eligible for. The {0} parameter is a link to another website, where the text is the name of that site. It may read "Access Arkansas", for example.
-content.commonIntakeNoMatchingProgramsTi=لم يتمكن الفحص المُسبق للطلبات من العثور على برامج قد يكون عميلك مؤهلاً للانضمام إليها حاليًا. ومع ذلك، قد يكون بإمكانك إرسال طلبات في أي وقت بالنقر على "إرسال طلبات للانضمام إلى البرامج"، أو الاطّلاع على برامج إضافية من خلال الانتقال إلى {0}.
+content.preScreenerNoMatchingProgramsTi=لم يتمكن الفحص المُسبق للطلبات من العثور على برامج قد يكون عميلك مؤهلاً للانضمام إليها حاليًا. ومع ذلك، قد يكون بإمكانك إرسال طلبات في أي وقت بالنقر على "إرسال طلبات للانضمام إلى البرامج"، أو الاطّلاع على برامج إضافية من خلال الانتقال إلى {0}.
 # A message explaining a second option when there are no eligible programs, which is to edit your responses.
-content.commonIntakeNoMatchingProgramsNextStep=يمكنك أيضًا الرجوع إلى الصفحة السابقة لتعديل إجاباتك.
+content.preScreenerNoMatchingProgramsNextStep=يمكنك أيضًا الرجوع إلى الصفحة السابقة لتعديل إجاباتك.
 # A header above a list of other programs the applicant might be interested in applying to.
 content.otherProgramsToApplyFor=برامج أخرى قد تهمّك
 # Button on the "Application Submitted" page. Clicking it downloads the user's application.

--- a/server/conf/i18n/messages.de
+++ b/server/conf/i18n/messages.de
@@ -214,11 +214,11 @@ button.viewAndApplySr=View and apply to {0}
 # The text for the button that allows a guest to bypass the login prompt modal.
 button.continueToApplication=Continue to application
 # The screen reader text for a button an applicant clicks to start filling out a pre-screener form.
-button.startHereCommonIntakeSr=Start here by filling out {0}
+button.startHerePreScreenerSr=Start here by filling out {0}
 # The screen reader text for a button an applicant clicks to edit their responses to a pre-screener form.
-button.editCommonIntakeSr=Edit submitted information for {0}
+button.editPreScreenerSr=Edit submitted information for {0}
 # The screen reader text for a button an applicant clicks to continue filling out a pre-screener form.
-button.continueCommonIntakeSr=Continue filling out {0}
+button.continuePreScreenerSr=Continue filling out {0}
 # Text describing the date the application was last submitted.
 content.submittedDate=Submitted {0}
 # Text for applicants to understand the section is for finding programs
@@ -460,7 +460,7 @@ ariaLabel.answer=Answer {0}
 # question, so this might say "Edit What is your name?". The {0} variable is the question text.
 ariaLabel.edit=Edit {0}
 # Title for the summary of the pre-screener page
-title.commonIntakeSummary=Benefits pre-screener summary
+title.preScreenerSummary=Benefits pre-screener summary
 # Heading content at the top of the review page, where applicants can start answering questions.
 title.getStarted=Let''s get started.
 title.programSummary=Program application summary
@@ -601,23 +601,23 @@ content.generalLoginModalPrompt=You are not logged in to an account. Without an 
 content.initialLoginModalPrompt=Before you continue, log in to your {0} account or create an account. You''ll be able to apply for multiple programs without having to enter the same information again. You can also edit applications and check your application statuses.
 # A button for continuing to apply to other programs without an account.
 button.continueWithoutAnAccount=Continue without an account
-title.commonIntakeConfirmation=Programme, für die Sie sich möglicherweise qualifizieren
-# Title on the page after a trusted intermediary has successfully filled out the common intake form.
-title.commonIntakeConfirmationTi=Programs your client may qualify for
+title.preScreenerConfirmation=Programs you may qualify for
+# Title on the page after a trusted intermediary has successfully filled out the pre-screener form.
+title.preScreenerConfirmationTi=Programs your client may qualify for
 # A message explaining that the applicant may be eligible for the following list of programs, and that they need to apply to them.
-content.commonIntakeConfirmation=You may be able to enroll in these programs if you apply through the online application by clicking ''Apply to programs''.
+content.preScreenerConfirmation=You may be able to enroll in these programs if you apply through the online application by clicking ''Apply to programs''.
 # A message explaining that the applicant may be eligible for the following list of programs.
-content.commonIntakeConfirmation.v2=Basierend auf Ihren Antworten können Sie sich für die folgenden Programme qualifizieren:
+content.preScreenerConfirmation.v2=Based on your responses, you may qualify for the following programs:
 # A message explaining that the trusted intermediary's client may be eligible for the following list of programs, and that they need to apply to them.
-content.commonIntakeConfirmationTi=Your client may be able to enroll in these programs if you apply through the online application by clicking ''Apply to programs''.
+content.preScreenerConfirmationTi=Your client may be able to enroll in these programs if you apply through the online application by clicking ''Apply to programs''.
 # A message explaining that the trusted intermediary's client may be eligible for the following list of programs.
-content.commonIntakeConfirmationTi.v2=Based on your responses, your client may qualify for the following programs:
+content.preScreenerConfirmationTi.v2=Based on your responses, your client may qualify for the following programs:
 # A message explaining that there were no programs the applicant is currently eligible for. The {0} parameter is a link to another website, where the text is the name of that site. It may read "Access Arkansas", for example.
-content.commonIntakeNoMatchingPrograms=The pre-screener could not find programs you may qualify for at this time. However, you may apply for programs at any time, by clicking ''Apply to programs''. Or to view additional programs you can visit {0}
+content.preScreenerNoMatchingPrograms=The pre-screener could not find programs you may qualify for at this time. However, you may apply for programs at any time, by clicking ''Apply to programs''. Or to view additional programs you can visit {0}
 # A message explaining that there were no programs the trusted intermediary's client is currently eligible for. The {0} parameter is a link to another website, where the text is the name of that site. It may read "Access Arkansas", for example.
-content.commonIntakeNoMatchingProgramsTi=The pre-screener could not find programs your client may qualify for at this time. However, you may apply for programs at any time, by clicking ''Apply to programs''. Or to view additional programs you can visit {0}
+content.preScreenerNoMatchingProgramsTi=The pre-screener could not find programs your client may qualify for at this time. However, you may apply for programs at any time, by clicking ''Apply to programs''. Or to view additional programs you can visit {0}
 # A message explaining a second option when there are no eligible programs, which is to edit your responses.
-content.commonIntakeNoMatchingProgramsNextStep=You can also return to the previous page to edit your responses.
+content.preScreenerNoMatchingProgramsNextStep=You can also return to the previous page to edit your responses.
 # A header above a list of other programs the applicant might be interested in applying to.
 content.otherProgramsToApplyFor=Andere Programme, die Sie interessieren könnten
 # Button on the "Application Submitted" page. Clicking it downloads the user's application.

--- a/server/conf/i18n/messages.de
+++ b/server/conf/i18n/messages.de
@@ -601,13 +601,13 @@ content.generalLoginModalPrompt=You are not logged in to an account. Without an 
 content.initialLoginModalPrompt=Before you continue, log in to your {0} account or create an account. You''ll be able to apply for multiple programs without having to enter the same information again. You can also edit applications and check your application statuses.
 # A button for continuing to apply to other programs without an account.
 button.continueWithoutAnAccount=Continue without an account
-title.preScreenerConfirmation=Programs you may qualify for
+title.preScreenerConfirmation=Programme, für die Sie sich möglicherweise qualifizieren
 # Title on the page after a trusted intermediary has successfully filled out the pre-screener form.
 title.preScreenerConfirmationTi=Programs your client may qualify for
 # A message explaining that the applicant may be eligible for the following list of programs, and that they need to apply to them.
 content.preScreenerConfirmation=You may be able to enroll in these programs if you apply through the online application by clicking ''Apply to programs''.
 # A message explaining that the applicant may be eligible for the following list of programs.
-content.preScreenerConfirmation.v2=Based on your responses, you may qualify for the following programs:
+content.preScreenerConfirmation.v2=Basierend auf Ihren Antworten können Sie sich für die folgenden Programme qualifizieren:
 # A message explaining that the trusted intermediary's client may be eligible for the following list of programs, and that they need to apply to them.
 content.preScreenerConfirmationTi=Your client may be able to enroll in these programs if you apply through the online application by clicking ''Apply to programs''.
 # A message explaining that the trusted intermediary's client may be eligible for the following list of programs.

--- a/server/conf/i18n/messages.es-US
+++ b/server/conf/i18n/messages.es-US
@@ -214,11 +214,11 @@ button.viewAndApplySr=Ver y aplicar a {0}
 # The text for the button that allows a guest to bypass the login prompt modal.
 button.continueToApplication=Continuar a la solicitud
 # The screen reader text for a button an applicant clicks to start filling out a pre-screener form.
-button.startHereCommonIntakeSr=Comenzar aquí completando la solicitud {0}
+button.startHerePreScreenerSr=Comenzar aquí completando la solicitud {0}
 # The screen reader text for a button an applicant clicks to edit their responses to a pre-screener form.
-button.editCommonIntakeSr=Editar la información enviada para {0}
+button.editPreScreenerSr=Editar la información enviada para {0}
 # The screen reader text for a button an applicant clicks to continue filling out a pre-screener form.
-button.continueCommonIntakeSr=Continuar completando la solicitud {0}
+button.continuePreScreenerSr=Continuar completando la solicitud {0}
 # Text describing the date the application was last submitted.
 content.submittedDate=Enviada el {0}
 # Text for applicants to understand the section is for finding programs
@@ -460,7 +460,7 @@ ariaLabel.answer=Responder {0}
 # question, so this might say "Edit What is your name?". The {0} variable is the question text.
 ariaLabel.edit=Editar {0}
 # Title for the summary of the pre-screener page
-title.commonIntakeSummary=Resumen del proceso de evaluación para acceder a los beneficios
+title.preScreenerSummary=Resumen del proceso de evaluación para acceder a los beneficios
 # Heading content at the top of the review page, where applicants can start answering questions.
 title.getStarted=Comencemos.
 title.programSummary=Resumen de la inscripción al programa
@@ -601,23 +601,23 @@ content.generalLoginModalPrompt=No accediste a una cuenta. No podrás modificar 
 content.initialLoginModalPrompt=Antes de continuar, accede a tu cuenta de {0} o crea una. Podrás enviar solicitudes de inscripción a varios programas sin necesidad de volver a ingresar la misma información. También puedes editar tus solicitudes y revisar su estado.
 # A button for continuing to apply to other programs without an account.
 button.continueWithoutAnAccount=Continuar sin una cuenta
-title.commonIntakeConfirmation=Programas para los que cumples los requisitos
-# Title on the page after a trusted intermediary has successfully filled out the common intake form.
-title.commonIntakeConfirmationTi=Programas para los que tu cliente cumple los requisitos
+title.preScreenerConfirmation=Programas para los que cumples los requisitos
+# Title on the page after a trusted intermediary has successfully filled out the pre-screener form.
+title.preScreenerConfirmationTi=Programas para los que tu cliente cumple los requisitos
 # A message explaining that the applicant may be eligible for the following list of programs, and that they need to apply to them.
-content.commonIntakeConfirmation=Puedes inscribirte en estos programas si completas la solicitud en línea haciendo clic en ''Apply to programs''.
+content.preScreenerConfirmation=Puedes inscribirte en estos programas si completas la solicitud en línea haciendo clic en ''Apply to programs''.
 # A message explaining that the applicant may be eligible for the following list of programs.
-content.commonIntakeConfirmation.v2=Según tus respuestas, es posible que califiques para los siguientes programas:
+content.preScreenerConfirmation.v2=Según tus respuestas, es posible que califiques para los siguientes programas:
 # A message explaining that the trusted intermediary's client may be eligible for the following list of programs, and that they need to apply to them.
-content.commonIntakeConfirmationTi=Puedes inscribir a tu cliente en estos programas si completas la solicitud en línea haciendo clic en ''Apply to programs''.
+content.preScreenerConfirmationTi=Puedes inscribir a tu cliente en estos programas si completas la solicitud en línea haciendo clic en ''Apply to programs''.
 # A message explaining that the trusted intermediary's client may be eligible for the following list of programs.
-content.commonIntakeConfirmationTi.v2=Según tus respuestas, es posible que tu cliente califique para los siguientes programas:
+content.preScreenerConfirmationTi.v2=Según tus respuestas, es posible que tu cliente califique para los siguientes programas:
 # A message explaining that there were no programs the applicant is currently eligible for. The {0} parameter is a link to another website, where the text is the name of that site. It may read "Access Arkansas", for example.
-content.commonIntakeNoMatchingPrograms=El proceso de evaluación no pudo encontrar programas para los que cumplas los requisitos en este momento. Sin embargo, puedes enviar una solicitud de inscripción para los programas en cualquier momento haciendo clic en ''Apply to programs''. Para ver programas adicionales, puedes visitar {0}.
+content.preScreenerNoMatchingPrograms=El proceso de evaluación no pudo encontrar programas para los que cumplas los requisitos en este momento. Sin embargo, puedes enviar una solicitud de inscripción para los programas en cualquier momento haciendo clic en ''Apply to programs''. Para ver programas adicionales, puedes visitar {0}.
 # A message explaining that there were no programs the trusted intermediary's client is currently eligible for. The {0} parameter is a link to another website, where the text is the name of that site. It may read "Access Arkansas", for example.
-content.commonIntakeNoMatchingProgramsTi=El proceso de evaluación no pudo encontrar programas para los que tu cliente cumpla los requisitos en este momento. Sin embargo, puedes enviar una solicitud de inscripción para los programas en cualquier momento haciendo clic en ''Apply to programs''. Para ver programas adicionales, puedes visitar {0}.
+content.preScreenerNoMatchingProgramsTi=El proceso de evaluación no pudo encontrar programas para los que tu cliente cumpla los requisitos en este momento. Sin embargo, puedes enviar una solicitud de inscripción para los programas en cualquier momento haciendo clic en ''Apply to programs''. Para ver programas adicionales, puedes visitar {0}.
 # A message explaining a second option when there are no eligible programs, which is to edit your responses.
-content.commonIntakeNoMatchingProgramsNextStep=También puedes volver a la página anterior para editar tus respuestas.
+content.preScreenerNoMatchingProgramsNextStep=También puedes volver a la página anterior para editar tus respuestas.
 # A header above a list of other programs the applicant might be interested in applying to.
 content.otherProgramsToApplyFor=Otros programas que te pueden interesar
 # Button on the "Application Submitted" page. Clicking it downloads the user's application.

--- a/server/conf/i18n/messages.fr
+++ b/server/conf/i18n/messages.fr
@@ -214,11 +214,11 @@ button.viewAndApplySr=Afficher {0} et faire une demande
 # The text for the button that allows a guest to bypass the login prompt modal.
 button.continueToApplication=Remplir la demande
 # The screen reader text for a button an applicant clicks to start filling out a pre-screener form.
-button.startHereCommonIntakeSr=Commencer ici en remplissant {0}
+button.startHerePreScreenerSr=Commencer ici en remplissant {0}
 # The screen reader text for a button an applicant clicks to edit their responses to a pre-screener form.
-button.editCommonIntakeSr=Modifier les informations fournies pour {0}
+button.editPreScreenerSr=Modifier les informations fournies pour {0}
 # The screen reader text for a button an applicant clicks to continue filling out a pre-screener form.
-button.continueCommonIntakeSr=Continuer à remplir {0}
+button.continuePreScreenerSr=Continuer à remplir {0}
 # Text describing the date the application was last submitted.
 content.submittedDate=Date d''envoi : {0}
 # Text for applicants to understand the section is for finding programs
@@ -460,7 +460,7 @@ ariaLabel.answer=Répondre à la question {0}
 # question, so this might say "Edit What is your name?". The {0} variable is the question text.
 ariaLabel.edit=Modifier la question {0}
 # Title for the summary of the pre-screener page
-title.commonIntakeSummary=Résumé de la présélection pour les avantages
+title.preScreenerSummary=Résumé de la présélection pour les avantages
 # Heading content at the top of the review page, where applicants can start answering questions.
 title.getStarted=C''est parti.
 title.programSummary=Résumé de la demande d''inscription au programme
@@ -601,23 +601,23 @@ content.generalLoginModalPrompt=Vous n''êtes connecté à aucun compte. Sans co
 content.initialLoginModalPrompt=Avant de continuer, connectez-vous à votre compte {0} ou créez-en un. Vous pourrez vous inscrire à plusieurs programmes sans avoir à saisir de nouveau les mêmes informations. Vous pourrez également modifier vos demandes et vérifier leur état.
 # A button for continuing to apply to other programs without an account.
 button.continueWithoutAnAccount=Continuer sans compte
-title.commonIntakeConfirmation=Programmes auxquels vous pouvez être éligible
-# Title on the page after a trusted intermediary has successfully filled out the common intake form.
-title.commonIntakeConfirmationTi=Programmes auxquels votre client peut être éligible
+title.preScreenerConfirmation=Programmes auxquels vous pouvez être éligible
+# Title on the page after a trusted intermediary has successfully filled out the pre-screener form.
+title.preScreenerConfirmationTi=Programmes auxquels votre client peut être éligible
 # A message explaining that the applicant may be eligible for the following list of programs, and that they need to apply to them.
-content.commonIntakeConfirmation=Il se peut que vous puissiez vous inscrire à ces programmes, si vous effectuez votre demande en ligne en cliquant sur "S''inscrire à des programmes".
+content.preScreenerConfirmation=Il se peut que vous puissiez vous inscrire à ces programmes, si vous effectuez votre demande en ligne en cliquant sur "S''inscrire à des programmes".
 # A message explaining that the applicant may be eligible for the following list of programs.
-content.commonIntakeConfirmation.v2=Selon vos réponses, vous êtes peut-être éligible aux programmes suivants :
+content.preScreenerConfirmation.v2=Selon vos réponses, vous êtes peut-être éligible aux programmes suivants :
 # A message explaining that the trusted intermediary's client may be eligible for the following list of programs, and that they need to apply to them.
-content.commonIntakeConfirmationTi=Il se peut que votre client puisse s''inscrire à ces programmes, si vous effectuez la demande en ligne en cliquant sur "S''inscrire à des programmes".
+content.preScreenerConfirmationTi=Il se peut que votre client puisse s''inscrire à ces programmes, si vous effectuez la demande en ligne en cliquant sur "S''inscrire à des programmes".
 # A message explaining that the trusted intermediary's client may be eligible for the following list of programs.
-content.commonIntakeConfirmationTi.v2=Selon vos réponses, votre client est peut-être éligible aux programmes suivants :
+content.preScreenerConfirmationTi.v2=Selon vos réponses, votre client est peut-être éligible aux programmes suivants :
 # A message explaining that there were no programs the applicant is currently eligible for. The {0} parameter is a link to another website, where the text is the name of that site. It may read "Access Arkansas", for example.
-content.commonIntakeNoMatchingPrograms=L''outil de présélection n''a trouvé aucun programme auquel vous pourriez être éligible pour le moment. Vous pouvez cependant vous inscrire à des programmes à tout moment en cliquant sur "S''inscrire à des programmes". Vous trouverez d''autres programmes ici : {0}.
+content.preScreenerNoMatchingPrograms=L''outil de présélection n''a trouvé aucun programme auquel vous pourriez être éligible pour le moment. Vous pouvez cependant vous inscrire à des programmes à tout moment en cliquant sur "S''inscrire à des programmes". Vous trouverez d''autres programmes ici : {0}.
 # A message explaining that there were no programs the trusted intermediary's client is currently eligible for. The {0} parameter is a link to another website, where the text is the name of that site. It may read "Access Arkansas", for example.
-content.commonIntakeNoMatchingProgramsTi=L''outil de présélection n''a trouvé aucun programme auquel votre client pourrait être éligible pour le moment. Vous pouvez cependant l''inscrire à des programmes à tout moment en cliquant sur "S''inscrire à des programmes". Vous trouverez d''autres programmes ici : {0}.
+content.preScreenerNoMatchingProgramsTi=L''outil de présélection n''a trouvé aucun programme auquel votre client pourrait être éligible pour le moment. Vous pouvez cependant l''inscrire à des programmes à tout moment en cliquant sur "S''inscrire à des programmes". Vous trouverez d''autres programmes ici : {0}.
 # A message explaining a second option when there are no eligible programs, which is to edit your responses.
-content.commonIntakeNoMatchingProgramsNextStep=Vous pouvez également retourner à la page précédente pour modifier vos réponses.
+content.preScreenerNoMatchingProgramsNextStep=Vous pouvez également retourner à la page précédente pour modifier vos réponses.
 # A header above a list of other programs the applicant might be interested in applying to.
 content.otherProgramsToApplyFor=Autres programmes susceptibles de vous intéresser
 # Button on the "Application Submitted" page. Clicking it downloads the user's application.

--- a/server/conf/i18n/messages.ja
+++ b/server/conf/i18n/messages.ja
@@ -214,11 +214,11 @@ button.viewAndApplySr=確認して {0} に申請
 # The text for the button that allows a guest to bypass the login prompt modal.
 button.continueToApplication=申請に進む
 # The screen reader text for a button an applicant clicks to start filling out a pre-screener form.
-button.startHereCommonIntakeSr={0} を入力してここから開始
+button.startHerePreScreenerSr={0} を入力してここから開始
 # The screen reader text for a button an applicant clicks to edit their responses to a pre-screener form.
-button.editCommonIntakeSr={0} の送信済み情報を編集
+button.editPreScreenerSr={0} の送信済み情報を編集
 # The screen reader text for a button an applicant clicks to continue filling out a pre-screener form.
-button.continueCommonIntakeSr={0} の入力を続ける
+button.continuePreScreenerSr={0} の入力を続ける
 # Text describing the date the application was last submitted.
 content.submittedDate={0} に送信済み
 # Text for applicants to understand the section is for finding programs
@@ -460,7 +460,7 @@ ariaLabel.answer={0} に回答
 # question, so this might say "Edit What is your name?". The {0} variable is the question text.
 ariaLabel.edit={0} を編集
 # Title for the summary of the pre-screener page
-title.commonIntakeSummary=資格要件に関する事前チェックの概要
+title.preScreenerSummary=資格要件に関する事前チェックの概要
 # Heading content at the top of the review page, where applicants can start answering questions.
 title.getStarted=さっそく始めましょう。
 title.programSummary=プログラム申請の概要
@@ -601,23 +601,23 @@ content.generalLoginModalPrompt=アカウントにログインしていません
 content.initialLoginModalPrompt=続行する前に {0} アカウントにログインするか、アカウントを作成してください。同じ情報を再度入力することなく、複数のプログラムに申請できるようになります。また、申請内容の編集や申請状況の確認も可能です。
 # A button for continuing to apply to other programs without an account.
 button.continueWithoutAnAccount=アカウントなしで続行する
-title.commonIntakeConfirmation=対象の可能性があるプログラム
-# Title on the page after a trusted intermediary has successfully filled out the common intake form.
-title.commonIntakeConfirmationTi=クライアントに対象の可能性があるプログラム
+title.preScreenerConfirmation=対象の可能性があるプログラム
+# Title on the page after a trusted intermediary has successfully filled out the pre-screener form.
+title.preScreenerConfirmationTi=クライアントに対象の可能性があるプログラム
 # A message explaining that the applicant may be eligible for the following list of programs, and that they need to apply to them.
-content.commonIntakeConfirmation=[プログラムに申請] をクリックしてオンライン申請で申請した場合、これらのプログラムに登録できる場合があります。
+content.preScreenerConfirmation=[プログラムに申請] をクリックしてオンライン申請で申請した場合、これらのプログラムに登録できる場合があります。
 # A message explaining that the applicant may be eligible for the following list of programs.
-content.commonIntakeConfirmation.v2=回答によると、以下のプログラムの対象となる可能性があります。
+content.preScreenerConfirmation.v2=回答によると、以下のプログラムの対象となる可能性があります。
 # A message explaining that the trusted intermediary's client may be eligible for the following list of programs, and that they need to apply to them.
-content.commonIntakeConfirmationTi=[プログラムに申請] をクリックしてオンライン申請で申請した場合、クライアントはこれらのプログラムに登録できる場合があります。
+content.preScreenerConfirmationTi=[プログラムに申請] をクリックしてオンライン申請で申請した場合、クライアントはこれらのプログラムに登録できる場合があります。
 # A message explaining that the trusted intermediary's client may be eligible for the following list of programs.
-content.commonIntakeConfirmationTi.v2=回答によると、クライアントは以下のプログラムの対象となる可能性があります。
+content.preScreenerConfirmationTi.v2=回答によると、クライアントは以下のプログラムの対象となる可能性があります。
 # A message explaining that there were no programs the applicant is currently eligible for. The {0} parameter is a link to another website, where the text is the name of that site. It may read "Access Arkansas", for example.
-content.commonIntakeNoMatchingPrograms=事前チェックでは、現時点で対象となる可能性のあるプログラムが見つかりませんでした。ただし、[プログラムに申請] をクリックすることで、いつでもプログラムに申請できます。{0} にアクセスしてその他のプログラムを表示することも可能です
+content.preScreenerNoMatchingPrograms=事前チェックでは、現時点で対象となる可能性のあるプログラムが見つかりませんでした。ただし、[プログラムに申請] をクリックすることで、いつでもプログラムに申請できます。{0} にアクセスしてその他のプログラムを表示することも可能です
 # A message explaining that there were no programs the trusted intermediary's client is currently eligible for. The {0} parameter is a link to another website, where the text is the name of that site. It may read "Access Arkansas", for example.
-content.commonIntakeNoMatchingProgramsTi=事前チェックでは、現時点でクライアントが対象となる可能性のあるプログラムが見つかりませんでした。ただし、[プログラムに申請] をクリックすることで、いつでもプログラムに申請できます。{0} にアクセスしてその他のプログラムを表示することも可能です
+content.preScreenerNoMatchingProgramsTi=事前チェックでは、現時点でクライアントが対象となる可能性のあるプログラムが見つかりませんでした。ただし、[プログラムに申請] をクリックすることで、いつでもプログラムに申請できます。{0} にアクセスしてその他のプログラムを表示することも可能です
 # A message explaining a second option when there are no eligible programs, which is to edit your responses.
-content.commonIntakeNoMatchingProgramsNextStep=前のページに戻って、回答を編集することもできます。
+content.preScreenerNoMatchingProgramsNextStep=前のページに戻って、回答を編集することもできます。
 # A header above a list of other programs the applicant might be interested in applying to.
 content.otherProgramsToApplyFor=あなたが興味を持ちそうなその他のプログラム
 # Button on the "Application Submitted" page. Clicking it downloads the user's application.

--- a/server/conf/i18n/messages.ko
+++ b/server/conf/i18n/messages.ko
@@ -214,11 +214,11 @@ button.viewAndApplySr=보기 및 {0} 신청
 # The text for the button that allows a guest to bypass the login prompt modal.
 button.continueToApplication=애플리케이션으로 계속하기
 # The screen reader text for a button an applicant clicks to start filling out a pre-screener form.
-button.startHereCommonIntakeSr={0} 작성
+button.startHerePreScreenerSr={0} 작성
 # The screen reader text for a button an applicant clicks to edit their responses to a pre-screener form.
-button.editCommonIntakeSr={0}에 대해 제출한 정보 수정
+button.editPreScreenerSr={0}에 대해 제출한 정보 수정
 # The screen reader text for a button an applicant clicks to continue filling out a pre-screener form.
-button.continueCommonIntakeSr={0} 계속 작성
+button.continuePreScreenerSr={0} 계속 작성
 # Text describing the date the application was last submitted.
 content.submittedDate=제출 날짜: {0}
 # Text for applicants to understand the section is for finding programs
@@ -460,7 +460,7 @@ ariaLabel.answer={0}에 답변
 # question, so this might say "Edit What is your name?". The {0} variable is the question text.
 ariaLabel.edit={0} 편집
 # Title for the summary of the pre-screener page
-title.commonIntakeSummary=혜택 사전 선별 요약
+title.preScreenerSummary=혜택 사전 선별 요약
 # Heading content at the top of the review page, where applicants can start answering questions.
 title.getStarted=시작하기
 title.programSummary=프로그램 신청 요약
@@ -601,23 +601,23 @@ content.generalLoginModalPrompt=계정에 로그인되어 있지 않습니다. �
 content.initialLoginModalPrompt=계속하기 전에 {0} 계정에 로그인하거나 계정을 만드세요. 같은 정보를 다시 입력하지 않고도 여러 프로그램을 신청할 수 있습니다. 신청서를 수정하고 신청서 상태를 확인할 수도 있습니다.
 # A button for continuing to apply to other programs without an account.
 button.continueWithoutAnAccount=계정 없이 계속
-title.commonIntakeConfirmation=자격 요건에 해당될 수 있는 프로그램
-# Title on the page after a trusted intermediary has successfully filled out the common intake form.
-title.commonIntakeConfirmationTi=고객이 자격 요건에 해당될 수 있는 프로그램
+title.preScreenerConfirmation=자격 요건에 해당될 수 있는 프로그램
+# Title on the page after a trusted intermediary has successfully filled out the pre-screener form.
+title.preScreenerConfirmationTi=고객이 자격 요건에 해당될 수 있는 프로그램
 # A message explaining that the applicant may be eligible for the following list of programs, and that they need to apply to them.
-content.commonIntakeConfirmation='프로그램 신청'을 클릭하여 온라인으로 신청하면 등록될 가능성이 있는 프로그램입니다.
+content.preScreenerConfirmation='프로그램 신청'을 클릭하여 온라인으로 신청하면 등록될 가능성이 있는 프로그램입니다.
 # A message explaining that the applicant may be eligible for the following list of programs.
-content.commonIntakeConfirmation.v2=귀하의 답변에 따라 귀하는 다음과 같은 프로그램의 자격 요건을 충족할 수도 있습니다.
+content.preScreenerConfirmation.v2=귀하의 답변에 따라 귀하는 다음과 같은 프로그램의 자격 요건을 충족할 수도 있습니다.
 # A message explaining that the trusted intermediary's client may be eligible for the following list of programs, and that they need to apply to them.
-content.commonIntakeConfirmationTi=관리자가 '프로그램 신청'을 클릭하여 온라인으로 신청하면 고객이 등록될 가능성이 있는 프로그램입니다.
+content.preScreenerConfirmationTi=관리자가 '프로그램 신청'을 클릭하여 온라인으로 신청하면 고객이 등록될 가능성이 있는 프로그램입니다.
 # A message explaining that the trusted intermediary's client may be eligible for the following list of programs.
-content.commonIntakeConfirmationTi.v2=귀하의 답변에 따라 고객이 다음과 같은 프로그램의 자격 요건을 충족할 수도 있습니다.
+content.preScreenerConfirmationTi.v2=귀하의 답변에 따라 고객이 다음과 같은 프로그램의 자격 요건을 충족할 수도 있습니다.
 # A message explaining that there were no programs the applicant is currently eligible for. The {0} parameter is a link to another website, where the text is the name of that site. It may read "Access Arkansas", for example.
-content.commonIntakeNoMatchingPrograms=이번에는 사전 선별 과정에서 자격 요건에 해당될 수 있는 프로그램을 찾지 못했습니다. 하지만 언제든지 '프로그램 신청'을 클릭하여 프로그램을 신청할 수 있습니다. 또는 {0} 페이지를 방문하여 다른 프로그램을 확인해 보세요.
+content.preScreenerNoMatchingPrograms=이번에는 사전 선별 과정에서 자격 요건에 해당될 수 있는 프로그램을 찾지 못했습니다. 하지만 언제든지 '프로그램 신청'을 클릭하여 프로그램을 신청할 수 있습니다. 또는 {0} 페이지를 방문하여 다른 프로그램을 확인해 보세요.
 # A message explaining that there were no programs the trusted intermediary's client is currently eligible for. The {0} parameter is a link to another website, where the text is the name of that site. It may read "Access Arkansas", for example.
-content.commonIntakeNoMatchingProgramsTi=이번에는 사전 선별 과정에서 고객이 자격 요건에 해당될 수 있는 프로그램을 찾지 못했습니다. 하지만 언제든지 '프로그램 신청'을 클릭하여 프로그램을 신청할 수 있습니다. 또는 {0} 페이지를 방문하여 다른 프로그램을 확인해 보세요.
+content.preScreenerNoMatchingProgramsTi=이번에는 사전 선별 과정에서 고객이 자격 요건에 해당될 수 있는 프로그램을 찾지 못했습니다. 하지만 언제든지 '프로그램 신청'을 클릭하여 프로그램을 신청할 수 있습니다. 또는 {0} 페이지를 방문하여 다른 프로그램을 확인해 보세요.
 # A message explaining a second option when there are no eligible programs, which is to edit your responses.
-content.commonIntakeNoMatchingProgramsNextStep=이전 페이지로 돌아가 응답을 수정할 수도 있습니다.
+content.preScreenerNoMatchingProgramsNextStep=이전 페이지로 돌아가 응답을 수정할 수도 있습니다.
 # A header above a list of other programs the applicant might be interested in applying to.
 content.otherProgramsToApplyFor=관심 있을 만한 다른 프로그램
 # Button on the "Application Submitted" page. Clicking it downloads the user's application.

--- a/server/conf/i18n/messages.lo
+++ b/server/conf/i18n/messages.lo
@@ -214,11 +214,11 @@ button.viewAndApplySr=ເບິ່ງ ແລະ ນຳໃຊ້ກັບ {0}
 # The text for the button that allows a guest to bypass the login prompt modal.
 button.continueToApplication=ສືບຕໍ່ສະໝັກ
 # The screen reader text for a button an applicant clicks to start filling out a pre-screener form.
-button.startHereCommonIntakeSr=ເລີ່ມຕົ້ນບ່ອນນີ້ໂດຍການຕື່ມຂໍ້ມູນ {0}
+button.startHerePreScreenerSr=ເລີ່ມຕົ້ນບ່ອນນີ້ໂດຍການຕື່ມຂໍ້ມູນ {0}
 # The screen reader text for a button an applicant clicks to edit their responses to a pre-screener form.
-button.editCommonIntakeSr=ແກ້ໄຂຂໍ້ມູນທີ່ສົ່ງສຳລັບ {0}
+button.editPreScreenerSr=ແກ້ໄຂຂໍ້ມູນທີ່ສົ່ງສຳລັບ {0}
 # The screen reader text for a button an applicant clicks to continue filling out a pre-screener form.
-button.continueCommonIntakeSr=ສືບຕໍ່ຕື່ມຂໍ້ມູນ {0}
+button.continuePreScreenerSr=ສືບຕໍ່ຕື່ມຂໍ້ມູນ {0}
 # Text describing the date the application was last submitted.
 content.submittedDate=ສົ່ງ {0} ແລ້ວ
 # Text for applicants to understand the section is for finding programs
@@ -460,7 +460,7 @@ ariaLabel.answer=ຕອບ {0}
 # question, so this might say "Edit What is your name?". The {0} variable is the question text.
 ariaLabel.edit=ແກ້ໄຂ {0}
 # Title for the summary of the pre-screener page
-title.commonIntakeSummary=ສະຫຼຸບສິດທິປະໂຫຍດກວດສອບລ່ວງໜ້າ
+title.preScreenerSummary=ສະຫຼຸບສິດທິປະໂຫຍດກວດສອບລ່ວງໜ້າ
 # Heading content at the top of the review page, where applicants can start answering questions.
 title.getStarted=ມາເລີ່ມກັນເລີຍ.
 title.programSummary=ສະຫຼຸບການສະໝັກໂຄງການ
@@ -601,23 +601,23 @@ content.generalLoginModalPrompt=ທ່ານບໍ່ໄດ້ເຂົ້າສ
 content.initialLoginModalPrompt=ກ່ອນທ່ານສືບຕໍ່, ໃຫ້ເຂົ້າສູ່ລະບົບບັນຊີ {0} ຂອງທ່ານ ຫຼື ສ້າງບັນຊີ. ທ່ານຈະສາມາດສະໝັກຫຼາຍໂຄງການໄດ້ໂດຍບໍ່ຕ້ອງປ້ອນຂໍ້ມູນເກົ່າຄືນໃໝ່. ນອກຈາກນັ້ນ, ທ່ານຍັງສາມາດແກ້ໄຂໃບສະໝັກ ແລະ ກວດສອບສະຖານະໃບສະໝັກຂອງທ່ານໄດ້.
 # A button for continuing to apply to other programs without an account.
 button.continueWithoutAnAccount=ສືບຕໍ່ໂດຍບໍ່ຕ້ອງມີບັນຊີ
-title.commonIntakeConfirmation=ໂຄງການທີ່ທ່ານອາດມີຄຸນສົມບັດເຂົ້າຮ່ວມ
-# Title on the page after a trusted intermediary has successfully filled out the common intake form.
-title.commonIntakeConfirmationTi=ໂຄງການທີ່ລູກຄ້າຂອງທ່ານອາດມີຄຸນສົມບັດເຂົ້າຮ່ວມ
+title.preScreenerConfirmation=ໂຄງການທີ່ທ່ານອາດມີຄຸນສົມບັດເຂົ້າຮ່ວມ
+# Title on the page after a trusted intermediary has successfully filled out the pre-screener form.
+title.preScreenerConfirmationTi=ໂຄງການທີ່ລູກຄ້າຂອງທ່ານອາດມີຄຸນສົມບັດເຂົ້າຮ່ວມ
 # A message explaining that the applicant may be eligible for the following list of programs, and that they need to apply to them.
-content.commonIntakeConfirmation=ທ່ານອາດຈະສາມາດລົງທະບຽນໃນໂຄງການເຫຼົ່ານີ້ໄດ້ ຫາກທ່ານສະໝັກຜ່ານໃບສະໝັກທາງອອນລາຍໂດຍຄລິກ ''ສະໝັກເຂົ້າຮ່ວມໂຄງການ''.
+content.preScreenerConfirmation=ທ່ານອາດຈະສາມາດລົງທະບຽນໃນໂຄງການເຫຼົ່ານີ້ໄດ້ ຫາກທ່ານສະໝັກຜ່ານໃບສະໝັກທາງອອນລາຍໂດຍຄລິກ ''ສະໝັກເຂົ້າຮ່ວມໂຄງການ''.
 # A message explaining that the applicant may be eligible for the following list of programs.
-content.commonIntakeConfirmation.v2=ອີງຕາມຄຳຕອບຂອງທ່ານ, ທ່ານອາດມີຄຸນສົມບັດສຳລັບໂປຣແກຣມຕໍ່ໄປນີ້:
+content.preScreenerConfirmation.v2=ອີງຕາມຄຳຕອບຂອງທ່ານ, ທ່ານອາດມີຄຸນສົມບັດສຳລັບໂປຣແກຣມຕໍ່ໄປນີ້:
 # A message explaining that the trusted intermediary's client may be eligible for the following list of programs, and that they need to apply to them.
-content.commonIntakeConfirmationTi=ລູກຄ້າຂອງທ່ານອາດຈະສາມາດລົງທະບຽນໃນໂຄງການເຫຼົ່ານີ້ໄດ້ ຫາກທ່ານສະໝັກຜ່ານໃບສະໝັກທາງອອນລາຍໂດຍຄລິກ ''ສະໝັກເຂົ້າຮ່ວມໂຄງການ''.
+content.preScreenerConfirmationTi=ລູກຄ້າຂອງທ່ານອາດຈະສາມາດລົງທະບຽນໃນໂຄງການເຫຼົ່ານີ້ໄດ້ ຫາກທ່ານສະໝັກຜ່ານໃບສະໝັກທາງອອນລາຍໂດຍຄລິກ ''ສະໝັກເຂົ້າຮ່ວມໂຄງການ''.
 # A message explaining that the trusted intermediary's client may be eligible for the following list of programs.
-content.commonIntakeConfirmationTi.v2=ອີງຕາມຄຳຕອບຂອງທ່ານ, ລູກຄ້າຂອງທ່ານອາດມີຄຸນສົມບັດສຳລັບໂປຣແກຣມຕໍ່ໄປນີ້:
+content.preScreenerConfirmationTi.v2=ອີງຕາມຄຳຕອບຂອງທ່ານ, ລູກຄ້າຂອງທ່ານອາດມີຄຸນສົມບັດສຳລັບໂປຣແກຣມຕໍ່ໄປນີ້:
 # A message explaining that there were no programs the applicant is currently eligible for. The {0} parameter is a link to another website, where the text is the name of that site. It may read "Access Arkansas", for example.
-content.commonIntakeNoMatchingPrograms=ຕົວກວດສອບລ່ວງໜ້າບໍ່ພົບໂຄງການທີ່ທ່ານອາດມີຄຸນສົມບັດເຂົ້າຮ່ວມໃນເວລານີ້. ແນວໃດກໍຕາມ, ທ່ານອາດສະໝັກໂຄງການໄດ້ທຸກເວລາ, ໂດຍຄລິກ ''ສະໝັກເຂົ້າຮ່ວມໂຄງການ''. ຫຼື ເພື່ອເບິ່ງໂຄງການເພີ່ມເຕີມ ທ່ານສາມາດເຂົ້າໄປ {0} ໄດ້
+content.preScreenerNoMatchingPrograms=ຕົວກວດສອບລ່ວງໜ້າບໍ່ພົບໂຄງການທີ່ທ່ານອາດມີຄຸນສົມບັດເຂົ້າຮ່ວມໃນເວລານີ້. ແນວໃດກໍຕາມ, ທ່ານອາດສະໝັກໂຄງການໄດ້ທຸກເວລາ, ໂດຍຄລິກ ''ສະໝັກເຂົ້າຮ່ວມໂຄງການ''. ຫຼື ເພື່ອເບິ່ງໂຄງການເພີ່ມເຕີມ ທ່ານສາມາດເຂົ້າໄປ {0} ໄດ້
 # A message explaining that there were no programs the trusted intermediary's client is currently eligible for. The {0} parameter is a link to another website, where the text is the name of that site. It may read "Access Arkansas", for example.
-content.commonIntakeNoMatchingProgramsTi=ຕົວກວດສອບລ່ວງໜ້າບໍ່ພົບໂຄງການທີ່ລູກຄ້າຂອງທ່ານອາດມີຄຸນສົມບັດເຂົ້າຮ່ວມໃນເວລານີ້. ແນວໃດກໍຕາມ, ທ່ານອາດສະໝັກໂຄງການໄດ້ທຸກເວລາ, ໂດຍຄລິກ ''ສະໝັກເຂົ້າຮ່ວມໂຄງການ''. ຫຼື ເພື່ອເບິ່ງໂຄງການເພີ່ມເຕີມ ທ່ານສາມາດເຂົ້າໄປ {0} ໄດ້
+content.preScreenerNoMatchingProgramsTi=ຕົວກວດສອບລ່ວງໜ້າບໍ່ພົບໂຄງການທີ່ລູກຄ້າຂອງທ່ານອາດມີຄຸນສົມບັດເຂົ້າຮ່ວມໃນເວລານີ້. ແນວໃດກໍຕາມ, ທ່ານອາດສະໝັກໂຄງການໄດ້ທຸກເວລາ, ໂດຍຄລິກ ''ສະໝັກເຂົ້າຮ່ວມໂຄງການ''. ຫຼື ເພື່ອເບິ່ງໂຄງການເພີ່ມເຕີມ ທ່ານສາມາດເຂົ້າໄປ {0} ໄດ້
 # A message explaining a second option when there are no eligible programs, which is to edit your responses.
-content.commonIntakeNoMatchingProgramsNextStep=ນອກຈາກນັ້ນ, ທ່ານຍັງສາມາດກັບຄືນໄປຫາໜ້າກ່ອນໜ້ານີ້ເພື່ອແກ້ໄຂຄຳຕອບຂອງທ່ານໄດ້ນຳ.
+content.preScreenerNoMatchingProgramsNextStep=ນອກຈາກນັ້ນ, ທ່ານຍັງສາມາດກັບຄືນໄປຫາໜ້າກ່ອນໜ້ານີ້ເພື່ອແກ້ໄຂຄຳຕອບຂອງທ່ານໄດ້ນຳ.
 # A header above a list of other programs the applicant might be interested in applying to.
 content.otherProgramsToApplyFor=ໂປຣແກຣມອື່ນທີ່ທ່ານອາດສົນໃຈ
 # Button on the "Application Submitted" page. Clicking it downloads the user's application.

--- a/server/conf/i18n/messages.ru
+++ b/server/conf/i18n/messages.ru
@@ -214,11 +214,11 @@ button.viewAndApplySr=Узнать больше и подать заявку н�
 # The text for the button that allows a guest to bypass the login prompt modal.
 button.continueToApplication=Заполнить заявку
 # The screen reader text for a button an applicant clicks to start filling out a pre-screener form.
-button.startHereCommonIntakeSr=Заполнить форму "{0}"
+button.startHerePreScreenerSr=Заполнить форму "{0}"
 # The screen reader text for a button an applicant clicks to edit their responses to a pre-screener form.
-button.editCommonIntakeSr=Изменить сведения, указанные в форме "{0}"
+button.editPreScreenerSr=Изменить сведения, указанные в форме "{0}"
 # The screen reader text for a button an applicant clicks to continue filling out a pre-screener form.
-button.continueCommonIntakeSr=Продолжить заполнять форму "{0}"
+button.continuePreScreenerSr=Продолжить заполнять форму "{0}"
 # Text describing the date the application was last submitted.
 content.submittedDate=Вы отправили заявку {0}
 # Text for applicants to understand the section is for finding programs
@@ -460,7 +460,7 @@ ariaLabel.answer=Ответить на вопрос "{0}"
 # question, so this might say "Edit What is your name?". The {0} variable is the question text.
 ariaLabel.edit=Изменить ответ на вопрос "{0}"
 # Title for the summary of the pre-screener page
-title.commonIntakeSummary=Сводные данные об этой форме
+title.preScreenerSummary=Сводные данные об этой форме
 # Heading content at the top of the review page, where applicants can start answering questions.
 title.getStarted=Давайте начнем
 title.programSummary=Сводные данные о заявке на участие в программе
@@ -601,23 +601,23 @@ content.generalLoginModalPrompt=Вы не вошли в аккаунт. Без �
 content.initialLoginModalPrompt=Прежде чем продолжить, войдите в свой аккаунт, зарегистрированный в сервисе "{0}". Тогда вам не придется повторно вводить свою информацию при подаче нескольких заявок. Вы также сможете изменять заполненные заявки и проверять их статус. Если у вас нет аккаунта, вы можете его создать.
 # A button for continuing to apply to other programs without an account.
 button.continueWithoutAnAccount=Продолжить без входа в аккаунт
-title.commonIntakeConfirmation=Программы, которые могут быть вам доступны
-# Title on the page after a trusted intermediary has successfully filled out the common intake form.
-title.commonIntakeConfirmationTi=Программы, которые могут быть доступны вашему клиенту
+title.preScreenerConfirmation=Программы, которые могут быть вам доступны
+# Title on the page after a trusted intermediary has successfully filled out the pre-screener form.
+title.preScreenerConfirmationTi=Программы, которые могут быть доступны вашему клиенту
 # A message explaining that the applicant may be eligible for the following list of programs, and that they need to apply to them.
-content.commonIntakeConfirmation=Возможно, вы соответствуете критериям допуска к этим программам. Чтобы подать заявки, нажмите "Зарегистрироваться в программах" и заполните онлайн-формы.
+content.preScreenerConfirmation=Возможно, вы соответствуете критериям допуска к этим программам. Чтобы подать заявки, нажмите "Зарегистрироваться в программах" и заполните онлайн-формы.
 # A message explaining that the applicant may be eligible for the following list of programs.
-content.commonIntakeConfirmation.v2=На основе ваших ответов мы подобрали программы, которые могут быть вам доступны:
+content.preScreenerConfirmation.v2=На основе ваших ответов мы подобрали программы, которые могут быть вам доступны:
 # A message explaining that the trusted intermediary's client may be eligible for the following list of programs, and that they need to apply to them.
-content.commonIntakeConfirmationTi=Возможно, ваш клиент соответствует критериям допуска к этим программам. Чтобы подать заявки, нажмите "Зарегистрироваться в программах" и заполните онлайн-формы.
+content.preScreenerConfirmationTi=Возможно, ваш клиент соответствует критериям допуска к этим программам. Чтобы подать заявки, нажмите "Зарегистрироваться в программах" и заполните онлайн-формы.
 # A message explaining that the trusted intermediary's client may be eligible for the following list of programs.
-content.commonIntakeConfirmationTi.v2=На основе ваших ответов мы подобрали программы, которые могут быть доступны вашему клиенту:
+content.preScreenerConfirmationTi.v2=На основе ваших ответов мы подобрали программы, которые могут быть доступны вашему клиенту:
 # A message explaining that there were no programs the applicant is currently eligible for. The {0} parameter is a link to another website, where the text is the name of that site. It may read "Access Arkansas", for example.
-content.commonIntakeNoMatchingPrograms=Функция предварительного подбора не обнаружила программ, которые сейчас могут быть вам доступны. Однако вы в любое время можете подавать заявки, нажав "Зарегистрироваться в программах". Чтобы посмотреть дополнительные программы, перейдите на сайт {0}.
+content.preScreenerNoMatchingPrograms=Функция предварительного подбора не обнаружила программ, которые сейчас могут быть вам доступны. Однако вы в любое время можете подавать заявки, нажав "Зарегистрироваться в программах". Чтобы посмотреть дополнительные программы, перейдите на сайт {0}.
 # A message explaining that there were no programs the trusted intermediary's client is currently eligible for. The {0} parameter is a link to another website, where the text is the name of that site. It may read "Access Arkansas", for example.
-content.commonIntakeNoMatchingProgramsTi=Функция предварительного подбора не обнаружила программ, которые сейчас могут быть доступны вашему клиенту. Однако вы в любое время можете подавать заявки, нажав "Зарегистрироваться в программах". Чтобы посмотреть дополнительные программы, перейдите на сайт {0}.
+content.preScreenerNoMatchingProgramsTi=Функция предварительного подбора не обнаружила программ, которые сейчас могут быть доступны вашему клиенту. Однако вы в любое время можете подавать заявки, нажав "Зарегистрироваться в программах". Чтобы посмотреть дополнительные программы, перейдите на сайт {0}.
 # A message explaining a second option when there are no eligible programs, which is to edit your responses.
-content.commonIntakeNoMatchingProgramsNextStep=Вы также можете вернуться на предыдущую страницу и изменить свои ответы.
+content.preScreenerNoMatchingProgramsNextStep=Вы также можете вернуться на предыдущую страницу и изменить свои ответы.
 # A header above a list of other programs the applicant might be interested in applying to.
 content.otherProgramsToApplyFor=Другие программы, которые могут быть вам интересны
 # Button on the "Application Submitted" page. Clicking it downloads the user's application.

--- a/server/conf/i18n/messages.so
+++ b/server/conf/i18n/messages.so
@@ -214,11 +214,11 @@ button.viewAndApplySr=Eeg oo codso {0}
 # The text for the button that allows a guest to bypass the login prompt modal.
 button.continueToApplication=Ku sii soco codsiga
 # The screen reader text for a button an applicant clicks to start filling out a pre-screener form.
-button.startHereCommonIntakeSr=Ka bilow halkan addoo buuxinaya {0}
+button.startHerePreScreenerSr=Ka bilow halkan addoo buuxinaya {0}
 # The screen reader text for a button an applicant clicks to edit their responses to a pre-screener form.
-button.editCommonIntakeSr=Wax ka beddel macluumaadka la gudbiyay {0}
+button.editPreScreenerSr=Wax ka beddel macluumaadka la gudbiyay {0}
 # The screen reader text for a button an applicant clicks to continue filling out a pre-screener form.
-button.continueCommonIntakeSr=Sii wad buuxinta {0}
+button.continuePreScreenerSr=Sii wad buuxinta {0}
 # Text describing the date the application was last submitted.
 content.submittedDate=La gudbiyay {0}
 # Text for applicants to understand the section is for finding programs
@@ -460,7 +460,7 @@ ariaLabel.answer=Jawaab {0}
 # question, so this might say "Edit What is your name?". The {0} variable is the question text.
 ariaLabel.edit=Wax ka beddel {0}
 # Title for the summary of the pre-screener page
-title.commonIntakeSummary=Faa'iidooyinka hore u baadhaha oo kooban
+title.preScreenerSummary=Faa'iidooyinka hore u baadhaha oo kooban
 # Heading content at the top of the review page, where applicants can start answering questions.
 title.getStarted=Aan bilowno.
 title.programSummary=Soo koobida barnaamijka codsiga
@@ -601,23 +601,23 @@ content.generalLoginModalPrompt=Adigu akoon kuma aanad soo galin. Akoon la'aanti
 content.initialLoginModalPrompt=Ka hor inta aanad sii wadin, soo gal {0} akoonkaaga ama samayso akoon. Waxaad awoodi doontaa inaad codsatid dhowr barnaamij adigoon galineyn isla macluumaadkii markale. Waxaad sidoo kale wax ka beddeli kartaa codsiyadaada oo hubin kartaa heerarka codsigaagu marayo.
 # A button for continuing to apply to other programs without an account.
 button.continueWithoutAnAccount=Sii soco koonto la'aan
-title.commonIntakeConfirmation=Barnaamijyada aad u qalmi karaysid
-# Title on the page after a trusted intermediary has successfully filled out the common intake form.
-title.commonIntakeConfirmationTi=Barnaamijyada macmiilkaagu u qalmi karayo
+title.preScreenerConfirmation=Barnaamijyada aad u qalmi karaysid
+# Title on the page after a trusted intermediary has successfully filled out the pre-screener form.
+title.preScreenerConfirmationTi=Barnaamijyada macmiilkaagu u qalmi karayo
 # A message explaining that the applicant may be eligible for the following list of programs, and that they need to apply to them.
-content.commonIntakeConfirmation=Waxaad awoodi kartaa inaad iska-diwaan galisid barnaamijyadan hadii aad ku codsatid qaabka codsiga onlaynka ah adigoo gujinaya ''Codso barnaamijyada''.
+content.preScreenerConfirmation=Waxaad awoodi kartaa inaad iska-diwaan galisid barnaamijyadan hadii aad ku codsatid qaabka codsiga onlaynka ah adigoo gujinaya ''Codso barnaamijyada''.
 # A message explaining that the applicant may be eligible for the following list of programs.
-content.commonIntakeConfirmation.v2=Iyada oo lagu saleynayo jawaabahaaga, waxaa laga yaabaa inaad u qalanto barnaamijyada soo socda:
+content.preScreenerConfirmation.v2=Iyada oo lagu saleynayo jawaabahaaga, waxaa laga yaabaa inaad u qalanto barnaamijyada soo socda:
 # A message explaining that the trusted intermediary's client may be eligible for the following list of programs, and that they need to apply to them.
-content.commonIntakeConfirmationTi=Macmiilkaagu wuxuu awoodi karaa inuu iska diwaangaliyo barnaamijyadan hadii aad codsiga ugu dalabtid/buuxisid qaabka codsiga onlaynka ah adigoo gujinaya ''Codso barnaamijyada''
+content.preScreenerConfirmationTi=Macmiilkaagu wuxuu awoodi karaa inuu iska diwaangaliyo barnaamijyadan hadii aad codsiga ugu dalabtid/buuxisid qaabka codsiga onlaynka ah adigoo gujinaya ''Codso barnaamijyada''
 # A message explaining that the trusted intermediary's client may be eligible for the following list of programs.
-content.commonIntakeConfirmationTi.v2=Iyada oo lagu saleynayo jawaabahaaga, macmiilkaagu waxaa laga yaabaa inuu u qalmo barnaamijyada soo socda:
+content.preScreenerConfirmationTi.v2=Iyada oo lagu saleynayo jawaabahaaga, macmiilkaagu waxaa laga yaabaa inuu u qalmo barnaamijyada soo socda:
 # A message explaining that there were no programs the applicant is currently eligible for. The {0} parameter is a link to another website, where the text is the name of that site. It may read "Access Arkansas", for example.
-content.commonIntakeNoMatchingPrograms=Qiimeeyaha-hore waa uu heli kari waayey barnaamijyada aad u qalmi karto wakhtigan. Si kastaba ha ahaatee, waxaad codsan kartaa barnaamijyada wakhti kasta, adigoo gujinaya "Codso barnaamiyada". Ama si aad u eegtid barnaamijyo dheeraad ah waxaad booqan kartaa {0}
+content.preScreenerNoMatchingPrograms=Qiimeeyaha-hore waa uu heli kari waayey barnaamijyada aad u qalmi karto wakhtigan. Si kastaba ha ahaatee, waxaad codsan kartaa barnaamijyada wakhti kasta, adigoo gujinaya "Codso barnaamiyada". Ama si aad u eegtid barnaamijyo dheeraad ah waxaad booqan kartaa {0}
 # A message explaining that there were no programs the trusted intermediary's client is currently eligible for. The {0} parameter is a link to another website, where the text is the name of that site. It may read "Access Arkansas", for example.
-content.commonIntakeNoMatchingProgramsTi=Qiimeeyaha-hore waa uu heli kari waayey barnaamijyada uu macmiilkaagu u qalmi karo wakhtigan. Si kastaba ha ahaatee, waxaad codsan kartaa barnaamijyada wakhti kasta, adigoo gujinaya "Codso barnaamiyada". Ama si aad u eegtid barnaamijyo dheeraad ah waxaad booqan kartaa {0}
+content.preScreenerNoMatchingProgramsTi=Qiimeeyaha-hore waa uu heli kari waayey barnaamijyada uu macmiilkaagu u qalmi karo wakhtigan. Si kastaba ha ahaatee, waxaad codsan kartaa barnaamijyada wakhti kasta, adigoo gujinaya "Codso barnaamiyada". Ama si aad u eegtid barnaamijyo dheeraad ah waxaad booqan kartaa {0}
 # A message explaining a second option when there are no eligible programs, which is to edit your responses.
-content.commonIntakeNoMatchingProgramsNextStep=Sidoo kale waxaad ku noqon kartaa bogga hore si aad wax uga beddesho jawaabahaaga.
+content.preScreenerNoMatchingProgramsNextStep=Sidoo kale waxaad ku noqon kartaa bogga hore si aad wax uga beddesho jawaabahaaga.
 # A header above a list of other programs the applicant might be interested in applying to.
 content.otherProgramsToApplyFor=Barnaamijyada kale ee laga yaabo inaad xiisaynayso
 # Button on the "Application Submitted" page. Clicking it downloads the user's application.

--- a/server/conf/i18n/messages.tl
+++ b/server/conf/i18n/messages.tl
@@ -214,11 +214,11 @@ button.viewAndApplySr=Tingnan at mag-apply sa {0}
 # The text for the button that allows a guest to bypass the login prompt modal.
 button.continueToApplication=Magpatuloy sa application
 # The screen reader text for a button an applicant clicks to start filling out a pre-screener form.
-button.startHereCommonIntakeSr=Magsimula rito sa pamamagitan ng pagsasagot sa {0}
+button.startHerePreScreenerSr=Magsimula rito sa pamamagitan ng pagsasagot sa {0}
 # The screen reader text for a button an applicant clicks to edit their responses to a pre-screener form.
-button.editCommonIntakeSr=I-edit ang isinumiteng impormasyon para sa {0}
+button.editPreScreenerSr=I-edit ang isinumiteng impormasyon para sa {0}
 # The screen reader text for a button an applicant clicks to continue filling out a pre-screener form.
-button.continueCommonIntakeSr=Ipagpatuloy ang pagsasagot ng {0}
+button.continuePreScreenerSr=Ipagpatuloy ang pagsasagot ng {0}
 # Text describing the date the application was last submitted.
 content.submittedDate=Isinumite noong {0}
 # Text for applicants to understand the section is for finding programs
@@ -460,7 +460,7 @@ ariaLabel.answer=Sagot {0}
 # question, so this might say "Edit What is your name?". The {0} variable is the question text.
 ariaLabel.edit=I-edit {0}
 # Title for the summary of the pre-screener page
-title.commonIntakeSummary=Buod ng pre-screener para sa mga benepisyo
+title.preScreenerSummary=Buod ng pre-screener para sa mga benepisyo
 # Heading content at the top of the review page, where applicants can start answering questions.
 title.getStarted=Magsimula na tayo
 title.programSummary=Buod ng application para sa programa
@@ -601,23 +601,23 @@ content.generalLoginModalPrompt=Hindi ka naka-log in sa isang account. Hindi mo 
 content.initialLoginModalPrompt=Bago ka magpatuloy, mag-log in sa iyong {0} account o gumawa ng account. Makakapag-apply ka para sa maraming programa nang hindi kinakailangang ilagay ulit ang parehong impormasyon. Puwede ka ring mag-edit ng mga aplikasyon at tumingin ng mga status ng iyong aplikasyon.
 # A button for continuing to apply to other programs without an account.
 button.continueWithoutAnAccount=Magpatuloy nang walang account
-title.commonIntakeConfirmation=Mga programa kung saan puwede kang maging kwalipikado
-# Title on the page after a trusted intermediary has successfully filled out the common intake form.
-title.commonIntakeConfirmationTi=Mga programa kung saan puwedeng maging kwalipikado ang kliyente mo
+title.preScreenerConfirmation=Mga programa kung saan puwede kang maging kwalipikado
+# Title on the page after a trusted intermediary has successfully filled out the pre-screener form.
+title.preScreenerConfirmationTi=Mga programa kung saan puwedeng maging kwalipikado ang kliyente mo
 # A message explaining that the applicant may be eligible for the following list of programs, and that they need to apply to them.
-content.commonIntakeConfirmation=Posibleng makapag-enroll ka sa mga programang ito kung mag-a-apply ka sa pamamagitan ng online na aplikasyon sa pamamagitan ng pag-click sa "Mag-apply sa mga programa."
+content.preScreenerConfirmation=Posibleng makapag-enroll ka sa mga programang ito kung mag-a-apply ka sa pamamagitan ng online na aplikasyon sa pamamagitan ng pag-click sa "Mag-apply sa mga programa."
 # A message explaining that the applicant may be eligible for the following list of programs.
-content.commonIntakeConfirmation.v2=Batay sa iyong mga sagot, posibleng kwalipikado ka sa mga sumusunod na programa:
+content.preScreenerConfirmation.v2=Batay sa iyong mga sagot, posibleng kwalipikado ka sa mga sumusunod na programa:
 # A message explaining that the trusted intermediary's client may be eligible for the following list of programs, and that they need to apply to them.
-content.commonIntakeConfirmationTi=Posibleng makapag-enroll ang kliyente mo sa mga programang ito kung mag-a-apply ka sa pamamagitan ng online na aplikasyon sa pamamagitan ng pag-click sa "Mag-apply sa mga programa."
+content.preScreenerConfirmationTi=Posibleng makapag-enroll ang kliyente mo sa mga programang ito kung mag-a-apply ka sa pamamagitan ng online na aplikasyon sa pamamagitan ng pag-click sa "Mag-apply sa mga programa."
 # A message explaining that the trusted intermediary's client may be eligible for the following list of programs.
-content.commonIntakeConfirmationTi.v2=Batay sa iyong mga sagot, posbileng kwalipikado ang kliyente mo sa mga sumusunod na programa:
+content.preScreenerConfirmationTi.v2=Batay sa iyong mga sagot, posbileng kwalipikado ang kliyente mo sa mga sumusunod na programa:
 # A message explaining that there were no programs the applicant is currently eligible for. The {0} parameter is a link to another website, where the text is the name of that site. It may read "Access Arkansas", for example.
-content.commonIntakeNoMatchingPrograms=Hindi makahanap ang pre-screener ng mga programa kung saan puwede kang maging kwalipikado sa panahong ito. Pero puwede kang mag-apply sa mga programa anumang oras sa pamamagitan ng pag-click sa "Mag-apply sa mga programa." O para tumingin ng mga karagdagang programa, puwede kang pumunta sa {0}
+content.preScreenerNoMatchingPrograms=Hindi makahanap ang pre-screener ng mga programa kung saan puwede kang maging kwalipikado sa panahong ito. Pero puwede kang mag-apply sa mga programa anumang oras sa pamamagitan ng pag-click sa "Mag-apply sa mga programa." O para tumingin ng mga karagdagang programa, puwede kang pumunta sa {0}
 # A message explaining that there were no programs the trusted intermediary's client is currently eligible for. The {0} parameter is a link to another website, where the text is the name of that site. It may read "Access Arkansas", for example.
-content.commonIntakeNoMatchingProgramsTi=Hindi makahanap ang pre-screener ng mga programa kung saan puwedeng maging kwalipikado ang kliyente mo sa panahong ito. Pero puwede kang mag-apply sa mga programa anumang oras sa pamamagitan ng pag-click sa "Mag-apply sa mga programa." O para tumingin ng mga karagdagang programa, puwede kang pumunta sa {0}
+content.preScreenerNoMatchingProgramsTi=Hindi makahanap ang pre-screener ng mga programa kung saan puwedeng maging kwalipikado ang kliyente mo sa panahong ito. Pero puwede kang mag-apply sa mga programa anumang oras sa pamamagitan ng pag-click sa "Mag-apply sa mga programa." O para tumingin ng mga karagdagang programa, puwede kang pumunta sa {0}
 # A message explaining a second option when there are no eligible programs, which is to edit your responses.
-content.commonIntakeNoMatchingProgramsNextStep=Puwede ka ring bumalik sa nakaraang page para i-edit ang iyong mga sagot.
+content.preScreenerNoMatchingProgramsNextStep=Puwede ka ring bumalik sa nakaraang page para i-edit ang iyong mga sagot.
 # A header above a list of other programs the applicant might be interested in applying to.
 content.otherProgramsToApplyFor=Ibang programang posibleng kainteresan mo
 # Button on the "Application Submitted" page. Clicking it downloads the user's application.

--- a/server/conf/i18n/messages.vi
+++ b/server/conf/i18n/messages.vi
@@ -214,11 +214,11 @@ button.viewAndApplySr=Xem và đăng ký {0}
 # The text for the button that allows a guest to bypass the login prompt modal.
 button.continueToApplication=Tiếp tục chuyển đến đơn đăng ký
 # The screen reader text for a button an applicant clicks to start filling out a pre-screener form.
-button.startHereCommonIntakeSr=Bắt đầu tại đây bằng cách điền vào {0}
+button.startHerePreScreenerSr=Bắt đầu tại đây bằng cách điền vào {0}
 # The screen reader text for a button an applicant clicks to edit their responses to a pre-screener form.
-button.editCommonIntakeSr=Chỉnh sửa thông tin đã gửi cho {0}
+button.editPreScreenerSr=Chỉnh sửa thông tin đã gửi cho {0}
 # The screen reader text for a button an applicant clicks to continue filling out a pre-screener form.
-button.continueCommonIntakeSr=Tiếp tục điền vào {0}
+button.continuePreScreenerSr=Tiếp tục điền vào {0}
 # Text describing the date the application was last submitted.
 content.submittedDate=Đã gửi {0}
 # Text for applicants to understand the section is for finding programs
@@ -460,7 +460,7 @@ ariaLabel.answer=Câu trả lời {0}
 # question, so this might say "Edit What is your name?". The {0} variable is the question text.
 ariaLabel.edit=Chỉnh sửa {0}
 # Title for the summary of the pre-screener page
-title.commonIntakeSummary=Tóm tắt sàng lọc sơ bộ về lợi ích
+title.preScreenerSummary=Tóm tắt sàng lọc sơ bộ về lợi ích
 # Heading content at the top of the review page, where applicants can start answering questions.
 title.getStarted=Hãy bắt đầu.
 title.programSummary=Tóm tắt dữ liệu đăng ký tham gia chương trình
@@ -601,23 +601,23 @@ content.generalLoginModalPrompt=Bạn chưa đăng nhập vào tài khoản nào
 content.initialLoginModalPrompt=Trước khi tiếp tục, hãy đăng nhập vào tài khoản {0} của bạn hoặc tạo một tài khoản. Bạn sẽ có thể đăng ký nhiều chương trình mà không cần phải nhập lại cùng một thông tin. Bạn cũng có thể chỉnh sửa đơn đăng ký và kiểm tra trạng thái của đơn đăng ký.
 # A button for continuing to apply to other programs without an account.
 button.continueWithoutAnAccount=Tiếp tục mà không dùng tài khoản
-title.commonIntakeConfirmation=Chương trình bạn có thể đủ tiêu chuẩn tham gia
-# Title on the page after a trusted intermediary has successfully filled out the common intake form.
-title.commonIntakeConfirmationTi=Chương trình khách hàng của bạn có thể đủ tiêu chuẩn tham gia
+title.preScreenerConfirmation=Chương trình bạn có thể đủ tiêu chuẩn tham gia
+# Title on the page after a trusted intermediary has successfully filled out the pre-screener form.
+title.preScreenerConfirmationTi=Chương trình khách hàng của bạn có thể đủ tiêu chuẩn tham gia
 # A message explaining that the applicant may be eligible for the following list of programs, and that they need to apply to them.
-content.commonIntakeConfirmation=Bạn có thể đăng ký tham gia các chương trình này nếu đăng ký thông qua đơn đăng ký trực tuyến bằng cách nhấp vào ''Đăng ký tham gia chương trình''.
+content.preScreenerConfirmation=Bạn có thể đăng ký tham gia các chương trình này nếu đăng ký thông qua đơn đăng ký trực tuyến bằng cách nhấp vào ''Đăng ký tham gia chương trình''.
 # A message explaining that the applicant may be eligible for the following list of programs.
-content.commonIntakeConfirmation.v2=Dựa trên câu trả lời của bạn, bạn có thể đủ điều kiện tham gia các chương trình sau:
+content.preScreenerConfirmation.v2=Dựa trên câu trả lời của bạn, bạn có thể đủ điều kiện tham gia các chương trình sau:
 # A message explaining that the trusted intermediary's client may be eligible for the following list of programs, and that they need to apply to them.
-content.commonIntakeConfirmationTi=Khách hàng của bạn có thể đăng ký tham gia các chương trình này nếu bạn đăng ký thông qua đơn đăng ký trực tuyến bằng cách nhấp vào ''Đăng ký tham gia chương trình''.
+content.preScreenerConfirmationTi=Khách hàng của bạn có thể đăng ký tham gia các chương trình này nếu bạn đăng ký thông qua đơn đăng ký trực tuyến bằng cách nhấp vào ''Đăng ký tham gia chương trình''.
 # A message explaining that the trusted intermediary's client may be eligible for the following list of programs.
-content.commonIntakeConfirmationTi.v2=Dựa trên câu trả lời của bạn, khách hàng của bạn có thể đủ điều kiện tham gia các chương trình sau:
+content.preScreenerConfirmationTi.v2=Dựa trên câu trả lời của bạn, khách hàng của bạn có thể đủ điều kiện tham gia các chương trình sau:
 # A message explaining that there were no programs the applicant is currently eligible for. The {0} parameter is a link to another website, where the text is the name of that site. It may read "Access Arkansas", for example.
-content.commonIntakeNoMatchingPrograms=Trình sàng lọc sơ bộ không thể tìm thấy những chương trình mà bạn có thể đủ tiêu chuẩn tham gia vào lúc này. Tuy nhiên, bạn có thể đăng ký tham gia chương trình bất cứ lúc nào bằng cách nhấp vào ''Đăng ký tham gia chương trình''. Hoặc để xem thêm chương trình, bạn có thể truy cập {0}
+content.preScreenerNoMatchingPrograms=Trình sàng lọc sơ bộ không thể tìm thấy những chương trình mà bạn có thể đủ tiêu chuẩn tham gia vào lúc này. Tuy nhiên, bạn có thể đăng ký tham gia chương trình bất cứ lúc nào bằng cách nhấp vào ''Đăng ký tham gia chương trình''. Hoặc để xem thêm chương trình, bạn có thể truy cập {0}
 # A message explaining that there were no programs the trusted intermediary's client is currently eligible for. The {0} parameter is a link to another website, where the text is the name of that site. It may read "Access Arkansas", for example.
-content.commonIntakeNoMatchingProgramsTi=Trình sàng lọc sơ bộ không thể tìm thấy những chương trình mà khách hàng của bạn có thể đủ tiêu chuẩn tham gia vào lúc này. Tuy nhiên, bạn có thể đăng ký tham gia chương trình bất cứ lúc nào bằng cách nhấp vào ''Đăng ký tham gia chương trình''. Hoặc để xem thêm chương trình, bạn có thể truy cập {0}
+content.preScreenerNoMatchingProgramsTi=Trình sàng lọc sơ bộ không thể tìm thấy những chương trình mà khách hàng của bạn có thể đủ tiêu chuẩn tham gia vào lúc này. Tuy nhiên, bạn có thể đăng ký tham gia chương trình bất cứ lúc nào bằng cách nhấp vào ''Đăng ký tham gia chương trình''. Hoặc để xem thêm chương trình, bạn có thể truy cập {0}
 # A message explaining a second option when there are no eligible programs, which is to edit your responses.
-content.commonIntakeNoMatchingProgramsNextStep=Bạn cũng có thể quay lại trang trước để chỉnh sửa câu trả lời của mình.
+content.preScreenerNoMatchingProgramsNextStep=Bạn cũng có thể quay lại trang trước để chỉnh sửa câu trả lời của mình.
 # A header above a list of other programs the applicant might be interested in applying to.
 content.otherProgramsToApplyFor=Các chương trình khác bạn có thể quan tâm
 # Button on the "Application Submitted" page. Clicking it downloads the user's application.

--- a/server/conf/i18n/messages.zh-TW
+++ b/server/conf/i18n/messages.zh-TW
@@ -214,11 +214,11 @@ button.viewAndApplySr=查看及申請「{0}」
 # The text for the button that allows a guest to bypass the login prompt modal.
 button.continueToApplication=繼續申請
 # The screen reader text for a button an applicant clicks to start filling out a pre-screener form.
-button.startHereCommonIntakeSr=按這裡開始填寫「{0}」
+button.startHerePreScreenerSr=按這裡開始填寫「{0}」
 # The screen reader text for a button an applicant clicks to edit their responses to a pre-screener form.
-button.editCommonIntakeSr=編輯您針對「{0}」提交的資訊
+button.editPreScreenerSr=編輯您針對「{0}」提交的資訊
 # The screen reader text for a button an applicant clicks to continue filling out a pre-screener form.
-button.continueCommonIntakeSr=繼續填寫「{0}」
+button.continuePreScreenerSr=繼續填寫「{0}」
 # Text describing the date the application was last submitted.
 content.submittedDate=提交於 {0}
 # Text for applicants to understand the section is for finding programs
@@ -460,7 +460,7 @@ ariaLabel.answer=回答以下問題：{0}
 # question, so this might say "Edit What is your name?". The {0} variable is the question text.
 ariaLabel.edit=編輯「{0}」
 # Title for the summary of the pre-screener page
-title.commonIntakeSummary=福利預先篩選表單摘要
+title.preScreenerSummary=福利預先篩選表單摘要
 # Heading content at the top of the review page, where applicants can start answering questions.
 title.getStarted=開始填寫
 title.programSummary=計畫申請摘要
@@ -601,23 +601,23 @@ content.generalLoginModalPrompt=您尚未登入帳戶。如未登入帳戶，將
 content.initialLoginModalPrompt=請先登入「{0}」帳戶或建立帳戶，再繼續操作。登入之後，您就可以申請參加多項計畫，而不必一再輸入相同的資訊，還可編輯申請書及查看申請狀態。
 # A button for continuing to apply to other programs without an account.
 button.continueWithoutAnAccount=在不登入帳戶的狀態下繼續操作
-title.commonIntakeConfirmation=您可能有資格參加的計畫
-# Title on the page after a trusted intermediary has successfully filled out the common intake form.
-title.commonIntakeConfirmationTi=您的客戶可能有資格參加的計畫
+title.preScreenerConfirmation=您可能有資格參加的計畫
+# Title on the page after a trusted intermediary has successfully filled out the pre-screener form.
+title.preScreenerConfirmationTi=您的客戶可能有資格參加的計畫
 # A message explaining that the applicant may be eligible for the following list of programs, and that they need to apply to them.
-content.commonIntakeConfirmation=如果點選「申請參加計畫」，並填寫線上申請書提出申請，您就有可能加入這些計畫。
+content.preScreenerConfirmation=如果點選「申請參加計畫」，並填寫線上申請書提出申請，您就有可能加入這些計畫。
 # A message explaining that the applicant may be eligible for the following list of programs.
-content.commonIntakeConfirmation.v2=根據您的回覆，您可能符合下列計畫的資格：
+content.preScreenerConfirmation.v2=根據您的回覆，您可能符合下列計畫的資格：
 # A message explaining that the trusted intermediary's client may be eligible for the following list of programs, and that they need to apply to them.
-content.commonIntakeConfirmationTi=如果點選「申請參加計畫」，並填寫線上申請書提出申請，您的客戶就有可能加入這些計畫。
+content.preScreenerConfirmationTi=如果點選「申請參加計畫」，並填寫線上申請書提出申請，您的客戶就有可能加入這些計畫。
 # A message explaining that the trusted intermediary's client may be eligible for the following list of programs.
-content.commonIntakeConfirmationTi.v2=根據您的回覆，您的客戶可能符合下列計畫的資格：
+content.preScreenerConfirmationTi.v2=根據您的回覆，您的客戶可能符合下列計畫的資格：
 # A message explaining that there were no programs the applicant is currently eligible for. The {0} parameter is a link to another website, where the text is the name of that site. It may read "Access Arkansas", for example.
-content.commonIntakeNoMatchingPrograms=預先篩選工具目前找不到您可能有資格參加的計畫。不過，您隨時可以點選「申請參加計畫」提出計畫申請，或是前往「{0}」查看其他計畫
+content.preScreenerNoMatchingPrograms=預先篩選工具目前找不到您可能有資格參加的計畫。不過，您隨時可以點選「申請參加計畫」提出計畫申請，或是前往「{0}」查看其他計畫
 # A message explaining that there were no programs the trusted intermediary's client is currently eligible for. The {0} parameter is a link to another website, where the text is the name of that site. It may read "Access Arkansas", for example.
-content.commonIntakeNoMatchingProgramsTi=預先篩選工具目前找不到您的客戶可能有資格參加的計畫。不過，您隨時可以點選「申請參加計畫」提出計畫申請，或是前往「{0}」查看其他計畫
+content.preScreenerNoMatchingProgramsTi=預先篩選工具目前找不到您的客戶可能有資格參加的計畫。不過，您隨時可以點選「申請參加計畫」提出計畫申請，或是前往「{0}」查看其他計畫
 # A message explaining a second option when there are no eligible programs, which is to edit your responses.
-content.commonIntakeNoMatchingProgramsNextStep=您也可以返回上一頁編輯回答。
+content.preScreenerNoMatchingProgramsNextStep=您也可以返回上一頁編輯回答。
 # A header above a list of other programs the applicant might be interested in applying to.
 content.otherProgramsToApplyFor=您可能會感興趣的其他計畫
 # Button on the "Application Submitted" page. Clicking it downloads the user's application.


### PR DESCRIPTION
### Description

Slowly renaming "common intake" to "pre-screener" to minimize confusion. This PR handles message keys and file names.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.