### PR TITLE
Allow any IP to be used for API access in dev mode

### DIFF
--- a/server/conf/application.dev.conf
+++ b/server/conf/application.dev.conf
@@ -63,6 +63,9 @@ esri_address_service_area_validation_labels = ["Seattle"]
 esri_address_service_area_validation_ids = ["Seattle"]
 esri_address_service_area_validation_attributes = ["CITYNAME"]
 
+# Allow any IP for local development
+api_keys_ban_global_subnet = false
+
 # Allow dev sessions to last 5 days
 maximum_session_duration_minutes = 7200
 

--- a/server/conf/application.test.conf
+++ b/server/conf/application.test.conf
@@ -28,7 +28,8 @@ esri_address_service_area_validation_labels = ["Seattle"]
 esri_address_service_area_validation_ids = ["Seattle"]
 esri_address_service_area_validation_attributes = ["CITYNAME"]
 
-
+# Use the default stricter IP requirements for unit tests
+api_keys_ban_global_subnet = true
 
 question_cache_enabled=true
 name_suffix_dropdown_enabled = true


### PR DESCRIPTION
Typically we disallow the use of 0.0.0.0/0 in API keys for security reasons. This makes it more difficult to use the API locally for developers as it needs to be the Docker network IP which isn't guaranteed to be the same when starting a container.

This will let developers enter 0.0.0.0/0 when creating an API key on their local machine, which then the IP validation will allow any IP to connect.

This also reverts the unit tests config back to the stricter settings they already expect.

No changes to the browser tests config as they already allow any IP.
