### PR TITLE
[External Program Cards] Add aria label to external program card button

### DIFF
--- a/browser-test/src/applicant/northstar_applicant_application_index.test.ts
+++ b/browser-test/src/applicant/northstar_applicant_application_index.test.ts
@@ -1399,7 +1399,9 @@ test.describe(
           has: page.getByText(externalProgramAName),
         })
         await expect(
-          externalProgramCard.getByRole('button', {name: 'View in new tab'}),
+          externalProgramCard.getByRole('button', {
+            name: 'View External Program A in new tab',
+          }),
         ).toBeVisible()
 
         await validateAccessibility(page)

--- a/server/app/services/MessageKey.java
+++ b/server/app/services/MessageKey.java
@@ -137,6 +137,7 @@ public enum MessageKey {
   BUTTON_VIEW_AND_APPLY("button.viewAndApply"), // North Star only
   BUTTON_VIEW_AND_APPLY_SR("button.viewAndApplySr"), // North Star only
   BUTTON_VIEW_IN_NEW_TAB("button.viewInNewTab"),
+  BUTTON_VIEW_IN_NEW_TAB_SR("button.viewInNewTabSr"),
   BUTTON_HOME_PAGE("button.homePage"),
   CURRENCY_VALIDATION_MISFORMATTED("validation.currencyMisformatted"),
   CONTACT_INFO_LABEL("label.contactInfo"),

--- a/server/app/views/applicant/ProgramCardsFragment.html
+++ b/server/app/views/applicant/ProgramCardsFragment.html
@@ -203,6 +203,7 @@
       class="usa-button usa-button--outline cf-apply-button"
       th:href="${'#external-program-modal-' + card.programId()}"
       th:aria-controls="${'external-program-modal-' + card.programId()}"
+      th:aria-label="#{button.viewInNewTabSr(${card.title()})}"
       role="button"
       data-open-modal
     >

--- a/server/conf/i18n/messages
+++ b/server/conf/i18n/messages
@@ -215,6 +215,8 @@ button.viewAndApply=View and apply
 button.viewAndApplySr=View and apply to {0}
 # The text on a button to view program on a new tab. This is used for external programs.
 button.viewInNewTab=View in new tab
+# The screen reader text on a button to view program on a new tab. The variable represents the program name. This is used for external programs.
+button.viewInNewTabSr=View {0} in new tab
 # The text for the button that allows a guest to bypass the login prompt modal.
 button.continueToApplication=Continue to application
 # The screen reader text for a button an applicant clicks to start filling out a pre-screener form.


### PR DESCRIPTION
### Description

Add aria label to the button in the card for external program that informs the user clicking the button will open the modal for that specific program

### Checklist

#### General
- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

#### User visible changes

- [ ] Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
  - [ ] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [ ] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Made equivalent changes in Thymeleaf for applicant-facing features and changes (or created an issue in the [Northstar epic](https://github.com/orgs/civiform/projects/1/views/94) to track that it's missing from Thymeleaf)
- [x] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [x] Manually tested at 200% size
- [x] Manually evaluated tab order
- [x] Manually tested with a screen reader if the feature is applicant-facing. See [screen reader testing](https://github.com/civiform/civiform/wiki/Testing#screen-reader-testing)

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/helper/feature-flags.conf`
- [x] Conditioned new functionality on a [FeatureFlag](https://github.com/civiform/civiform/wiki/Feature-Flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Instructions for manual testing

1. As an admin, create an external program
2. Go back to the applicant home page
3. Turn the screen reader on
4. Tab to the "View in new tab" button on the external program card
5. Verify screen reader says "View <program name> in new tab"

### Issue(s) this completes

Fixes #10595
