### PR TITLE
[External Program Cards] Hide share actions for external program cards in admin panel

### DIFF
--- a/browser-test/src/admin/admin_program_list.test.ts
+++ b/browser-test/src/admin/admin_program_list.test.ts
@@ -7,6 +7,7 @@ import {
   validateScreenshot,
 } from '../support'
 import {
+  ProgramAction,
   ProgramCategories,
   ProgramExtraAction,
   ProgramLifecycle,
@@ -565,42 +566,41 @@ test.describe('Program list page.', () => {
     )
     await expectProgramListElements(adminPrograms, [externalProgram])
 
-    // On draft mode, 'manage applications' button is hidden
-    await adminPrograms
-      .getProgramExtraActionsButton(externalProgram, ProgramLifecycle.DRAFT)
-      .click()
-    await adminPrograms.expectProgramExtraActionsVisible(
+    // On draft mode, 'manage applications' extra action is hidden
+    await adminPrograms.expectProgramActionsVisible(
       externalProgram,
       ProgramLifecycle.DRAFT,
+      [ProgramAction.PUBLISH, ProgramAction.EDIT],
       [
         ProgramExtraAction.MANAGE_ADMINS,
         ProgramExtraAction.MANAGE_TRANSLATIONS,
         ProgramExtraAction.EXPORT,
       ],
     )
-    await adminPrograms.expectProgramExtraActionsHidden(
+    await adminPrograms.expectProgramActionsHidden(
       externalProgram,
       ProgramLifecycle.DRAFT,
+      [],
       [ProgramExtraAction.MANAGE_APPLICATIONS],
     )
 
-    // On active mode, 'applications' button is hidden
+    // On active mode, 'share' action and 'applications' extra action are
+    // hidden
     await adminPrograms.publishProgram(externalProgram)
-    await adminPrograms
-      .getProgramExtraActionsButton(externalProgram, ProgramLifecycle.ACTIVE)
-      .click()
-    await adminPrograms.expectProgramExtraActionsVisible(
+    await adminPrograms.expectProgramActionsVisible(
       externalProgram,
       ProgramLifecycle.ACTIVE,
+      [ProgramAction.VIEW],
       [
         ProgramExtraAction.EDIT,
         ProgramExtraAction.MANAGE_ADMINS,
         ProgramExtraAction.EXPORT,
       ],
     )
-    await adminPrograms.expectProgramExtraActionsHidden(
+    await adminPrograms.expectProgramActionsHidden(
       externalProgram,
       ProgramLifecycle.ACTIVE,
+      [ProgramAction.SHARE],
       [ProgramExtraAction.VIEW_APPLICATIONS],
     )
   })

--- a/browser-test/src/support/admin_programs.ts
+++ b/browser-test/src/support/admin_programs.ts
@@ -87,6 +87,13 @@ export enum ProgramLifecycle {
   ACTIVE = 'Active',
 }
 
+export enum ProgramAction {
+  EDIT = 'Edit',
+  PUBLISH = 'Publish',
+  SHARE = 'Share link',
+  VIEW = 'View',
+}
+
 export enum ProgramExtraAction {
   VIEW_APPLICATIONS = 'Applications',
   EDIT = 'Edit',
@@ -474,18 +481,26 @@ export class AdminPrograms {
   }
 
   /**
-   * Verifies the extra action are visible when the extra actions dropdown is
-   * opened for a program's card on a specific lifecycle
+   * Verifies a program card has the given actions visible
    *
    * @param programName - Name of the program
    * @param lifecycle - Lifecycle of the program
-   * @param extraActions - Extra actions to verify
+   * @param actions - Actions that should be visible on the card
+   * @param extraActions - Extra actions that should be visible on the extra
+   * actions dropdown
    */
-  async expectProgramExtraActionsVisible(
+  async expectProgramActionsVisible(
     programName: string,
     lifecycle: ProgramLifecycle,
+    actions: ProgramAction[],
     extraActions: ProgramExtraAction[],
   ) {
+    for (const action of actions) {
+      const actionButton = this.getProgramAction(programName, lifecycle, action)
+      await expect(actionButton).toBeVisible()
+    }
+
+    await this.getProgramExtraActionsButton(programName, lifecycle).click()
     for (const action of extraActions) {
       const actionButton = this.getProgramExtraAction(
         programName,
@@ -497,18 +512,26 @@ export class AdminPrograms {
   }
 
   /**
-   * Verifies the extra action are hidden when the extra actions dropdown is
-   * opened in a program's card on a specific lifecycle
+   * Verifies a program card has the given actions hidden
    *
    * @param programName - Name of the program
    * @param lifecycle - Lifecycle of the program
-   * @param extraActions - Extra actions to verify
+   * @param actions - Actions that should be hidden on the card
+   * @param extraActions - Extra actions that should be hidden on the extra
+   * actions dropdown
    */
-  async expectProgramExtraActionsHidden(
+  async expectProgramActionsHidden(
     programName: string,
     lifecycle: ProgramLifecycle,
+    actions: ProgramAction[],
     extraActions: ProgramExtraAction[],
   ) {
+    for (const action of actions) {
+      const actionButton = this.getProgramAction(programName, lifecycle, action)
+      await expect(actionButton).toBeHidden()
+    }
+
+    await this.getProgramExtraActionsButton(programName, lifecycle).click()
     for (const action of extraActions) {
       const actionButton = this.getProgramExtraAction(
         programName,
@@ -1709,6 +1732,17 @@ export class AdminPrograms {
       .locator('div.cf-admin-program-card')
       .filter({has: this.page.getByText(programName)})
       .filter({has: this.page.getByText(lifecycle)})
+  }
+
+  getProgramAction(
+    programName: string,
+    lifecycle: string,
+    action: ProgramAction,
+  ) {
+    const programCard = this.getProgramCard(programName, lifecycle)
+    return programCard.getByRole('button', {
+      name: action,
+    })
   }
 
   getProgramExtraActionsButton(

--- a/server/app/views/admin/programs/ProgramIndexView.java
+++ b/server/app/views/admin/programs/ProgramIndexView.java
@@ -537,7 +537,11 @@ public final class ProgramIndexView extends BaseHtmlView {
       List<ButtonTag> activeRowExtraActions = Lists.newArrayList();
 
       activeRowActions.add(renderViewLink(activeProgram.get(), request));
-      activeRowActions.add(renderShareLink(activeProgram.get()));
+      ProgramType programType = activeProgram.get().programType();
+      if (programType.equals(ProgramType.DEFAULT)
+          || programType.equals(ProgramType.COMMON_INTAKE_FORM)) {
+        activeRowActions.add(renderShareLink(activeProgram.get()));
+      }
 
       Optional<ButtonTag> applicationsLink =
           maybeRenderViewApplicationsLink(activeProgram.get(), profile, request);


### PR DESCRIPTION
### Description

Remove 'share' action from the program card for external program on active mode, since external programs don't have a program link.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [ ] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

#### User visible changes

- [ ] Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
  - [ ] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [ ] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Made equivalent changes in Thymeleaf for applicant-facing features and changes (or created an issue in the [Northstar epic](https://github.com/orgs/civiform/projects/1/views/94) to track that it's missing from Thymeleaf)
- [x] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [x] Manually tested at 200% size
- [x] Manually evaluated tab order
- [ ] Manually tested with a screen reader if the feature is applicant-facing. See [screen reader testing](https://github.com/civiform/civiform/wiki/Testing#screen-reader-testing)

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/helper/feature-flags.conf`
- [x] Conditioned new functionality on a [FeatureFlag](https://github.com/civiform/civiform/wiki/Feature-Flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Instructions for manual testing

1. Log in as an admin
2. Enable EXTERNAL_PROGRAM_CARDS_ENABLED feature flag
3. Create an external program
4. Go to the admin dashboard
5. Publish the external program
6. Verify 'share link' is not shown on the external program card

### Issue(s) this completes

Part of #10183
