### PR TITLE
[External Program Cards] Hide actions for external program cards for program admins

### DIFF
--- a/browser-test/src/support/admin_programs.ts
+++ b/browser-test/src/support/admin_programs.ts
@@ -92,6 +92,7 @@ export enum ProgramAction {
   PUBLISH = 'Publish',
   SHARE = 'Share link',
   VIEW = 'View',
+  VIEW_APPLICATIONS = 'Applications',
 }
 
 export enum ProgramExtraAction {
@@ -500,6 +501,10 @@ export class AdminPrograms {
       await expect(actionButton).toBeVisible()
     }
 
+    if (extraActions.length === 0) {
+      return
+    }
+
     await this.getProgramExtraActionsButton(programName, lifecycle).click()
     for (const action of extraActions) {
       const actionButton = this.getProgramExtraAction(
@@ -529,6 +534,10 @@ export class AdminPrograms {
     for (const action of actions) {
       const actionButton = this.getProgramAction(programName, lifecycle, action)
       await expect(actionButton).toBeHidden()
+    }
+
+    if (extraActions.length === 0) {
+      return
     }
 
     await this.getProgramExtraActionsButton(programName, lifecycle).click()

--- a/server/app/views/admin/programs/ProgramAdministratorProgramListView.java
+++ b/server/app/views/admin/programs/ProgramAdministratorProgramListView.java
@@ -18,6 +18,7 @@ import play.mvc.Http.Request;
 import play.twirl.api.Content;
 import services.program.ActiveAndDraftPrograms;
 import services.program.ProgramDefinition;
+import services.program.ProgramType;
 import views.BaseHtmlView;
 import views.HtmlBundle;
 import views.admin.AdminLayout;
@@ -71,15 +72,21 @@ public final class ProgramAdministratorProgramListView extends BaseHtmlView {
 
   private ProgramCardFactory.ProgramCardData buildCardData(
       ProgramDefinition activeProgram, Optional<CiviFormProfile> profile) {
+    ImmutableList.Builder<ButtonTag> actionsBuilder = ImmutableList.builder();
+
+    ProgramType programType = activeProgram.programType();
+    if (programType.equals(ProgramType.DEFAULT)
+        || programType.equals(ProgramType.COMMON_INTAKE_FORM)) {
+      actionsBuilder.add(renderShareLink(activeProgram));
+      actionsBuilder.add(renderViewApplicationsLink(activeProgram));
+    }
+
     return ProgramCardFactory.ProgramCardData.builder()
         .setActiveProgram(
             Optional.of(
                 ProgramCardData.ProgramRow.builder()
                     .setProgram(activeProgram)
-                    .setRowActions(
-                        ImmutableList.of(
-                            renderShareLink(activeProgram),
-                            renderViewApplicationsLink(activeProgram)))
+                    .setRowActions(actionsBuilder.build())
                     .setExtraRowActions(ImmutableList.of())
                     .build()))
         .setIsCiviFormAdmin(profile.isPresent() && profile.get().isCiviFormAdmin())


### PR DESCRIPTION
### Description

Remove 'share' and 'view' action from the external program card for program administrators (not civiform administrators) since external programs don't have a program link or overview.

Note: external programs shouldn't be visible for program administrators since there is no action they can take. For this we need to remove 'manage program administrators' from the cards in the CiviForm admin panel (will be done in separate PR). However, demo versions add a program fake admin even if we remove the control. Thus we still handle hiding the actions for external program cards for program admins

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

#### User visible changes

- [ ] Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
  - [ ] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [ ] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Made equivalent changes in Thymeleaf for applicant-facing features and changes (or created an issue in the [Northstar epic](https://github.com/orgs/civiform/projects/1/views/94) to track that it's missing from Thymeleaf)
- [x] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [x] Manually tested at 200% size
- [x] Manually evaluated tab order
- [ ] Manually tested with a screen reader if the feature is applicant-facing. See [screen reader testing](https://github.com/civiform/civiform/wiki/Testing#screen-reader-testing)

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/helper/feature-flags.conf`
- [x] Conditioned new functionality on a [FeatureFlag](https://github.com/civiform/civiform/wiki/Feature-Flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Instructions for manual testing
1. Log in as a CiviForm admin
2. Enable EXTERNAL_PROGRAM_CARDS_ENABLED feature flag
3. Create an external program
4. Logout
5. Log in as a Program admin
6. Verify 'share link' and 'applications' buttons are not visible

### Issue(s) this completes

Part of #10183