### PR TITLE
[API] Support time filter for list applications

### DIFF
--- a/server/app/controllers/api/ProgramApplicationsApiController.java
+++ b/server/app/controllers/api/ProgramApplicationsApiController.java
@@ -220,7 +220,7 @@ public final class ProgramApplicationsApiController extends CiviFormApiControlle
 
   private Instant parseParamDateToInstant(String paramName, String paramDate) {
     try {
-      return dateConverter.parseIso8601DateToStartOfLocalDateInstant(paramDate);
+      return dateConverter.parseIso8601DateToLocalDateTimeInstant(paramDate);
     } catch (DateTimeParseException e) {
       throw new BadApiRequestException("Malformed query param: " + paramName);
     }

--- a/server/app/services/DateConverter.java
+++ b/server/app/services/DateConverter.java
@@ -8,6 +8,7 @@ import java.text.SimpleDateFormat;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
@@ -55,6 +56,16 @@ public final class DateConverter {
   }
 
   /**
+   * Parses a string containing a ISO-8601 date-time with the offset and zone if available (i.e.
+   * "YYYY-MM-DDThh:mm:ssZ") and converts it to an {@link LocalDateTime}
+   *
+   * @throws DateTimeParseException if dateString is not well-formed.
+   */
+  public LocalDateTime parseIso8601DateToLocalDateTime(String dateString) {
+    return LocalDateTime.parse(dateString, DateTimeFormatter.ISO_DATE_TIME);
+  }
+
+  /**
    * Parses string day, month and year and converts them to a {@link LocalDate}
    *
    * @throws DateTimeParseException if conjoined date string is not well-formed.
@@ -87,6 +98,34 @@ public final class DateConverter {
    */
   public Instant parseIso8601DateToEndOfLocalDateInstant(String dateString) {
     return parseIso8601DateToLocalDate(dateString).atTime(LocalTime.MAX).atZone(zoneId).toInstant();
+  }
+
+  /**
+   * Parses a string containing an ISO-8601 date-time and converts it to an {@link Instant}.
+   *
+   * <p>This method handles three parsing scenarios in order of preference: 1) Full ISO-8601 string
+   * with timezone information (e.g., "2023-12-25T10:30:00Z") 2) ISO-8601 date-time without timezone
+   * (e.g., "2023-12-25T10:30:00"), converted using the configured local zone 3) ISO-8601 date only
+   * (e.g., "2023-12-25"), defaulting to start of day in local timezone
+   *
+   * @param dateString the ISO-8601 formatted date string to parse
+   * @return {@link Instant} representing the parsed date-time in the appropriate timezone
+   * @throws DateTimeParseException if dateString cannot be parsed in any of the supported formats
+   */
+  public Instant parseIso8601DateToLocalDateTimeInstant(String dateString) {
+    // Parse as complete ISO-8601 instant with timezone info
+    try {
+      return Instant.parse(dateString);
+    } catch (DateTimeParseException instantParseException) {
+      // Parse as local date-time and apply configured timezone
+      try {
+        LocalDateTime localDateTime = parseIso8601DateToLocalDateTime(dateString);
+        return localDateTime.atZone(zoneId).toInstant();
+      } catch (DateTimeParseException localDateTimeParseException) {
+        // Parse as date-only and default to start of day
+        return parseIso8601DateToStartOfLocalDateInstant(dateString);
+      }
+    }
   }
 
   /** Formats an {@link Instant} to a human-readable date and time in the local time zone. */

--- a/server/app/services/openapi/v2/Swagger2SchemaGenerator.java
+++ b/server/app/services/openapi/v2/Swagger2SchemaGenerator.java
@@ -101,19 +101,23 @@ public class Swagger2SchemaGenerator extends AbstractOpenApiSchemaGenerator
                                       .name("fromDate")
                                       .type(DefinitionType.STRING.toString())
                                       .description(
-                                          "An ISO-8601 formatted date (i.e. YYYY-MM-DD). Limits"
-                                              + " results to applications submitted on or after the"
-                                              + " provided date, in the CiviForm instance's local"
-                                              + " time."))
+                                          "An ISO-8601 formatted date-time with zone id (i.e."
+                                              + " YYYY-MM-DDTThh:mm:ssZ). Limits results to"
+                                              + " applications submitted on or after the provided"
+                                              + " date. Uses the CiviForm instance's local timezone"
+                                              + " when no timezone is provided, and the beginning"
+                                              + " of the day when no time is provided."))
                               .parameter(
                                   new QueryParameter()
                                       .name("toDate")
                                       .type(DefinitionType.STRING.toString())
                                       .description(
-                                          "An ISO-8601 formatted date (i.e. YYYY-MM-DD). Limits"
-                                              + " results to applications submitted before the"
-                                              + " provided date, in the CiviForm instance's"
-                                              + " local time."))
+                                          "An ISO-8601 formatted date-time with zone id (i.e."
+                                              + " YYYY-MM-DDTThh:mm:ssZ). Limits results to"
+                                              + " applications submitted before the provided date."
+                                              + " Uses the CiviForm instance's local timezone when"
+                                              + " no timezone is provided, and the beginning of the"
+                                              + " day when no time is provided."))
                               .parameter(
                                   new QueryParameter()
                                       .name("pageSize")

--- a/server/app/services/openapi/v3/OpenApi3SchemaGenerator.java
+++ b/server/app/services/openapi/v3/OpenApi3SchemaGenerator.java
@@ -165,19 +165,26 @@ public class OpenApi3SchemaGenerator extends AbstractOpenApiSchemaGenerator
                                           new QueryParameter()
                                               .name("fromDate")
                                               .description(
-                                                  "An ISO-8601 formatted date (i.e. YYYY-MM-DD)."
-                                                      + " Limits results to applications submitted"
-                                                      + " on or after the provided date, in the"
-                                                      + " CiviForm instance's local time.")
+                                                  "An ISO-8601 formatted date-time with zone id"
+                                                      + " (i.e. YYYY-MM-DDTThh:mm:ssZ). Limits"
+                                                      + " results to applications submitted on or"
+                                                      + " after the provided date. Uses the"
+                                                      + " CiviForm instance's local timezone when"
+                                                      + " no timezone is provided, and the"
+                                                      + " beginning of the day when no time is"
+                                                      + " provided.")
                                               .schema(new StringSchema()))
                                       .addParametersItem(
                                           new QueryParameter()
                                               .name("toDate")
                                               .description(
-                                                  "An ISO-8601 formatted date (i.e. YYYY-MM-DD)."
-                                                      + " Limits results to applications submitted"
-                                                      + " before the provided date, in the CiviForm"
-                                                      + " instance's local time.")
+                                                  "An ISO-8601 formatted date-time with zone id"
+                                                      + " (i.e. YYYY-MM-DDTThh:mm:ssZ). Limits"
+                                                      + " results to applications submitted before"
+                                                      + " the provided date. Uses the CiviForm"
+                                                      + " instance's local timezone when no"
+                                                      + " timezone is provided, and the beginning"
+                                                      + " of the day when no time is provided.")
                                               .schema(new StringSchema()))
                                       .addParametersItem(
                                           new QueryParameter()

--- a/server/test/services/DateConverterTest.java
+++ b/server/test/services/DateConverterTest.java
@@ -7,6 +7,7 @@ import java.text.ParseException;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeParseException;
@@ -56,6 +57,53 @@ public class DateConverterTest {
   public void parseIso8601DateToEndOfLocalDateInstant_DateTimeParseExceptionIsGenerated() {
     String inputDate = "abcd";
     assertThatThrownBy(() -> dateConverterUTC.parseIso8601DateToEndOfLocalDateInstant(inputDate))
+        .isInstanceOf(DateTimeParseException.class);
+  }
+
+  @Test
+  public void parseIso8601DateToLocalDateTimeInstant_dateOnly_isSuccessful() {
+    String dateOnly = "2025-05-26";
+    Instant result = dateConverterUTC.parseIso8601DateToLocalDateTimeInstant(dateOnly);
+
+    // When no time is provided, it should be set to start of day
+    Instant expected = LocalDate.of(2025, 5, 26).atStartOfDay(ZoneId.of("UTC")).toInstant();
+
+    assertThat(result).isEqualTo(expected);
+  }
+
+  @Test
+  public void parseIso8601DateToLocalDateTimeInstant_dateTime_isSuccessful() {
+    String dateTime = "2025-05-26T11:00:00";
+    Instant result = dateConverterUTC.parseIso8601DateToLocalDateTimeInstant(dateTime);
+
+    Instant expected = LocalDateTime.of(2025, 5, 26, 11, 0, 0).atZone(ZoneId.of("UTC")).toInstant();
+    assertThat(result).isEqualTo(expected);
+  }
+
+  @Test
+  public void parseIso8601DateToLocalDateTimeInstant_dateTimeTimezone_isSuccessful() {
+    // Date uses UTC timezone
+    String dateTime = "2025-05-26T02:00:00.00Z";
+
+    // When the string uses the same local timezone than the local one, the parsed time will use
+    // such timezone.
+    Instant resultUTC = dateConverterUTC.parseIso8601DateToLocalDateTimeInstant(dateTime);
+    Instant expectedUTC =
+        LocalDateTime.of(2025, 5, 26, 2, 0, 0).atZone(ZoneId.of("UTC")).toInstant();
+    assertThat(resultUTC).isEqualTo(expectedUTC);
+
+    // When the string uses a different timezone than the local one, the parsed time should use the
+    // timezone given.
+    Instant resultPT = dateConverterPT.parseIso8601DateToLocalDateTimeInstant(dateTime);
+    Instant expectedPT =
+        LocalDateTime.of(2025, 5, 26, 2, 0, 0).atZone(ZoneId.of("UTC")).toInstant();
+    assertThat(resultPT).isEqualTo(expectedPT);
+  }
+
+  @Test
+  public void parseIso8601DateToLocalDateTimeInstant_DateTimeParseExceptionIsGenerated() {
+    String inputDate = "abcd";
+    assertThatThrownBy(() -> dateConverterUTC.parseIso8601DateToLocalDateTimeInstant(inputDate))
         .isInstanceOf(DateTimeParseException.class);
   }
 

--- a/server/test/services/openapi/v2/Swagger2SchemaGeneratorTest.java
+++ b/server/test/services/openapi/v2/Swagger2SchemaGeneratorTest.java
@@ -103,16 +103,18 @@ paths:
       parameters:
       - name: "fromDate"
         in: "query"
-        description: "An ISO-8601 formatted date (i.e. YYYY-MM-DD). Limits results\\
-          \\ to applications submitted on or after the provided date, in the CiviForm\\
-          \\ instance's local time."
+        description: "An ISO-8601 formatted date-time with zone id (i.e. YYYY-MM-DDTThh:mm:ssZ).\\
+          \\ Limits results to applications submitted on or after the provided date.\\
+          \\ Uses the CiviForm instance's local timezone when no timezone is provided,\\
+          \\ and the beginning of the day when no time is provided."
         required: false
         type: "string"
       - name: "toDate"
         in: "query"
-        description: "An ISO-8601 formatted date (i.e. YYYY-MM-DD). Limits results\\
-          \\ to applications submitted before the provided date, in the CiviForm instance's\\
-          \\ local time."
+        description: "An ISO-8601 formatted date-time with zone id (i.e. YYYY-MM-DDTThh:mm:ssZ).\\
+          \\ Limits results to applications submitted before the provided date. Uses\\
+          \\ the CiviForm instance's local timezone when no timezone is provided, and\\
+          \\ the beginning of the day when no time is provided."
         required: false
         type: "string"
       - name: "pageSize"
@@ -289,16 +291,18 @@ paths:
       parameters:
       - name: "fromDate"
         in: "query"
-        description: "An ISO-8601 formatted date (i.e. YYYY-MM-DD). Limits results\\
-          \\ to applications submitted on or after the provided date, in the CiviForm\\
-          \\ instance's local time."
+        description: "An ISO-8601 formatted date-time with zone id (i.e. YYYY-MM-DDTThh:mm:ssZ).\\
+          \\ Limits results to applications submitted on or after the provided date.\\
+          \\ Uses the CiviForm instance's local timezone when no timezone is provided,\\
+          \\ and the beginning of the day when no time is provided."
         required: false
         type: "string"
       - name: "toDate"
         in: "query"
-        description: "An ISO-8601 formatted date (i.e. YYYY-MM-DD). Limits results\\
-          \\ to applications submitted before the provided date, in the CiviForm instance's\\
-          \\ local time."
+        description: "An ISO-8601 formatted date-time with zone id (i.e. YYYY-MM-DDTThh:mm:ssZ).\\
+          \\ Limits results to applications submitted before the provided date. Uses\\
+          \\ the CiviForm instance's local timezone when no timezone is provided, and\\
+          \\ the beginning of the day when no time is provided."
         required: false
         type: "string"
       - name: "pageSize"
@@ -828,16 +832,18 @@ paths:
       parameters:
       - name: "fromDate"
         in: "query"
-        description: "An ISO-8601 formatted date (i.e. YYYY-MM-DD). Limits results\\
-          \\ to applications submitted on or after the provided date, in the CiviForm\\
-          \\ instance's local time."
+        description: "An ISO-8601 formatted date-time with zone id (i.e. YYYY-MM-DDTThh:mm:ssZ).\\
+          \\ Limits results to applications submitted on or after the provided date.\\
+          \\ Uses the CiviForm instance's local timezone when no timezone is provided,\\
+          \\ and the beginning of the day when no time is provided."
         required: false
         type: "string"
       - name: "toDate"
         in: "query"
-        description: "An ISO-8601 formatted date (i.e. YYYY-MM-DD). Limits results\\
-          \\ to applications submitted before the provided date, in the CiviForm instance's\\
-          \\ local time."
+        description: "An ISO-8601 formatted date-time with zone id (i.e. YYYY-MM-DDTThh:mm:ssZ).\\
+          \\ Limits results to applications submitted before the provided date. Uses\\
+          \\ the CiviForm instance's local timezone when no timezone is provided, and\\
+          \\ the beginning of the day when no time is provided."
         required: false
         type: "string"
       - name: "pageSize"

--- a/server/test/services/openapi/v3/OpenApi3SchemaGeneratorTest.java
+++ b/server/test/services/openapi/v3/OpenApi3SchemaGeneratorTest.java
@@ -98,16 +98,18 @@ paths:
       parameters:
       - name: fromDate
         in: query
-        description: "An ISO-8601 formatted date (i.e. YYYY-MM-DD). Limits results\\
-          \\ to applications submitted on or after the provided date, in the CiviForm\\
-          \\ instance's local time."
+        description: "An ISO-8601 formatted date-time with zone id (i.e. YYYY-MM-DDTThh:mm:ssZ).\\
+          \\ Limits results to applications submitted on or after the provided date.\\
+          \\ Uses the CiviForm instance's local timezone when no timezone is provided,\\
+          \\ and the beginning of the day when no time is provided."
         schema:
           type: string
       - name: toDate
         in: query
-        description: "An ISO-8601 formatted date (i.e. YYYY-MM-DD). Limits results\\
-          \\ to applications submitted before the provided date, in the CiviForm instance's\\
-          \\ local time."
+        description: "An ISO-8601 formatted date-time with zone id (i.e. YYYY-MM-DDTThh:mm:ssZ).\\
+          \\ Limits results to applications submitted before the provided date. Uses\\
+          \\ the CiviForm instance's local timezone when no timezone is provided, and\\
+          \\ the beginning of the day when no time is provided."
         schema:
           type: string
       - name: pageSize
@@ -288,16 +290,18 @@ paths:
       parameters:
       - name: fromDate
         in: query
-        description: "An ISO-8601 formatted date (i.e. YYYY-MM-DD). Limits results\\
-          \\ to applications submitted on or after the provided date, in the CiviForm\\
-          \\ instance's local time."
+        description: "An ISO-8601 formatted date-time with zone id (i.e. YYYY-MM-DDTThh:mm:ssZ).\\
+          \\ Limits results to applications submitted on or after the provided date.\\
+          \\ Uses the CiviForm instance's local timezone when no timezone is provided,\\
+          \\ and the beginning of the day when no time is provided."
         schema:
           type: string
       - name: toDate
         in: query
-        description: "An ISO-8601 formatted date (i.e. YYYY-MM-DD). Limits results\\
-          \\ to applications submitted before the provided date, in the CiviForm instance's\\
-          \\ local time."
+        description: "An ISO-8601 formatted date-time with zone id (i.e. YYYY-MM-DDTThh:mm:ssZ).\\
+          \\ Limits results to applications submitted before the provided date. Uses\\
+          \\ the CiviForm instance's local timezone when no timezone is provided, and\\
+          \\ the beginning of the day when no time is provided."
         schema:
           type: string
       - name: pageSize
@@ -831,16 +835,18 @@ paths:
       parameters:
       - name: fromDate
         in: query
-        description: "An ISO-8601 formatted date (i.e. YYYY-MM-DD). Limits results\\
-          \\ to applications submitted on or after the provided date, in the CiviForm\\
-          \\ instance's local time."
+        description: "An ISO-8601 formatted date-time with zone id (i.e. YYYY-MM-DDTThh:mm:ssZ).\\
+          \\ Limits results to applications submitted on or after the provided date.\\
+          \\ Uses the CiviForm instance's local timezone when no timezone is provided,\\
+          \\ and the beginning of the day when no time is provided."
         schema:
           type: string
       - name: toDate
         in: query
-        description: "An ISO-8601 formatted date (i.e. YYYY-MM-DD). Limits results\\
-          \\ to applications submitted before the provided date, in the CiviForm instance's\\
-          \\ local time."
+        description: "An ISO-8601 formatted date-time with zone id (i.e. YYYY-MM-DDTThh:mm:ssZ).\\
+          \\ Limits results to applications submitted before the provided date. Uses\\
+          \\ the CiviForm instance's local timezone when no timezone is provided, and\\
+          \\ the beginning of the day when no time is provided."
         schema:
           type: string
       - name: pageSize


### PR DESCRIPTION
### Description

List applications have `fromDate` and `toDate` parameters that receive an ISO-8601 date (YYYY-MM-DD). This PR updates the date parser to support time stamps, still with the ISO-8601 format.

In order to not break current calls, we need to continue supporting only date parameters. Therefore, we introduce `parseIso8601DateToLocalDateTimeInstant(dateString)` with three parsing scenarios in order of preference:

1.  Full ISO-8601 string with timezone information (e.g., "2023-12-25T10:30:00Z")
2.  ISO-8601 date-time without timezone (e.g., "2023-12-25T10:30:00"), converted using the configured local zone
3.  ISO-8601 date only (e.g., "2023-12-25"), defaulting to start of day in local timezone

Since we are maintaining existing functionality, this change is not under a feature flag

User-facing documentation will be updated in https://github.com/civiform/docs/pull/559

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

### Issue(s) this completes

Part of #5483
