### PR TITLE
Add a loading spinner for HTMX button click

### DIFF
--- a/browser-test/src/admin/admin_program_migration.test.ts
+++ b/browser-test/src/admin/admin_program_migration.test.ts
@@ -912,7 +912,7 @@ test.describe('program migration', () => {
           ['Sample Email Question', adminProgramMigration.CREATE_DUPLICATE],
         ]),
       )
-      await adminProgramMigration.clickButton('Save')
+      await adminProgramMigration.clickButtonWithSpinner('Save')
       await adminProgramMigration.expectAlert(
         'Your program has been successfully imported',
         ALERT_SUCCESS,

--- a/browser-test/src/support/admin_program_migration.ts
+++ b/browser-test/src/support/admin_program_migration.ts
@@ -72,7 +72,14 @@ export class AdminProgramMigration {
   async submitProgramJson(content: string) {
     await waitForPageJsLoad(this.page)
     await this.page.getByRole('textbox').fill(content)
-    await this.clickButton('Preview program')
+    await this.clickButtonWithSpinner('Preview program')
+  }
+
+  private async expectButtonDisabledAndSpinning(buttonText: string) {
+    const button = this.page.getByRole('button', {name: buttonText})
+    await expect(button).toBeDisabled()
+    await expect(button).toHaveClass(/(^|\s)htmx-request(\s|$)/)
+    await waitForPageJsLoad(this.page)
   }
 
   async expectAlert(alertText: string, alertType: string) {
@@ -100,6 +107,11 @@ export class AdminProgramMigration {
 
   async expectOptionSelected(question: Locator, option: string) {
     await expect(question.getByLabel(option)).toBeChecked()
+  }
+
+  async clickButtonWithSpinner(buttonText: string) {
+    await this.page.getByRole('button', {name: buttonText}).click()
+    await this.expectButtonDisabledAndSpinning(buttonText)
   }
 
   async clickButton(buttonText: string) {

--- a/server/app/assets/stylesheets/uswds/_uswds-theme-custom-styles.scss
+++ b/server/app/assets/stylesheets/uswds/_uswds-theme-custom-styles.scss
@@ -160,3 +160,62 @@ h1.usa-step-indicator__heading {
     @include u-padding-x(6);
   }
 }
+
+// The following styles support an HTMX request "loading" spinner on buttons.
+@keyframes spinner {
+  0% {
+    transform: translate3d(-50%, -50%, 0) rotate(0deg);
+  }
+  100% {
+    transform: translate3d(-50%, -50%, 0) rotate(360deg);
+  }
+}
+
+// We allow any button with the `htmx-request` class to show a spinner.
+button.usa-button.htmx-request {
+  opacity: 1;
+  position: relative;
+  transition: opacity linear 0.1s;
+  // Make text transparent, so the spinner can show.
+  color: rgba(0, 0, 0, 0);
+
+  &::before {
+    animation: 1.3s linear infinite spinner;
+    // Same as .usa-button (#005ea2), but 1/8 lighter
+    border: solid 3px #2073bc;
+    border-bottom-color: white;
+    border-radius: 50%;
+    content: '';
+    height: 25px;
+    left: 50%;
+    position: absolute;
+    top: 50%;
+    transform: translate3d(-50%, -50%, 0);
+    transform-origin: center;
+    width: 25px;
+    will-change: transform;
+  }
+  // Sometimes, we may also disable the button when the request is pending.
+  // In this case, we should remove default disabled-button styling.
+  &:disabled {
+    box-shadow: inset 0 0 0 2px #005ea2;
+    &:hover {
+      // Make text transparent, so the spinner can show.
+      color: rgba(0, 0, 0, 0);
+      background-color: #005ea2;
+    }
+  }
+}
+
+// Different colors for outlined buttons
+button.usa-button.usa-button--outline.htmx-request,
+button.usa-button.usa-button--unstyled.htmx-request {
+  &::before {
+    // Same as .usa-button--outline (#005ea2), but 7/8 lighter
+    border: solid 3px rgba(0, 94, 162, 0.125);
+    border-bottom-color: #005ea2;
+  }
+  &:disabled:hover {
+    background-color: transparent;
+  }
+}

--- a/server/app/views/admin/migration/AdminImportView.java
+++ b/server/app/views/admin/migration/AdminImportView.java
@@ -133,10 +133,13 @@ public class AdminImportView extends BaseHtmlView {
                 .attr("hx-post", routes.AdminImportController.hxImportProgram().url())
                 .attr("hx-target", "#" + AdminImportViewPartial.PROGRAM_DATA_ID)
                 .attr("hx-swap", "outerHTML")
+                .attr("hx-indicator", "#hx-submit-button")
+                .attr("hx-disabled-elt", "#hx-submit-button")
                 .with(makeCsrfTokenInputTag(request), jsonInputElement)
                 .with(
                     submitButton("Preview program")
-                        .withClasses("usa-button", "usa-button--outline", "mb-5")));
+                        .withClasses("usa-button", "usa-button--outline", "mb-5")
+                        .withId("hx-submit-button")));
   }
 
   private DivTag renderBackButton() {

--- a/server/app/views/admin/migration/AdminImportViewPartial.java
+++ b/server/app/views/admin/migration/AdminImportViewPartial.java
@@ -142,7 +142,7 @@ public final class AdminImportViewPartial extends BaseHtmlView {
     DivTag formButtons =
         div()
             .with(
-                submitButton("Save").withClasses("usa-button", "mr-2"),
+                submitButton("Save").withClasses("usa-button", "mr-2").withId("hx-submit-button"),
                 asRedirectElement(
                         button("Delete and start over"), routes.AdminImportController.index().url())
                     .withClasses("usa-button", "usa-button--outline"))
@@ -156,6 +156,8 @@ public final class AdminImportViewPartial extends BaseHtmlView {
             .attr("hx-post", routes.AdminImportController.hxSaveProgram().url())
             .attr("hx-target", "#" + AdminImportViewPartial.PROGRAM_DATA_ID)
             .attr("hx-swap", "outerHTML")
+            .attr("hx-indicator", "#hx-submit-button")
+            .attr("hx-disabled-elt", "#hx-submit-button")
             .with(makeCsrfTokenInputTag(request))
             .with(
                 FieldWithLabel.textArea()
@@ -167,8 +169,6 @@ public final class AdminImportViewPartial extends BaseHtmlView {
             .condWith(
                 duplicateHandlingOptionsEnabled && duplicateQuestionNames.size() > 1,
                 renderToplevelDuplicateQuestionHandlingOptions())
-            // TODO: #9628 - Add styling to signal that the program is saving, as it can take a few
-            // seconds
             .withAction(routes.AdminImportController.hxSaveProgram().url());
 
     for (BlockDefinition block : program.blockDefinitions()) {


### PR DESCRIPTION
### Description

Adds styles to support a loading spinner, and adds the `htmx-request` class to USWDS submit buttons in the program import flow. Also disable the buttons during load. Note this change is *not* feature-flag guarded.

We add themes in `server/app/assets/stylesheets/uswds/_uswds-theme-custom-styles.scss` rather than `server/app/assets/stylesheets/northstar/_uswds-theme-custom-styles.scss`, since the admin bundle doesn't include northstar styles.

https://github.com/user-attachments/assets/460562a4-5ead-489f-86c5-1e7f5c45e9e0

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

### Issue(s) this completes

Fixes #9289
