### PR TITLE
[External Program Cards] Hide 'manage program admin' for external program in civiform admin panel

### DIFF
--- a/browser-test/src/admin/admin_program_list.test.ts
+++ b/browser-test/src/admin/admin_program_list.test.ts
@@ -572,42 +572,41 @@ test.describe('Program list page.', () => {
     })
 
     await test.step('verify external program cards on program list for Civiform admin', async () => {
-      // On draft mode, 'manage applications' extra action is hidden
+      // On draft mode, 'manage admins' and 'manage applications' extra actions
+      // are hidden
       await adminPrograms.expectProgramActionsVisible(
         externalProgram,
         ProgramLifecycle.DRAFT,
         [ProgramAction.PUBLISH, ProgramAction.EDIT],
-        [
-          ProgramExtraAction.MANAGE_ADMINS,
-          ProgramExtraAction.MANAGE_TRANSLATIONS,
-          ProgramExtraAction.EXPORT,
-        ],
+        [ProgramExtraAction.MANAGE_TRANSLATIONS, ProgramExtraAction.EXPORT],
       )
       await adminPrograms.expectProgramActionsHidden(
         externalProgram,
         ProgramLifecycle.DRAFT,
         [],
-        [ProgramExtraAction.MANAGE_APPLICATIONS],
+        [
+          ProgramExtraAction.MANAGE_ADMINS,
+          ProgramExtraAction.MANAGE_APPLICATIONS,
+        ],
       )
 
-      // On active mode, 'share' action and 'applications' extra action are
-      // hidden
+      // On active mode, 'share' action, and 'manage admins' and 'manage
+      // applications' extra actions are hidden
       await adminPrograms.publishProgram(externalProgram)
       await adminPrograms.expectProgramActionsVisible(
         externalProgram,
         ProgramLifecycle.ACTIVE,
         [ProgramAction.VIEW],
-        [
-          ProgramExtraAction.EDIT,
-          ProgramExtraAction.MANAGE_ADMINS,
-          ProgramExtraAction.EXPORT,
-        ],
+        [ProgramExtraAction.EDIT, ProgramExtraAction.EXPORT],
       )
       await adminPrograms.expectProgramActionsHidden(
         externalProgram,
         ProgramLifecycle.ACTIVE,
         [ProgramAction.SHARE],
-        [ProgramExtraAction.VIEW_APPLICATIONS],
+        [
+          ProgramExtraAction.MANAGE_ADMINS,
+          ProgramExtraAction.VIEW_APPLICATIONS,
+        ],
       )
 
       await logout(page)

--- a/server/app/views/admin/programs/ProgramIndexView.java
+++ b/server/app/views/admin/programs/ProgramIndexView.java
@@ -509,7 +509,7 @@ public final class ProgramIndexView extends BaseHtmlView {
               });
       draftRowActions.add(renderEditLink(/* isActive= */ false, draftProgram.get(), request));
 
-      draftRowExtraActions.add(renderManageProgramAdminsLink(draftProgram.get()));
+      maybeRenderManageProgramAdminsLink(draftProgram.get()).ifPresent(draftRowExtraActions::add);
       maybeRenderManageTranslationsLink(draftProgram.get()).ifPresent(draftRowExtraActions::add);
       maybeRenderManageApplications(draftProgram.get()).ifPresent(draftRowExtraActions::add);
       draftRowExtraActions.add(renderExportProgramLink(draftProgram.get()));
@@ -537,8 +537,8 @@ public final class ProgramIndexView extends BaseHtmlView {
       if (draftProgram.isEmpty()) {
         activeRowExtraActions.add(
             renderEditLink(/* isActive= */ true, activeProgram.get(), request));
-        activeRowExtraActions.add(renderManageProgramAdminsLink(activeProgram.get()));
       }
+      maybeRenderManageProgramAdminsLink(activeProgram.get()).ifPresent(activeRowExtraActions::add);
       activeRowExtraActions.add(renderExportProgramLink(activeProgram.get()));
 
       activeRow =
@@ -686,13 +686,19 @@ public final class ProgramIndexView extends BaseHtmlView {
     return Optional.empty();
   }
 
-  private ButtonTag renderManageProgramAdminsLink(ProgramDefinition program) {
+  private Optional<ButtonTag> maybeRenderManageProgramAdminsLink(ProgramDefinition program) {
+    // External programs don't have program administrators, since they cannot edit external programs
+    ProgramType programType = program.programType();
+    if (programType.equals(ProgramType.EXTERNAL)) {
+      return Optional.empty();
+    }
+
     String adminLink = routes.ProgramAdminManagementController.edit(program.id()).url();
     ButtonTag button =
         makeSvgTextButton("Manage program admins", Icons.GROUP)
             .withId("manage-program-admin-link-" + program.id())
             .withClass(ButtonStyles.CLEAR_WITH_ICON_FOR_DROPDOWN);
-    return asRedirectElement(button, adminLink);
+    return Optional.of(asRedirectElement(button, adminLink));
   }
 
   private ButtonTag renderExportProgramLink(ProgramDefinition program) {


### PR DESCRIPTION
### Description

Remove 'manage admins' action from the program card for external program on active mode. Program admins can't edit anything on external programs, therefore there is no reason to add program admins to external programs.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

#### User visible changes

- [ ] Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
  - [ ] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [ ] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Made equivalent changes in Thymeleaf for applicant-facing features and changes (or created an issue in the [Northstar epic](https://github.com/orgs/civiform/projects/1/views/94) to track that it's missing from Thymeleaf)
- [x] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [x] Manually tested at 200% size
- [x] Manually evaluated tab order
- [ ] Manually tested with a screen reader if the feature is applicant-facing. See [screen reader testing](https://github.com/civiform/civiform/wiki/Testing#screen-reader-testing)

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/helper/feature-flags.conf`
- [x] Conditioned new functionality on a [FeatureFlag](https://github.com/civiform/civiform/wiki/Feature-Flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Instructions for manual testing

1. Log in as an admin
2. Enable EXTERNAL_PROGRAM_CARDS_ENABLED feature flag
3. Create an external program
4. Go to the admin dashboard
6. Verify 'manage admins' is not shown on the extra actions (clicking the three dot button) for an external program card

### Issue(s) this completes

Part of #10183
