### PR TITLE
[RTL] Add arabic translations to seed questions

### DIFF
--- a/server/app/controllers/dev/seeding/SampleQuestionDefinitions.java
+++ b/server/app/controllers/dev/seeding/SampleQuestionDefinitions.java
@@ -291,7 +291,7 @@ public final class SampleQuestionDefinitions {
                   LocalizedStrings.of(
                       ImmutableMap.of(
                           Lang.forCode("en-US").toLocale(),
-                          "What is your name?",
+                          "How many pets do you have?",
                           Lang.forCode("ar").toLocale(),
                           "كم عدد الحيوانات الأليفة لديك؟")))
               .setQuestionHelpText(

--- a/server/app/controllers/dev/seeding/SampleQuestionDefinitions.java
+++ b/server/app/controllers/dev/seeding/SampleQuestionDefinitions.java
@@ -2,7 +2,9 @@ package controllers.dev.seeding;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import play.i18n.Lang;
 import services.LocalizedStrings;
 import services.question.PrimaryApplicantInfoTag;
 import services.question.QuestionOption;
@@ -33,8 +35,20 @@ public final class SampleQuestionDefinitions {
           QuestionDefinitionConfig.builder()
               .setName("Sample Address Question")
               .setDescription("description")
-              .setQuestionText(LocalizedStrings.withDefaultValue("What is your address?"))
-              .setQuestionHelpText(LocalizedStrings.withDefaultValue("help text"))
+              .setQuestionText(
+                  LocalizedStrings.of(
+                      ImmutableMap.of(
+                          Lang.forCode("en-US").toLocale(),
+                          "What is your address?",
+                          Lang.forCode("ar").toLocale(),
+                          "ما هو عنوانك؟?")))
+              .setQuestionHelpText(
+                  LocalizedStrings.of(
+                      ImmutableMap.of(
+                          Lang.forCode("en-US").toLocale(),
+                          "help text",
+                          Lang.forCode("ar").toLocale(),
+                          "نص المساعدة")))
               .build());
 
   private static final QuestionDefinitionConfig CHECKBOX_QUESTION_DEFINITION_CONFIG =
@@ -42,18 +56,53 @@ public final class SampleQuestionDefinitions {
           .setName("Sample Checkbox Question")
           .setDescription("description")
           .setQuestionText(
-              LocalizedStrings.withDefaultValue(
-                  "Which of the following kitchen instruments do you own?"))
-          .setQuestionHelpText(LocalizedStrings.withDefaultValue("help text"))
+              LocalizedStrings.of(
+                  ImmutableMap.of(
+                      Lang.forCode("en-US").toLocale(),
+                      "Which of the following kitchen instruments do you own?",
+                      Lang.forCode("ar").toLocale(),
+                      "أي من أدوات المطبخ التالية تملكها؟")))
+          .setQuestionHelpText(
+              LocalizedStrings.of(
+                  ImmutableMap.of(
+                      Lang.forCode("en-US").toLocale(),
+                      "help text",
+                      Lang.forCode("ar").toLocale(),
+                      "نص المساعدة")))
           .build();
 
   private static final ImmutableList<QuestionOption> CHECKBOX_QUESTION_OPTIONS =
       ImmutableList.of(
-          QuestionOption.create(1L, 1L, "toaster", LocalizedStrings.withDefaultValue("Toaster")),
           QuestionOption.create(
-              2L, 2L, "pepper_grinder", LocalizedStrings.withDefaultValue("Pepper Grinder")),
+              1L,
+              1L,
+              "toaster",
+              LocalizedStrings.of(
+                  ImmutableMap.of(
+                      Lang.forCode("en-US").toLocale(),
+                      "Toaster",
+                      Lang.forCode("ar").toLocale(),
+                      "محمصة الخبز"))),
           QuestionOption.create(
-              3L, 3L, "garlic_press", LocalizedStrings.withDefaultValue("Garlic Press")));
+              2L,
+              2L,
+              "pepper_grinder",
+              LocalizedStrings.of(
+                  ImmutableMap.of(
+                      Lang.forCode("en-US").toLocale(),
+                      "Pepper Grinder",
+                      Lang.forCode("ar").toLocale(),
+                      "مطحنة الفلفل"))),
+          QuestionOption.create(
+              3L,
+              3L,
+              "garlic_press",
+              LocalizedStrings.of(
+                  ImmutableMap.of(
+                      Lang.forCode("en-US").toLocale(),
+                      "Garlic Press",
+                      Lang.forCode("ar").toLocale(),
+                      "عصارة الثوم"))));
 
   @VisibleForTesting
   public static final MultiOptionQuestionDefinition CHECKBOX_QUESTION_DEFINITION =
