### PR TITLE
[External Program Cards] Invalidate program URL for external programs

### DIFF
--- a/server/app/controllers/applicant/ProgramSlugHandler.java
+++ b/server/app/controllers/applicant/ProgramSlugHandler.java
@@ -24,7 +24,9 @@ import services.applicant.ApplicantService;
 import services.applicant.ApplicantService.ApplicantProgramData;
 import services.applicant.ApplicantService.ApplicationPrograms;
 import services.program.ProgramDefinition;
+import services.program.ProgramNotFoundException;
 import services.program.ProgramService;
+import services.program.ProgramType;
 import services.settings.SettingsManifest;
 import views.applicant.NorthStarProgramOverviewView;
 
@@ -149,6 +151,11 @@ public final class ProgramSlugHandler {
       long applicantId,
       ProgramDefinition activeProgramDefinition,
       ApplicationPrograms relevantPrograms) {
+    // External programs don't have an overview or review page
+    if (activeProgramDefinition.programType().equals(ProgramType.EXTERNAL)) {
+      return Results.badRequest(new ProgramNotFoundException(programSlug).getMessage());
+    }
+
     CompletableFuture<ApplicantPersonalInfo> applicantPersonalInfo =
         applicantService.getPersonalInfo(applicantId).toCompletableFuture();
 


### PR DESCRIPTION
### Description

Remove the program url for external programs.

External programs don't have a program overview or review page. Either giving the applicant a link that navigates to an external page or immediately shows a modal is a weird experience. Thus, we decided for program urls to be invalid for external programs. We use ProgramNotFoundException error to mimic the behavior when an invalid program url is provided, instead of re-directing to the base url.

<img width="1727" alt="image" src="https://github.com/user-attachments/assets/5b32eb03-207f-49c9-b614-c0e1a27bcb30" />

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/helper/feature-flags.conf`
- [x] Conditioned new functionality on a [FeatureFlag](https://github.com/civiform/civiform/wiki/Feature-Flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Instructions for manual testing

1. Log in as an admin
2. Enable EXTERNAL_PROGRAM_CARDS_ENABLED feature flag
3. Start creation of a program
4. Select 'external program' on program type
5. Copy the program url (e.g http://localhost:9000/programs/ext1)
6. Publish program
7. Navigate to the program url. Verify error is shown

### Issue(s) this completes

Part of #10184
