### PR TITLE
Fix errorprone message for TextQuestionTest

### DIFF
--- a/browser-test/src/api_docs_schema_viewer.test.ts
+++ b/browser-test/src/api_docs_schema_viewer.test.ts
@@ -10,6 +10,10 @@ test.describe('Viewing API docs', () => {
     await enableFeatureFlag(page, 'api_generated_docs_enabled')
   })
 
+  test.use({
+    bypassCSP: true,
+  })
+
   test('Views OpenApi Schema', async ({page, adminPrograms}) => {
     await test.step('Login as admin and publish drafts', async () => {
       await page.goto('/')

--- a/browser-test/src/api_docs_schema_viewer.test.ts
+++ b/browser-test/src/api_docs_schema_viewer.test.ts
@@ -10,10 +10,6 @@ test.describe('Viewing API docs', () => {
     await enableFeatureFlag(page, 'api_generated_docs_enabled')
   })
 
-  test.use({
-    bypassCSP: true,
-  })
-
   test('Views OpenApi Schema', async ({page, adminPrograms}) => {
     await test.step('Login as admin and publish drafts', async () => {
       await page.goto('/')

--- a/server/test/services/applicant/question/TextQuestionTest.java
+++ b/server/test/services/applicant/question/TextQuestionTest.java
@@ -2,7 +2,6 @@ package services.applicant.question;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import java.util.Locale;
@@ -13,9 +12,6 @@ import models.ApplicantModel;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import play.i18n.Lang;
-import play.i18n.Messages;
-import play.i18n.MessagesApi;
 import repository.ResetPostgres;
 import services.LocalizedStrings;
 import services.MessageKey;
@@ -53,13 +49,11 @@ public class TextQuestionTest extends ResetPostgres {
 
   private ApplicantModel applicant;
   private ApplicantData applicantData;
-  private Messages messages;
 
   @Before
   public void setUp() {
     applicant = new ApplicantModel();
     applicantData = applicant.getApplicantData();
-    messages = instanceOf(MessagesApi.class).preferred(ImmutableList.of(Lang.defaultLang()));
   }
 
   @Test


### PR DESCRIPTION
### Description

See #10471. Fixing "unused variable" message.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.