### PR TITLE
Remove readonly attribute when admin program fields are enabled

### DIFF
--- a/browser-test/src/admin/admin_program_creation.test.ts
+++ b/browser-test/src/admin/admin_program_creation.test.ts
@@ -1074,6 +1074,13 @@ test.describe('program creation', () => {
       await adminPrograms.expectFormFieldDisabled(FormField.PROGRAM_CATEGORIES)
       await adminPrograms.expectFormFieldDisabled(FormField.APPLICATION_STEPS)
     })
+
+    await test.step('click pre-screener toggle and confirm fields are re-enabled', async () => {
+      await adminPrograms.clickPreScreenerFormToggle()
+      await adminPrograms.expectFormFieldEnabled(FormField.PROGRAM_ELIGIBILITY)
+      await adminPrograms.expectFormFieldEnabled(FormField.PROGRAM_CATEGORIES)
+      await adminPrograms.expectFormFieldEnabled(FormField.APPLICATION_STEPS)
+    })
   })
 
   test('correctly renders pre-screener form change confirmation modal', async ({

--- a/browser-test/src/support/admin_programs.ts
+++ b/browser-test/src/support/admin_programs.ts
@@ -342,10 +342,6 @@ export class AdminPrograms {
         const notificationPreferences =
           this.getNotificationsPreferenceCheckbox()
         await expect(notificationPreferences).toBeDisabled()
-        expect(
-          await notificationPreferences.getAttribute('readonly'),
-        ).not.toBeNull()
-
         await expect(notificationPreferences).not.toBeChecked()
         break
       }
@@ -427,9 +423,6 @@ export class AdminPrograms {
         const notificationPreferences =
           this.getNotificationsPreferenceCheckbox()
         await expect(notificationPreferences).toBeEnabled()
-        expect(
-          await notificationPreferences.getAttribute('readonly'),
-        ).toBeNull()
         break
       }
 
@@ -439,7 +432,6 @@ export class AdminPrograms {
             name: categoryName,
           })
           await expect(category).toBeEnabled()
-          expect(await category.getAttribute('readonly')).toBeNull()
         }
         break
       }
@@ -450,7 +442,6 @@ export class AdminPrograms {
             name: eligibilityName,
           })
           await expect(option).toBeEnabled()
-          expect(await option.getAttribute('readonly')).toBeNull()
         }
         break
       }

--- a/browser-test/src/support/admin_programs.ts
+++ b/browser-test/src/support/admin_programs.ts
@@ -311,7 +311,9 @@ export class AdminPrograms {
             name: `Step ${indexPlusOne} description`,
           })
           await expect(stepTitle).toBeDisabled()
+          expect(await stepTitle.getAttribute('readonly')).not.toBeNull()
           await expect(stepDescription).toBeDisabled()
+          expect(await stepDescription.getAttribute('readonly')).not.toBeNull()
           if (indexPlusOne == 1) {
             await stepTitle.locator('span').isHidden()
           }
@@ -322,12 +324,17 @@ export class AdminPrograms {
       case FormField.CONFIRMATION_MESSAGE: {
         const confirmationMessage = this.getConfirmationMessageField()
         await expect(confirmationMessage).toBeDisabled()
+        expect(
+          await confirmationMessage.getAttribute('readonly'),
+        ).not.toBeNull()
         break
       }
 
       case FormField.LONG_DESCRIPTION: {
         const longDescription = this.getLongDescriptionField()
         await expect(longDescription).toBeDisabled()
+        expect(await longDescription.getAttribute('readonly')).not.toBeNull()
+
         break
       }
 
@@ -335,6 +342,10 @@ export class AdminPrograms {
         const notificationPreferences =
           this.getNotificationsPreferenceCheckbox()
         await expect(notificationPreferences).toBeDisabled()
+        expect(
+          await notificationPreferences.getAttribute('readonly'),
+        ).not.toBeNull()
+
         await expect(notificationPreferences).not.toBeChecked()
         break
       }
@@ -388,9 +399,9 @@ export class AdminPrograms {
             name: `Step ${indexPlusOne} description`,
           })
           await expect(stepTitle).toBeEnabled()
