### PR TITLE
Making createProgramWithNongatingEligibility() a public method

### DIFF
--- a/server/test/services/applicant/ApplicantServiceTest.java
+++ b/server/test/services/applicant/ApplicantServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static support.FakeRequestBuilder.fakeRequest;
 import static support.FakeRequestBuilder.fakeRequestBuilder;
+import static support.TestProgramUtility.createProgramWithNongatingEligibility;
 
 import auth.CiviFormProfile;
 import auth.ProfileFactory;
@@ -1747,7 +1748,9 @@ public class ApplicantServiceTest extends ResetPostgres {
   @Test
   public void
       submitApplication_allowsIneligibleApplicationToBeSubmittedWhenEligibilityIsNongating() {
-    createProgramWithNongatingEligibility(questionDefinition);
+    programDefinition =
+        createProgramWithNongatingEligibility(
+            questionService, versionRepository, questionDefinition);
     ApplicantModel applicant = subject.createApplicant().toCompletableFuture().join();
     applicant.setAccount(resourceCreator.insertAccount());
     applicant.save();
@@ -3833,41 +3836,6 @@ public class ApplicantServiceTest extends ResetPostgres {
             .buildDefinition();
   }
 
-  private void createProgramWithNongatingEligibility(NameQuestionDefinition question) {
-    EligibilityDefinition eligibilityDef =
-        EligibilityDefinition.builder()
-            .setPredicate(
-                PredicateDefinition.create(
-                    PredicateExpressionNode.create(
-                        LeafOperationExpressionNode.create(
-                            question.getId(),
-                            Scalar.FIRST_NAME,
-                            Operator.EQUAL_TO,
-                            PredicateValue.of("eligible name"))),
-                    PredicateAction.ELIGIBLE_BLOCK))
-            .build();
-    programDefinition =
-        ProgramBuilder.newDraftProgram(
-                ProgramDefinition.builder()
-                    .setId(new Random().nextLong())
-                    .setAdminName("name")
-                    .setAdminDescription("desc")
-                    .setExternalLink("https://usa.gov")
-                    .setDisplayMode(DisplayMode.PUBLIC)
-                    .setProgramType(ProgramType.DEFAULT)
-                    .setEligibilityIsGating(false)
-                    .setAcls(new ProgramAcls())
-                    .setCategories(ImmutableList.of())
-                    .setApplicationSteps(
-                        ImmutableList.of(new ApplicationStep("title", "description")))
-                    .build())
-            .withBlock()
-            .withRequiredQuestionDefinitions(ImmutableList.of(question))
-            .withEligibilityDefinition(eligibilityDef)
-            .buildDefinition();
-    versionRepository.publishNewSynchronizedVersion();
-  }
-
   private Messages getMessages(Locale locale) {
     return messagesApi.preferred(ImmutableSet.of(Lang.forCode(locale.toLanguageTag())));
   }
@@ -4375,7 +4343,9 @@ public class ApplicantServiceTest extends ResetPostgres {
 
   @Test
   public void getApplicantMayBeEligibleStatus() {
-    createProgramWithNongatingEligibility(questionDefinition);
+    programDefinition =
+        createProgramWithNongatingEligibility(
+            questionService, versionRepository, questionDefinition);
     ApplicantModel applicant = subject.createApplicant().toCompletableFuture().join();
     applicant.setAccount(resourceCreator.insertAccount());
     applicant.save();
@@ -4415,7 +4385,9 @@ public class ApplicantServiceTest extends ResetPostgres {
 
   @Test
   public void getApplicationEligibilityStatus() {
-    createProgramWithNongatingEligibility(questionDefinition);
+    programDefinition =
+        createProgramWithNongatingEligibility(
+            questionService, versionRepository, questionDefinition);
     ApplicantModel applicant = subject.createApplicant().toCompletableFuture().join();
     applicant.setAccount(resourceCreator.insertAccount());
     applicant.save();

--- a/server/test/support/TestProgramUtility.java
+++ b/server/test/support/TestProgramUtility.java
@@ -1,0 +1,84 @@
+package support;
+
+import auth.ProgramAcls;
+import com.google.common.collect.ImmutableList;
+import java.util.Random;
+import models.ApplicationStep;
+import models.DisplayMode;
+import repository.VersionRepository;
+import services.applicant.question.Scalar;
+import services.program.EligibilityDefinition;
+import services.program.ProgramDefinition;
+import services.program.ProgramType;
+import services.program.predicate.LeafOperationExpressionNode;
+import services.program.predicate.Operator;
+import services.program.predicate.PredicateAction;
+import services.program.predicate.PredicateDefinition;
+import services.program.predicate.PredicateExpressionNode;
+import services.program.predicate.PredicateValue;
+import services.question.QuestionService;
+import services.question.types.NameQuestionDefinition;
+
+/**
+ * Utility class for creating program definitions in tests.
+ *
+ * <p>This class provides helper methods to construct ProgramDefinition objects with specific
+ * configurations for testing purposes, such as programs with non-gating eligibility rules.
+ */
+public class TestProgramUtility {
+  /**
+   * Creates a new program definition with a non-gating eligibility rule.
+   *
+   * <p>The program will have a basic setup including an ID, admin name, description, external link,
+   * display mode, and program type. It will include a single application step and a single required
+   * question. The eligibility definition is set to be non-gating, meaning that even if an applicant
+   * does not meet the eligibility criteria, they can still proceed with the application. The
+   * eligibility is based on a simple predicate: the first name of the provided question must be
+   * "eligible name".
+   *
+   * @param questionService The {@link QuestionService} instance to use.
+   * @param versionRepository The {@link VersionRepository} instance to use for publishing the new
+   *     version.
+   * @param question The {@link NameQuestionDefinition} to be used as a required question and for
+   *     the eligibility predicate.
+   * @return A {@link ProgramDefinition} configured with a non-gating eligibility rule.
+   */
+  public static ProgramDefinition createProgramWithNongatingEligibility(
+      QuestionService questionService,
+      VersionRepository versionRepository,
+      NameQuestionDefinition question) {
+    EligibilityDefinition eligibilityDef =
+        EligibilityDefinition.builder()
+            .setPredicate(
+                PredicateDefinition.create(
+                    PredicateExpressionNode.create(
+                        LeafOperationExpressionNode.create(
+                            question.getId(),
+                            Scalar.FIRST_NAME,
+                            Operator.EQUAL_TO,
+                            PredicateValue.of("eligible name"))),
+                    PredicateAction.ELIGIBLE_BLOCK))
+            .build();
+    ProgramDefinition programDefinition =
+        ProgramBuilder.newDraftProgram(
+                ProgramDefinition.builder()
+                    .setId(new Random().nextLong())
+                    .setAdminName("name")
+                    .setAdminDescription("desc")
+                    .setExternalLink("https://usa.gov")
+                    .setDisplayMode(DisplayMode.PUBLIC)
+                    .setProgramType(ProgramType.DEFAULT)
+                    .setEligibilityIsGating(false)
+                    .setAcls(new ProgramAcls())
+                    .setCategories(ImmutableList.of())
+                    .setApplicationSteps(
+                        ImmutableList.of(new ApplicationStep("title", "description")))
+                    .build())
+            .withBlock()
+            .withRequiredQuestionDefinitions(ImmutableList.of(question))
+            .withEligibilityDefinition(eligibilityDef)
+            .buildDefinition();
+    versionRepository.publishNewSynchronizedVersion();
+    return programDefinition;
+  }
+}


### PR DESCRIPTION
### Description

Making createProgramWithNongatingEligibility() public so we can use it in other test files. More specifically the test file about to be created to test the durable job for eligibility determination.


### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [x] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [x] Noted in the PR description which, if any, code in this PR was generated by AI.


### Instructions for manual testing

If instructions are needed for manual testing by reviewers, include them here.

### Issue(s) this completes

Part of https://github.com/civiform/civiform/issues/8852
