### PR TITLE
[Cleanup] Use getProgramCard instead of withinProgramCardSelector

### DIFF
--- a/browser-test/src/admin/admin_program_email_notifications.test.ts
+++ b/browser-test/src/admin/admin_program_email_notifications.test.ts
@@ -1,5 +1,6 @@
 import {test} from '../support/civiform_fixtures'
 import {loginAsAdmin} from '../support'
+import {ProgramLifecycle} from '../support/admin_programs'
 
 // TODO(#8576): Add tests that emails are actually sent, once #8575 is complete
 
@@ -53,20 +54,29 @@ test.describe('program email notifications', () => {
     })
 
     await test.step('verify unset email preference persists through publish', async () => {
-      await adminPrograms.goToProgramDescriptionPage(programName, true)
+      await adminPrograms.goToProgramDescriptionPage(
+        programName,
+        ProgramLifecycle.ACTIVE,
+      )
       await adminPrograms.expectEmailNotificationPreferenceIsChecked(false)
       await adminPrograms.publishAllDrafts()
     })
 
     await test.step('set email preference', async () => {
-      await adminPrograms.goToProgramDescriptionPage(programName, true)
+      await adminPrograms.goToProgramDescriptionPage(
+        programName,
+        ProgramLifecycle.ACTIVE,
+      )
       await adminPrograms.setEmailNotificationPreferenceCheckbox(true)
       await adminPrograms.submitProgramDetailsEdits()
       await adminPrograms.publishAllDrafts()
     })
 
     await test.step('verify set email preference persists through publish', async () => {
-      await adminPrograms.goToProgramDescriptionPage(programName, true)
+      await adminPrograms.goToProgramDescriptionPage(
+        programName,
+        ProgramLifecycle.ACTIVE,
+      )
       await adminPrograms.expectEmailNotificationPreferenceIsChecked(true)
     })
   })

