### PR TITLE
Truncate relational tables when tests clear the database

### DIFF
--- a/server/app/models/Models.java
+++ b/server/app/models/Models.java
@@ -26,8 +26,9 @@ public final class Models {
 
   /** Get the complete list of ebean models to truncate. */
   public static void truncate(Database database) {
-    database.truncate(MODELS.toArray(new Class[0]));
     // Truncate the relational tables we don't want to have models for.
+    // Do them first just in case something slips in before the second truncate.
     database.truncate("programs_categories", "versions_programs", "versions_questions");
+    database.truncate(MODELS.toArray(new Class[0]));
   }
 }

--- a/server/app/models/Models.java
+++ b/server/app/models/Models.java
@@ -27,5 +27,7 @@ public final class Models {
   /** Get the complete list of ebean models to truncate. */
   public static void truncate(Database database) {
     database.truncate(MODELS.toArray(new Class[0]));
+    // Truncate the relational tables we don't want to have models for.
+    database.truncate("programs_categories", "versions_programs", "versions_questions");
   }
 }


### PR DESCRIPTION
### Description

When we truncate tables to reset the DB for tests, we don't clear the relational tables which build up defunct relations over time.   In Staging probers we're up to program ID 350k which means versions_programs has at least that many rows, and versions_questions likely even more.


### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [x] Noted in the PR description which, if any, code in this PR was generated by AI.

### Issue(s) this completes

Fixes #10441