@@ -69,8 +118,19 @@ public final class SampleQuestionDefinitions {
               .setName("Sample Currency Question")
               .setDescription("description")
               .setQuestionText(
-                  LocalizedStrings.withDefaultValue("How much should a scoop of ice cream cost?"))
-              .setQuestionHelpText(LocalizedStrings.withDefaultValue("help text"))
+                  LocalizedStrings.of(
+                      ImmutableMap.of(
+                          Lang.forCode("en-US").toLocale(),
+                          "How much should a scoop of ice cream cost?",
+                          Lang.forCode("ar").toLocale(),
+                          "كم ينبغي أن يكون سعر مغرفة الآيس كريم؟")))
+              .setQuestionHelpText(
+                  LocalizedStrings.of(
+                      ImmutableMap.of(
+                          Lang.forCode("en-US").toLocale(),
+                          "help text",
+                          Lang.forCode("ar").toLocale(),
+                          "نص المساعدة")))
               .build());
 
   private static final QuestionDefinitionConfig DROPDOWN_QUESTION_CONFIG =
@@ -78,9 +138,19 @@ public final class SampleQuestionDefinitions {
           .setName("Sample Dropdown Question")
           .setDescription("select your favorite ice cream flavor")
           .setQuestionText(
-              LocalizedStrings.withDefaultValue(
-                  "Select your favorite ice cream flavor from the following"))
-          .setQuestionHelpText(LocalizedStrings.withDefaultValue("this is sample help text"))
+              LocalizedStrings.of(
+                  ImmutableMap.of(
+                      Lang.forCode("en-US").toLocale(),
+                      "Select your favorite ice cream flavor from the following",
+                      Lang.forCode("ar").toLocale(),
+                      "اختر نكهة الآيس كريم المفضلة لديك من التالي")))
+          .setQuestionHelpText(
+              LocalizedStrings.of(
+                  ImmutableMap.of(
+                      Lang.forCode("en-US").toLocale(),
+                      "this is sample help text",
+                      Lang.forCode("ar").toLocale(),
+                      "هذه هي عينة مساعدة النص")))
           .build();
   private static final ImmutableList<QuestionOption> DROPDOWN_QUESTION_OPTIONS =
       ImmutableList.of(
@@ -102,8 +172,20 @@ public final class SampleQuestionDefinitions {
           QuestionDefinitionConfig.builder()
               .setName("Sample Email Question")
               .setDescription("description")
-              .setQuestionText(LocalizedStrings.withDefaultValue("What is your email?"))
-              .setQuestionHelpText(LocalizedStrings.withDefaultValue("help text"))
+              .setQuestionText(
+                  LocalizedStrings.of(
+                      ImmutableMap.of(
+                          Lang.forCode("en-US").toLocale(),
+                          "What is your email?",
+                          Lang.forCode("ar").toLocale(),
+                          "ما هو بريدك الالكتروني؟")))
+              .setQuestionHelpText(
+                  LocalizedStrings.of(
+                      ImmutableMap.of(
+                          Lang.forCode("en-US").toLocale(),
+                          "help text",
+                          Lang.forCode("ar").toLocale(),
+                          "نص المساعدة")))
               .setUniversal(true)
               .setPrimaryApplicantInfoTags(ImmutableSet.of(PrimaryApplicantInfoTag.APPLICANT_EMAIL))
               .build());
@@ -116,9 +198,20 @@ public final class SampleQuestionDefinitions {
               .setDescription("description")
               .setQuestionText(
                   LocalizedStrings.withDefaultValue("List all members of your household."))
-              .setQuestionHelpText(LocalizedStrings.withDefaultValue("help text"))
+              .setQuestionHelpText(
+                  LocalizedStrings.of(
+                      ImmutableMap.of(
+                          Lang.forCode("en-US").toLocale(),
+                          "help text",
+                          Lang.forCode("ar").toLocale(),
+                          "نص المساعدة")))
               .build(),
-          LocalizedStrings.withDefaultValue("household member"));
+          LocalizedStrings.of(
+              ImmutableMap.of(
+                  Lang.forCode("en-US").toLocale(),
+                  "household member",
+                  Lang.forCode("ar").toLocale(),
+                  "عضو في الأسرة")));
 
   @VisibleForTesting
   public static final FileUploadQuestionDefinition FILE_UPLOAD_QUESTION_DEFINITION =
