### PR TITLE
Move North Star, color theming and program filtering flags out of experimental section

### DIFF
--- a/server/app/services/settings/SettingsManifest.java
+++ b/server/app/services/settings/SettingsManifest.java
@@ -1038,6 +1038,21 @@ public final class SettingsManifest extends AbstractSettingsManifest {
     return getBool("CUSTOMIZED_ELIGIBILITY_MESSAGE_ENABLED", request);
   }
 
+  /** Enables showing new UI with an updated user experience in Applicant flows */
+  public boolean getNorthStarApplicantUi(RequestHeader request) {
+    return getBool("NORTH_STAR_APPLICANT_UI", request);
+  }
+
+  /** Enables filtering programs by category on the homepage */
+  public boolean getProgramFilteringEnabled(RequestHeader request) {
+    return getBool("PROGRAM_FILTERING_ENABLED", request);
+  }
+
+  /** Enable using custom theme colors on North Star applicant UI. */
+  public boolean getCustomThemeColorsEnabled(RequestHeader request) {
+    return getBool("CUSTOM_THEME_COLORS_ENABLED", request);
+  }
+
   /**
    * (NOT FOR PRODUCTION USE) Ensures duplicate questions aren't created when migrating programs
    * between deployed environments. Note: this should only be used on new environments, since
@@ -1045,11 +1060,6 @@ public final class SettingsManifest extends AbstractSettingsManifest {
    */
   public boolean getNoDuplicateQuestionsForMigrationEnabled(RequestHeader request) {
     return getBool("NO_DUPLICATE_QUESTIONS_FOR_MIGRATION_ENABLED", request);
-  }
-
-  /** (NOT FOR PRODUCTION USE) Enables filtering programs by category on the homepage */
-  public boolean getProgramFilteringEnabled(RequestHeader request) {
-    return getBool("PROGRAM_FILTERING_ENABLED", request);
   }
 
   /** (NOT FOR PRODUCTION USE) Enables suffix dropdown field in name question. */
@@ -1065,22 +1075,9 @@ public final class SettingsManifest extends AbstractSettingsManifest {
     return getBool("SESSION_REPLAY_PROTECTION_ENABLED");
   }
 
-  /**
-   * (NOT FOR PRODUCTION USE) Enables showing new UI with an updated user experience in Applicant
-   * flows
-   */
-  public boolean getNorthStarApplicantUi(RequestHeader request) {
-    return getBool("NORTH_STAR_APPLICANT_UI", request);
-  }
-
   /** (NOT FOR PRODUCTION USE) Enable session timeout based on inactivity and maximum duration. */
   public boolean getSessionTimeoutEnabled(RequestHeader request) {
     return getBool("SESSION_TIMEOUT_ENABLED", request);
-  }
-
-  /** (NOT FOR PRODUCTION USE) Enable using custom theme colors on North Star applicant UI. */
-  public boolean getCustomThemeColorsEnabled(RequestHeader request) {
-    return getBool("CUSTOM_THEME_COLORS_ENABLED", request);
   }
 
   /** (NOT FOR PRODUCTION USE) Enable showing external program cards on North Star applicant UI. */
@@ -2259,6 +2256,25 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                               + " screen.",
                           /* isRequired= */ false,
                           SettingType.BOOLEAN,
+                          SettingMode.ADMIN_WRITEABLE),
+                      SettingDescription.create(
+                          "NORTH_STAR_APPLICANT_UI",
+                          "Enables showing new UI with an updated user experience in Applicant"
+                              + " flows",
+                          /* isRequired= */ false,
+                          SettingType.BOOLEAN,
+                          SettingMode.ADMIN_WRITEABLE),
+                      SettingDescription.create(
+                          "PROGRAM_FILTERING_ENABLED",
+                          "Enables filtering programs by category on the homepage",
+                          /* isRequired= */ false,
+                          SettingType.BOOLEAN,
+                          SettingMode.ADMIN_WRITEABLE),
+                      SettingDescription.create(
+                          "CUSTOM_THEME_COLORS_ENABLED",
+                          "Enable using custom theme colors on North Star applicant UI.",
+                          /* isRequired= */ false,
+                          SettingType.BOOLEAN,
                           SettingMode.ADMIN_WRITEABLE))))
           .put(
               "Experimental",
@@ -2279,13 +2295,6 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                           SettingType.BOOLEAN,
                           SettingMode.ADMIN_WRITEABLE),
                       SettingDescription.create(
-                          "PROGRAM_FILTERING_ENABLED",
-                          "(NOT FOR PRODUCTION USE) Enables filtering programs by category on the"
-                              + " homepage",
-                          /* isRequired= */ false,
-                          SettingType.BOOLEAN,
-                          SettingMode.ADMIN_WRITEABLE),
-                      SettingDescription.create(
                           "NAME_SUFFIX_DROPDOWN_ENABLED",
                           "(NOT FOR PRODUCTION USE) Enables suffix dropdown field in name"
                               + " question.",
@@ -2300,23 +2309,9 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                           SettingType.BOOLEAN,
                           SettingMode.ADMIN_READABLE),
                       SettingDescription.create(
-                          "NORTH_STAR_APPLICANT_UI",
-                          "(NOT FOR PRODUCTION USE) Enables showing new UI with an updated user"
-                              + " experience in Applicant flows",
-                          /* isRequired= */ false,
-                          SettingType.BOOLEAN,
-                          SettingMode.ADMIN_WRITEABLE),
-                      SettingDescription.create(
                           "SESSION_TIMEOUT_ENABLED",
                           "(NOT FOR PRODUCTION USE) Enable session timeout based on inactivity and"
                               + " maximum duration.",
-                          /* isRequired= */ false,
-                          SettingType.BOOLEAN,
-                          SettingMode.ADMIN_WRITEABLE),
-                      SettingDescription.create(
-                          "CUSTOM_THEME_COLORS_ENABLED",
-                          "(NOT FOR PRODUCTION USE) Enable using custom theme colors on North Star"
-                              + " applicant UI.",
                           /* isRequired= */ false,
                           SettingType.BOOLEAN,
                           SettingMode.ADMIN_WRITEABLE),

