### PR TITLE
Only update enumerator IDs for newly saved Qs

### DIFF
--- a/server/test/repository/QuestionRepositoryTest.java
+++ b/server/test/repository/QuestionRepositoryTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertThrows;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.ebean.DataIntegrityException;
 import java.util.Locale;
@@ -510,7 +511,7 @@ public class QuestionRepositoryTest extends ResetPostgres {
             disconnectedQuestionBank.nameApplicantName().getQuestionDefinition(),
             disconnectedQuestionBank.addressApplicantAddress().getQuestionDefinition());
 
-    ImmutableList<QuestionModel> savedQuestions =
+    ImmutableMap<String, QuestionDefinition> savedQuestions =
         transactionManager.execute(
             () -> {
               return repo.bulkCreateQuestions(questionsToSave);

--- a/server/test/services/migration/ProgramMigrationServiceTest.java
+++ b/server/test/services/migration/ProgramMigrationServiceTest.java
@@ -747,7 +747,13 @@ public final class ProgramMigrationServiceTest extends ResetPostgres {
     assertThat(result.get(QUESTION_3_NAME).getEnumeratorId())
         .hasValue(result.get(QUESTION_1_NAME).getId());
     assertThat(result.get(QUESTION_4_NAME).getEnumeratorId())
-        .hasValue(result.get(QUESTION_1_NAME).getId());
+        .hasValueSatisfying(
+            id -> {
+              // Since we are reusing the child question, the enumerator ID should not be the newly
+              // saved parent question's ID.
+              // TODO: #9628 - disallow reusing a child question when the parent is newly saved
+              assertThat(id).isNotEqualTo(result.get(QUESTION_1_NAME).getId());
+            });
   }
 
   @Test


### PR DESCRIPTION
### Description

Only loop over newly saved Qs to update them.

Importing [this program](https://docs.google.com/document/d/16dVvxv2uVdHflDJK4N02AulcmyrtlvVMhc3kULY3q0k/edit?resourcekey=0-GaFLL5D1hJm8X5JCxDuNwQ&tab=t.0) then [this one](https://docs.google.com/document/d/1UYyVjizFc53RZ67JnO2-XnzvlaPrBEHYmvyAD34qWXs/edit?tab=t.0) yielded the following error upon saving with the default `use existing` option:

```
Error: java.lang.NullPointerException: Cannot invoke "services.question.types.QuestionDefinition.getName()" because the return value of "com.google.common.collect.ImmutableMap.get(Object)" is null
```

This error was because the `updateEnumeratorIdsAndSaveQuestions` method was trying to update enumerator IDs on all questions (including reused questions) but we should only be looping over the newly saved questions.

https://github.com/civiform/civiform/issues/9628

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.