### PR TITLE
Adding new execution context

### DIFF
--- a/server/app/services/apibridge/ApiBridgeExecutionContext.java
+++ b/server/app/services/apibridge/ApiBridgeExecutionContext.java
@@ -1,0 +1,21 @@
+package services.apibridge;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import org.apache.pekko.actor.ActorSystem;
+import play.libs.concurrent.CustomExecutionContext;
+
+/**
+ * Custom execution context wired to "api-bridge.dispatcher" thread pool
+ *
+ * <p>This is only to be used with the API Bridge
+ */
+@Singleton
+public class ApiBridgeExecutionContext extends CustomExecutionContext {
+  @Inject
+  public ApiBridgeExecutionContext(ActorSystem actorSystem) {
+    super(checkNotNull(actorSystem), "api-bridge.dispatcher");
+  }
+}

--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -17,6 +17,7 @@
 #
 # Environment variable substitutions should all be SCREAMING_SNAKE_CASE.
 
+include "helper/api-bridge.conf"
 include "helper/auth.conf"
 include "helper/cloud.conf"
 include "helper/email.conf"

--- a/server/conf/helper/api-bridge.conf
+++ b/server/conf/helper/api-bridge.conf
@@ -1,0 +1,10 @@
+api-bridge {
+  # Threadpool config
+  dispatcher {
+    executor = "thread-pool-executor"
+    throughput = 1
+    thread-pool-executor {
+      fixed-pool-size = 10
+    }
+  }
+}


### PR DESCRIPTION
Adding in a new execution context for future api bridge stuff to work off of a separate threadpool

Related to: #10555