### PR TITLE
(fix) Hide language selector when only one language is enabled (NorthStar Ui)

### DIFF
--- a/browser-test/src/applicant/northstar_applicant_question_translation.test.ts
+++ b/browser-test/src/applicant/northstar_applicant_question_translation.test.ts
@@ -202,4 +202,14 @@ test.describe('Admin can manage translations', {tag: ['@northstar']}, () => {
 
     expect(await page.innerText('main form')).toContain('miembro de la familia')
   })
+
+  test.describe('Language Selector Visibility', () => {
+    test('shows language selector when multiple languages are enabled', async ({
+      page,
+    }) => {
+      await expect(
+        page.getByRole('button', {name: 'Select Language'}),
+      ).toBeVisible()
+    })
+  })
 })

--- a/server/app/views/applicant/NavigationFragment.html
+++ b/server/app/views/applicant/NavigationFragment.html
@@ -67,7 +67,9 @@
             <div>
               <button th:replace="~{this :: loginOrLogout}"></button>
             </div>
-            <button th:replace="~{this :: languageSelector}"></button>
+            <th:block th:if="${enabledLanguages.size() > 1}">
+              <button th:replace="~{this :: languageSelector}"></button>
+            </th:block>
           </div>
         </div>
       </nav>


### PR DESCRIPTION
### Description
This PR fixes a UI bug in the NorthStar applicant header where the language selector was being shown even when only one language was enabled.

- Updates the logic in `NavigationFragment.html` to conditionally render the language selector only if there are multiple enabled languages.
- Adds a browser test (`northstar_language_selector.test.ts`) to verify that the selector:
  - Does appear when multiple languages are enabled.

## Release notes

- Fixed: Hide language selector when only one language is enabled in NorthStar UI
- Added: browser test to verify language selector visibility under multi-language conditions.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [ ] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [ ] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

#### User visible changes

- [ ] Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
  - [ ] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [ ] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [x] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [x] Made equivalent changes in Thymeleaf for applicant-facing features and changes (or created an issue in the [Northstar epic](https://github.com/orgs/civiform/projects/1/views/94) to track that it's missing from Thymeleaf)
- [ ] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order
- [ ] Manually tested with a screen reader if the feature is applicant-facing. See [screen reader testing](https://github.com/civiform/civiform/wiki/Testing#screen-reader-testing)

### Instructions for manual testing

If instructions are needed for manual testing by reviewers, include them here.
Navigate to the applicant home page in NorthStar UI.
Confirm that the language selector:
- Appears when multiple languages are configured.
- Is hidden when only one language is configured.

To adjust language visibility, modify `play.i18n.langs` setting in `application.dev.conf`

## Screenshots:
**Dropdown is visible when multiple languages are enabled:**
![Language selector shown](https://github.com/user-attachments/assets/5025cc36-0ac2-41dc-ad0f-c60972617760)

**Dropdown is hidden when only one languages is enabled:**
![Language selector hidden](https://github.com/user-attachments/assets/1cb89a7b-7926-40a6-a3a1-894ddd642109)




### Issue(s) this completes

Fixes #10432
