### PR TITLE
Disable external field v2

### DIFF
--- a/browser-test/src/support/admin_programs.ts
+++ b/browser-test/src/support/admin_programs.ts
@@ -46,6 +46,7 @@ export enum FormField {
   NOTIFICATION_PREFERENCES,
   PROGRAM_CATEGORIES,
   PROGRAM_ELIGIBILITY,
+  PROGRAM_EXTERNAL_LINK
 }
 
 export enum ProgramType {
@@ -213,8 +214,8 @@ export class AdminPrograms {
   }
 
   /**
-   * Creates a pre-screener with the given fields. Only the required fields for
-   * a pre-screener in North Star are filled in.
+   * Creates a pre-screener with the given fields, which are all the ones
+   * required for creating a pre-screener in North Star.
    *
    * @param {boolean} programName - Name of the program
    * @param {string} shortDescription - Short description of the program
@@ -254,7 +255,7 @@ export class AdminPrograms {
     programName: string,
     description = 'program description',
     shortDescription = 'short program description',
-    externalLink = 'https://usa.gov',
+    externalLink = '',
     visibility = ProgramVisibility.PUBLIC,
     adminDescription = 'admin description',
     programType: ProgramType = ProgramType.DEFAULT,
@@ -291,6 +292,10 @@ export class AdminPrograms {
       '#program-confirmation-message-textarea',
       confirmationMessage,
     )
+
+    if (externalLink.length > 0) {
+      await this.page.fill('#program-external-link-input', externalLink)
+    }
 
     await this.page.check(`label:has-text("${visibility}")`)
     if (visibility == ProgramVisibility.SELECT_TI) {
@@ -376,7 +381,6 @@ export class AdminPrograms {
         const longDescription = this.getLongDescriptionField()
         await expect(longDescription).toBeDisabled()
         expect(await longDescription.getAttribute('readonly')).not.toBeNull()
-
         break
       }
 
@@ -407,6 +411,13 @@ export class AdminPrograms {
           await expect(option).toBeDisabled()
           await expect(option).not.toBeChecked()
         }
+        break
+      }
+
+      case FormField.PROGRAM_EXTERNAL_LINK: {
+        const externalLink = this.getExternalLinkField()
+        await expect(externalLink).toBeDisabled()
+        expect(await externalLink.getAttribute('readonly')).not.toBeNull()
         break
       }
 
@@ -485,6 +496,13 @@ export class AdminPrograms {
           })
           await expect(option).toBeEnabled()
         }
+        break
+      }
+
+      case FormField.PROGRAM_EXTERNAL_LINK: {
+        const externalLink = this.getExternalLinkField()
+        await expect(externalLink).toBeEnabled()
+        expect(await externalLink.getAttribute('readonly')).toBeNull()
         break
       }
 
@@ -1758,6 +1776,12 @@ export class AdminPrograms {
   getProgramTypeOption(programType: string): Locator {
     return this.page.getByRole('radio', {
       name: programType,
+    })
+  }
+
+  getExternalLinkField(): Locator {
+    return this.page.getByRole('textbox', {
+      name: 'Link to program website',
     })
   }
 

--- a/server/app/assets/javascripts/admin_programs.ts
+++ b/server/app/assets/javascripts/admin_programs.ts
@@ -103,16 +103,31 @@ class AdminPrograms {
       /* shouldDisable= */ disableNotificationPreferences,
     )
 
