### PR TITLE
Fix Errorprone errors for AdminApplicationControllerTest

### DIFF
--- a/server/test/controllers/admin/AdminApplicationControllerTest.java
+++ b/server/test/controllers/admin/AdminApplicationControllerTest.java
@@ -648,7 +648,6 @@ public class AdminApplicationControllerTest extends ResetPostgres {
   @Test
   public void updateStatuses_emptySendEmail_succeeds() throws Exception {
     // Setup
-    Instant start = Instant.now();
     AccountModel adminAccount = resourceCreator.insertAccount();
     controller = makeNoOpProfileController(Optional.of(adminAccount));
     ProgramModel program = ProgramBuilder.newActiveProgram("test name", "test description").build();
@@ -683,7 +682,6 @@ public class AdminApplicationControllerTest extends ResetPostgres {
 
     // Evaluate
     assertThat(result.status()).isEqualTo(SEE_OTHER);
-    verifyApplicationStatusChange(application, Optional.of(adminAccount), Optional.of(start));
     application.refresh();
     assertThat(application.getApplicationEvents()).hasSize(1);
     ApplicationEventModel gotEvent = application.getApplicationEvents().get(0);

--- a/server/test/controllers/admin/AdminApplicationControllerTest.java
+++ b/server/test/controllers/admin/AdminApplicationControllerTest.java
@@ -840,8 +840,7 @@ public class AdminApplicationControllerTest extends ResetPostgres {
             adminAccount,
             instanceOf(AccountRepository.class));
     ProfileUtils profileUtilsNoOpTester =
-        new ProfileUtilsNoOpTester(
-            instanceOf(SessionStore.class), profileFactory, profileTester);
+        new ProfileUtilsNoOpTester(instanceOf(SessionStore.class), profileFactory, profileTester);
     return new AdminApplicationController(
         instanceOf(ProgramService.class),
         instanceOf(ApplicantService.class),

--- a/server/test/controllers/admin/AdminApplicationControllerTest.java
+++ b/server/test/controllers/admin/AdminApplicationControllerTest.java
@@ -683,6 +683,7 @@ public class AdminApplicationControllerTest extends ResetPostgres {
 
     // Evaluate
     assertThat(result.status()).isEqualTo(SEE_OTHER);
+    verifyApplicationStatusChange(application, Optional.of(adminAccount), Optional.of(start));
     application.refresh();
     assertThat(application.getApplicationEvents()).hasSize(1);
     ApplicationEventModel gotEvent = application.getApplicationEvents().get(0);
@@ -840,7 +841,7 @@ public class AdminApplicationControllerTest extends ResetPostgres {
             instanceOf(AccountRepository.class));
     ProfileUtils profileUtilsNoOpTester =
         new ProfileUtilsNoOpTester(
-            instanceOf(SessionStore.class), instanceOf(ProfileFactory.class), profileTester);
+            instanceOf(SessionStore.class), profileFactory, profileTester);
     return new AdminApplicationController(
         instanceOf(ProgramService.class),
         instanceOf(ApplicantService.class),


### PR DESCRIPTION
### Description

Fix the Errorprone errors for AdminApplicationControllerTest.

Removes unused start time variable and swaps out a local instance for the private instance of profileFactory.

See issue #10471