### PR TITLE
[API] Support revisionState filter for list applications 

### DIFF
--- a/server/app/controllers/api/ProgramApplicationsApiController.java
+++ b/server/app/controllers/api/ProgramApplicationsApiController.java
@@ -10,10 +10,12 @@ import com.google.inject.Inject;
 import com.typesafe.config.Config;
 import java.time.Instant;
 import java.time.format.DateTimeParseException;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import models.ApplicationModel;
 import models.LifecycleStage;
@@ -25,6 +27,7 @@ import repository.TimeFilter;
 import repository.VersionRepository;
 import services.DateConverter;
 import services.export.JsonExporterService;
+import services.export.enums.RevisionState;
 import services.pagination.PaginationResult;
 import services.pagination.RowIdSequentialAccessPaginationSpec;
 import services.program.ProgramNotFoundException;
@@ -36,6 +39,7 @@ public final class ProgramApplicationsApiController extends CiviFormApiControlle
   public static final String PROGRAM_SLUG_PARAM_NAME = "programSlug";
   public static final String FROM_DATE_PARAM_NAME = "fromDate";
   public static final String UNTIL_DATE_PARAM_NAME = "toDate";
+  public static final String REVISION_STATE_PARAM_NAME = "revisionState";
   private final DateConverter dateConverter;
   private final ProgramService programService;
   private final ClassLoaderExecutionContext classLoaderExecutionContext;
@@ -61,18 +65,30 @@ public final class ProgramApplicationsApiController extends CiviFormApiControlle
     this.maxPageSize = checkNotNull(config).getInt("civiform_api_applications_list_max_page_size");
   }
 
+  /**
+   * Lists submitted applications for a given program with pagination and filtering support.
+   *
+   * @param request - HTTP request
+   * @param programSlug - unique identifier for the program
+   * @param fromDateParam - optional inclusive start date filter for application submissions
+   * @param toDateParam - optional exclusive end date filter for application submissions
+   * @param revisionStateParam - optional revision state filter
+   * @param serializedNextPageToken - optional pagination token for retrieving next page
+   * @param pageSizeParam - optional number of applications to return per page
+   * @return CompletionStage containing the JSON response with applications and pagination info
+   */
   public CompletionStage<Result> list(
       Http.Request request,
       String programSlug,
       Optional<String> fromDateParam,
       Optional<String> toDateParam,
+      Optional<String> revisionStateParam,
       Optional<String> serializedNextPageToken,
       Optional<Integer> pageSizeParam) {
     assertHasProgramReadPermission(request, programSlug);
 
     Optional<ApiPaginationTokenPayload> paginationToken =
         serializedNextPageToken.map(apiPaginationTokenSerializer::deserialize);
-
     paginationToken.ifPresent(
         (token) -> {
           if (!token
@@ -84,22 +100,11 @@ public final class ProgramApplicationsApiController extends CiviFormApiControlle
         });
 
     SubmittedApplicationFilter filters =
-        SubmittedApplicationFilter.builder()
-            .setSubmitTimeFilter(
-                TimeFilter.builder()
-                    .setFromTime(
-                        resolveDateParam(paginationToken, FROM_DATE_PARAM_NAME, fromDateParam))
-                    .setUntilTime(
-                        resolveDateParam(paginationToken, UNTIL_DATE_PARAM_NAME, toDateParam))
-                    .build())
-            .setLifecycleStages(ImmutableList.of(LifecycleStage.ACTIVE, LifecycleStage.OBSOLETE))
-            .build();
-    int pageSize = resolvePageSize(paginationToken, pageSizeParam);
+        buildListFilters(paginationToken, fromDateParam, toDateParam, revisionStateParam);
 
+    int pageSize = resolvePageSize(paginationToken, pageSizeParam);
     RowIdSequentialAccessPaginationSpec paginationSpec =
-        paginationToken
-            .map(this::createPaginationSpec)
-            .orElse(new RowIdSequentialAccessPaginationSpec(pageSize, Long.MAX_VALUE));
+        buildPaginationSpec(paginationToken, pageSize);
 
     return programService
         .getActiveFullProgramDefinitionAsync(programSlug)
@@ -116,7 +121,11 @@ public final class ProgramApplicationsApiController extends CiviFormApiControlle
                   apiPayloadWrapper.wrapPayload(
                       applicationsJson,
                       getNextPageToken(
-                          paginationResult, programSlug, pageSize, filters.submitTimeFilter()));
+                          paginationResult,
+                          programSlug,
+                          pageSize,
+                          filters.submitTimeFilter(),
+                          filters.lifecycleStages()));
 
               return ok(responseJson).as("application/json");
             },
