### PR TITLE
[External Program Cards] Remove application related extra actions for external program cards

### DIFF
--- a/browser-test/src/support/admin_programs.ts
+++ b/browser-test/src/support/admin_programs.ts
@@ -82,6 +82,20 @@ export enum ProgramCategories {
   UTILITIES = 'Utilities',
 }
 
+export enum ProgramLifecycle {
+  DRAFT = 'Draft',
+  ACTIVE = 'Active',
+}
+
+export enum ProgramExtraAction {
+  VIEW_APPLICATIONS = 'Applications',
+  EDIT = 'Edit',
+  EXPORT = 'Export program',
+  MANAGE_ADMINS = 'Manage program admins',
+  MANAGE_APPLICATIONS = 'Manage application statuses',
+  MANAGE_TRANSLATIONS = 'Manage translations',
+}
+
 /**
  * List of buttons that are displayed in the program information header. This
  * list is not exhaustive, as fields are added when needed by a test.
@@ -1636,6 +1650,23 @@ export class AdminPrograms {
         'after an application has been submitted. You can use this ' +
         'message to explain next steps of the application process and/or ' +
         'highlight other programs to apply for. (optional)',
+    })
+  }
+
+  getProgramExtraActionsButton(
+    programName: string,
+    lifecycle: ProgramLifecycle,
+  ): string {
+    return this.withinProgramCardSelector(
+      programName,
+      lifecycle,
+      '.cf-with-dropdown',
+    )
+  }
+
+  getProgramExtraAction(action: ProgramExtraAction): Locator {
+    return this.page.getByRole('button', {
+      name: action,
     })
   }
 


### PR DESCRIPTION
### Description

Remove the buttons from the extra rows that are not applicable for external program on their program cards:
  - On active mode: 'Applications'
  - On draft mode: 'Manage application statutes'

### Checklist

#### General
- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

#### User visible changes
- [ ] Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
  - [ ] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [ ] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Made equivalent changes in Thymeleaf for applicant-facing features and changes (or created an issue in the [Northstar epic](https://github.com/orgs/civiform/projects/1/views/94) to track that it's missing from Thymeleaf)
- [x] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [x] Manually tested at 200% size
- [x] Manually evaluated tab order
- [ ] Manually tested with a screen reader if the feature is applicant-facing. See [screen reader testing](https://github.com/civiform/civiform/wiki/Testing#screen-reader-testing)

#### New Features
- [ ] Add new FeatureFlag env vars to `server/conf/helper/feature-flags.conf`
- [x] Conditioned new functionality on a [FeatureFlag](https://github.com/civiform/civiform/wiki/Feature-Flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Instructions for manual testing
1. Log in as an admin
2. Enable EXTERNAL_PROGRAM_CARDS_ENABLED feature flag
3. Create an external program
4. Go to the admin dashboard, verify 'manage program applications' is not shown on the extra rows dropdown
5. Publish the external program, verify 'applications' is not shown on the extra rows dropdown


### Issue(s) this completes

Part of #10183
