### PR TITLE
[Cleanup] Remove static from buildApplicationStepDiv() used only by tests

### DIFF
--- a/server/app/views/admin/programs/ProgramFormBuilder.java
+++ b/server/app/views/admin/programs/ProgramFormBuilder.java
@@ -471,7 +471,7 @@ abstract class ProgramFormBuilder extends BaseHtmlView {
             .getCheckboxTag());
   }
 
-  static DivTag buildApplicationStepDiv(
+  protected DivTag buildApplicationStepDiv(
       int i, ImmutableList<Map<String, String>> applicationSteps, boolean isDisabled) {
 
     // Fill in the existing application steps

--- a/server/test/views/admin/programs/ProgramFormBuilderTest.java
+++ b/server/test/views/admin/programs/ProgramFormBuilderTest.java
@@ -33,7 +33,7 @@ public class ProgramFormBuilderTest {
   @Test
   public void buildApplicationStepDiv_buildsApplicationStepFormElement() {
     DivTag applicationStepsDiv =
-        ProgramFormBuilder.buildApplicationStepDiv(0, ImmutableList.of(), /* isDisabled= */ false);
+        formBuilder.buildApplicationStepDiv(0, ImmutableList.of(), /* isDisabled= */ false);
     String renderedDiv = applicationStepsDiv.render();
 
     // field id
@@ -47,7 +47,7 @@ public class ProgramFormBuilderTest {
     assertThat(renderedDiv).contains("Step 1 description");
 
     DivTag optionalApplicationStepsDiv =
-        ProgramFormBuilder.buildApplicationStepDiv(1, ImmutableList.of(), /* isDisabled= */ false);
+        formBuilder.buildApplicationStepDiv(1, ImmutableList.of(), /* isDisabled= */ false);
     String renderedOptionalDiv = optionalApplicationStepsDiv.render();
 
     // field label for divs other than the first one are labeled "optional"
@@ -58,7 +58,7 @@ public class ProgramFormBuilderTest {
   @Test
   public void buildApplicationStepDiv_rendersExistingValues() {
     DivTag applicationStepDiv =
-        ProgramFormBuilder.buildApplicationStepDiv(
+        formBuilder.buildApplicationStepDiv(
             0,
             ImmutableList.of(
                 Map.of("title", "Step one title", "description", "Step one description")),


### PR DESCRIPTION
### Description

`buildApplicationStepDiv()` was declared as a static method in order to call it directly from the unit test. However, that's not a good practice since the method is no longer contained inside the class. #10640 introduced a setup method where a mock `ProgramFormBuilder` is built. Thus, we can use it to call `buildApplicationStepDiv()` which allows us to change the static method to a protected one.

No functionality or UI changed

### Issue(s) this completes

None