@@ -134,11 +143,49 @@ public final class ProgramApplicationsApiController extends CiviFormApiControlle
             });
   }
 
+  /** Builds filter criteria for submitted applications based on request parameters. */
+  private SubmittedApplicationFilter buildListFilters(
+      Optional<ApiPaginationTokenPayload> paginationToken,
+      Optional<String> fromDateParam,
+      Optional<String> toDateParam,
+      Optional<String> revisionStateParam) {
+    TimeFilter timeFilter =
+        TimeFilter.builder()
+            .setFromTime(resolveDateParam(paginationToken, FROM_DATE_PARAM_NAME, fromDateParam))
+            .setUntilTime(resolveDateParam(paginationToken, UNTIL_DATE_PARAM_NAME, toDateParam))
+            .build();
+    ImmutableList<LifecycleStage> lifecycleStage =
+        resolveRevisionStateParam(paginationToken, revisionStateParam);
+
+    return SubmittedApplicationFilter.builder()
+        .setSubmitTimeFilter(timeFilter)
+        .setLifecycleStages(lifecycleStage)
+        .build();
+  }
+
+  /** Creates pagination specification for database queries. */
+  private RowIdSequentialAccessPaginationSpec buildPaginationSpec(
+      Optional<ApiPaginationTokenPayload> paginationToken, Integer pageSize) {
+    return paginationToken
+        .map(
+            token ->
+                new RowIdSequentialAccessPaginationSpec(
+                    token.getPageSpec().getPageSize(),
+                    Long.valueOf(token.getPageSpec().getOffsetIdentifier())))
+        .orElse(new RowIdSequentialAccessPaginationSpec(pageSize, Long.MAX_VALUE));
+  }
+
+  /**
+   * Generates a pagination token for retrieving the next page of results. The token encapsulates
+   * both pagination state and filter parameters to ensure consistent filtering across paginated
+   * requests.
+   */
   private Optional<ApiPaginationTokenPayload> getNextPageToken(
       PaginationResult<ApplicationModel> paginationResult,
       String programSlug,
       int pageSize,
-      TimeFilter timeFilter) {
+      TimeFilter timeFilter,
+      ImmutableList<LifecycleStage> lifecycleStages) {
     if (!paginationResult.hasMorePages()) {
       return Optional.empty();
     }
@@ -161,6 +208,14 @@ public final class ProgramApplicationsApiController extends CiviFormApiControlle
             (untilInstant) ->
                 requestSpec.put(
                     UNTIL_DATE_PARAM_NAME, dateConverter.formatIso8601Date(untilInstant)));
+    String revisionStates =
+        lifecycleStages.stream()
+            .map(
+                (LifecycleStage stage) ->
+                    stage == LifecycleStage.ACTIVE ? RevisionState.CURRENT : RevisionState.OBSOLETE)
+            .map((RevisionState state) -> state.name())
+            .collect(Collectors.joining(","));
+    requestSpec.put(REVISION_STATE_PARAM_NAME, revisionStates);
 
     return Optional.of(new ApiPaginationTokenPayload(pageSpec, requestSpec.build()));
   }
@@ -229,10 +284,62 @@ public final class ProgramApplicationsApiController extends CiviFormApiControlle
     }
   }
 
