### PR TITLE
Disallow duplicate question keys during import

### DIFF
--- a/server/app/controllers/admin/AdminImportController.java
+++ b/server/app/controllers/admin/AdminImportController.java
@@ -244,6 +244,9 @@ public class AdminImportController extends CiviFormController {
         questions = ImmutableList.copyOf(updatedQuestionsMap.values());
       }
 
+      if (duplicateHandlingOptionsEnabled) {
+        programMigrationService.validateQuestionKeyUniqueness(questions);
+      }
       ImmutableSet<CiviFormError> questionErrors =
           questions.stream()
               .map(

--- a/server/test/services/migration/ProgramMigrationServiceTest.java
+++ b/server/test/services/migration/ProgramMigrationServiceTest.java
@@ -4,6 +4,7 @@ import static controllers.admin.AdminImportControllerTest.PROGRAM_JSON_WITH_ONE_
 import static controllers.admin.AdminImportControllerTest.PROGRAM_JSON_WITH_PREDICATES;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
@@ -743,6 +744,42 @@ public final class ProgramMigrationServiceTest extends ResetPostgres {
     assertThat(
             versionRepository.getProgramNamesForVersion(versionRepository.getDraftVersion().get()))
         .containsExactlyInAnyOrder(PROGRAM_NAME_1, PROGRAM_NAME_2);
+  }
+
+  @Test
+  public void validateQuestionKeyUniqueness_noConflicts_doesNotThrow() {
+    service.validateQuestionKeyUniqueness(QUESTIONS_1_2);
+  }
+
+  @Test
+  public void validateQuestionKeyUniqueness_importTwoConflictingKeys_throws() {
+    ImmutableList<QuestionDefinition> questions =
+        ImmutableList.of(QUESTION_1, createTextQuestion(QUESTION_1_NAME + "01_023", 2L));
+
+    Exception e =
+        assertThrows(
+            RuntimeException.class, () -> service.validateQuestionKeyUniqueness(questions));
+
+    assertThat(e)
+        .hasMessageContaining(
+            "Question keys (Admin IDs with non-letter characters removed and spaces transformed to"
+                + " underscores) must be unique. Duplicate question keys found:");
+  }
+
+  @Test
+  public void validateQuestionKeyUniqueness_existingKeyConflictHasDifferentName_throws() {
+    resourceCreator.insertQuestion(QUESTION_1_NAME);
+    ImmutableList<QuestionDefinition> questions =
+        ImmutableList.of(createTextQuestion(QUESTION_1_NAME + "01_023", 2L));
+
+    Exception e =
+        assertThrows(
+            RuntimeException.class, () -> service.validateQuestionKeyUniqueness(questions));
+
+    assertThat(e)
+        .hasMessageContaining(
+            "Please change the Admin ID so it either matches the existing one, or compiles to a"
+                + " different question key.");
   }
 
   // Helper methods to create test questions


### PR DESCRIPTION
### Description

Add a validation method in the `ProgramMigrationService` to disallow importing questions whose keys (JSON API keys) conflict with each other, or with an existing question. If the key conflicts with an existing question, it is allowed as long the admin name also matches, so it can be handled "smartly" by the duplicate-handling logic. #9628

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

### Instructions for manual testing

Try importing two questions in the same program with admin names `foo_bar01` and `foobar23`. 

Try saving a question named `foo_bar01` and then importing a question named `foobar23`, and a question named `foo_bar01`

### Issue(s) this completes

Fixes #10552
