### PR TITLE
Fix typo in dev csp setting

### DIFF
--- a/browser-test/src/api_docs_schema_viewer.test.ts
+++ b/browser-test/src/api_docs_schema_viewer.test.ts
@@ -10,6 +10,10 @@ test.describe('Viewing API docs', () => {
     await enableFeatureFlag(page, 'api_generated_docs_enabled')
   })
 
+  test.use({
+    bypassCSP: true,
+  })
+
   test('Views OpenApi Schema', async ({page, adminPrograms}) => {
     await test.step('Login as admin and publish drafts', async () => {
       await page.goto('/')

--- a/server/conf/application.dev.conf
+++ b/server/conf/application.dev.conf
@@ -30,7 +30,7 @@ play.filters {
     reportOnly = false
     nonce.enabled = true
     directives.script-src = ${play.filters.csp.nonce.pattern} "'strict-dynamic' https: 'unsafe-inline'"
-    directives.script-src = ${play.filters.csp.nonce.pattern} "'strict-dynamic' 'self'"
+    directives.style-src = ${play.filters.csp.nonce.pattern} "'strict-dynamic' 'self'"
     directives.frame-ancestors = 'self'
   }
 }


### PR DESCRIPTION
### Description

https://github.com/civiform/civiform/pull/10316 was meant to set the style-src for dev environments but accidentally set the script-src twice.

https://github.com/civiform/civiform/issues/9980

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.