-  private RowIdSequentialAccessPaginationSpec createPaginationSpec(
+  /**
+   * Resolves the lifecycle stage from either the revision state parameter or pagination token.
+   * Ensures consistency between pagination token and query parameter when both are present.
+   */
+  private ImmutableList<LifecycleStage> resolveRevisionStateParam(
+      Optional<ApiPaginationTokenPayload> apiPaginationTokenPayload,
+      Optional<String> revisionStateParam) {
+    // Defaults to all submitted applications if no revision state is provided
+    ImmutableList<LifecycleStage> queryLifecycleStages =
+        revisionStateParam.isEmpty()
+            ? ImmutableList.of(LifecycleStage.ACTIVE, LifecycleStage.OBSOLETE)
+            : ImmutableList.of(getLifecycleStage(revisionStateParam.get()));
+    ImmutableList<LifecycleStage> tokenLifecycleStages =
+        apiPaginationTokenPayload
+            .map((token) -> extractLifecycleStagesFromPaginationToken(token))
+            .orElse(ImmutableList.of());
+
+    if (tokenLifecycleStages.equals(queryLifecycleStages)) {
+      return tokenLifecycleStages;
+    }
+
+    if (!tokenLifecycleStages.isEmpty() && !queryLifecycleStages.isEmpty()) {
+      throw new BadApiRequestException(
+          "Request parameters must match pagination token: " + revisionStateParam);
+    }
+
+    return !tokenLifecycleStages.isEmpty() ? tokenLifecycleStages : queryLifecycleStages;
+  }
+
+  /**
+   * Extracts the lifecycle stage from a pagination token's request specification.
+   *
+   * @param apiPaginationTokenPayload The pagination token containing previous request context
+   * @return Optional LifecycleStage if found in token, empty otherwise
+   */
+  private ImmutableList<LifecycleStage> extractLifecycleStagesFromPaginationToken(
       ApiPaginationTokenPayload apiPaginationTokenPayload) {
-    return new RowIdSequentialAccessPaginationSpec(
-        apiPaginationTokenPayload.getPageSpec().getPageSize(),
-        Long.valueOf(apiPaginationTokenPayload.getPageSpec().getOffsetIdentifier()));
+    Map<String, String> requestSpec = apiPaginationTokenPayload.getRequestSpec();
+
+    if (!requestSpec.containsKey(REVISION_STATE_PARAM_NAME)) {
+      return ImmutableList.of();
+    }
+
+    return Arrays.stream(requestSpec.get(REVISION_STATE_PARAM_NAME).split(","))
+        .map(String::trim)
+        .map(this::getLifecycleStage)
+        .collect(ImmutableList.toImmutableList());
+  }
+
+  /** Converts a revision state parameter string to the corresponding LifecycleStage enum */
+  private LifecycleStage getLifecycleStage(String revisionStateParam) {
+    try {
+      RevisionState state = RevisionState.valueOf(revisionStateParam);
+      return state == RevisionState.CURRENT ? LifecycleStage.ACTIVE : LifecycleStage.OBSOLETE;
+    } catch (IllegalArgumentException e) {
+      throw new BadApiRequestException("Invalid revision state parameter: " + revisionStateParam);
+    }
   }
 }

--- a/server/app/services/openapi/v3/OpenApi3SchemaGenerator.java
+++ b/server/app/services/openapi/v3/OpenApi3SchemaGenerator.java
@@ -24,10 +24,12 @@ import io.swagger.v3.oas.models.responses.ApiResponses;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
+import java.util.Arrays;
 import java.util.Locale;
 import java.util.Optional;
 import services.applicant.question.Scalar;
 import services.export.enums.ApiPathSegment;
+import services.export.enums.RevisionState;
 import services.openapi.AbstractOpenApiSchemaGenerator;
 import services.openapi.DefinitionType;
 import services.openapi.Format;
@@ -186,6 +188,19 @@ public class OpenApi3SchemaGenerator extends AbstractOpenApiSchemaGenerator
                                                       + " timezone is provided, and the beginning"
                                                       + " of the day when no time is provided.")
                                               .schema(new StringSchema()))