--- a/browser-test/src/admin/admin_program_migration.test.ts
+++ b/browser-test/src/admin/admin_program_migration.test.ts
@@ -68,7 +68,10 @@ test.describe('program migration', () => {
     })
 
     await test.step('load export page', async () => {
-      await adminPrograms.goToExportProgramPage(programName, 'DRAFT')
+      await adminPrograms.goToExportProgramPage(
+        programName,
+        ProgramLifecycle.DRAFT,
+      )
 
       const jsonPreview = await adminProgramMigration.expectJsonPreview()
       expect(jsonPreview).toContain(programName)
@@ -185,7 +188,7 @@ test.describe('program migration', () => {
     await page.goto('/')
     await adminPrograms.goToExportProgramPage(
       'Comprehensive Sample Program',
-      'DRAFT',
+      ProgramLifecycle.DRAFT,
     )
     let downloadedComprehensiveProgram =
       await adminProgramMigration.downloadJson()
@@ -315,7 +318,7 @@ test.describe('program migration', () => {
     await test.step('export comprehensive program', async () => {
       await adminPrograms.goToExportProgramPage(
         'Comprehensive Sample Program',
-        'DRAFT',
+        ProgramLifecycle.DRAFT,
       )
       downloadedComprehensiveProgram =
         await adminProgramMigration.downloadJson()
@@ -329,7 +332,7 @@ test.describe('program migration', () => {
       await adminPrograms.gotoAdminProgramsPage()
       await adminPrograms.goToExportProgramPage(
         'Minimal Sample Program',
-        'DRAFT',
+        ProgramLifecycle.DRAFT,
       )
       downloadedMinimalProgram = await adminProgramMigration.downloadJson()
       expect(downloadedMinimalProgram).toContain('minimal-sample-program')
@@ -501,7 +504,7 @@ test.describe('program migration', () => {
     await test.step('export comprehensive program', async () => {
       await adminPrograms.goToExportProgramPage(
         'Comprehensive Sample Program',
-        'DRAFT',
+        ProgramLifecycle.DRAFT,
       )
       downloadedComprehensiveProgram =
         await adminProgramMigration.downloadJson()
@@ -515,7 +518,7 @@ test.describe('program migration', () => {
       await adminPrograms.gotoAdminProgramsPage()
       await adminPrograms.goToExportProgramPage(
         'Minimal Sample Program',
-        'DRAFT',
+        ProgramLifecycle.DRAFT,
       )
       downloadedMinimalProgram = await adminProgramMigration.downloadJson()
       expect(downloadedMinimalProgram).toContain('minimal-sample-program')
@@ -737,7 +740,7 @@ test.describe('program migration', () => {
     await test.step('export comprehensive program', async () => {
       await adminPrograms.goToExportProgramPage(
         'Comprehensive Sample Program',
-        'DRAFT',
+        ProgramLifecycle.DRAFT,
       )
       downloadedComprehensiveProgram =
         await adminProgramMigration.downloadJson()

--- a/browser-test/src/applicant/application_review.test.ts
+++ b/browser-test/src/applicant/application_review.test.ts
@@ -11,6 +11,7 @@ import {
   validateScreenshot,
   enableFeatureFlag,
 } from '../support'
+import {ProgramExtraAction, ProgramLifecycle} from '../support/admin_programs'
 
 test.describe('Program admin review of submitted applications', () => {
   test.beforeEach(async ({page}) => {
@@ -373,19 +374,10 @@ test.describe('Program admin review of submitted applications', () => {
     })
 
     await test.step('Go to applications list page', async () => {
-      await page.click(
-        adminPrograms.withinProgramCardSelector(
-          programName,
-          'Active',
-          '.cf-with-dropdown',
-        ),
-      )
-      await page.click(
-        adminPrograms.withinProgramCardSelector(
-          programName,
-          'ACTIVE',
-          'button :text("Applications")',
-        ),
+      await adminPrograms.selectProgramExtraAction(
+        programName,
+        ProgramLifecycle.ACTIVE,
+        ProgramExtraAction.VIEW_APPLICATIONS,
       )
       await waitForPageJsLoad(page)
       await validateScreenshot(page, 'cf-admin-applications-page')

--- a/browser-test/src/applicant/northstar_application_review.test.ts
+++ b/browser-test/src/applicant/northstar_application_review.test.ts
@@ -11,6 +11,7 @@ import {
   validateScreenshot,
   enableFeatureFlag,
 } from '../support'
+import {ProgramExtraAction, ProgramLifecycle} from '../support/admin_programs'
 
 test.describe(
   'Program admin review of submitted applications',
@@ -365,19 +366,10 @@ test.describe(
       })
 
       await test.step('Go to applications list page', async () => {
-        await page.click(
-          adminPrograms.withinProgramCardSelector(
-            programName,
-            'Active',
-            '.cf-with-dropdown',
-          ),
-        )
-        await page.click(
-          adminPrograms.withinProgramCardSelector(
-            programName,
-            'ACTIVE',
-            'button :text("Applications")',
-          ),
+        await adminPrograms.selectProgramExtraAction(
+          programName,
+          ProgramLifecycle.ACTIVE,
+          ProgramExtraAction.VIEW_APPLICATIONS,
         )
         await waitForPageJsLoad(page)
         await validateScreenshot(page, 'cf-admin-applications-page')

--- a/browser-test/src/applicant/northstar_program_overview.test.ts
+++ b/browser-test/src/applicant/northstar_program_overview.test.ts
@@ -10,7 +10,7 @@ import {
   validateScreenshot,
   setDirRtl,
 } from '../support'
-import {Eligibility} from '../support/admin_programs'
+import {Eligibility, ProgramLifecycle} from '../support/admin_programs'
 
 test.describe('Applicant program overview', {tag: ['@northstar']}, () => {
   const programName = 'test'
@@ -45,7 +45,7 @@ test.describe('Applicant program overview', {tag: ['@northstar']}, () => {
       await loginAsAdmin(page)
       await adminPrograms.goToProgramDescriptionPage(
         programName,
-        /* createNewDraft= */ true,
+        ProgramLifecycle.ACTIVE,
       )
       await page
         .getByRole('textbox', {name: 'Long program description (optional)'})
@@ -131,7 +131,7 @@ test.describe('Applicant program overview', {tag: ['@northstar']}, () => {
       await loginAsAdmin(page)
       await adminPrograms.goToProgramDescriptionPage(
         programName,
-        /* createNewDraft= */ true,
+        ProgramLifecycle.ACTIVE,
       )
       await page
         .getByRole('textbox', {name: 'Long program description (optional)'})
@@ -241,7 +241,7 @@ test.describe('Applicant program overview', {tag: ['@northstar']}, () => {
       await loginAsAdmin(page)
       await adminPrograms.goToProgramDescriptionPage(
         secondProgram,
-        /* createNewDraft= */ true,
+        ProgramLifecycle.ACTIVE,
       )
       await adminPrograms.chooseEligibility(Eligibility.IS_NOT_GATING)
       await adminPrograms.submitProgramDetailsEdits()

--- a/browser-test/src/support/admin_programs.ts
+++ b/browser-test/src/support/admin_programs.ts
@@ -799,22 +799,22 @@ export class AdminPrograms {
   async gotoEditDraftProgramPage(
     programName: string,
     isProgramDisabled: boolean = false,
-    createNewDraft: boolean = false,
+    lifecycle: ProgramLifecycle = ProgramLifecycle.DRAFT,
   ) {
     await this.gotoAdminProgramsPage(isProgramDisabled)
 
-    if (createNewDraft) {
+    if (lifecycle === ProgramLifecycle.ACTIVE) {
       await this.expectActiveProgram(programName)
       await this.selectProgramExtraAction(
         programName,
-        ProgramLifecycle.ACTIVE,
+        lifecycle,
         ProgramExtraAction.EDIT,
       )
     } else {
       await this.expectDraftProgram(programName)
       await this.getProgramAction(
         programName,
-        ProgramLifecycle.DRAFT,
+        lifecycle,
         ProgramAction.EDIT,
       ).click()
     }
@@ -885,9 +885,13 @@ export class AdminPrograms {
 
   async goToProgramDescriptionPage(
     programName: string,
-    createNewDraft: boolean = false,
+    lifecycle: ProgramLifecycle = ProgramLifecycle.DRAFT,
   ) {
-    await this.gotoEditDraftProgramPage(programName, false, createNewDraft)
+    await this.gotoEditDraftProgramPage(
+      programName,
+      /* isProgramDisabled= */ false,
+      lifecycle,
+    )
     await this.page.click('button:has-text("Edit program details")')
     await waitForPageJsLoad(this.page)
   }


### PR DESCRIPTION
### Description

Use `getProgramCard()`, and methods which use it, instead of `withinProgramCardSelector()` in browser tests. This reduces code complexity.

With this we can remove `withinProgramCardSelector()` and `programCardSelector()`, which are no longer used.

No functionality changed

### Issue(s) this completes

Part of #10513
