### PR TITLE
Add addPreScreenerNS() to browser tests

### DIFF
--- a/browser-test/src/admin/admin_program_list.test.ts
+++ b/browser-test/src/admin/admin_program_list.test.ts
@@ -257,14 +257,10 @@ test.describe('Program list page.', () => {
     const preScreenerProgram = 'Pre screener program'
     const externalProgram = 'External'
     await adminPrograms.addProgram(program)
-    await adminPrograms.addProgram(
+    await adminPrograms.addPreScreenerNS(
       preScreenerProgram,
-      'program description',
       'short program description',
-      'https://usa.gov',
       ProgramVisibility.PUBLIC,
-      'admin description',
-      ProgramType.PRE_SCREENER,
     )
     await adminPrograms.addProgram(
       externalProgram,

--- a/browser-test/src/applicant/navigation/northstar_application_navigation_pre_screener.test.ts
+++ b/browser-test/src/applicant/navigation/northstar_application_navigation_pre_screener.test.ts
@@ -12,7 +12,7 @@ import {
   validateScreenshot,
   waitForPageJsLoad,
 } from '../../support'
-import {ProgramType, ProgramVisibility} from '../../support/admin_programs'
+import {ProgramVisibility} from '../../support/admin_programs'
 import {CardSectionName} from '../../support/applicant_program_list'
 
 test.describe('Applicant navigation flow', {tag: ['@northstar']}, () => {
@@ -37,14 +37,10 @@ test.describe('Applicant navigation flow', {tag: ['@northstar']}, () => {
         })
 
         // Set up pre-screener form
-        await adminPrograms.addProgram(
+        await adminPrograms.addPreScreenerNS(
           preScreenerProgramName,
-          'program description',
           'short program description',
-          'https://usa.gov',
           ProgramVisibility.PUBLIC,
-          'admin description',
-          ProgramType.PRE_SCREENER,
         )
 
         await adminPrograms.editProgramBlock(

--- a/browser-test/src/applicant/northstar_applicant_application_index.test.ts
+++ b/browser-test/src/applicant/northstar_applicant_application_index.test.ts
@@ -702,14 +702,10 @@ test.describe('applicant program index page', {tag: ['@northstar']}, () => {
     test.beforeEach(async ({page, adminPrograms}) => {
       await loginAsAdmin(page)
 
-      await adminPrograms.addProgram(
+      await adminPrograms.addPreScreenerNS(
         preScreenerFormProgramName,
-        'program description',
         'short program description',
-        'https://usa.gov',
         ProgramVisibility.PUBLIC,
-        'admin description',
-        ProgramType.PRE_SCREENER,
       )
 
       await adminPrograms.addProgramBlockUsingSpec(preScreenerFormProgramName, {
@@ -1153,14 +1149,10 @@ test.describe(
       await test.step('create program with image as admin', async () => {
         await loginAsAdmin(page)
         const preScreenerFormProgramName = 'Benefits finder'
-        await adminPrograms.addProgram(
+        await adminPrograms.addPreScreenerNS(
           preScreenerFormProgramName,
-          'program description',
           'short program description',
-          'https://usa.gov',
           ProgramVisibility.PUBLIC,
-          'admin description',
-          ProgramType.PRE_SCREENER,
         )
 
         await adminPrograms.addProgram(programNameInProgressImage)

--- a/browser-test/src/applicant/northstar_pre_screener_upsell.test.ts
+++ b/browser-test/src/applicant/northstar_pre_screener_upsell.test.ts
@@ -10,7 +10,7 @@ import {
   loginAsTrustedIntermediary,
   waitForPageJsLoad,
 } from '../support'
-import {ProgramType, ProgramVisibility} from '../support/admin_programs'
+import {ProgramVisibility} from '../support/admin_programs'
 
 test.describe(
   'North Star Pre-Screener Upsell Tests',
@@ -23,14 +23,10 @@ test.describe(
       await loginAsAdmin(page)
 
       await test.step('Setup: Publish pre-screener program', async () => {
-        await adminPrograms.addProgram(
+        await adminPrograms.addPreScreenerNS(
           programName,
-          'Display description',
           'Short description',
-          'https://usa.gov',
           ProgramVisibility.PUBLIC,
-          'admin description',
-          ProgramType.PRE_SCREENER,
         )
         await adminPrograms.publishProgram(programName)
         await adminPrograms.expectActiveProgram(programName)

--- a/browser-test/src/support/admin_programs.ts
+++ b/browser-test/src/support/admin_programs.ts
@@ -213,6 +213,37 @@ export class AdminPrograms {
   }
 
   /**
+   * Creates a pre-screener with the given fields. Only the required fields for
+   * a pre-screener in North Star are filled in.
+   * If a test needs to add an optional field, add a new parameter with a
+   * default value to this function.
+   *
+   * @param {boolean} programName - Name of the program
+   * @param {string} shortDescription - Short description of the program
+   * @param {ProgramVisibility} visibility - Visibility of the program
+   */
+  async addPreScreenerNS(
+    programName: string,
+    shortDescription: string,
+    visibility: ProgramVisibility,
+  ) {
+    return this.addProgram(
+      programName,
+      /* description =*/ '',
+      shortDescription,
+      /* externalLink= */ '',
+      visibility,
+      /* adminDescription= */ '',
+      ProgramType.PRE_SCREENER,
+      /* selectedTI= */ 'none',
+      /* confirmationMessage= */ '',
+      /* eligibility= */ undefined,
+      /* submitNewProgram= */ true,
+      /* applicationSteps= */ [],
+    )
+  }
+
+  /**
    * Creates a program with given name.
    *
    * @param {boolean} submitNewProgram - If true, the new program will be submitted
@@ -258,7 +289,6 @@ export class AdminPrograms {
       '#program-display-short-description-textarea',
       shortDescription,
     )
-    await this.page.fill('#program-external-link-input', externalLink)
     await this.page.fill(
       '#program-confirmation-message-textarea',
       confirmationMessage,
@@ -269,7 +299,13 @@ export class AdminPrograms {
       await this.page.check(`label:has-text("${selectedTI}")`)
     }
 
-    await this.chooseEligibility(eligibility)
+    if (eligibility) {
+      await this.chooseEligibility(eligibility)
+    }
+
+    if (externalLink.length > 0) {
+      await this.page.fill('#program-external-link-input', externalLink)
+    }
 
     // Program type selector varies with the EXTERNAL_PROGRAM_CARDS feature.
     // When enabled, form has program type options. Otherwise, form has a


### PR DESCRIPTION
### Description

Add `addPreScreenerNS()` util method to browser tests. The existent `addProgram()` adds default values to form fields that are not used by pre-screeners. This new method guarantees that we only add all the required values for pre screeners in North Star. This will be helpful once we add more validation for disabled fields (e.g external link should be disabled for pre-screeners in NS)

No functionality changed.

### Checklist

#### General

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

### Issue(s) this completes

Part of #10183
