### PR TITLE
Wrap program import in a transaction

### DIFF
--- a/server/app/controllers/admin/AdminImportController.java
+++ b/server/app/controllers/admin/AdminImportController.java
@@ -17,6 +17,8 @@ import models.DisplayMode;
 import models.ProgramModel;
 import models.VersionModel;
 import org.pac4j.play.java.Secure;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import parsers.LargeFormUrlEncodedBodyParser;
 import play.data.DynamicForm;
 import play.data.Form;
@@ -51,6 +53,7 @@ import views.admin.migration.AdminProgramImportForm;
  * environment (e.g. production).
  */
 public class AdminImportController extends CiviFormController {
+  private final Logger logger = LoggerFactory.getLogger(AdminImportController.class);
   private final AdminImportView adminImportView;
   private final AdminImportViewPartial adminImportViewPartial;
   private final FormFactory formFactory;
@@ -349,6 +352,7 @@ public class AdminImportController extends CiviFormController {
                   request, savedProgramDefinition.adminName(), savedProgramDefinition.id())
               .render());
     } catch (RuntimeException error) {
+      logger.error("Error saving program", error);
       return ok(
           adminImportViewPartial
               .renderError(

--- a/server/app/services/migration/ProgramMigrationService.java
+++ b/server/app/services/migration/ProgramMigrationService.java
@@ -35,6 +35,7 @@ import org.slf4j.LoggerFactory;
 import repository.ApplicationStatusesRepository;
 import repository.ProgramRepository;
 import repository.QuestionRepository;
+import repository.TransactionManager;
 import repository.VersionRepository;
 import services.ErrorAnd;
 import services.LocalizedStrings;
@@ -68,6 +69,7 @@ public final class ProgramMigrationService {
   private final QuestionRepository questionRepository;
   private final QuestionService questionService;
   private final VersionRepository versionRepository;
+  private final TransactionManager transactionManager;
 
   @Inject
   public ProgramMigrationService(
@@ -76,7 +78,8 @@ public final class ProgramMigrationService {
       ProgramRepository programRepository,
       QuestionRepository questionRepository,
       QuestionService questionService,
-      VersionRepository versionRepository) {
+      VersionRepository versionRepository,
+      TransactionManager transactionManager) {
     // These extra modules let ObjectMapper serialize Guava types like ImmutableList.
     this.objectMapper =
         checkNotNull(objectMapper)
@@ -88,6 +91,7 @@ public final class ProgramMigrationService {
     this.questionRepository = checkNotNull(questionRepository);
     this.questionService = checkNotNull(questionService);
     this.versionRepository = checkNotNull(versionRepository);
+    this.transactionManager = checkNotNull(transactionManager);
   }
 
   /**
@@ -384,8 +388,6 @@ public final class ProgramMigrationService {
           duplicateHandlingOptions,
       boolean withDuplicates,
       boolean duplicateHandlingEnabled) {
-    ProgramDefinition updatedProgram = programDefinition;
-    // Get the overwritten admin names
     // TODO: #9628 - Validate that repeated questions are not being reused/overwritten if their
     // parent question was duplicated with a new admin name. If a parent question is duplicated, the
     // repeated questions must also be duplicated (or updated, if it's new).
@@ -393,7 +395,50 @@ public final class ProgramMigrationService {
         Utils.getQuestionNamesForDuplicateHandling(
             duplicateHandlingOptions,
             ProgramMigrationWrapper.DuplicateQuestionHandlingOption.OVERWRITE_EXISTING);
+    ImmutableList<String> duplicatedQuestions =
+        Utils.getQuestionNamesForDuplicateHandling(
+            duplicateHandlingOptions,
+            ProgramMigrationWrapper.DuplicateQuestionHandlingOption.CREATE_DUPLICATE);
+    ImmutableList<String> reusedQuestions =
+        Utils.getQuestionNamesForDuplicateHandling(
+            duplicateHandlingOptions,
+            ProgramMigrationWrapper.DuplicateQuestionHandlingOption.USE_EXISTING);
 
+    if (duplicateHandlingEnabled) {
+      // Using a transaction batch could improve performance. Ebeans batching consistently
+      // misbehaves in this instance, since there are many nested transactions. So we do not enable
+      // batching.
+      return transactionManager.execute(
+          () ->
+              doSaveProgram(
+                  programDefinition,
+                  questionDefinitions,
+                  overwrittenQuestions,
+                  duplicatedQuestions,
+                  reusedQuestions,
+                  withDuplicates,
+                  duplicateHandlingEnabled));
+    }
+
+    return doSaveProgram(
+        programDefinition,
+        questionDefinitions,
+        overwrittenQuestions,
+        duplicatedQuestions,
+        reusedQuestions,
+        withDuplicates,
+        duplicateHandlingEnabled);
+  }
+
+  private ErrorAnd<ProgramModel, String> doSaveProgram(
+      ProgramDefinition programDefinition,
+      ImmutableList<QuestionDefinition> questionDefinitions,
+      ImmutableList<String> overwrittenQuestions,
+      ImmutableList<String> duplicatedQuestions,
+      ImmutableList<String> reusedQuestions,
+      boolean withDuplicates,
+      boolean duplicateHandlingEnabled) {
+    ProgramDefinition updatedProgram = programDefinition;
     if (questionDefinitions != null) {
       if (duplicateHandlingEnabled) {
         if (overwrittenQuestions.size() > 0 && draftIsPopulated()) {
@@ -407,36 +452,27 @@ public final class ProgramMigrationService {
         // name at this point.
         questionDefinitions =
             ImmutableList.copyOf(
-                overwriteDuplicateNames(
-                        questionDefinitions,
-                        Utils.getQuestionNamesForDuplicateHandling(
-                            duplicateHandlingOptions,
-                            ProgramMigrationWrapper.DuplicateQuestionHandlingOption
-                                .CREATE_DUPLICATE))
-                    .values());
+                overwriteDuplicateNames(questionDefinitions, duplicatedQuestions).values());
       }
       ImmutableMap<Long, QuestionDefinition> questionsOnJsonById =
           questionDefinitions.stream()
               .collect(ImmutableMap.toImmutableMap(QuestionDefinition::getId, qd -> qd));
 
-      ImmutableList<String> reusedQuestionNames =
-          Utils.getQuestionNamesForDuplicateHandling(
-              duplicateHandlingOptions,
-              ProgramMigrationWrapper.DuplicateQuestionHandlingOption.USE_EXISTING);
       // Get the questions that will be reused
-      ImmutableList<QuestionDefinition> reusedQuestions =
+      ImmutableList<QuestionDefinition> reusedQuestionDefinitions =
           questionDefinitions.stream()
-              .filter(q -> reusedQuestionNames.contains(q.getName()))
+              .filter(q -> reusedQuestions.contains(q.getName()))
               .collect(ImmutableList.toImmutableList());
       // Need IDs of currently saved Qs
       ImmutableMap<String, QuestionDefinition> updatedQuestionsMap =
           updateEnumeratorIdsAndSaveQuestions(
               // Only save questions that are not reused from the question bank
               questionDefinitions.stream()
-                  .filter(q -> !reusedQuestionNames.contains(q.getName()))
+                  .filter(q -> !reusedQuestions.contains(q.getName()))
                   .collect(ImmutableList.toImmutableList()),
-              reusedQuestions,
-              questionsOnJsonById);
+              reusedQuestionDefinitions,
+              questionsOnJsonById,
+              duplicateHandlingEnabled);
 
       ImmutableList<BlockDefinition> updatedBlockDefinitions =
           Utils.updateBlockDefinitions(programDefinition, questionsOnJsonById, updatedQuestionsMap);
@@ -473,17 +509,21 @@ public final class ProgramMigrationService {
    *     have a new adminName or updated configuration
    * @param questionsToReuseFromBank full question definitions that are being reused from the bank
    * @param questionsOnJsonById a map of question IDs to the question definitions from the JSON
+   * @param duplicateHandlingEnabled whether duplicate handling is enabled
    * @return a map of question names to the fully updated question definitions
    */
   @VisibleForTesting
   ImmutableMap<String, QuestionDefinition> updateEnumeratorIdsAndSaveQuestions(
       ImmutableList<QuestionDefinition> questionsToWrite,
       ImmutableList<QuestionDefinition> questionsToReuseFromBank,
-      ImmutableMap<Long, QuestionDefinition> questionsOnJsonById) {
+      ImmutableMap<Long, QuestionDefinition> questionsOnJsonById,
+      boolean duplicateHandlingEnabled) {
 
     // Save all the questions
     ImmutableList<QuestionModel> newlySavedQuestions =
-        questionRepository.bulkCreateQuestions(questionsToWrite);
+        duplicateHandlingEnabled
+            ? questionRepository.bulkCreateQuestions(questionsToWrite)
+            : questionRepository.bulkCreateQuestionsInTransaction(questionsToWrite);
 
     // Get the question IDs of the questions we are reusing from the question bank
     ImmutableMap<String, QuestionDefinition> reusedQuestions =
@@ -527,7 +567,6 @@ public final class ProgramMigrationService {
                   return question;
                 })
             .collect(ImmutableMap.toImmutableMap(QuestionDefinition::getName, qd -> qd));
-
     return fullyUpdatedQuestions;
   }
 

--- a/server/test/repository/QuestionRepositoryTest.java
+++ b/server/test/repository/QuestionRepositoryTest.java
@@ -2,7 +2,9 @@ package repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.assertThrows;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import io.ebean.DataIntegrityException;
 import java.util.Locale;
@@ -20,15 +22,19 @@ import services.question.types.QuestionDefinition;
 import services.question.types.QuestionDefinitionBuilder;
 import services.question.types.QuestionDefinitionConfig;
 import services.question.types.TextQuestionDefinition;
+import support.TestQuestionBank;
 
 public class QuestionRepositoryTest extends ResetPostgres {
-
+  private static final TestQuestionBank disconnectedQuestionBank =
+      new TestQuestionBank(/* canSave= */ false);
   private QuestionRepository repo;
+  private TransactionManager transactionManager;
   private VersionRepository versionRepo;
 
   @Before
   public void setupQuestionRepository() {
     repo = instanceOf(QuestionRepository.class);
+    transactionManager = instanceOf(TransactionManager.class);
     versionRepo = instanceOf(VersionRepository.class);
   }
 
@@ -191,18 +197,8 @@ public class QuestionRepositoryTest extends ResetPostgres {
 
   @Test
   public void insertQuestion() {
-    QuestionDefinition questionDefinition =
-        new TextQuestionDefinition(
-            QuestionDefinitionConfig.builder()
-                .setName("question")
-                .setDescription("applicant's name")
-                .setQuestionText(LocalizedStrings.of(Locale.US, "What is your name?"))
-                .setQuestionHelpText(LocalizedStrings.empty())
-                .build());
-    QuestionModel question = new QuestionModel(questionDefinition);
-
-    repo.insertQuestion(question).toCompletableFuture().join();
-    long id = question.id;
+    repo.insertQuestion(disconnectedQuestionBank.nameApplicantName()).toCompletableFuture().join();
+    long id = testQuestionBank.nameApplicantName().id;
     QuestionModel q = repo.lookupQuestion(id).toCompletableFuture().join().get();
 
     assertThat(q.id).isEqualTo(id);
@@ -495,6 +491,33 @@ public class QuestionRepositoryTest extends ResetPostgres {
                 .getQuestionTags()
                 .contains(PrimaryApplicantInfoTag.APPLICANT_PHONE.getQuestionTag()))
         .isFalse();
+  }
+
+  @Test
+  public void bulkCreateQuestions_withoutTransaction_throws() {
+    Exception e =
+        assertThrows(
+            IllegalStateException.class, () -> repo.bulkCreateQuestions(ImmutableList.of()));
+
+    assertThat(e)
+        .hasMessageContaining("bulkCreateQuestions must be called from within a transaction");
+  }
+
+  @Test
+  public void bulkCreateQuestions_createsAllQuestions() {
+    ImmutableList<QuestionDefinition> questionsToSave =
+        ImmutableList.of(
+            disconnectedQuestionBank.nameApplicantName().getQuestionDefinition(),
+            disconnectedQuestionBank.addressApplicantAddress().getQuestionDefinition());
+
+    ImmutableList<QuestionModel> savedQuestions =
+        transactionManager.execute(
+            () -> {
+              return repo.bulkCreateQuestions(questionsToSave);
+            });
+
+    assertThat(savedQuestions).hasSize(2);
+    assertThat(repo.listQuestions().toCompletableFuture().join()).hasSize(2);
   }
 
   private QuestionDefinition addTagToDefinition(QuestionModel question)


### PR DESCRIPTION
### Description

Since we are performing a series of sequential reads writes, we wrap all the business logic that interacts with the DB in a transaction. To do this, we had to tweak a few other classes, but it is pretty straightforward.

`bulkCreateQuestions` is only called from the `programMigrationService`, so since we added a top-level transaction, we can remove the transaction at that nested level.

#9628

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.