--- a/server/conf/env-var-docs.json
+++ b/server/conf/env-var-docs.json
@@ -899,6 +899,22 @@
         "mode": "ADMIN_WRITEABLE",
         "description": "Enables civiform admins to set up a customized eligibility message per screen.",
         "type": "bool"
+      },
+      "NORTH_STAR_APPLICANT_UI": {
+        "mode": "ADMIN_WRITEABLE",
+        "description": "Enables showing new UI with an updated user experience in Applicant flows",
+        "type": "bool"
+      },
+      "PROGRAM_FILTERING_ENABLED": {
+        "mode": "ADMIN_WRITEABLE",
+        "description": "Enables filtering programs by category on the homepage",
+        "type": "bool"
+      },
+      "CUSTOM_THEME_COLORS_ENABLED": {
+        "mode": "ADMIN_WRITEABLE",
+        "description": "Enable using custom theme colors on North Star applicant UI.",
+        "type": "bool",
+        "required": false
       }
     }
   },
@@ -908,11 +924,6 @@
       "NO_DUPLICATE_QUESTIONS_FOR_MIGRATION_ENABLED": {
         "mode": "ADMIN_WRITEABLE",
         "description": "(NOT FOR PRODUCTION USE) Ensures duplicate questions aren't created when migrating programs between deployed environments. Note: this should only be used on new environments, since existing programs will be modified if a program with the same question gets imported.",
-        "type": "bool"
-      },
-      "PROGRAM_FILTERING_ENABLED": {
-        "mode": "ADMIN_WRITEABLE",
-        "description": "(NOT FOR PRODUCTION USE) Enables filtering programs by category on the homepage",
         "type": "bool"
       },
       "NAME_SUFFIX_DROPDOWN_ENABLED": {
@@ -925,20 +936,9 @@
         "description": "(NOT FOR PRODUCTION USE) Enable session replay protection, so that a session cookie cannot be replayed if the user logs out",
         "type": "bool"
       },
-      "NORTH_STAR_APPLICANT_UI": {
-        "mode": "ADMIN_WRITEABLE",
-        "description": "(NOT FOR PRODUCTION USE) Enables showing new UI with an updated user experience in Applicant flows",
-        "type": "bool"
-      },
       "SESSION_TIMEOUT_ENABLED": {
         "mode": "ADMIN_WRITEABLE",
         "description": "(NOT FOR PRODUCTION USE) Enable session timeout based on inactivity and maximum duration.",
-        "type": "bool",
-        "required": false
-      },
-      "CUSTOM_THEME_COLORS_ENABLED": {
-        "mode": "ADMIN_WRITEABLE",
-        "description": "(NOT FOR PRODUCTION USE) Enable using custom theme colors on North Star applicant UI.",
         "type": "bool",
         "required": false
       },


### PR DESCRIPTION
### Description

In anticipation of our 3.0 launch, moving the North Star, color theming and program filtering flags out of the experimental section of our settings to the regular "Feature flags" section.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [ ] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [ ] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

#### Database evolutions

Read the guidelines [here](https://github.com/civiform/civiform/wiki/Database#writing-database-evolutions)

- [ ] Assigned two reviewers
- [ ] Guarded against already existing resources using `IF NOT EXISTS` and `IF EXISTS`
- [ ] Downs created to undo changes in Ups
- [ ] Every comment in script should begin with -- and not # --- unless it denotes Ups or Downs. See [here](https://www.playframework.com/documentation/2.9.x/Evolutions) for details.
- [ ] Tested both the Downs and the Ups scripts manually (When testing, include all comments from the evolution in your test script to ensure any syntax errors in the comments are caught.)
- [ ] Data migrations aren't being done (please use a [Durable Job](https://github.com/civiform/civiform/wiki/Database#durable-jobs-for-data-updates) if doing a data migration)
- [ ] Update the model documentation in our [wiki](https://github.com/civiform/civiform/wiki/Database) if necessary

#### Durable jobs

Read the docs [here](https://github.com/civiform/civiform/wiki/Database#durable-jobs-for-data-updates)

- [ ] Assigned two reviewers
- [ ] Included a rollback plan and a job to undo the data changes if appropriate

#### User visible changes

- [ ] Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
  - [ ] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [ ] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Made equivalent changes in Thymeleaf for applicant-facing features and changes (or created an issue in the [Northstar epic](https://github.com/orgs/civiform/projects/1/views/94) to track that it's missing from Thymeleaf)
- [ ] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order
- [ ] Manually tested with a screen reader if the feature is applicant-facing. See [screen reader testing](https://github.com/civiform/civiform/wiki/Testing#screen-reader-testing)

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/helper/feature-flags.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://github.com/civiform/civiform/wiki/Feature-Flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Instructions for manual testing

If instructions are needed for manual testing by reviewers, include them here.

### Issue(s) this completes

Fixes #<issue_number>; Fixes #<issue_number>...
