### PR TITLE
Fix test race condition

### DIFF
--- a/browser-test/src/support/admin_program_migration.ts
+++ b/browser-test/src/support/admin_program_migration.ts
@@ -1,6 +1,6 @@
-import {expect, Locator} from '@playwright/test'
-import {Page} from 'playwright'
-import {waitForPageJsLoad} from './wait'
+import {Locator, Page} from '@playwright/test'
+import {expect} from './civiform_fixtures'
+import {waitForHtmxReady, waitForPageJsLoad} from './wait'
 import {readFileSync} from 'fs'
 
 export class AdminProgramMigration {
@@ -75,10 +75,47 @@ export class AdminProgramMigration {
     await this.clickButtonWithSpinner('Preview program')
   }
 
-  private async expectButtonDisabledAndSpinning(buttonText: string) {
-    const button = this.page.getByRole('button', {name: buttonText})
-    await expect(button).toBeDisabled()
-    await expect(button).toHaveClass(/(^|\s)htmx-request(\s|$)/)
+  async clickButtonWithSpinner(buttonText: string) {
+    // Look up the button by accessible name and get the element ID so
+    // that the ID doesn't have to be hard coded.
+    const buttonId = await this.page
+      .getByRole('button', {name: buttonText})
+      .getAttribute('id')
+
+    // There is a race condition with htmx when trying to check if
+    // the button is disabled while the network request is being processed.
+    //
+    // Instead of using Playwright's normal `locator.click()` to trigger
+    // the click event do so from within the browser so that the button
+    // disabled state can be captured.
+    //
+    // This has the browser listen for htmx's beforeSend event which
+    // occurs directly before the network request is made. This is the point
+    // at which the button will be disabled when we capture it. Then later
+    // it can be asserted that it was in a disabled state at some point.
+    const buttonWasDisabled = await this.page.evaluate((buttonId) => {
+      return new Promise<boolean>((resolve) => {
+        const button = document.querySelector<HTMLButtonElement>(
+          '#' + buttonId,
+        )!
+
+        document.body.addEventListener(
+          'htmx:beforeSend',
+          () => {
+            resolve(button.disabled)
+          },
+          {once: true},
+        )
+
+        button.click()
+      })
+    }, buttonId)
+
+    // Finally here we verify that the element had been in a disabled state
+    // at some point.
+    expect(buttonWasDisabled).toBeTruthy()
+
+    await waitForHtmxReady(this.page)
     await waitForPageJsLoad(this.page)
   }
 
@@ -107,11 +144,6 @@ export class AdminProgramMigration {
 
   async expectOptionSelected(question: Locator, option: string) {
     await expect(question.getByLabel(option)).toBeChecked()
-  }
-
-  async clickButtonWithSpinner(buttonText: string) {
-    await this.page.getByRole('button', {name: buttonText}).click()
-    await this.expectButtonDisabledAndSpinning(buttonText)
   }
 
   async clickButton(buttonText: string) {


### PR DESCRIPTION
### Description

Fixes a race condition with HTMX and the button disabled check. The awful formatting is out of my control.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [ ] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