-    // Long program description
-    const longDescription = document.getElementById(
-      'program-display-description-textarea',
+    // External link
+    const externalLink = document.getElementById(
+      'program-external-link-input',
     ) as HTMLInputElement
+    const isNorthstarEnabled = externalLink.dataset.northstarEnabled === 'true'
+    const disableExternalLink =
+      (programType === ProgramType.DEFAULT ||
+        programType === ProgramType.COMMON_INTAKE_FORM) &&
+      isNorthstarEnabled
+    this.updateTextFieldElementDisabledState(
+      /* fieldElement= */ externalLink,
+      /* shouldDisable= */ disableExternalLink,
+    )
+    this.hideRequiredIndicators(
+      /* fieldSelector= */ 'label[for="program-external-link-input"]',
+      /* shouldHide= */ disableExternalLink,
+    )
+
+    // Long program description
     const disableLongDescription =
       (programType === ProgramType.COMMON_INTAKE_FORM ||
         programType === ProgramType.EXTERNAL) &&
-      longDescription.dataset.northstarEnabled === 'true'
-    this.updateTextFieldElementDisabledState(
-      /* fieldElement= */ longDescription,
+      isNorthstarEnabled
+    this.updateTextFieldSelectorsDisabledState(
+      /* fieldElement= */ 'textarea[id="program-display-description-textarea"]',
       /* shouldDisable= */ disableLongDescription,
     )
 
@@ -129,7 +144,11 @@ class AdminPrograms {
       /* shouldDisable= */ disableApplicationSteps,
     )
     this.hideRequiredIndicators(
-      /* fieldSelector= */ '#apply-step-1-div',
+      /* fieldSelector= */ 'label[for="apply-step-1-title"]',
+      /* shouldHide= */ disableApplicationSteps,
+    )
+    this.hideRequiredIndicators(
+      /* fieldSelector= */ 'label[for="apply-step-1-description"]',
       /* shouldHide= */ disableApplicationSteps,
     )
 
@@ -211,15 +230,28 @@ class AdminPrograms {
    * @param {boolean} shouldHide - Whether to show or hide the required indicator
    */
   static hideRequiredIndicators(fieldSelector: string, shouldHide: boolean) {
-    const field = document.querySelector(fieldSelector)
-    const requiredIndicators = field?.querySelectorAll('span')
-    requiredIndicators?.forEach((indicator) => {
-      if (shouldHide) {
-        indicator.classList.add('hidden')
-      } else {
-        indicator.classList.remove('hidden')
-      }
-    })
+    const labelElement = document.querySelector(fieldSelector)
+    if (!labelElement) {
+      return
+    }
+
+    let requiredSpan = labelElement.querySelector(
+      'span.text-red-600.font-semibold',
+    )
+    if (!requiredSpan) {
+      // If the required indicator is not present, add it.
+      requiredSpan = document.createElement('span')
+      requiredSpan.className = 'text-red-600 font-semibold'
+      requiredSpan.setAttribute('aria-hidden', 'true')
+      requiredSpan.innerHTML = '&nbsp;*'
+      labelElement.appendChild(requiredSpan)
+    }
+
+    if (shouldHide) {
+      requiredSpan.classList.add('hidden')
+    } else {
+      requiredSpan.classList.remove('hidden')
+    }
   }
 
   static attachEventListenersToEditTIButton() {

--- a/server/app/views/admin/programs/ProgramFormBuilder.java
+++ b/server/app/views/admin/programs/ProgramFormBuilder.java
@@ -153,12 +153,15 @@ abstract class ProgramFormBuilder extends BaseHtmlView {
       ImmutableSet<Long> selectedTi,
       ImmutableList<Long> categories,
       ImmutableList<Map<String, String>> applicationSteps) {
+    boolean isDefaultProgram = programType.equals(ProgramType.DEFAULT);
     boolean isCommonIntakeForm = programType.equals(ProgramType.COMMON_INTAKE_FORM);
     boolean isExternalProgram = programType.equals(ProgramType.EXTERNAL);
+    boolean isNorthStartEnabled = settingsManifest.getNorthStarApplicantUi(request);
+
     boolean disableProgramEligibility = isCommonIntakeForm || isExternalProgram;
+    boolean disableExternalLink = (isDefaultProgram || isCommonIntakeForm) && isNorthStartEnabled;
     boolean disableLongDescription =
-        (isCommonIntakeForm || isExternalProgram)
-            && settingsManifest.getNorthStarApplicantUi(request);
+        (isCommonIntakeForm || isExternalProgram) && isNorthStartEnabled;
     boolean disableEmailNotifications = isExternalProgram;
     boolean disableApplicationSteps = isCommonIntakeForm || isExternalProgram;
     boolean disableConfirmationMessage = isExternalProgram;
@@ -290,6 +293,12 @@ abstract class ProgramFormBuilder extends BaseHtmlView {
             .setFieldName("externalLink")
             .setLabelText("Link to program website (optional)")
             .setValue(externalLink)
+            .setRequired(!disableExternalLink)
+            .setDisabled(disableExternalLink)
+            .setReadOnly(disableExternalLink)
+            .setAttribute(
+                "data-northstar-enabled",
+                String.valueOf(settingsManifest.getNorthStarApplicantUi(request)))
             .getInputTag()
             .withClass(SPACE_BETWEEN_FORM_ELEMENTS),
         // Email notifications
@@ -313,12 +322,9 @@ abstract class ProgramFormBuilder extends BaseHtmlView {
         FieldWithLabel.textArea()
             .setId("program-display-description-textarea")
             .setFieldName("localizedDisplayDescription")
-            .setLabelText("Long program description (optional)")
+            .setLabelText("Long program description")
             .setMarkdownSupported(true)
             .setValue(displayDescription)
-            .setAttribute(
-                "data-northstar-enabled",
-                String.valueOf(settingsManifest.getNorthStarApplicantUi(request)))
             .setDisabled(disableLongDescription)
             .setReadOnly(disableLongDescription)
             .getTextareaTag()


### PR DESCRIPTION
### Description

Please explain the changes you made here.

## Release notes

Remove this section if the title of the pull request can be used as the default release notes description. If more detail is needed to communicate to partners the scope of the PR's changes, use this release notes section (and remove this placeholder text).

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [ ] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [ ] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

#### Database evolutions

Read the guidelines [here](https://github.com/civiform/civiform/wiki/Database#writing-database-evolutions)

- [ ] Assigned two reviewers
- [ ] Guarded against already existing resources using `IF NOT EXISTS` and `IF EXISTS`
- [ ] Downs created to undo changes in Ups
- [ ] Every comment in script should begin with -- and not # --- unless it denotes Ups or Downs. See [here](https://www.playframework.com/documentation/2.9.x/Evolutions) for details.
- [ ] Tested both the Downs and the Ups scripts manually (When testing, include all comments from the evolution in your test script to ensure any syntax errors in the comments are caught.)
- [ ] Data migrations aren't being done (please use a [Durable Job](https://github.com/civiform/civiform/wiki/Database#durable-jobs-for-data-updates) if doing a data migration)
- [ ] Update the model documentation in our [wiki](https://github.com/civiform/civiform/wiki/Database) if necessary

#### Durable jobs

Read the docs [here](https://github.com/civiform/civiform/wiki/Database#durable-jobs-for-data-updates)

- [ ] Assigned two reviewers
- [ ] Included a rollback plan and a job to undo the data changes if appropriate

#### User visible changes

- [ ] Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
  - [ ] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [ ] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Made equivalent changes in Thymeleaf for applicant-facing features and changes (or created an issue in the [Northstar epic](https://github.com/orgs/civiform/projects/1/views/94) to track that it's missing from Thymeleaf)
- [ ] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order
- [ ] Manually tested with a screen reader if the feature is applicant-facing. See [screen reader testing](https://github.com/civiform/civiform/wiki/Testing#screen-reader-testing)

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/helper/feature-flags.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://github.com/civiform/civiform/wiki/Feature-Flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Instructions for manual testing

If instructions are needed for manual testing by reviewers, include them here.

### Issue(s) this completes

Fixes #<issue_number>; Fixes #<issue_number>...
