### PR TITLE
[Cleanup] Use getProgramCard instead of programCardSelector

### DIFF
--- a/browser-test/src/admin/admin_program_migration.test.ts
+++ b/browser-test/src/admin/admin_program_migration.test.ts
@@ -1,6 +1,10 @@
 import {expect, test} from '../support/civiform_fixtures'
 import {enableFeatureFlag, loginAsAdmin, validateScreenshot} from '../support'
-import {ProgramType, ProgramVisibility} from '../support/admin_programs'
+import {
+  ProgramLifecycle,
+  ProgramType,
+  ProgramVisibility,
+} from '../support/admin_programs'
 
 test.describe('program migration', () => {
   // These values should be kept in sync with USWDS Alert style classes in views/style/BaseStyles.java.
@@ -655,19 +659,18 @@ test.describe('program migration', () => {
       // but long term this needs to be written in a way that better targets the
       // card selector
       await expect(
-        page
-          .locator(
-            adminPrograms.programCardSelector(
-              'Comprehensive Sample Program',
-              'Draft',
-            ),
+        adminPrograms
+          .getProgramCard(
+            'Comprehensive Sample Program',
+            ProgramLifecycle.DRAFT,
           )
           .first(),
       ).toBeVisible()
 
       await expect(
-        page.locator(
-          adminPrograms.programCardSelector('Minimal Sample Program', 'Draft'),
+        adminPrograms.getProgramCard(
+          'Minimal Sample Program',
+          ProgramLifecycle.DRAFT,
         ),
       ).toBeVisible()
     })

--- a/browser-test/src/support/admin_programs.ts
+++ b/browser-test/src/support/admin_programs.ts
@@ -864,19 +864,19 @@ export class AdminPrograms {
 
   async expectDraftProgram(programName: string) {
     await expect(
-      this.page.locator(this.programCardSelector(programName, 'Draft')),
+      this.getProgramCard(programName, ProgramLifecycle.DRAFT),
     ).toBeVisible()
   }
 
   async expectDoesNotHaveDraftProgram(programName: string) {
     await expect(
-      this.page.locator(this.programCardSelector(programName, 'Draft')),
+      this.getProgramCard(programName, ProgramLifecycle.DRAFT),
     ).toBeHidden()
   }
 
   async expectActiveProgram(programName: string) {
     await expect(
-      this.page.locator(this.programCardSelector(programName, 'Active')),
+      this.getProgramCard(programName, ProgramLifecycle.ACTIVE),
     ).toBeVisible()
   }
 


### PR DESCRIPTION
### Description

Use `getProgramCard` instead of `programCardSelector` in browser tests. This reduces code complexity. Only instance left of `programCardSelector`  is by `withinProgramCardSelector`, which will be migrated along with its callers in a separate PR.

No functionality changed

### Issue(s) this completes

Fixes #10513