+                                      .addParametersItem(
+                                          new QueryParameter()
+                                              .name("revisionState")
+                                              .description(
+                                                  "The revision state of applications to include in"
+                                                      + " results. When omitted, applications of"
+                                                      + " all revision states are returned.")
+                                              .schema(
+                                                  new StringSchema()
+                                                      ._enum(
+                                                          Arrays.asList(
+                                                              RevisionState.CURRENT.name(),
+                                                              RevisionState.OBSOLETE.name()))))
                                       .addParametersItem(
                                           new QueryParameter()
                                               .name("pageSize")

--- a/server/conf/routes
+++ b/server/conf/routes
@@ -215,7 +215,7 @@ POST    /applicants/:applicantId/programs/:programId/blocks/:blockId/:inReview/:
 
 # API
 GET     /api/v1/checkAuth                                   controllers.api.CiviFormApiController.checkAuth()
-GET     /api/v1/admin/programs/:programSlug/applications    controllers.api.ProgramApplicationsApiController.list(request: Request, programSlug: String, fromDate: java.util.Optional[String], toDate: java.util.Optional[String], nextPageToken: java.util.Optional[String], pageSize: java.util.Optional[Integer])
+GET     /api/v1/admin/programs/:programSlug/applications    controllers.api.ProgramApplicationsApiController.list(request: Request, programSlug: String, fromDate: java.util.Optional[String], toDate: java.util.Optional[String], revisionState: java.util.Optional[String], nextPageToken: java.util.Optional[String], pageSize: java.util.Optional[Integer])
 
 # API Docs
 GET     /docs/api/programs                            controllers.docs.ApiDocsController.index(request: Request)

--- a/server/test/services/openapi/v3/OpenApi3SchemaGeneratorTest.java
+++ b/server/test/services/openapi/v3/OpenApi3SchemaGeneratorTest.java
@@ -112,6 +112,15 @@ paths:
           \\ the beginning of the day when no time is provided."
         schema:
           type: string
+      - name: revisionState
+        in: query
+        description: "The revision state of applications to include in results. When\\
+          \\ omitted, applications of all revision states are returned."
+        schema:
+          type: string
+          enum:
+          - CURRENT
+          - OBSOLETE
       - name: pageSize
         in: query
         description: "A positive integer. Limits the number of results per page. If\\
@@ -304,6 +313,15 @@ paths:
           \\ the beginning of the day when no time is provided."
         schema:
           type: string
+      - name: revisionState
+        in: query
+        description: "The revision state of applications to include in results. When\\
+          \\ omitted, applications of all revision states are returned."
+        schema:
+          type: string
+          enum:
+          - CURRENT
+          - OBSOLETE
       - name: pageSize
         in: query
         description: "A positive integer. Limits the number of results per page. If\\
@@ -849,6 +867,15 @@ paths:
           \\ the beginning of the day when no time is provided."
         schema:
           type: string
+      - name: revisionState
+        in: query
+        description: "The revision state of applications to include in results. When\\
+          \\ omitted, applications of all revision states are returned."
+        schema:
+          type: string
+          enum:
+          - CURRENT
+          - OBSOLETE
       - name: pageSize
         in: query
         description: "A positive integer. Limits the number of results per page. If\\


### PR DESCRIPTION
### Description

Currently, list applications API returns all submitted applications. That is, all applications that have `LifecycleStage.ACTIVE` or `Lifecycle.OBSOLETE`. This PR adds a `revisionState` filter, which maps to internal `LifecycleStage`, to the API.

Follow ups:
- Add `revisionState`  to Swagger schema (v2)
- Update public docs site page

Design doc: https://docs.google.com/document/d/1uwon5sEg2jHcjlDJ4qs0RZfiNMBTvHnKeJSDdKyf3Nw/edit?usp=sharing

**AI usage**
AI was used to generate unit tests for ProgramApplicationsApiController. Generated code was used as a reference, but actual PR code was implemented by PR owner.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

### Issue(s) this completes

Part of #4995