@@ -127,8 +220,19 @@ public final class SampleQuestionDefinitions {
               .setName("Sample File Upload Question")
               .setDescription("description")
               .setQuestionText(
-                  LocalizedStrings.withDefaultValue("Upload anything from your computer"))
-              .setQuestionHelpText(LocalizedStrings.withDefaultValue("help text"))
+                  LocalizedStrings.of(
+                      ImmutableMap.of(
+                          Lang.forCode("en-US").toLocale(),
+                          "Upload anything from your computer",
+                          Lang.forCode("ar").toLocale(),
+                          "تحميل أي شيء من جهاز الكمبيوتر الخاص بك")))
+              .setQuestionHelpText(
+                  LocalizedStrings.of(
+                      ImmutableMap.of(
+                          Lang.forCode("en-US").toLocale(),
+                          "help text",
+                          Lang.forCode("ar").toLocale(),
+                          "نص المساعدة")))
               .build());
 
   @VisibleForTesting
@@ -138,8 +242,19 @@ public final class SampleQuestionDefinitions {
               .setName("Sample ID Question")
               .setDescription("description")
               .setQuestionText(
-                  LocalizedStrings.withDefaultValue("What is your driver's license ID?"))
-              .setQuestionHelpText(LocalizedStrings.withDefaultValue("help text"))
+                  LocalizedStrings.of(
+                      ImmutableMap.of(
+                          Lang.forCode("en-US").toLocale(),
+                          "What is your driver's license ID?",
+                          Lang.forCode("ar").toLocale(),
+                          "ما هو رقم رخصة القيادة الخاصة بك؟")))
+              .setQuestionHelpText(
+                  LocalizedStrings.of(
+                      ImmutableMap.of(
+                          Lang.forCode("en-US").toLocale(),
+                          "help text",
+                          Lang.forCode("ar").toLocale(),
+                          "نص المساعدة")))
               .build());
 
   @VisibleForTesting
@@ -148,8 +263,20 @@ public final class SampleQuestionDefinitions {
           QuestionDefinitionConfig.builder()
               .setName("Sample Name Question")
               .setDescription("description")
-              .setQuestionText(LocalizedStrings.withDefaultValue("What is your name?"))
-              .setQuestionHelpText(LocalizedStrings.withDefaultValue("help text"))
+              .setQuestionText(
+                  LocalizedStrings.of(
+                      ImmutableMap.of(
+                          Lang.forCode("en-US").toLocale(),
+                          "What is your name?",
+                          Lang.forCode("ar").toLocale(),
+                          "ما اسمك؟")))
+              .setQuestionHelpText(
+                  LocalizedStrings.of(
+                      ImmutableMap.of(
+                          Lang.forCode("en-US").toLocale(),
+                          "help text",
+                          Lang.forCode("ar").toLocale(),
+                          "نص المساعدة")))
               .setUniversal(true)
               .setPrimaryApplicantInfoTags(ImmutableSet.of(PrimaryApplicantInfoTag.APPLICANT_NAME))
               .build());
@@ -160,16 +287,40 @@ public final class SampleQuestionDefinitions {
           QuestionDefinitionConfig.builder()
               .setName("Sample Number Question")
               .setDescription("description")
-              .setQuestionText(LocalizedStrings.withDefaultValue("How many pets do you have?"))
-              .setQuestionHelpText(LocalizedStrings.withDefaultValue("help text"))
+              .setQuestionText(
+                  LocalizedStrings.of(
+                      ImmutableMap.of(
+                          Lang.forCode("en-US").toLocale(),
+                          "What is your name?",
+                          Lang.forCode("ar").toLocale(),
+                          "كم عدد الحيوانات الأليفة لديك؟")))
+              .setQuestionHelpText(
+                  LocalizedStrings.of(
+                      ImmutableMap.of(
+                          Lang.forCode("en-US").toLocale(),
+                          "help text",
+                          Lang.forCode("ar").toLocale(),
+                          "نص المساعدة")))
               .build());
 
   private static final QuestionDefinitionConfig RADIO_BUTTON_QUESTION_CONFIG =
       QuestionDefinitionConfig.builder()
           .setName("Sample Radio Button Question")
           .setDescription("favorite season in the year")
