### PR TITLE
[External Program Cards] Show external program modal based on program id

### DIFF
--- a/browser-test/src/applicant/northstar_applicant_application_index.test.ts
+++ b/browser-test/src/applicant/northstar_applicant_application_index.test.ts
@@ -1301,35 +1301,50 @@ test.describe(
       })
     })
 
-    test('Shows card for external program and opens external link', async ({
+    test('External program cards are show when feature flag is on', async ({
       page,
       adminPrograms,
       applicantQuestions,
     }) => {
-      const externalProgramName = 'External Program'
+      const externalProgramAName = 'External Program A'
+      const externalProgramALink = 'https://www.usa.gov'
+      const externalProgramBName = 'External Program B'
+      const externalProgramBLink = 'https://civiform.us'
 
-      await test.step('add external program', async () => {
+      await test.step('add external programs', async () => {
         await enableFeatureFlag(page, 'external_program_cards_enabled')
 
         await loginAsAdmin(page)
         await adminPrograms.addProgram(
-          externalProgramName,
+          externalProgramAName,
           /* description= */ '',
           /* shortDescription= */ 'description',
-          /* externalLink= */ 'https://usa.gov',
+          externalProgramALink,
           ProgramVisibility.PUBLIC,
           /* adminDescription= */ 'admin description',
           ProgramType.EXTERNAL,
         )
-        await adminPrograms.publishProgram(externalProgramName)
+        await adminPrograms.addProgram(
+          externalProgramBName,
+          /* description= */ '',
+          /* shortDescription= */ 'description',
+          externalProgramBLink,
+          ProgramVisibility.PUBLIC,
+          /* adminDescription= */ 'admin description',
+          ProgramType.EXTERNAL,
+        )
+        await adminPrograms.publishAllDrafts()
         await logout(page)
       })
 
-      await test.step("'Programs and Services' section includes a card for the external program", async () => {
+      await test.step("'Programs and Services' section includes cards for the external programs", async () => {
         await applicantQuestions.expectProgramsinCorrectSections(
           {
             expectedProgramsInMyApplicationsSection: [],
-            expectedProgramsInProgramsAndServicesSection: [externalProgramName],
+            expectedProgramsInProgramsAndServicesSection: [
+              externalProgramAName,
+              externalProgramBName,
+            ],
             expectedProgramsInRecommendedSection: [],
             expectedProgramsInOtherProgramsSection: [],
           },
@@ -1339,15 +1354,17 @@ test.describe(
 
         // Button for external program card has a different text.
         const externalProgramCard = page.locator('.cf-application-card', {
-          has: page.getByText(externalProgramName),
+          has: page.getByText(externalProgramAName),
         })
         await expect(
           externalProgramCard.getByRole('button', {name: 'View in new window'}),
         ).toBeVisible()
+
+        await validateAccessibility(page)
       })
 
-      await test.step('Clicking on the external program card opens a modal', async () => {
-        await applicantQuestions.clickApplyProgramButton(externalProgramName)
+      await test.step("card for external program A opens a modal which redirects to the extenal program A's site", async () => {
+        await applicantQuestions.clickApplyProgramButton(externalProgramAName)
 
         // Verify external program modal is visible
         const modal = page.getByRole('dialog', {state: 'visible'})
@@ -1361,16 +1378,31 @@ test.describe(
             "To go to the program's website where you can get more details and apply, click Continue",
           ),
         ).toBeVisible()
-        await expect(
-          modal.getByRole('button', {name: 'Continue'}),
-        ).toBeVisible()
+        const continueButton = modal.getByRole('button', {name: 'Continue'})
+        await expect(continueButton).toBeVisible()
         await expect(modal.getByRole('button', {name: 'Go back'})).toBeVisible()
+
+        // Clicking continue should redirect to the external program A's site
+        await continueButton.click()
+        await expect(page).toHaveURL(externalProgramALink)
       })
 
-      await test.step("Accepting the modal redirects to the external program's site", async () => {
+      await test.step('go back to the applicant home page', async () => {
+        await page.goto(BASE_URL)
+      })
+
+      await test.step("card for external program B opens a modal which redirects to the external program B's site", async () => {
+        await applicantQuestions.clickApplyProgramButton(externalProgramBName)
+
+        // Verify external program modal is visible. We don't need to check
+        // every element since last step verified it
         const modal = page.getByRole('dialog', {state: 'visible'})
-        await modal.getByRole('button', {name: 'Continue'}).click()
-        await expect(page).toHaveURL('https://www.usa.gov')
+        const continueButton = modal.getByRole('button', {name: 'Continue'})
+        await expect(continueButton).toBeVisible()
+
+        // Clicking continue should redirect to the external program B's site
+        await continueButton.click()
+        await expect(page).toHaveURL(externalProgramBLink)
       })
     })
 

--- a/server/app/views/applicant/ModalFragment.html
+++ b/server/app/views/applicant/ModalFragment.html
@@ -416,26 +416,26 @@
 </div>
 
 <div
-  th:fragment="externalProgramModal(externalLink)"
-  id="modal-container"
+  th:fragment="externalProgramModal(externalLink, modalId)"
+  th:id="${'modal-container-' + modalId}"
   class="display-none position-fixed height-viewport width-full z-100"
 >
   <div
     class="usa-modal cf-ns-modal"
-    id="external-program-modal"
-    aria-labelledby="external-program-modal-heading"
-    aria-describedby="external-program-modal-description"
+    th:id="${'external-program-modal-' + modalId}"
+    th:aria-labelledby="${'external-program-modal-heading-' + modalId}"
+    th:aria-describedby="${'external-program-modal-description-' + modalId}"
   >
     <div class="usa-modal__content">
       <div class="usa-modal__main">
         <h2
           class="usa-modal__heading"
-          id="external-program-modal-heading"
+          th:id="${'external-program-modal-heading-' + modalId}"
           th:text="#{title.externalProgramModal}"
         ></h2>
         <div class="usa-prose">
           <p
-            id="external-program-modal-description"
+            th:id="${'external-program-modal-description-' + modalId}"
             th:text="#{content.externalProgramModal}"
             class="margin-y-2"
           ></p>

--- a/server/app/views/applicant/ProgramCardsFragment.html
+++ b/server/app/views/applicant/ProgramCardsFragment.html
@@ -201,8 +201,8 @@
   <th:block th:if="${card.programType().toString() == 'EXTERNAL'}">
     <a
       class="usa-button usa-button--outline cf-apply-button"
-      href="#external-program-modal"
-      aria-controls="external-program-modal"
+      th:href="${'#external-program-modal-' + card.programId()}"
+      th:aria-controls="${'external-program-modal-' + card.programId()}"
       data-open-modal
     >
       <svg
@@ -212,7 +212,7 @@
     </a>
 
     <div
-      th:replace="~{applicant/ModalFragment:: externalProgramModal(${card.actionUrl()})}"
+      th:replace="~{applicant/ModalFragment:: externalProgramModal(${card.actionUrl()}, ${card.programId()})}"
     ></div>
   </th:block>
 


### PR DESCRIPTION
### Description

Use a unique ID for each external program modal to ensure clicking different external program cards opens their respective modals with the correct external link.

Changes in the PR include:
1. Modify the externalProgramModal fragment to accept a unique modalId, build from the program id, parameter alongside the existing externalLink parameter
2. Use this modalId to create unique IDs for each modal instance
3. Update the card's modal trigger button to reference its unique modal ID

Screencast: 
https://github.com/user-attachments/assets/7ae4d8e0-7d2e-4433-a190-4d2742d7b510


### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

#### User visible changes

- [x] Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
  - [x] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [x] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [x] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [x] Made equivalent changes in Thymeleaf for applicant-facing features and changes (or created an issue in the [Northstar epic](https://github.com/orgs/civiform/projects/1/views/94) to track that it's missing from Thymeleaf)
- [x] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [x] Manually tested at 200% size
- [x] Manually evaluated tab order
- [ ] Manually tested with a screen reader if the feature is applicant-facing. See [screen reader testing](https://github.com/civiform/civiform/wiki/Testing#screen-reader-testing)

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/helper/feature-flags.conf`
- [x] Conditioned new functionality on a [FeatureFlag](https://github.com/civiform/civiform/wiki/Feature-Flags)
- [x] Wrote browser tests with the feature flag off and on, etc.

### Instructions for manual testing

1. Log in as an admin
2. Enable EXTERNAL_PROGRAM_CARDS_ENABLED feature flag
3. Create and publish two external program with different sites
4. Logout
5. In the applicant home, verify both external program have cards on the 'Programs and Services' section
6. Click on first external program and accept the modal. The correct link should be opened
7. Go back to the applicant home
8.  Click on second external program and accept the modal. The correct link should be opene

### Issue(s) this completes

Part of #10184
