### PR TITLE
[External Program Cards] Show external program modal when triggered from HTMX card

### DIFF
--- a/server/app/assets/javascripts/north_star_modal.ts
+++ b/server/app/assets/javascripts/north_star_modal.ts
@@ -1,3 +1,32 @@
+/**
+ * Toggles the visibility of the modal
+ * @param {Element} modalWrapper The wrapper holding the modal
+ * @param {boolean} showModal Whether the modal should be visible
+ **/
+function toggleModalVisibility(modalWrapper: Element, showModal: boolean) {
+  modalWrapper.classList.toggle('is-visible', showModal)
+  modalWrapper.classList.toggle('is-hidden', !showModal)
+}
+
+/**
+ * Shows the modal
+ * @param {Element} modalWrapper The wrapper holding the modal
+ **/
+function showModal(modalWrapper: Element) {
+  toggleModalVisibility(modalWrapper, true)
+}
+
+/**
+ * Hides the modal
+ * @param {Element} modalWrapper The wrapper holding the modal
+ * @param {HTMLElement} modalTrigger The button that triggered the modal
+ **/
+function hideModal(modalWrapper: Element, triggerButton: HTMLElement) {
+  toggleModalVisibility(modalWrapper, false)
+  // Return focus to the button that opened the modal
+  triggerButton.focus()
+}
+
 export class NorthStarModalController {
   /**
    * Find the modals, and add on-click listeners on their respective buttons to toggle them.
@@ -55,6 +84,73 @@ export class NorthStarModalController {
     })
   }
 
+  /**
+   * Attaches an event listener to a button element rendered by HTMX after
+   * initialization that triggers a USWDS modal dialog
+   *
+   * This method configures the button to show the modal when clicked, and to
+   * hide the modal when a close action is triggered.
+   *
+   * @param {HTMLElement} triggerButton  The button element that will trigger
+   *                                     the modal. Must have an 'aria-controls'
+   *                                     attribute containing the ID of the
+   *                                     target modal.
+   */
+  static attachHTMXModalListener(triggerButton: HTMLElement) {
+    triggerButton.addEventListener('click', (e) => {
+      // Default anchor navigation would focus on the href target. However, the
+      // modal we want to display is a wrapper element added by USWDS and not
+      // the one directly referenced by the href. Therefore, we need to remove
+      // the default behavior and manually focus on the modal element (in a
+      // later step).
+      e.preventDefault()
+
+      // Get the target modal ID
+      const modalId = triggerButton.getAttribute('aria-controls')
+      if (!modalId) {
+        return
+      }
+
+      // Find the modal wrapper added to the DOM by the USWDS package
+      const modalWrapper = document.querySelector(
+        `.usa-modal-wrapper#${modalId}`,
+      )
+      if (!modalWrapper) {
+        return
+      }
+
+      showModal(modalWrapper)
+
+      // Focus on an element in the modal wrapper when it opens
+      const openFocusEl: HTMLElement | null = modalWrapper.querySelector(
+        `usa-modal *[data-focus]`,
+      )
+        ? modalWrapper.querySelector(`.usa-modal *[data-focus]`)
+        : modalWrapper.querySelector(`.usa-modal`)
+      if (openFocusEl) {
+        openFocusEl.focus()
+      }
+
+      // Add listener to hide modal when a close attribute is clicked
+      const closeButtons = modalWrapper.querySelectorAll('[data-close-modal]')
+      closeButtons.forEach((closeButton) => {
+        closeButton.addEventListener('click', () => {
+          hideModal(modalWrapper, triggerButton)
+        })
+      })
+
+      // Add listener to hide modal when the escape key is pressed
+      const escapeKeyHandler = (event: KeyboardEvent) => {
+        if (event.key === 'Escape') {
+          hideModal(modalWrapper, triggerButton)
+          // Remove listener after being triggered
+          document.removeEventListener('keydown', escapeKeyHandler)
+        }
+      }
+      document.addEventListener('keydown', escapeKeyHandler)
+    })
+  }
+
   constructor() {
     const modals = document.querySelectorAll('.cf-ns-modal')
 
@@ -71,6 +167,26 @@ export class NorthStarModalController {
         )
         modalButton?.click()
       }
+    })
+
+    // USWDS modal trigger buttons added dynamically by HTMX after initial page
+    // load don't automatically receive the event listeners that USWDS normally
+    // attaches during its initialization. This is because USWDS only processes
+    // elements that exist when it initializes.
+    //
+    // This event listener detects when HTMX adds new content to the page and
+    // finds any external program modal triggers that were added. We then
+    // manually attach our custom modal event listeners to these buttons to
+    // ensure they can properly open their target modals.
+    document.body.addEventListener('htmx:afterSwap', () => {
+      const modalTrigger = document.querySelectorAll(
+        'a[data-open-modal][href*="external-program-modal"]',
+      )
+
+      modalTrigger.forEach((trigger) => {
+        const triggerElement = trigger as HTMLElement
+        NorthStarModalController.attachHTMXModalListener(triggerElement)
+      })
     })
 
     // Advertise (e.g., for browser tests) that modal.ts initialization is done

