### PR TITLE
Update Transaction usage in ProgramRepository

### DIFF
--- a/server/app/repository/ProgramRepository.java
+++ b/server/app/repository/ProgramRepository.java
@@ -220,7 +220,7 @@ public final class ProgramRepository {
     // Otherwise, it will be creating a new transaction.
     // After the fact note: Based on the docs this isn't a savepoint as the
     // above says, because setNestedUseSavepoint() was not called, other code
-    // does use is FWIW.
+    // does do that FWIW.
     // https://ebean.io/docs/transactions/savepoints
     Transaction transaction =
         database.beginTransaction(TxScope.required().setIsolation(TxIsolation.SERIALIZABLE));

--- a/server/app/repository/ProgramRepository.java
+++ b/server/app/repository/ProgramRepository.java
@@ -279,7 +279,7 @@ public final class ProgramRepository {
       transaction.end();
       // After the fact comment: potential infinite loop here for systemic
       // issues. Unclear from the original 2021 PR what situation warranted
-      // catching/ IllegalStageException, and then also retrying when the
+      // catching IllegalStageException, and then also retrying when the
       // exception is typically for un-retryable things.
       return createOrUpdateDraft(existingProgram);
     } finally {
@@ -471,7 +471,7 @@ public final class ProgramRepository {
   }
 
   /**
-   * Adds an ExpressionList to {@code query} that searches applications based on the implied
+   * Add an ExpressionList to {@code query} that searches applications based on the implied
    * contents of {@code search}.
    *
    * <p>A phone number only search is done if {@code search} contains no alphabetic characters and

--- a/server/app/repository/ProgramRepository.java
+++ b/server/app/repository/ProgramRepository.java
@@ -279,7 +279,7 @@ public final class ProgramRepository {
       transaction.end();
       // After the fact comment: potential infinite loop here for systemic
       // issues. Unclear from the original 2021 PR what situation warranted
-      // catching IllegalStageException, and then also retrying when the
+      // catching IllegalStateException, and then also retrying when the
       // exception is typically for un-retryable things.
       return createOrUpdateDraft(existingProgram);
     } finally {

--- a/server/app/repository/ProgramRepository.java
+++ b/server/app/repository/ProgramRepository.java
@@ -471,8 +471,8 @@ public final class ProgramRepository {
   }
 
   /**
-   * Add an ExpressionList to {@code query} that searches applications based on the implied
-   * contents of {@code search}.
+   * Add an ExpressionList to {@code query} that searches applications based on the implied contents
+   * of {@code search}.
    *
    * <p>A phone number only search is done if {@code search} contains no alphabetic characters and
    * some numeric characters. All other characters are removed.

--- a/server/app/repository/ProgramRepository.java
+++ b/server/app/repository/ProgramRepository.java
@@ -241,9 +241,14 @@ public final class ProgramRepository {
               existingProgramDraft.id,
               existingProgram.id());
         }
+        // After the fact comment: This appears to largely be a no-op outside
+        // the previous warning if block.  If that block doesn't trigger then
+        // the ids are the same and nothing is being changed.
         ProgramModel updatedDraft =
             existingProgram.toBuilder().setId(existingProgramDraft.id).build().toProgram();
-        return updateProgramSync(updatedDraft);
+        updateProgramSync(updatedDraft);
+        transaction.commit();
+        return updatedDraft;
       }
 
       // Create a draft.

--- a/server/app/repository/ProgramRepository.java
+++ b/server/app/repository/ProgramRepository.java
@@ -14,6 +14,7 @@ import io.ebean.Query;
 import io.ebean.SqlRow;
 import io.ebean.Transaction;
 import io.ebean.TxScope;
+import io.ebean.annotation.TxIsolation;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -207,7 +208,7 @@ public final class ProgramRepository {
   }
 
   /**
-   * Makes {@code existingProgram} the DRAFT revision configuration of the question, creating a new
+   * Makes {@code existingProgram} the DRAFT revision configuration of the program, creating a new
    * DRAFT if necessary.
    */
   public ProgramModel createOrUpdateDraft(ProgramModel existingProgram) {
@@ -215,30 +216,37 @@ public final class ProgramRepository {
   }
 
   public ProgramModel createOrUpdateDraft(ProgramDefinition existingProgram) {
-    VersionModel draftVersion = versionRepository.get().getDraftVersionOrCreate();
-    Optional<ProgramModel> existingDraftOpt =
-        versionRepository
-            .get()
-            .getProgramByNameForVersion(existingProgram.adminName(), draftVersion);
-    if (existingDraftOpt.isPresent()) {
-      ProgramModel existingDraft = existingDraftOpt.get();
-      if (!existingDraft.id.equals(existingProgram.id())) {
-        // This may be indicative of a coding error, as it does a reset of the draft and not an
-        // update of the draft, so log it.
-        logger.warn(
-            "Replacing Draft revision {} with definition from a different revision {}.",
-            existingDraft.id,
-            existingProgram.id());
-      }
-      ProgramModel updatedDraft =
-          existingProgram.toBuilder().setId(existingDraft.id).build().toProgram();
-      return updateProgramSync(updatedDraft);
-    }
-
-    // Inside a question update, this will be a savepoint rather than a full transaction.  Otherwise
-    // it will be creating a new transaction.
-    Transaction transaction = database.beginTransaction(TxScope.required());
+    // Inside a question update, this will be a savepoint rather than a full transaction.
+    // Otherwise, it will be creating a new transaction.
+    // After the fact note: Based on the docs this isn't a savepoint as the
+    // above says, because setNestedUseSavepoint() was not called, other code
+    // does use is FWIW.
+    // https://ebean.io/docs/transactions/savepoints
+    Transaction transaction =
+        database.beginTransaction(TxScope.required().setIsolation(TxIsolation.SERIALIZABLE));
     try {
+      // Replace the existing draft if present.
+      VersionModel draftVersion = versionRepository.get().getDraftVersionOrCreate();
+      Optional<ProgramModel> existingProgramDraftOpt =
+          versionRepository
+              .get()
+              .getProgramByNameForVersion(existingProgram.adminName(), draftVersion);
+      if (existingProgramDraftOpt.isPresent()) {
+        ProgramModel existingProgramDraft = existingProgramDraftOpt.get();
+        if (!existingProgramDraft.id.equals(existingProgram.id())) {
+          // This may be indicative of a coding error, as it does a reset of the draft and not an
+          // update of the draft, so log it.
+          logger.warn(
+              "Replacing Draft revision {} with definition from a different revision {}.",
+              existingProgramDraft.id,
+              existingProgram.id());
+        }
+        ProgramModel updatedDraft =
+            existingProgram.toBuilder().setId(existingProgramDraft.id).build().toProgram();
+        return updateProgramSync(updatedDraft);
+      }
+
+      // Create a draft.
       // Program -> builder -> back to program in order to clear any metadata stored in the program
       // (for example, version information).
       ProgramModel newDraft = new ProgramModel(existingProgram.toBuilder().build(), draftVersion);
@@ -269,6 +277,10 @@ public final class ProgramRepository {
       // We cannot have this transaction on the thread-local transaction stack when that
       // happens.
       transaction.end();
+      // After the fact comment: potential infinite loop here for systemic
+      // issues. Unclear from the original 2021 PR what situation warranted
+      // catching/ IllegalStageException, and then also retrying when the
+      // exception is typically for un-retryable things.
       return createOrUpdateDraft(existingProgram);
     } finally {
       // This may come after a prior call to `transaction.end` in the event of a precondition
@@ -458,6 +470,16 @@ public final class ProgramRepository {
         .query();
   }
 
+  /**
+   * Adds an ExpressionList to {@code query} that searches applications based on the implied
+   * contents of {@code search}.
+   *
+   * <p>A phone number only search is done if {@code search} contains no alphabetic characters and
+   * some numeric characters. All other characters are removed.
+   *
+   * <p>Otherwise, a broad search is returned which includes a match on any of phone number,
+   * submitter email, and first name last name patterns.
+   */
   private ExpressionList<ApplicationModel> searchUsingPrimaryApplicantInfo(
       String search, ExpressionList<ApplicationModel> query) {
     // Remove all special characters

--- a/server/app/repository/ProgramRepository.java
+++ b/server/app/repository/ProgramRepository.java
@@ -227,12 +227,12 @@ public final class ProgramRepository {
     try {
       // Replace the existing draft if present.
       VersionModel draftVersion = versionRepository.get().getDraftVersionOrCreate();
-      Optional<ProgramModel> existingProgramDraftOpt =
+      Optional<ProgramModel> optionalExistingProgramDraft =
           versionRepository
               .get()
               .getProgramByNameForVersion(existingProgram.adminName(), draftVersion);
-      if (existingProgramDraftOpt.isPresent()) {
-        ProgramModel existingProgramDraft = existingProgramDraftOpt.get();
+      if (optionalExistingProgramDraft.isPresent()) {
+        ProgramModel existingProgramDraft = optionalExistingProgramDraft.get();
         if (!existingProgramDraft.id.equals(existingProgram.id())) {
           // This may be indicative of a coding error, as it does a reset of the draft and not an
           // update of the draft, so log it.


### PR DESCRIPTION
### Description

Expands the transaction in createOrUpdateDraft() which encompasses the Create flow to encompass the Update too so that both are consistent with the Draft program read that is used as the create or update switch.

Add comments about other transaction usage for future refinement.

Manually tested the "update" flow by changing which program is the pre-screener which requires the one being changed from to be a draft.

Manually tested the "create" flow by editing programs.

## Release notes

Improves data consistency by updating database transaction usage to Program database code.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [ ] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.


Addresses: #10188 