### PR TITLE
[External Program Cards] Disable confirmation message on external program creation

### DIFF
--- a/browser-test/src/admin/admin_program_creation.test.ts
+++ b/browser-test/src/admin/admin_program_creation.test.ts
@@ -1434,6 +1434,9 @@ test.describe('program creation', () => {
           await adminPrograms.expectFormFieldDisabled(
             FormField.APPLICATION_STEPS,
           )
+          await adminPrograms.expectFormFieldDisabled(
+            FormField.CONFIRMATION_MESSAGE,
+          )
 
           // Changing the program type is allowed during program creation.
           // Therefore, all the program type options should be enabled.
@@ -1461,6 +1464,9 @@ test.describe('program creation', () => {
           await adminPrograms.expectFormFieldEnabled(
             FormField.APPLICATION_STEPS,
           )
+          await adminPrograms.expectFormFieldEnabled(
+            FormField.CONFIRMATION_MESSAGE,
+          )
         })
 
         await test.step('save external program', async () => {
@@ -1482,6 +1488,9 @@ test.describe('program creation', () => {
           )
           await adminPrograms.expectFormFieldDisabled(
             FormField.APPLICATION_STEPS,
+          )
+          await adminPrograms.expectFormFieldDisabled(
+            FormField.CONFIRMATION_MESSAGE,
           )
 
           // Changing the program type of an external program is disallowed

--- a/server/app/assets/javascripts/admin_programs.ts
+++ b/server/app/assets/javascripts/admin_programs.ts
@@ -136,7 +136,7 @@ class AdminPrograms {
     // Confirmation message
     const disableConfirmationMessage = programType === ProgramType.EXTERNAL
     this.updateTextFieldSelectorsDisabledState(
-      /* fieldSelectors= */ 'input[id="program-confirmation-message-textarea"]',
+      /* fieldSelectors= */ 'textarea[id="program-confirmation-message-textarea"]',
       /* shouldDisable= */ disableConfirmationMessage,
     )
   }


### PR DESCRIPTION
### Description

Disable 'confirmation message' text field when adding an external program, since an external program application is hosted outside of Civiform.

#10397 disabled the `confirmation message` text field when editing an external program, but there was a small bug when creating an external program. This should have been caught in the test, but test was missing! (this was part of a larger change so I may have split the files incorrectly.. ).

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

#### User visible changes

- [ ] Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
  - [ ] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [ ] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Made equivalent changes in Thymeleaf for applicant-facing features and changes (or created an issue in the [Northstar epic](https://github.com/orgs/civiform/projects/1/views/94) to track that it's missing from Thymeleaf)
- [x] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [x] Manually tested at 200% size
- [x] Manually evaluated tab order
- [ ] Manually tested with a screen reader if the feature is applicant-facing. See [screen reader testing](https://github.com/civiform/civiform/wiki/Testing#screen-reader-testing)

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/helper/feature-flags.conf`
- [x] Conditioned new functionality on a [FeatureFlag](https://github.com/civiform/civiform/wiki/Feature-Flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Instructions for manual testing

1. Log in as an admin
2. Enable EXTERNAL_PROGRAM_CARDS_ENABLED feature flag
3. Start creation of a program
4. Select 'external program' on program type
5. Verify 'confirmation message' text field is disabled
6. Save program
7. Edit program
8. Verify 'confirmation message' text field is disabled

### Issue(s) this completes

Part of #10183