--- a/server/app/views/applicant/ProgramCardsFragment.html
+++ b/server/app/views/applicant/ProgramCardsFragment.html
@@ -203,6 +203,7 @@
       class="usa-button usa-button--outline cf-apply-button"
       th:href="${'#external-program-modal-' + card.programId()}"
       th:aria-controls="${'external-program-modal-' + card.programId()}"
+      role="button"
       data-open-modal
     >
       <svg


### PR DESCRIPTION
### Description

External programs are displayed in the applicant home page as program cards. Currently
- A program card is added directly on [ProgramIndexTemplate](https://sourcegraph.com/github.com/civiform/civiform/-/blob/server/app/views/applicant/ProgramIndexTemplate.html?L75-79) 
- [Clicking](https://sourcegraph.com/github.com/civiform/civiform/-/blob/server/app/views/applicant/ProgramCardsFragment.html?L202-212) on an external program card shows the 'external program' modal.
- When a filter is selected, the [NorthStarFilteredProgramsViewPartial](https://sourcegraph.com/github.com/civiform/civiform/-/blob/server/app/views/applicant/NorthStarFilteredProgramsViewPartial.java?L125-127) renders the HTMX partial view containing the program cards and clicking the button doesn't show the modal

This PR fixes the issue of not showing the modal triggered from a HTMX partial view. 

The modal trigger is added after initialization via HTMX and doesn't have an event listener. Therefore, we add a 'htmx:afterSwap' listener that adds a click listener to the modal trigger buittons to:
- show the modal
- listen for close actions to hide the modal

This implementation is based on [packages/usa-modal/src/index.js](https://github.com/uswds/uswds/blob/3c37abfe597941775a897e4f6491684a22a8feff/packages/usa-modal/src/index.js#L370). We cannot copy `toggleModal()` because a) function doesn't have listener for the close actions and b) couldn't find a way to access the uswds package from civiform

##### Screencast
https://github.com/user-attachments/assets/22a02f09-1f3c-484c-a3bd-a271abcd4c92
1. Close button
2. Go back
3. Esc
4. Click outside modal (for some reason takes two clicks to close)
5. Continue

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

#### User visible changes

- [ ] Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
  - [ ] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [ ] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Made equivalent changes in Thymeleaf for applicant-facing features and changes (or created an issue in the [Northstar epic](https://github.com/orgs/civiform/projects/1/views/94) to track that it's missing from Thymeleaf)
- [x] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [x] Manually tested at 200% size
- [x] Manually evaluated tab order
- [ ] Manually tested with a screen reader if the feature is applicant-facing. See [screen reader testing](https://github.com/civiform/civiform/wiki/Testing#screen-reader-testing)

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/helper/feature-flags.conf`
- [x] Conditioned new functionality on a [FeatureFlag](https://github.com/civiform/civiform/wiki/Feature-Flags)
- [x] Wrote browser tests with the feature flag off and on, etc.

### Instructions for manual testing

1. Log in as an admin
2. Enable EXTERNAL_PROGRAM_CARDS_ENABLED feature flag
3. Create and publish an external program with a filter
4. Logout
5. In the applicant home, verify the external program has a card on the 'Programs and Services' section
6. Apply the filter, verify the external program has a card on the 'Programs based on your selections ' section
7. Click on 'View on a new tab' which opens a modal
8. Click on 'Continue' in the modal. External program link is opened in a new tab

### Issue(s) this completes

Part of #10184