-          // expect(stepTitle.getAttribute('readonly')).toBeNull()
+          expect(await stepTitle.getAttribute('readonly')).toBeNull()
           await expect(stepDescription).toBeEnabled()
-          // expect(stepDescription.getAttribute('readonly')).toBeNull()
+          expect(await stepDescription.getAttribute('readonly')).toBeNull()
           if (indexPlusOne == 1) {
             await stepTitle.locator('span').isVisible()
           }
@@ -401,12 +412,14 @@ export class AdminPrograms {
       case FormField.CONFIRMATION_MESSAGE: {
         const confirmationMessage = this.getConfirmationMessageField()
         await expect(confirmationMessage).toBeEnabled()
+        expect(await confirmationMessage.getAttribute('readonly')).toBeNull()
         break
       }
 
       case FormField.LONG_DESCRIPTION: {
         const longDescription = this.getLongDescriptionField()
         await expect(longDescription).toBeEnabled()
+        expect(await longDescription.getAttribute('readonly')).toBeNull()
         break
       }
 
@@ -414,6 +427,9 @@ export class AdminPrograms {
         const notificationPreferences =
           this.getNotificationsPreferenceCheckbox()
         await expect(notificationPreferences).toBeEnabled()
+        expect(
+          await notificationPreferences.getAttribute('readonly'),
+        ).toBeNull()
         break
       }
 
@@ -423,6 +439,7 @@ export class AdminPrograms {
             name: categoryName,
           })
           await expect(category).toBeEnabled()
+          expect(await category.getAttribute('readonly')).toBeNull()
         }
         break
       }
@@ -433,6 +450,7 @@ export class AdminPrograms {
             name: eligibilityName,
           })
           await expect(option).toBeEnabled()
+          expect(await option.getAttribute('readonly')).toBeNull()
         }
         break
       }

--- a/browser-test/src/support/admin_programs.ts
+++ b/browser-test/src/support/admin_programs.ts
@@ -388,7 +388,9 @@ export class AdminPrograms {
             name: `Step ${indexPlusOne} description`,
           })
           await expect(stepTitle).toBeEnabled()
+          // expect(stepTitle.getAttribute('readonly')).toBeNull()
           await expect(stepDescription).toBeEnabled()
+          // expect(stepDescription.getAttribute('readonly')).toBeNull()
           if (indexPlusOne == 1) {
             await stepTitle.locator('span').isVisible()
           }

--- a/server/app/assets/javascripts/admin_programs.ts
+++ b/server/app/assets/javascripts/admin_programs.ts
@@ -170,12 +170,14 @@ class AdminPrograms {
   ) {
     if (shouldDisable) {
       fieldElement.disabled = true
+      fieldElement.readOnly = true
       fieldElement.classList.add(
         this.DISABLED_TEXT_CLASS,
         this.DISABLED_BACKGROUND_CLASS,
       )
     } else {
       fieldElement.disabled = false
+      fieldElement.readOnly = false
     }
   }
 


### PR DESCRIPTION
### Description

We add the `readonly` attribute on initial render when a field should be disabled so it shows up as greyed out. Previously, we were dynamically adding and removing the `disabled` attribute, but not the `readonly` attribute which was causing fields to appear disabled when they should have been enabled. This PR fixes that by toggling the `readonly` attribute at the same time as the `disabled` attribute when admins are editing program details.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [x] Noted in the PR description which, if any, code in this PR was generated by AI.

### Instructions for manual testing

Create a program and try as many combos as you can think of for enabling/disabling fields for a pre-screener. Try:
- save a program as a pre-screener, edit it, check/un-check the "pre-screener" box and confirm fields re-enable and disable
- save a program as a regular program type, edit it, check/un-check the "pre-screener" box and confirm fields disable and re-enable

### Issue(s) this completes

Fixes #10511 
