### PR TITLE
Validate questions during import

### DIFF
--- a/server/app/services/migration/QuestionValidationUtils.java
+++ b/server/app/services/migration/QuestionValidationUtils.java
@@ -1,0 +1,110 @@
+package services.migration;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import services.CiviFormError;
+import services.program.ProgramDefinition;
+import services.question.types.MultiOptionQuestionDefinition;
+import services.question.types.QuestionDefinition;
+
+/** Utility class to validate questions during the program import flow. */
+final class QuestionValidationUtils {
+
+  /**
+   * Validates attributes of the question, including admin name, help text, and question options.
+   */
+  static ImmutableSet<CiviFormError> validateQuestionOptionAdminNames(
+      ImmutableList<QuestionDefinition> questions) {
+    return questions.stream()
+        .map(
+            question -> {
+              if (question.getQuestionType().isMultiOptionType()) {
+                MultiOptionQuestionDefinition multiOptionQuestion =
+                    (MultiOptionQuestionDefinition) question;
+                return multiOptionQuestion.setValidateQuestionOptionAdminNames(false).validate();
+              }
+              return question.validate();
+            })
+        .flatMap(errors -> errors.stream())
+        .collect(ImmutableSet.toImmutableSet());
+  }
+
+  /**
+   * Ensures all questions contained in the program are defined with a {@link QuestionDefinition}.
+   */
+  static ImmutableSet<CiviFormError> validateAllProgramQuestionsPresent(
+      ProgramDefinition program, ImmutableList<QuestionDefinition> questions) {
+    ImmutableList<Long> questionDefinitionIds =
+        questions.stream().map(QuestionDefinition::getId).collect(ImmutableList.toImmutableList());
+    return program.getQuestionIdsInProgram().stream()
+        .filter(qid -> !questionDefinitionIds.contains(qid))
+        .map(qid -> CiviFormError.of("Question ID " + qid + " is not defined"))
+        .collect(ImmutableSet.toImmutableSet());
+  }
+
+  /**
+   * Ensures that repeated questions (1) each have an associated enumerator, and (2) only exists in
+   * the question bank if the associated enumerator also already exists in the question bank.
+   */
+  static ImmutableSet<CiviFormError> validateRepeatedQuestions(
+      ProgramDefinition program,
+      ImmutableList<QuestionDefinition> questions,
+      ImmutableList<String> existingAdminNames) {
+    ImmutableMap<QuestionDefinition, Optional<QuestionDefinition>> repeatedQsToEnumerators =
+        questions.stream()
+            .filter(q -> q.getEnumeratorId().isPresent())
+            .collect(
+                ImmutableMap.toImmutableMap(
+                    q -> q,
+                    q ->
+                        questions.stream()
+                            .filter(parentEnum -> parentEnum.getId() == q.getEnumeratorId().get())
+                            .findFirst()));
+    ImmutableSet.Builder<CiviFormError> errors = ImmutableSet.builder();
+    ImmutableSet.Builder<String> repeatedQsMissingEnumeratorsBuilder = ImmutableSet.builder();
+    // First we check that all repeated questions have an enumerator
+    repeatedQsMissingEnumeratorsBuilder.addAll(
+        repeatedQsToEnumerators.keySet().stream()
+            .filter(q -> !repeatedQsToEnumerators.get(q).isPresent())
+            .map(QuestionDefinition::getName)
+            .collect(ImmutableSet.toImmutableSet()));
+    repeatedQsMissingEnumeratorsBuilder.addAll(
+        repeatedQsToEnumerators.keySet().stream()
+            .filter(q -> !program.getQuestionIdsInProgram().contains(q.getEnumeratorId().get()))
+            .map(QuestionDefinition::getName)
+            .collect(ImmutableSet.toImmutableSet()));
+    ImmutableSet<String> repeatedQsMissingEnumerators = repeatedQsMissingEnumeratorsBuilder.build();
+    if (!repeatedQsMissingEnumerators.isEmpty()) {
+      errors.add(
+          CiviFormError.of(
+              "Some repeated questions reference enumerators that could not be found in the program"
+                  + " and/or question definitions: "
+                  + repeatedQsMissingEnumerators.stream().collect(Collectors.joining(", "))));
+    }
+    // Then we check that repeated questions only exist in the question bank if their enumerator
+    // does too
+    ImmutableList<QuestionDefinition> repeatedQsAlreadyExistWithoutExistingEnumerators =
+        repeatedQsToEnumerators.keySet().stream()
+            .filter(
+                q ->
+                    existingAdminNames.contains(q.getName())
+                        && !repeatedQsMissingEnumerators.contains(q.getName()))
+            .filter(
+                q -> !existingAdminNames.contains(repeatedQsToEnumerators.get(q).get().getName()))
+            .collect(ImmutableList.toImmutableList());
+    if (!repeatedQsAlreadyExistWithoutExistingEnumerators.isEmpty()) {
+      errors.add(
+          CiviFormError.of(
+              "The following repeated questions already exist in the question bank, and must"
+                  + " reference an enumerator that also already exists: "
+                  + repeatedQsAlreadyExistWithoutExistingEnumerators.stream()
+                      .map(QuestionDefinition::getName)
+                      .collect(Collectors.joining(", "))));
+    }
+
+    return errors.build();
+  }
+}

