### PR TITLE
Disable DevTools actions when DevTools is disabled in settings

### DIFF
--- a/browser-test/src/admin/dev_tools.test.ts
+++ b/browser-test/src/admin/dev_tools.test.ts
@@ -1,11 +1,17 @@
 import {test, expect} from '../support/civiform_fixtures'
 import {
   enableFeatureFlag,
+  disableFeatureFlag,
   validateAccessibility,
   validateScreenshot,
 } from '../support'
 
 test.describe('developer tools', () => {
+  test.afterEach(async ({ page }) => {
+    // Ensure the 'staging_disable_demo_mode_logins' flag is DISABLED for each test
+    // unless a specific test intends to enable it.
+    await disableFeatureFlag(page, 'staging_disable_demo_mode_logins');
+  });
   test('dev link exists', async ({page}) => {
     const header = page.locator('nav')
 

--- a/browser-test/src/admin/dev_tools.test.ts
+++ b/browser-test/src/admin/dev_tools.test.ts
@@ -1,5 +1,9 @@
 import {test, expect} from '../support/civiform_fixtures'
-import {validateAccessibility, validateScreenshot} from '../support'
+import {
+  enableFeatureFlag,
+  validateAccessibility,
+  validateScreenshot,
+} from '../support'
 
 test.describe('developer tools', () => {
   test('dev link exists', async ({page}) => {
@@ -13,7 +17,32 @@ test.describe('developer tools', () => {
 
     await test.step('modal appears on click', async () => {
       await header.getByText('DevTools').click()
+      expect(await page.innerText('h1')).toContain('Dev tools')
       await validateScreenshot(page, 'dev-tools-modal')
+    })
+  })
+  test('not functional when disable demo mode logins is enabled', async ({
+    page,
+  }) => {
+    await enableFeatureFlag(page, 'staging_disable_demo_mode_logins')
+
+    const header = page.locator('nav')
+
+    await test.step('link not shown in the header', async () => {
+      await expect(header.getByText('DevTools')).not.toBeInViewport()
+      await validateAccessibility(page)
+    })
+
+    await test.step('navigating to dev tools URL unsuccessful', async () => {
+      await page.goto(`/dev/seed`)
+      expect(page.url()).toEqual('/')
+      expect(await page.innerText('h1')).not.toContain('Dev tools')
+    })
+
+    await test.step('navigating to clear URL unsuccessful', async () => {
+      await page.goto(`/dev/seed/clear`)
+      expect(page.url()).toEqual('/')
+      expect(await page.innerText('h1')).not.toContain('Dev tools')
     })
   })
 })

--- a/browser-test/src/admin/dev_tools.test.ts
+++ b/browser-test/src/admin/dev_tools.test.ts
@@ -7,11 +7,11 @@ import {
 } from '../support'
 
 test.describe('developer tools', () => {
-  test.afterEach(async ({ page }) => {
+  test.afterEach(async ({page}) => {
     // Ensure the 'staging_disable_demo_mode_logins' flag is DISABLED for each test
     // unless a specific test intends to enable it.
-    await disableFeatureFlag(page, 'staging_disable_demo_mode_logins');
-  });
+    await disableFeatureFlag(page, 'staging_disable_demo_mode_logins')
+  })
   test('dev link exists', async ({page}) => {
     const header = page.locator('nav')
 

--- a/browser-test/src/admin/dev_tools.test.ts
+++ b/browser-test/src/admin/dev_tools.test.ts
@@ -17,7 +17,6 @@ test.describe('developer tools', () => {
 
     await test.step('modal appears on click', async () => {
       await header.getByText('DevTools').click()
-      expect(await page.innerText('h1')).toContain('Dev tools')
       await validateScreenshot(page, 'dev-tools-modal')
     })
   })
@@ -35,13 +34,13 @@ test.describe('developer tools', () => {
 
     await test.step('navigating to dev tools URL unsuccessful', async () => {
       await page.goto(`/dev/seed`)
-      expect(page.url()).toEqual('/')
+      expect(page.url()).toContain('/programs')
       expect(await page.innerText('h1')).not.toContain('Dev tools')
     })
 
     await test.step('navigating to clear URL unsuccessful', async () => {
-      await page.goto(`/dev/seed/clear`)
-      expect(page.url()).toEqual('/')
+      await page.goto(`/dev/seed/data`)
+      expect(page.url()).toContain('/programs')
       expect(await page.innerText('h1')).not.toContain('Dev tools')
     })
   })

--- a/server/app/actions/DemoModeDisabledAction.java
+++ b/server/app/actions/DemoModeDisabledAction.java
@@ -1,0 +1,41 @@
+package actions;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import javax.inject.Inject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import play.mvc.Action;
+import play.mvc.Http.Request;
+import play.mvc.Result;
+import services.settings.SettingsManifest;
+
+/**
+ * Action that ensures the demo mode is enabled before allowing certain actions.
+ *
+ * <p>The action will redirect the request to the home page if the the action is disabled.
+ *
+ * <p>
+ */
+public class DemoModeDisabledAction extends Action.Simple {
+  private static final Logger logger = LoggerFactory.getLogger(DemoModeDisabledAction.class);
+  private final SettingsManifest settingsManifest;
+
+  @Inject
+  public DemoModeDisabledAction(SettingsManifest settingsManifest) {
+    this.settingsManifest = settingsManifest;
+  }
+
+  @Override
+  public CompletionStage<Result> call(Request req) {
+
+    if (settingsManifest.getStagingDisableDemoModeLogins(req)) {
+      logger.warn(
+          "There was an attempt to navigate to a dev tools action when demo mode was disabled");
+      return CompletableFuture.completedFuture(
+          redirect(controllers.routes.HomeController.index().url()));
+    }
+
+    return delegate.call(req); // continute processing next step
+  }
+}

--- a/server/app/controllers/dev/DevToolsController.java
+++ b/server/app/controllers/dev/DevToolsController.java
@@ -2,6 +2,7 @@ package controllers.dev;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import actions.DemoModeDisabledAction;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
 import controllers.FlashKey;
@@ -26,6 +27,7 @@ import play.cache.NamedCache;
 import play.mvc.Controller;
 import play.mvc.Http.Request;
 import play.mvc.Result;
+import play.mvc.With;
 import repository.TransactionManager;
 import services.program.ActiveAndDraftPrograms;
 import services.program.ProgramService;
@@ -36,6 +38,7 @@ import services.settings.SettingsService;
 import views.dev.DevToolsView;
 
 /** Controller for dev tools. */
+@With(DemoModeDisabledAction.class)
 public class DevToolsController extends Controller {
   private static final Logger logger = LoggerFactory.getLogger(DevToolsController.class);
 

--- a/server/test/actions/DemoModeDisabledActionTest.java
+++ b/server/test/actions/DemoModeDisabledActionTest.java
@@ -1,0 +1,54 @@
+package actions;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static support.FakeRequestBuilder.fakeRequestBuilder;
+
+import java.util.concurrent.CompletableFuture;
+import org.junit.Before;
+import org.junit.Test;
+import play.mvc.Action;
+import play.mvc.Http.Request;
+import play.mvc.Result;
+import repository.ResetPostgres;
+import services.settings.SettingsManifest;
+
+public class DemoModeDisabledActionTest extends ResetPostgres {
+
+  private SettingsManifest mockSettingsManifest;
+
+  @Before
+  public void setUp() {
+    mockSettingsManifest = mock(SettingsManifest.class);
+  }
+
+  @Test
+  public void testDemoModeEnabled_proceedsToAction() {
+    Request request = fakeRequestBuilder().build();
+    when(mockSettingsManifest.getStagingDisableDemoModeLogins(request)).thenReturn(false);
+
+    DemoModeDisabledAction action = new DemoModeDisabledAction(mockSettingsManifest);
+
+    // Set up a mock for the delegate action
+    Action.Simple delegateMock = mock(Action.Simple.class);
+    when(delegateMock.call(request)).thenReturn(CompletableFuture.completedFuture(null));
+    action.delegate = delegateMock;
+    Result result = action.call(request).toCompletableFuture().join();
+
+    // Verify that the delegate action was called
+    assertNull(result);
+  }
+
+  @Test
+  public void testDemoModeDisabled_redirectsToHomePage() {
+    Request request = fakeRequestBuilder().build();
+    when(mockSettingsManifest.getStagingDisableDemoModeLogins(request)).thenReturn(true);
+
+    DemoModeDisabledAction action = new DemoModeDisabledAction(mockSettingsManifest);
+
+    Result result = action.call(request).toCompletableFuture().join();
+    assertEquals(result.redirectLocation().get(), controllers.routes.HomeController.index().url());
+  }
+}


### PR DESCRIPTION
### Description

Ensure destructive DevTools actions can't be completed when staging_disable_demo_mode_logins is enabled. When someone navigates to a devtools URL, we will navigate to the home page.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

### Instructions for manual testing

Turn on flag and then attempt to navigate to one of the devtools URLs

### Issue(s) this completes

Fixes https://github.com/civiform/civiform/issues/10548
