### PR TITLE
Remove error thrown when modal container is not found

### DIFF
--- a/server/app/assets/javascripts/modal.ts
+++ b/server/app/assets/javascripts/modal.ts
@@ -73,8 +73,11 @@ export class ModalController {
   constructor() {
     const modalContainer = document.querySelector('#modal-container')
     if (modalContainer == null) {
-      // The modal container may not be found if northstar is enabled.
-      return
+      if (document.querySelectorAll('.cf-ns-modal').length > 0) {
+        // There is a northstar modal, so the legacy modal may not exist
+        return
+      }
+      throw new Error('Modal Container display not found!')
     }
 
     const modals = Array.from(

--- a/server/app/assets/javascripts/modal.ts
+++ b/server/app/assets/javascripts/modal.ts
@@ -73,7 +73,8 @@ export class ModalController {
   constructor() {
     const modalContainer = document.querySelector('#modal-container')
     if (modalContainer == null) {
-      throw new Error('Modal Container display not found!')
+      // The modal container may not be found if northstar is enabled.
+      return
     }
 
     const modals = Array.from(


### PR DESCRIPTION
### Description

Remove error thrown when modal container is not found, since there is another modal ts file for northstar.

Seattle was still seeing issues with file upload (https://github.com/civiform/civiform/issues/10444) when northstar mode was enabled with prod.

We could consider logging something in the console still, but it didn't seem necessary, since there is another modal file for northstar that is being used instead.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

### Instructions for manual testing

I tested this by bringing back this line (https://github.com/civiform/civiform/pull/10542/files#diff-4899391bb04e0d72d4014d90b7aabcd5b501510dc4b6bdde08390757b98439baL3) and ensuring that the error no longer gets thrown but functionality works the same way.

### Issue(s) this completes

Fixes https://github.com/civiform/civiform/issues/10444