--- a/server/test/services/migration/QuestionValidationUtilsTest.java
+++ b/server/test/services/migration/QuestionValidationUtilsTest.java
@@ -1,0 +1,226 @@
+package services.migration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import java.util.Locale;
+import java.util.Optional;
+import org.junit.Test;
+import repository.ResetPostgres;
+import services.CiviFormError;
+import services.LocalizedStrings;
+import services.program.ProgramDefinition;
+import services.program.ProgramType;
+import services.question.QuestionOption;
+import services.question.exceptions.UnsupportedQuestionTypeException;
+import services.question.types.MultiOptionQuestionDefinition;
+import services.question.types.MultiOptionQuestionDefinition.MultiOptionQuestionType;
+import services.question.types.QuestionDefinition;
+import services.question.types.QuestionDefinitionBuilder;
+import services.question.types.QuestionDefinitionConfig;
+import services.question.types.QuestionType;
+import support.ProgramBuilder;
+
+public final class QuestionValidationUtilsTest extends ResetPostgres {
+  private static final QuestionDefinitionConfig QUESTION_CONFIG =
+      QuestionDefinitionConfig.builder()
+          .setName("applicant ice cream")
+          .setDescription("Select your favorite ice cream flavor")
+          .setQuestionText(LocalizedStrings.of(Locale.US, "Ice cream?"))
+          .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help"))
+          .build();
+  private static final QuestionDefinition NAME_QUESTION = createQuestion("name", 1L);
+  private static final QuestionDefinition AGE_QUESTION = createQuestion("age", 2L);
+  private static final QuestionDefinition REPEATED_NAME_QUESTION =
+      createQuestionWithEnumerator("repeated_name", 3L, Optional.of(1L));
+  private static final String PROGRAM_NAME_1 = "Program 1";
+
+  @Test
+  public void validateQuestionOptionAdminNames_validMultiOption_noErrors() {
+    ImmutableList<QuestionOption> questionOptions =
+        ImmutableList.of(
+            QuestionOption.create(
+                1L, "chocolate_admin", LocalizedStrings.of(Locale.US, "chocolate")),
+            QuestionOption.create(
+                2L, "strawberry_admin", LocalizedStrings.of(Locale.US, "strawberry")),
+            QuestionOption.create(3L, "vanilla_admin", LocalizedStrings.of(Locale.US, "vanilla")));
+
+    ImmutableSet<CiviFormError> errors =
+        QuestionValidationUtils.validateQuestionOptionAdminNames(
+            ImmutableList.of(
+                new MultiOptionQuestionDefinition(
+                    QUESTION_CONFIG, questionOptions, MultiOptionQuestionType.CHECKBOX)));
+
+    assertThat(errors).isEmpty();
+  }
+
+  @Test
+  public void validateQuestionOptionAdminNames_duplicateAdminNames_returnsError()
+      throws UnsupportedQuestionTypeException {
+    ImmutableList<QuestionOption> questionOptions =
+        ImmutableList.of(
+            QuestionOption.create(
+                1L, "chocolate_admin", LocalizedStrings.of(Locale.US, "chocolate")),
+            QuestionOption.create(
+                2L, "chocolate_admin", LocalizedStrings.of(Locale.US, "strawberry")),
+            QuestionOption.create(3L, "vanilla_admin", LocalizedStrings.of(Locale.US, "vanilla")));
+
+    ImmutableSet<CiviFormError> errors =
+        QuestionValidationUtils.validateQuestionOptionAdminNames(
+            ImmutableList.of(
+                new MultiOptionQuestionDefinition(
+                    QUESTION_CONFIG, questionOptions, MultiOptionQuestionType.CHECKBOX)));
+
+    assertThat(errors).hasSize(1);
+    assertThat(errors.iterator().next().message())
+        .contains("Multi-option question admin names must be unique");
+  }
+
+  @Test
+  public void validateAllProgramQuestionsPresent_allPresent_noErrors() {
+    ProgramDefinition programDefinition =
+        ProgramBuilder.newActiveProgram(PROGRAM_NAME_1)
+            .withProgramType(ProgramType.DEFAULT)
+            .withBlock()
+            .withOptionalQuestion(NAME_QUESTION)
+            .withRequiredQuestionDefinition(AGE_QUESTION)
+            .buildDefinition();
+    ImmutableList<QuestionDefinition> questions = ImmutableList.of(NAME_QUESTION, AGE_QUESTION);
+
+    ImmutableSet<CiviFormError> errors =
+        QuestionValidationUtils.validateAllProgramQuestionsPresent(programDefinition, questions);
+
+    assertThat(errors).isEmpty();
+  }
+
+  @Test
+  public void validateAllProgramQuestionsPresent_questionMissing_returnsError() {
+    ProgramDefinition programDefinition =
+        ProgramBuilder.newActiveProgram(PROGRAM_NAME_1)
+            .withProgramType(ProgramType.DEFAULT)
+            .withBlock()
+            .withOptionalQuestion(NAME_QUESTION)
+            .withRequiredQuestionDefinition(AGE_QUESTION)
+            .withRequiredQuestionDefinition(createQuestion("phone", 3L))
+            .buildDefinition();
+    ImmutableList<QuestionDefinition> questions = ImmutableList.of(NAME_QUESTION);
+
+    ImmutableSet<CiviFormError> errors =
+        QuestionValidationUtils.validateAllProgramQuestionsPresent(programDefinition, questions);
+
+    assertThat(errors).hasSize(2); // age, phone
+    assertThat(errors.stream().map(CiviFormError::message))
+        .contains(
+            "Question ID " + AGE_QUESTION.getId() + " is not defined",
+            "Question ID 3 is not defined");
+  }
+
+  @Test
+  public void validateRepeatedQuestions_validRepeatedQuestion_noErrors() {
+    ProgramDefinition programDefinition =
+        ProgramBuilder.newActiveProgram(PROGRAM_NAME_1)
+            .withProgramType(ProgramType.DEFAULT)
+            .withBlock()
+            .withOptionalQuestion(NAME_QUESTION)
+            .withRequiredQuestionDefinition(REPEATED_NAME_QUESTION)
+            .buildDefinition();
+    ImmutableList<QuestionDefinition> questions =
+        ImmutableList.of(NAME_QUESTION, REPEATED_NAME_QUESTION);
+
+    ImmutableSet<CiviFormError> errors =
+        QuestionValidationUtils.validateRepeatedQuestions(
+            programDefinition,
+            questions,
+            ImmutableList.of(NAME_QUESTION.getName(), REPEATED_NAME_QUESTION.getName()));
+
+    assertThat(errors).isEmpty();
+  }
+
+  @Test
+  public void validateRepeatedQuestions_enumeratorMissingFromQuestionDefinitions_returnsError() {
+    ProgramDefinition programDefinition =
+        ProgramBuilder.newActiveProgram(PROGRAM_NAME_1)
+            .withProgramType(ProgramType.DEFAULT)
+            .withBlock()
+            .withOptionalQuestion(NAME_QUESTION)
+            .withRequiredQuestionDefinition(REPEATED_NAME_QUESTION)
+            .buildDefinition();
+    ImmutableList<QuestionDefinition> questions = ImmutableList.of(REPEATED_NAME_QUESTION);
+
+    ImmutableSet<CiviFormError> errors =
+        QuestionValidationUtils.validateRepeatedQuestions(
+            programDefinition, questions, ImmutableList.of());
+
+    assertThat(errors).hasSize(1);
+    assertThat(errors.iterator().next().message())
+        .contains("Some repeated questions reference enumerators that could not be found");
+    assertThat(errors.iterator().next().message()).contains(REPEATED_NAME_QUESTION.getName());
+  }
+
+  @Test
+  public void validateRepeatedQuestions_enumeratorMissingFromProgram_returnsError() {
+    ProgramDefinition programDefinition =
+        ProgramBuilder.newActiveProgram(PROGRAM_NAME_1)
+            .withProgramType(ProgramType.DEFAULT)
+            .withBlock()
+            .withRequiredQuestionDefinition(REPEATED_NAME_QUESTION)
+            .buildDefinition();
+    ImmutableList<QuestionDefinition> questions =
+        ImmutableList.of(NAME_QUESTION, REPEATED_NAME_QUESTION);
+
+    ImmutableSet<CiviFormError> errors =
+        QuestionValidationUtils.validateRepeatedQuestions(
+            programDefinition, questions, ImmutableList.of(NAME_QUESTION.getName()));
+
+    assertThat(errors).hasSize(1);
+    assertThat(errors.iterator().next().message())
+        .contains("Some repeated questions reference enumerators that could not be found");
+    assertThat(errors.iterator().next().message()).contains(REPEATED_NAME_QUESTION.getName());
+  }
+
+  @Test
+  public void validateRepeatedQuestions_repeatedExistsInBank_enumeratorNot_returnsError() {
+    ProgramDefinition programDefinition =
+        ProgramBuilder.newActiveProgram(PROGRAM_NAME_1)
+            .withProgramType(ProgramType.DEFAULT)
+            .withBlock()
+            .withOptionalQuestion(NAME_QUESTION)
+            .withRequiredQuestionDefinition(REPEATED_NAME_QUESTION)
+            .buildDefinition();
+    ImmutableList<QuestionDefinition> questions =
+        ImmutableList.of(NAME_QUESTION, REPEATED_NAME_QUESTION);
+
+    ImmutableSet<CiviFormError> errors =
+        QuestionValidationUtils.validateRepeatedQuestions(
+            programDefinition, questions, ImmutableList.of(REPEATED_NAME_QUESTION.getName()));
+
+    assertThat(errors).hasSize(1);
+    assertThat(errors.iterator().next().message())
+        .contains(
+            "The following repeated questions already exist in the question bank, and must"
+                + " reference an enumerator that also already exists");
+    assertThat(errors.iterator().next().message()).contains(REPEATED_NAME_QUESTION.getName());
+  }
+
+  // Helper methods to create test questions
+  private static QuestionDefinition createQuestion(String name, Long id) {
+    return createQuestionWithEnumerator(name, id, Optional.empty());
+  }
+
+  private static QuestionDefinition createQuestionWithEnumerator(
+      String name, Long id, Optional<Long> enumeratorId) {
+    try {
+      return new QuestionDefinitionBuilder()
+          .setName(name)
+          .setId(id)
+          .setQuestionType(QuestionType.TEXT)
+          .setQuestionText(LocalizedStrings.withDefaultValue(name))
+          .setDescription(name)
+          .setEnumeratorId(enumeratorId)
+          .build();
+    } catch (UnsupportedQuestionTypeException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}


### PR DESCRIPTION
### Description

Refactors question validation to the `ProgramMigrationService`, and an associated utility file. Adds validations in case the new duplicate-handling features are enabled:

1. All questions in the program definition are present in the `questions` list of `QuestionDefinition`s.
2. Repeated questions' referenced enumerators are present in both the `program` definition, and ion the `questions` list of `QuestionDefinition`s.
3. Repeated questions exist in the question bank already IFF their associated enumerator also exists in the question bank already

#9628 

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.
