### PR TITLE
Fixes for LogoutAllSessionsControllerTest

### DIFF
--- a/server/test/controllers/LogoutAllSessionsControllerTest.java
+++ b/server/test/controllers/LogoutAllSessionsControllerTest.java
@@ -1,12 +1,14 @@
 package controllers;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static support.FakeRequestBuilder.fakeRequestBuilder;
 
 import auth.CiviFormProfile;
 import auth.ClientIpResolver;
+import auth.ProfileUtils;
 import com.google.common.collect.ImmutableList;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -27,18 +29,23 @@ import services.settings.SettingsManifest;
 public class LogoutAllSessionsControllerTest extends WithMockedProfiles {
   private LogoutAllSessionsController controller;
   private CiviFormProfile testProfile;
+  private ProfileUtils profileUtils;
   private AccountRepository accountRepository;
   private ClientIpResolver clientIpResolver;
   private SettingsManifest settingsManifest;
 
   @Before
   public void setup() {
-    controller = instanceOf(LogoutAllSessionsController.class);
     accountRepository = instanceOf(AccountRepository.class);
 
+    profileUtils = mock(ProfileUtils.class);
     testProfile = mock(CiviFormProfile.class);
     clientIpResolver = mock(ClientIpResolver.class);
     settingsManifest = mock(SettingsManifest.class);
+
+    when(profileUtils.optionalCurrentUserProfile(any(Http.RequestHeader.class))).thenReturn(Optional.of(testProfile));
+
+    controller = new LogoutAllSessionsController(profileUtils, accountRepository, settingsManifest, clientIpResolver);
   }
 
   @Test

--- a/server/test/controllers/LogoutAllSessionsControllerTest.java
+++ b/server/test/controllers/LogoutAllSessionsControllerTest.java
@@ -10,13 +10,13 @@ import auth.CiviFormProfile;
 import auth.ClientIpResolver;
 import auth.ProfileUtils;
 import com.google.common.collect.ImmutableList;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
 import models.AccountModel;
 import models.ApplicantModel;
 import org.junit.Before;
@@ -43,9 +43,12 @@ public class LogoutAllSessionsControllerTest extends WithMockedProfiles {
     clientIpResolver = mock(ClientIpResolver.class);
     settingsManifest = mock(SettingsManifest.class);
 
-    when(profileUtils.optionalCurrentUserProfile(any(Http.RequestHeader.class))).thenReturn(Optional.of(testProfile));
+    when(profileUtils.optionalCurrentUserProfile(any(Http.RequestHeader.class)))
+        .thenReturn(Optional.of(testProfile));
 
-    controller = new LogoutAllSessionsController(profileUtils, accountRepository, settingsManifest, clientIpResolver);
+    controller =
+        new LogoutAllSessionsController(
+            profileUtils, accountRepository, settingsManifest, clientIpResolver);
   }
 
   @Test
@@ -56,7 +59,7 @@ public class LogoutAllSessionsControllerTest extends WithMockedProfiles {
   }
 
   @Test
-  public void testIndexWithProfile_withSession() {
+  public void testIndexWithProfile_withSession() throws InterruptedException, ExecutionException {
     // Add active session to account
     Clock clock = Clock.fixed(Instant.ofEpochSecond(10), ZoneOffset.UTC);
     ApplicantModel applicant = createApplicantWithMockedProfile();
@@ -67,18 +70,18 @@ public class LogoutAllSessionsControllerTest extends WithMockedProfiles {
     when(testProfile.getAccount()).thenReturn(CompletableFuture.completedFuture(account));
 
     Http.Request request = fakeRequestBuilder().header(skipUserProfile, "false").build();
-    controller
-        .index(request)
-        .thenAccept(
-            result -> {
-              AccountModel updatedAccount = accountRepository.lookupAccount(account.id).get();
-              assertThat(updatedAccount.getActiveSessions()).isEmpty();
-              assertThat(result.redirectLocation()).isEqualTo(Optional.of("/"));
-            });
+
+    CompletionStage<Result> resultStage = controller.index(request);
+    Result result = resultStage.toCompletableFuture().get();
+
+    AccountModel updatedAccount = accountRepository.lookupAccount(account.id).get();
+    assertThat(updatedAccount.getActiveSessions()).isEmpty();
+    assertThat(result.redirectLocation()).isEqualTo(Optional.of("/"));
   }
 
   @Test
-  public void testIndexWithProfile_withMultipleSessions() {
+  public void testIndexWithProfile_withMultipleSessions()
+      throws InterruptedException, ExecutionException {
     // Add active session to account
     Clock clock = Clock.fixed(Instant.ofEpochSecond(10), ZoneOffset.UTC);
     ApplicantModel applicant = createApplicantWithMockedProfile();
@@ -90,18 +93,18 @@ public class LogoutAllSessionsControllerTest extends WithMockedProfiles {
     when(testProfile.getAccount()).thenReturn(CompletableFuture.completedFuture(account));
 
     Http.Request request = fakeRequestBuilder().header(skipUserProfile, "false").build();
-    controller
-        .index(request)
-        .thenAccept(
-            result -> {
-              AccountModel updatedAccount = accountRepository.lookupAccount(account.id).get();
-              assertThat(updatedAccount.getActiveSessions()).isEmpty();
-              assertThat(result.redirectLocation()).isEqualTo(Optional.of("/"));
-            });
+
+    CompletionStage<Result> resultStage = controller.index(request);
+    Result result = resultStage.toCompletableFuture().get();
+
+    AccountModel updatedAccount = accountRepository.lookupAccount(account.id).get();
+    assertThat(updatedAccount.getActiveSessions()).isEmpty();
+    assertThat(result.redirectLocation()).isEqualTo(Optional.of("/"));
   }
 
   @Test
-  public void testLogoutWithAuthorityId_withSession() {
+  public void testLogoutWithAuthorityId_withSession()
+      throws InterruptedException, ExecutionException {
     // Add active session to account
     Clock clock = Clock.fixed(Instant.ofEpochSecond(10), ZoneOffset.UTC);
     AccountModel account = new AccountModel();
@@ -110,18 +113,18 @@ public class LogoutAllSessionsControllerTest extends WithMockedProfiles {
     String authorityId = setAndGetEncodedAuthorityId(account);
 
     Http.Request request = fakeRequestBuilder().header(skipUserProfile, "false").build();
-    controller
-        .logoutFromAuthorityId(request, authorityId)
-        .thenAccept(
-            result -> {
-              AccountModel updatedAccount = accountRepository.lookupAccount(account.id).get();
-              assertThat(updatedAccount.getActiveSessions()).isEmpty();
-              assertThat(result.redirectLocation()).isEqualTo(Optional.of("/"));
-            });
+
+    CompletionStage<Result> resultStage = controller.logoutFromAuthorityId(request, authorityId);
+    Result result = resultStage.toCompletableFuture().get();
+
+    AccountModel updatedAccount = accountRepository.lookupAccount(account.id).get();
+    assertThat(updatedAccount.getActiveSessions()).isEmpty();
+    assertThat(result.redirectLocation()).isEqualTo(Optional.of("/"));
   }
 
   @Test
-  public void testLogoutWithAuthorityId_withMultipleSessions() {
+  public void testLogoutWithAuthorityId_withMultipleSessions()
+      throws InterruptedException, ExecutionException {
     // Add active session to account
     Clock clock = Clock.fixed(Instant.ofEpochSecond(10), ZoneOffset.UTC);
     AccountModel account = new AccountModel();
@@ -131,18 +134,18 @@ public class LogoutAllSessionsControllerTest extends WithMockedProfiles {
     String authorityId = setAndGetEncodedAuthorityId(account);
 
     Http.Request request = fakeRequestBuilder().header(skipUserProfile, "false").build();
-    controller
-        .logoutFromAuthorityId(request, authorityId)
-        .thenAccept(
-            result -> {
-              AccountModel updatedAccount = accountRepository.lookupAccount(account.id).get();
-              assertThat(updatedAccount.getActiveSessions()).isEmpty();
-              assertThat(result.redirectLocation()).isEqualTo(Optional.of("/"));
-            });
+
+    CompletionStage<Result> resultStage = controller.logoutFromAuthorityId(request, authorityId);
+    Result result = resultStage.toCompletableFuture().get();
+
+    AccountModel updatedAccount = accountRepository.lookupAccount(account.id).get();
+    assertThat(updatedAccount.getActiveSessions()).isEmpty();
+    assertThat(result.redirectLocation()).isEqualTo(Optional.of("/"));
   }
 
   @Test
-  public void testLogoutWithAuthorityId_withAllowedIps_allowed() {
+  public void testLogoutWithAuthorityId_withAllowedIps_allowed()
+      throws InterruptedException, ExecutionException {
     // Add active session to account
     Clock clock = Clock.fixed(Instant.ofEpochSecond(10), ZoneOffset.UTC);
     AccountModel account = new AccountModel();
@@ -156,18 +159,17 @@ public class LogoutAllSessionsControllerTest extends WithMockedProfiles {
         .thenReturn(Optional.of(ImmutableList.of("allowed.ip")));
     when(clientIpResolver.resolveClientIp(request)).thenReturn("allowed.ip");
 
-    controller
-        .logoutFromAuthorityId(request, authorityId)
-        .thenAccept(
-            result -> {
-              AccountModel updatedAccount = accountRepository.lookupAccount(account.id).get();
-              assertThat(updatedAccount.getActiveSessions()).isEmpty();
-              assertThat(result.redirectLocation()).isEqualTo(Optional.of("/"));
-            });
+    CompletionStage<Result> resultStage = controller.logoutFromAuthorityId(request, authorityId);
+    Result result = resultStage.toCompletableFuture().get();
+
+    AccountModel updatedAccount = accountRepository.lookupAccount(account.id).get();
+    assertThat(updatedAccount.getActiveSessions()).isEmpty();
+    assertThat(result.redirectLocation()).isEqualTo(Optional.of("/"));
   }
 
   @Test
-  public void testLogoutWithAuthorityId_withAllowedIps_notAllowed() {
+  public void testLogoutWithAuthorityId_withAllowedIps_notAllowed()
+      throws InterruptedException, ExecutionException {
     // Add active session to account
     Clock clock = Clock.fixed(Instant.ofEpochSecond(10), ZoneOffset.UTC);
     AccountModel account = new AccountModel();
@@ -181,14 +183,12 @@ public class LogoutAllSessionsControllerTest extends WithMockedProfiles {
         .thenReturn(Optional.of(ImmutableList.of("allowed.ip")));
     when(clientIpResolver.resolveClientIp(request)).thenReturn("not.allowed.ip");
 
-    controller
-        .logoutFromAuthorityId(request, authorityId)
-        .thenAccept(
-            result -> {
-              AccountModel updatedAccount = accountRepository.lookupAccount(account.id).get();
-              assertThat(updatedAccount.getActiveSessions()).isNotEmpty();
-              assertThat(result.redirectLocation()).isEqualTo(Optional.of("/"));
-            });
+    CompletionStage<Result> resultStage = controller.logoutFromAuthorityId(request, authorityId);
+    Result result = resultStage.toCompletableFuture().get();
+
+    AccountModel updatedAccount = accountRepository.lookupAccount(account.id).get();
+    assertThat(updatedAccount.getActiveSessions()).isNotEmpty();
+    assertThat(result.redirectLocation()).isEqualTo(Optional.of("/"));
   }
 
   private String setAndGetEncodedAuthorityId(AccountModel account) {
@@ -196,6 +196,6 @@ public class LogoutAllSessionsControllerTest extends WithMockedProfiles {
     String authorityId = "iss: auth0 sub:" + account.id.toString();
     account.setAuthorityId(authorityId);
     account.save();
-    return URLEncoder.encode(authorityId, StandardCharsets.UTF_8);
+    return authorityId;
   }
 }


### PR DESCRIPTION
### Description

Initialize LogoutAllSessionsController with the mocks. Previously this test wasn't actually using the mocks, but we didn't realize because the assertions were happening in a `thenAccept()`. This completes the future before asserting values. 
There was also a bug with decoding the authorityId, which I removed.

I recommend clicking the "Hide whitespace" setting when reviewing.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

### Issue(s) this completes

Fixes #<issue_number>; Fixes #<issue_number>...
