### PR TITLE
[Cleanup] Remove unnecessary parameter from buildProgramTypeFieldset()

### DIFF
--- a/server/app/views/admin/programs/ProgramFormBuilder.java
+++ b/server/app/views/admin/programs/ProgramFormBuilder.java
@@ -205,7 +205,7 @@ abstract class ProgramFormBuilder extends BaseHtmlView {
             .getTextareaTag()
             .withClass(SPACE_BETWEEN_FORM_ELEMENTS),
         // Program type
-        buildProgramTypeFieldset(settingsManifest, request, programType, programEditStatus),
+        buildProgramTypeFieldset(request, programType, programEditStatus),
         // Program Eligibility
         fieldset(
                 legend("Program eligibility gating")
@@ -358,10 +358,7 @@ abstract class ProgramFormBuilder extends BaseHtmlView {
   }
 
   private DomContent buildProgramTypeFieldset(
-      SettingsManifest settingsManifest,
-      Request request,
-      ProgramType programType,
-      ProgramEditStatus programEditStatus) {
+      Request request, ProgramType programType, ProgramEditStatus programEditStatus) {
     DomContent programTypeFieldset;
     if (settingsManifest.getExternalProgramCardsEnabled(request)) {
       // When creating a program, program type fields (if visible) are never disabled.


### PR DESCRIPTION
### Description
Remove `settingsManifest` parameter from `buildProgramTypeFieldset()` since it's a class variable and can be accessed directly

### Issue(s) this completes
None
