### PR TITLE
[External Program Cards] Update strings for program slug field in program form

### DIFF
--- a/browser-test/src/admin/admin_program_creation.test.ts
+++ b/browser-test/src/admin/admin_program_creation.test.ts
@@ -227,18 +227,18 @@ test.describe('program creation', () => {
       /* submitNewProgram= */ false,
     )
 
-    // On initial program creation, expect an admin can fill in the program name.
-    expect(await page.locator('#program-name-input').count()).toEqual(1)
+    await test.step('On program creation, admin can fill in the program slug.', async () => {
+      expect(await page.locator('#program-slug').count()).toEqual(1)
 
-    await adminPrograms.submitProgramDetailsEdits()
-    await adminProgramImage.expectProgramImagePage()
+      await adminPrograms.submitProgramDetailsEdits()
+      await adminProgramImage.expectProgramImagePage()
+    })
 
-    // WHEN the admin goes back to the program details page
-    await adminProgramImage.clickBackButton()
-
-    // THEN they should not be able to modify the program name (used for the URL).
-    await adminPrograms.expectProgramEditPage(programName)
-    expect(await page.locator('#program-name-input').count()).toEqual(0)
+    await test.step('On program edit, admin cannot edit the program slug (which is used for the URL)', async () => {
+      await adminProgramImage.clickBackButton()
+      await adminPrograms.expectProgramEditPage(programName)
+      await expect(page.locator('#program-slug')).toBeHidden()
+    })
   })
 
   test('create program then go back can still go forward', async ({

--- a/browser-test/src/support/admin_programs.ts
+++ b/browser-test/src/support/admin_programs.ts
@@ -248,8 +248,8 @@ export class AdminPrograms {
     await this.page.click('#new-program-button')
     await waitForPageJsLoad(this.page)
 
-    // program name must be in url-compatible form so we slugify it
-    await this.page.fill('#program-name-input', slugify(programName))
+    // program slug must be in url-compatible form so we slugify the program name
+    await this.page.fill('#program-slug', slugify(programName))
     await this.page.fill('#program-description-textarea', adminDescription)
     await this.page.fill('#program-display-name-input', programName)
     await this.page.fill('#program-display-description-textarea', description)

--- a/server/test/views/admin/programs/ProgramFormBuilderTest.java
+++ b/server/test/views/admin/programs/ProgramFormBuilderTest.java
@@ -1,13 +1,34 @@
 package views.admin.programs;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 import com.google.common.collect.ImmutableList;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import j2html.tags.DomContent;
 import j2html.tags.specialized.DivTag;
 import java.util.Map;
+import org.junit.Before;
 import org.junit.Test;
+import repository.AccountRepository;
+import repository.CategoryRepository;
+import services.program.ProgramType;
+import services.settings.SettingsManifest;
 
 public class ProgramFormBuilderTest {
+  private ProgramFormBuilder formBuilder;
+  private Config config;
+
+  @Before
+  public void setup() {
+    config = ConfigFactory.load();
+    SettingsManifest settingsManifest = mock(SettingsManifest.class);
+    AccountRepository mockAccountRepo = mock(AccountRepository.class);
+    CategoryRepository mockCategoryRepo = mock(CategoryRepository.class);
+    formBuilder =
+        new ProgramFormBuilder(config, settingsManifest, mockAccountRepo, mockCategoryRepo) {};
+  }
 
   @Test
   public void buildApplicationStepDiv_buildsApplicationStepFormElement() {
@@ -46,5 +67,40 @@ public class ProgramFormBuilderTest {
 
     assertThat(renderedDiv).contains("Step one title");
     assertThat(renderedDiv).contains("Step one description");
+  }
+
+  @Test
+  public void buildProgramSlugField_creationStatus_externalProgramCardsFeatureEnabled() {
+    DomContent urlFieldResult =
+        formBuilder.buildProgramSlugFieldForExternalProgramsFeature(
+            "test-program", ProgramEditStatus.CREATION, ProgramType.DEFAULT);
+    String urlFieldRendered = urlFieldResult.render();
+    assertThat(urlFieldRendered)
+        .contains(
+            " Create a program ID. This ID can only contain lowercase letters, numbers, and dashes."
+                + " It will be used in the program’s applicant-facing URL (except for external"
+                + " programs), and it can’t be changed later.");
+  }
+
+  @Test
+  public void buildProgramSlugField_editStatus_DefaultProgram_externalProgramCardsFeatureEnabled() {
+    String baseUrl = config.getString("base_url");
+    DomContent urlFieldResult =
+        formBuilder.buildProgramSlugFieldForExternalProgramsFeature(
+            "test-program", ProgramEditStatus.EDIT, ProgramType.DEFAULT);
+    String urlFieldRendered = urlFieldResult.render();
+    assertThat(urlFieldRendered).contains("The URL for this program. This URL can’t be changed");
+    assertThat(urlFieldRendered).contains(baseUrl + "/programs/test-program");
+  }
+
+  @Test
+  public void
+      buildProgramSlugField_editStatus_ExternalProgram_externalProgramCardsFeatureEnabled() {
+    DomContent urlFieldResult =
+        formBuilder.buildProgramSlugFieldForExternalProgramsFeature(
+            "test-program", ProgramEditStatus.EDIT, ProgramType.EXTERNAL);
+    String urlFieldRendered = urlFieldResult.render();
+    assertThat(urlFieldRendered).contains("The program ID. This ID can’t be changed.");
+    assertThat(urlFieldRendered).contains("test-program");
   }
 }


### PR DESCRIPTION
### Description

Program ID field in the program create/edit form is used as a program identifier internally and to create the program URL for default programs and pre-screeners. Since external programs don't have URL, this PR updates the field to better communicate it.

String changes:
- Create page: _Create_ a program ID. This ID can only contain lowercase letters, numbers, and dashes. It will be used in the program’s applicant-facing URL (except for external programs), and it can’t be changed later._
- Edit page (default program / pre screener): _The URL for this program. This URL can't be changed._
- Edit page (external program): _The program ID. This ID can't be changed._

Field changes:
- Edit page (external program): show the program id instead of the URL, since there is no URL for external programs

Additionally, we change the id of the field to be `program-id` to better reflect what the field holds

These changes are under the external program cards feature

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

#### User visible changes

- [ ] Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
  - [ ] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [ ] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Made equivalent changes in Thymeleaf for applicant-facing features and changes (or created an issue in the [Northstar epic](https://github.com/orgs/civiform/projects/1/views/94) to track that it's missing from Thymeleaf)
- [x] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [x] Manually tested at 200% size
- [ ] Manually evaluated tab order
- [ ] Manually tested with a screen reader if the feature is applicant-facing. See [screen reader testing](https://github.com/civiform/civiform/wiki/Testing#screen-reader-testing)

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/helper/feature-flags.conf`
- [x] Conditioned new functionality on a [FeatureFlag](https://github.com/civiform/civiform/wiki/Feature-Flags)
- [x] Wrote browser tests with the feature flag off and on, etc.

### Instructions for manual testing

1. Login as a CiviForm admin
2. Create a program
4. Verify program id field has text  _Create_ a program ID. This ID can only contain lowercase letters, numbers, and dashes. It will be used in the program’s applicant-facing URL (except for external programs), and it can’t be changed later._
5. Finish creation of external program
6. Edit external program
7. Verify program id field has text _The program ID. This ID can't be changed._ and the program ID value (which cannot be changed)

### Issue(s) this completes

Part of #10183
