### PR TITLE
[External Program Cards] Close modal when clicking outside the modal for external program opened after HTMX initialization 

### DIFF
--- a/browser-test/src/applicant/northstar_applicant_application_index.test.ts
+++ b/browser-test/src/applicant/northstar_applicant_application_index.test.ts
@@ -1555,6 +1555,29 @@ test.describe(
         await expect(continueButton).toBeVisible()
       })
 
+      await test.step('clicking outside the modal closes the modal', async () => {
+        const modalWrapper = page
+          .locator('.usa-modal-wrapper')
+          .filter({hasText: 'This will open a different website'})
+        const wrapperBox = await modalWrapper.boundingBox()
+        // Click in the wrapper top left corner, which should  be outside the
+        // actual amodal
+        if (wrapperBox) {
+          await page.mouse.click(wrapperBox.x, wrapperBox.y)
+        }
+
+        const modal = page.getByRole('dialog', {state: 'visible'})
+        await expect(modal).toBeHidden()
+      })
+
+      await test.step('trigger the external program modal again', async () => {
+        await applicantQuestions.clickApplyProgramButton(externalProgramName)
+
+        const modal = page.getByRole('dialog', {state: 'visible'})
+        const continueButton = modal.getByRole('link', {name: 'Continue'})
+        await expect(continueButton).toBeVisible()
+      })
+
       await test.step("selecting 'continue' redirects to the program's external site", async () => {
         const modal = page.getByRole('dialog', {state: 'visible'})
         const continueButton = modal.getByRole('link', {name: 'Continue'})

--- a/server/app/assets/javascripts/north_star_modal.ts
+++ b/server/app/assets/javascripts/north_star_modal.ts
@@ -148,6 +148,17 @@ export class NorthStarModalController {
         }
       }
       document.addEventListener('keydown', escapeKeyHandler)
+
+      // Add listener to hide modal when clicking outside the modal
+      modalWrapper.addEventListener('click', (event) => {
+        // Find the actual modal dialog within the wrapper
+        const modalDialog = modalWrapper.querySelector('.usa-modal')
+
+        // Hide modal if the click was outside the modal dialog
+        if (modalDialog && !modalDialog.contains(event.target as Node)) {
+          hideModal(modalWrapper, triggerButton)
+        }
+      })
     })
   }
 


### PR DESCRIPTION
### Description

Program cards for external programs are rendered with HTMX when a filter is selected. Since the modal trigger is added after initialization via HTMX and doesn't have an event listener, 'htmx:afterSwap' listener adds a click listener to the modal trigger buttons to show the modal and listen for close actions to hide the modal.

This PR adds a click listener to the modal wrapper to close the modal if there is a click inside the wrapper but outside the actual dialog

Solution was suggested by AI, but fully verified by PR owner.

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

#### User visible changes

- [ ] Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
  - [ ] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [ ] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Made equivalent changes in Thymeleaf for applicant-facing features and changes (or created an issue in the [Northstar epic](https://github.com/orgs/civiform/projects/1/views/94) to track that it's missing from Thymeleaf)
- [x] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [x] Manually tested at 200% size
- [ ] Manually evaluated tab order
- [ ] Manually tested with a screen reader if the feature is applicant-facing. See [screen reader testing](https://github.com/civiform/civiform/wiki/Testing#screen-reader-testing)

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/helper/feature-flags.conf`
- [x] Conditioned new functionality on a [FeatureFlag](https://github.com/civiform/civiform/wiki/Feature-Flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Instructions for manual testing

1. Log in as an admin
2. Enable EXTERNAL_PROGRAM_CARDS_ENABLED feature flag
3. Create and publish an external program with a filter
4. Logout
5. In the applicant home, verify the external program has a card on the 'Programs and Services' section
6. Apply the filter, verify the external program has a card on the 'Programs based on your selections ' section
7. Click on 'View on a new tab' which opens a modal
8. Click outside the modal

### Issue(s) this completes

Fixes #10591