-          .setQuestionText(LocalizedStrings.withDefaultValue("What is your favorite season?"))
-          .setQuestionHelpText(LocalizedStrings.withDefaultValue("this is sample help text"))
+          .setQuestionText(
+              LocalizedStrings.of(
+                  ImmutableMap.of(
+                      Lang.forCode("en-US").toLocale(),
+                      "What is your favorite season?",
+                      Lang.forCode("ar").toLocale(),
+                      "ما هو موسمك المفضل؟")))
+          .setQuestionHelpText(
+              LocalizedStrings.of(
+                  ImmutableMap.of(
+                      Lang.forCode("en-US").toLocale(),
+                      "this is sample help text",
+                      Lang.forCode("ar").toLocale(),
+                      "هذه هي عينة مساعدة النص")))
           .build();
 
   private static final ImmutableList<QuestionOption> RADIO_BUTTON_QUESTION_OPTIONS =
@@ -195,14 +346,25 @@ public final class SampleQuestionDefinitions {
               .setName("Sample Static Content Question")
               .setDescription("description")
               .setQuestionText(
-                  LocalizedStrings.withDefaultValue(
-                      """
-                      Hi I'm a block of static text.
-                       * Welcome to this __test program__.
-                       * It contains one of every question type.
+                  LocalizedStrings.of(
+                      ImmutableMap.of(
+                          Lang.forCode("en-US").toLocale(),
+                          """
+                          Hi I'm a block of static text.
+                           * Welcome to this __test program__.
+                           * It contains one of every question type.
 
-                      ## What are the eligibility requirements?
-                      Please go [here](https://www.example.com) for more information"""))
+                          ## What are the eligibility requirements?
+                          Please go [here](https://www.example.com) for more information""",
+                          Lang.forCode("ar").toLocale(),
+                          """
+                           مرحبًا، أنا كتلة من النص الثابت.
+                            * مرحبا بكم في هذا برنامج الاختبار
+                            * يحتوي على سؤال واحد من كل نوع.
+
+                          ## ما هي متطلبات الأهلية؟
+                          يرجى الذهاب إلى [نا](https://www.example.com) لمزيد من المعلومات
+                          """)))
               .setQuestionHelpText(LocalizedStrings.withDefaultValue(""))
               .build());
 
@@ -212,8 +374,20 @@ public final class SampleQuestionDefinitions {
           QuestionDefinitionConfig.builder()
               .setName("Sample Text Question")
               .setDescription("description")
-              .setQuestionText(LocalizedStrings.withDefaultValue("What is your favorite color?"))
-              .setQuestionHelpText(LocalizedStrings.withDefaultValue("help text"))
+              .setQuestionText(
+                  LocalizedStrings.of(
+                      ImmutableMap.of(
+                          Lang.forCode("en-US").toLocale(),
+                          "What is your favorite color?",
+                          Lang.forCode("ar").toLocale(),
+                          "ما هو لونك المفضل؟")))
+              .setQuestionHelpText(
+                  LocalizedStrings.of(
+                      ImmutableMap.of(
+                          Lang.forCode("en-US").toLocale(),
+                          "help text",
+                          Lang.forCode("ar").toLocale(),
+                          "نص المساعدة")))
               .build());
 
   @VisibleForTesting
@@ -222,8 +396,20 @@ public final class SampleQuestionDefinitions {
           QuestionDefinitionConfig.builder()
               .setName("Sample Phone Question")
               .setDescription("description")
-              .setQuestionText(LocalizedStrings.withDefaultValue("what is your phone number"))
-              .setQuestionHelpText(LocalizedStrings.withDefaultValue("help text"))
+              .setQuestionText(
+                  LocalizedStrings.of(
+                      ImmutableMap.of(
+                          Lang.forCode("en-US").toLocale(),
+                          "what is your phone number",
+                          Lang.forCode("ar").toLocale(),
+                          "ما هو رقم هاتفك؟")))
+              .setQuestionHelpText(
+                  LocalizedStrings.of(
+                      ImmutableMap.of(
+                          Lang.forCode("en-US").toLocale(),
+                          "help text",
+                          Lang.forCode("ar").toLocale(),
+                          "نص المساعدة")))
               .setUniversal(true)
               .setPrimaryApplicantInfoTags(ImmutableSet.of(PrimaryApplicantInfoTag.APPLICANT_PHONE))
               .build());
@@ -234,8 +420,20 @@ public final class SampleQuestionDefinitions {
           QuestionDefinitionConfig.builder()
               .setName("Sample Date Question")
               .setDescription("description")
-              .setQuestionText(LocalizedStrings.withDefaultValue("When is your birthday?"))
-              .setQuestionHelpText(LocalizedStrings.withDefaultValue("help text"))
+              .setQuestionText(
+                  LocalizedStrings.of(
+                      ImmutableMap.of(
+                          Lang.forCode("en-US").toLocale(),
+                          "When is your birthday?",
+                          Lang.forCode("ar").toLocale(),
+                          "متى يحين عيد ميلادك؟")))
+              .setQuestionHelpText(
+                  LocalizedStrings.of(
+                      ImmutableMap.of(
+                          Lang.forCode("en-US").toLocale(),
+                          "help text",
+                          Lang.forCode("ar").toLocale(),
+                          "نص المساعدة")))
               .setUniversal(true)
               .setPrimaryApplicantInfoTags(ImmutableSet.of(PrimaryApplicantInfoTag.APPLICANT_DOB))
               .build());
@@ -245,8 +443,20 @@ public final class SampleQuestionDefinitions {
           QuestionDefinitionConfig.builder()
               .setName("Sample Predicate Date Question")
               .setDescription("description")
-              .setQuestionText(LocalizedStrings.withDefaultValue("When is your birthday?"))
-              .setQuestionHelpText(LocalizedStrings.withDefaultValue("help text"))
+              .setQuestionText(
+                  LocalizedStrings.of(
+                      ImmutableMap.of(
+                          Lang.forCode("en-US").toLocale(),
+                          "When is your birthday?",
+                          Lang.forCode("ar").toLocale(),
+                          "متى يحين عيد ميلادك؟")))
+              .setQuestionHelpText(
+                  LocalizedStrings.of(
+                      ImmutableMap.of(
+                          Lang.forCode("en-US").toLocale(),
+                          "help text",
+                          Lang.forCode("ar").toLocale(),
+                          "نص المساعدة")))
               .build());
 
   private static final QuestionDefinitionConfig.Builder

--- a/server/app/services/seeding/DatabaseSeedTask.java
+++ b/server/app/services/seeding/DatabaseSeedTask.java
@@ -62,6 +62,8 @@ public final class DatabaseSeedTask {
                   ImmutableMap.of(
                       Lang.forCode("am").toLocale(),
                       "ስም (የመጀመሪያ ስም እና የመጨረሻ ስም አህጽሮት ይሆናል)",
+                      Lang.forCode("ar").toLocale(),
+                      "الرجاء إدخال اسمك الأول والأخير",
                       Lang.forCode("ko").toLocale(),
                       "성함 (이름 및 성의 경우 이니셜도 괜찮음)",
                       Lang.forCode("so").toLocale(),
@@ -86,8 +88,11 @@ public final class DatabaseSeedTask {
           .setDescription("Applicant's date of birth")
           .setQuestionText(
               LocalizedStrings.of(
-                  Lang.forCode("en-US").toLocale(),
-                  "Please enter your date of birth in the format mm/dd/yyyy"))
+                  ImmutableMap.of(
+                      Lang.forCode("en-US").toLocale(),
+                      "Please enter your date of birth in the format mm/dd/yyyy",
+                      Lang.forCode("ar").toLocale(),
+                      "الرجاء إدخال تاريخ ميلادك بالتنسيق mm/dd/yyyy")))
           .unsafeBuild();
 
   private static final ImmutableList<QuestionDefinition> CANONICAL_QUESTIONS =


### PR DESCRIPTION
### Description

To help with testing, add Arabic translations to sample questions. 

This doesn't provide a translation for every single question/answer in Comprehensive Sample Program, but pretty close. I used Google Translate to source the Arabic translations and didn't verify accuracy, but that should be OK since it's a dev program, and we're only using the translations to determine whether or not the formatting looks correct in RTL mode.

#10606

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.
