### PR TITLE
Tallulah/common intake to pre screener java files

### DIFF
--- a/server/app/assets/javascripts/admin_programs.ts
+++ b/server/app/assets/javascripts/admin_programs.ts
@@ -35,7 +35,7 @@ class AdminPrograms {
    * manage the disabled state of related form elements.
    */
   static attachProgramTypeChangeListener() {
-    // Listens for changes to the common intake checkbox.
+    // Listens for changes to the pre-screener checkbox.
     // TODO(#10363): This should be removed once EXTERNAL_PROGRAM_CARDS feature
     // is enabled by default, which is handled by the next listener.
     addEventListenerToElements('#common-intake-checkbox', 'click', () => {

--- a/server/app/controllers/admin/AdminProgramController.java
+++ b/server/app/controllers/admin/AdminProgramController.java
@@ -146,7 +146,7 @@ public final class AdminProgramController extends CiviFormController {
       Optional<ProgramDefinition> maybeCommonIntakeForm = programService.getCommonIntakeForm();
       if (maybeCommonIntakeForm.isPresent()) {
         return ok(
-            newOneView.renderChangeCommonIntakeConfirmation(
+            newOneView.renderChangePreScreenerConfirmation(
                 request, programData, maybeCommonIntakeForm.get().localizedName().getDefault()));
       }
     }

--- a/server/app/controllers/admin/AdminProgramController.java
+++ b/server/app/controllers/admin/AdminProgramController.java
@@ -143,7 +143,7 @@ public final class AdminProgramController extends CiviFormController {
     // program to this one, show the confirmation dialog.
     if (programData.getProgramType().equals(ProgramType.COMMON_INTAKE_FORM)
         && !programData.getConfirmedChangePreScreenerForm()) {
-      Optional<ProgramDefinition> maybeCommonIntakeForm = programService.getCommonIntakeForm();
+      Optional<ProgramDefinition> maybeCommonIntakeForm = programService.getPreScreenerForm();
       if (maybeCommonIntakeForm.isPresent()) {
         return ok(
             newOneView.renderChangePreScreenerConfirmation(
@@ -284,7 +284,7 @@ public final class AdminProgramController extends CiviFormController {
     // program to this one, show the confirmation dialog.
     if (programData.getProgramType().equals(ProgramType.COMMON_INTAKE_FORM)
         && !programData.getConfirmedChangePreScreenerForm()) {
-      Optional<ProgramDefinition> maybeCommonIntakeForm = programService.getCommonIntakeForm();
+      Optional<ProgramDefinition> maybeCommonIntakeForm = programService.getPreScreenerForm();
       if (maybeCommonIntakeForm.isPresent()
           && !maybeCommonIntakeForm.get().adminName().equals(programDefinition.adminName())) {
         return ok(

--- a/server/app/controllers/admin/AdminProgramController.java
+++ b/server/app/controllers/admin/AdminProgramController.java
@@ -139,7 +139,7 @@ public final class AdminProgramController extends CiviFormController {
       return ok(newOneView.render(request, programData, message));
     }
 
-    // If the user needs to confirm that they want to change the common intake form from a different
+    // If the user needs to confirm that they want to change the pre-screener form from a different
     // program to this one, show the confirmation dialog.
     if (programData.getProgramType().equals(ProgramType.COMMON_INTAKE_FORM)
         && !programData.getConfirmedChangeCommonIntakeForm()) {
@@ -280,7 +280,7 @@ public final class AdminProgramController extends CiviFormController {
           editView.render(request, programDefinition, programEditStatus, programData, message));
     }
 
-    // If the user needs to confirm that they want to change the common intake form from a different
+    // If the user needs to confirm that they want to change the pre-screener form from a different
     // program to this one, show the confirmation dialog.
     if (programData.getProgramType().equals(ProgramType.COMMON_INTAKE_FORM)
         && !programData.getConfirmedChangeCommonIntakeForm()) {

--- a/server/app/controllers/admin/AdminProgramController.java
+++ b/server/app/controllers/admin/AdminProgramController.java
@@ -143,11 +143,11 @@ public final class AdminProgramController extends CiviFormController {
     // program to this one, show the confirmation dialog.
     if (programData.getProgramType().equals(ProgramType.COMMON_INTAKE_FORM)
         && !programData.getConfirmedChangePreScreenerForm()) {
-      Optional<ProgramDefinition> maybeCommonIntakeForm = programService.getPreScreenerForm();
-      if (maybeCommonIntakeForm.isPresent()) {
+      Optional<ProgramDefinition> maybePreScreenerForm = programService.getPreScreenerForm();
+      if (maybePreScreenerForm.isPresent()) {
         return ok(
             newOneView.renderChangePreScreenerConfirmation(
-                request, programData, maybeCommonIntakeForm.get().localizedName().getDefault()));
+                request, programData, maybePreScreenerForm.get().localizedName().getDefault()));
       }
     }
 
@@ -284,16 +284,16 @@ public final class AdminProgramController extends CiviFormController {
     // program to this one, show the confirmation dialog.
     if (programData.getProgramType().equals(ProgramType.COMMON_INTAKE_FORM)
         && !programData.getConfirmedChangePreScreenerForm()) {
-      Optional<ProgramDefinition> maybeCommonIntakeForm = programService.getPreScreenerForm();
-      if (maybeCommonIntakeForm.isPresent()
-          && !maybeCommonIntakeForm.get().adminName().equals(programDefinition.adminName())) {
+      Optional<ProgramDefinition> maybePreScreenerForm = programService.getPreScreenerForm();
+      if (maybePreScreenerForm.isPresent()
+          && !maybePreScreenerForm.get().adminName().equals(programDefinition.adminName())) {
         return ok(
             editView.renderChangeCommonIntakeConfirmation(
                 request,
                 programDefinition,
                 programEditStatus,
                 programData,
-                maybeCommonIntakeForm.get().localizedName().getDefault()));
+                maybePreScreenerForm.get().localizedName().getDefault()));
       }
     }
 

--- a/server/app/controllers/admin/AdminProgramController.java
+++ b/server/app/controllers/admin/AdminProgramController.java
@@ -142,7 +142,7 @@ public final class AdminProgramController extends CiviFormController {
     // If the user needs to confirm that they want to change the pre-screener form from a different
     // program to this one, show the confirmation dialog.
     if (programData.getProgramType().equals(ProgramType.COMMON_INTAKE_FORM)
-        && !programData.getConfirmedChangeCommonIntakeForm()) {
+        && !programData.getConfirmedChangePreScreenerForm()) {
       Optional<ProgramDefinition> maybeCommonIntakeForm = programService.getCommonIntakeForm();
       if (maybeCommonIntakeForm.isPresent()) {
         return ok(
@@ -283,7 +283,7 @@ public final class AdminProgramController extends CiviFormController {
     // If the user needs to confirm that they want to change the pre-screener form from a different
     // program to this one, show the confirmation dialog.
     if (programData.getProgramType().equals(ProgramType.COMMON_INTAKE_FORM)
-        && !programData.getConfirmedChangeCommonIntakeForm()) {
+        && !programData.getConfirmedChangePreScreenerForm()) {
       Optional<ProgramDefinition> maybeCommonIntakeForm = programService.getCommonIntakeForm();
       if (maybeCommonIntakeForm.isPresent()
           && !maybeCommonIntakeForm.get().adminName().equals(programDefinition.adminName())) {

--- a/server/app/controllers/admin/AdminProgramController.java
+++ b/server/app/controllers/admin/AdminProgramController.java
@@ -288,7 +288,7 @@ public final class AdminProgramController extends CiviFormController {
       if (maybePreScreenerForm.isPresent()
           && !maybePreScreenerForm.get().adminName().equals(programDefinition.adminName())) {
         return ok(
-            editView.renderChangeCommonIntakeConfirmation(
+            editView.renderChangePreScreenerConfirmation(
                 request,
                 programDefinition,
                 programEditStatus,

--- a/server/app/controllers/applicant/EligibilityAlertSettingsCalculator.java
+++ b/server/app/controllers/applicant/EligibilityAlertSettingsCalculator.java
@@ -239,7 +239,7 @@ public final class EligibilityAlertSettingsCalculator {
     try {
       var programDefinition = programService.getFullProgramDefinition(programId);
 
-      return !programDefinition.isCommonIntakeForm() && programDefinition.hasEligibilityEnabled();
+      return !programDefinition.isPreScreenerForm() && programDefinition.hasEligibilityEnabled();
     } catch (ProgramNotFoundException ex) {
       // Checked exceptions are the devil and we've already determined that this program exists by
       // this point

--- a/server/app/controllers/applicant/EligibilityAlertSettingsCalculator.java
+++ b/server/app/controllers/applicant/EligibilityAlertSettingsCalculator.java
@@ -232,7 +232,7 @@ public final class EligibilityAlertSettingsCalculator {
   private record Triple(AlertType alertType, MessageKey titleKey, MessageKey textKey) {}
 
   /**
-   * Returns true if eligibility is enabled on the program and it is not a common intake form, false
+   * Returns true if eligibility is enabled on the program and it is not a pre-screener form, false
    * otherwise.
    */
   private boolean canShowEligibilitySettings(long programId) {

--- a/server/app/controllers/applicant/UpsellController.java
+++ b/server/app/controllers/applicant/UpsellController.java
@@ -102,7 +102,7 @@ public final class UpsellController extends CiviFormController {
     CompletableFuture<Boolean> isCommonIntake =
         programService
             .getFullProgramDefinitionAsync(programId)
-            .thenApplyAsync(ProgramDefinition::isCommonIntakeForm)
+            .thenApplyAsync(ProgramDefinition::isPreScreenerForm)
             .toCompletableFuture();
 
     CompletableFuture<ApplicantPersonalInfo> applicantPersonalInfo =

--- a/server/app/controllers/applicant/UpsellController.java
+++ b/server/app/controllers/applicant/UpsellController.java
@@ -131,7 +131,7 @@ public final class UpsellController extends CiviFormController {
         .thenComposeAsync(
             ignored -> {
               if (!isCommonIntake.join()) {
-                // Only the common intake form needs to get the applicant's eligible
+                // Only the pre-screener form needs to get the applicant's eligible
                 // programs this way.
                 Optional<ImmutableList<ApplicantProgramData>> result = Optional.empty();
                 return CompletableFuture.completedFuture(result);

--- a/server/app/forms/ProgramForm.java
+++ b/server/app/forms/ProgramForm.java
@@ -19,7 +19,7 @@ public final class ProgramForm {
   private String programTypeValue;
 
   // Represents whether or not the user has confirmed that they want to change which program is
-  // marked as the common intake form.
+  // marked as the pre-screener form.
   private Boolean confirmedChangeCommonIntakeForm;
   private Boolean eligibilityIsGating;
   private List<Long> tiGroups;

--- a/server/app/forms/ProgramForm.java
+++ b/server/app/forms/ProgramForm.java
@@ -20,7 +20,7 @@ public final class ProgramForm {
 
   // Represents whether or not the user has confirmed that they want to change which program is
   // marked as the pre-screener form.
-  private Boolean confirmedChangeCommonIntakeForm;
+  private Boolean confirmedChangePreScreenerForm;
   private Boolean eligibilityIsGating;
   private List<Long> tiGroups;
   private List<Long> categories;
@@ -37,7 +37,7 @@ public final class ProgramForm {
     displayMode = "";
     notificationPreferences = new ArrayList<>();
     programTypeValue = "default";
-    confirmedChangeCommonIntakeForm = false;
+    confirmedChangePreScreenerForm = false;
     eligibilityIsGating = true;
     tiGroups = new ArrayList<>();
     categories = new ArrayList<>();
@@ -128,12 +128,12 @@ public final class ProgramForm {
     return ProgramType.fromValue(programTypeValue);
   }
 
-  public Boolean getConfirmedChangeCommonIntakeForm() {
-    return confirmedChangeCommonIntakeForm;
+  public Boolean getConfirmedChangePreScreenerForm() {
+    return confirmedChangePreScreenerForm;
   }
 
-  public void setConfirmedChangeCommonIntakeForm(Boolean confirmedChangeCommonIntakeForm) {
-    this.confirmedChangeCommonIntakeForm = confirmedChangeCommonIntakeForm;
+  public void setConfirmedChangePreScreenerForm(Boolean confirmedChangePreScreenerForm) {
+    this.confirmedChangePreScreenerForm = confirmedChangePreScreenerForm;
   }
 
   public boolean getEligibilityIsGating() {

--- a/server/app/services/applicant/ApplicantService.java
+++ b/server/app/services/applicant/ApplicantService.java
@@ -1113,7 +1113,7 @@ public final class ApplicantService {
    * @return All unsubmitted programs that are appropriate to serve to an applicant and that they
    *     may be eligible for. Includes programs with matching eligibility criteria or no eligibility
    *     criteria.
-   *     <p>Does not include the Common Intake Form.
+   *     <p>Does not include the Pre-Screener Form.
    *     <p>"Appropriate programs" those returned by {@link #relevantProgramsForApplicant(long,
    *     auth.CiviFormProfile)}.
    */
@@ -1747,7 +1747,7 @@ public final class ApplicantService {
   @AutoValue
   public abstract static class ApplicationPrograms {
     /**
-     * Common Intake Form, if it exists and hasn't been submitted, is populated here and not in
+     * Pre-Screener Form, if it exists and hasn't been submitted, is populated here and not in
      * inProgress or unapplied, regardless of its application status.
      */
     public abstract Optional<ApplicantProgramData> commonIntakeForm();
@@ -1802,7 +1802,7 @@ public final class ApplicantService {
     }
 
     /**
-     * Returns all programs that are in progress, including the Common Intake Form, which usually is
+     * Returns all programs that are in progress, including the Pre-Screener Form, which usually is
      * not included in the inProgress list.
      */
     public ImmutableList<ApplicantProgramData> inProgressIncludingCommonIntake() {

--- a/server/app/services/applicant/ApplicantService.java
+++ b/server/app/services/applicant/ApplicantService.java
@@ -1130,7 +1130,7 @@ public final class ApplicantService {
                     // Return all programs the user is eligible for, or that have no
                     // eligibility conditions.
                     .filter(programData -> programData.isProgramMaybeEligible().orElse(true))
-                    .filter(programData -> !programData.program().isCommonIntakeForm())
+                    .filter(programData -> !programData.program().isPreScreenerForm())
                     .collect(ImmutableList.toImmutableList()),
             classLoaderExecutionContext.current());
   }
@@ -1231,7 +1231,7 @@ public final class ApplicantService {
             applicantProgramDataBuilder.setIsProgramMaybeEligible(
                 getApplicantMayBeEligibleStatus(draftApp.getApplicant(), programDefinition));
 
-            if (programDefinition.isCommonIntakeForm()) {
+            if (programDefinition.isPreScreenerForm()) {
               relevantPrograms.setCommonIntakeForm(applicantProgramDataBuilder.build());
             } else {
               inProgressPrograms.add(applicantProgramDataBuilder.build());

--- a/server/app/services/migration/ProgramMigrationService.java
+++ b/server/app/services/migration/ProgramMigrationService.java
@@ -378,8 +378,7 @@ public final class ProgramMigrationService {
         .setAcls(new ProgramAcls())
         // Don't export environment specific notification preferences
         .setNotificationPreferences(ImmutableList.of())
-        // Explicitly set program type to DEFAULT so we don't import program as a
-        // pre-screener/common intake
+        // Explicitly set program type to DEFAULT so we don't import program as a pre-screener
         .setProgramType(ProgramType.DEFAULT)
         .build();
   }

--- a/server/app/services/program/ProgramDefinition.java
+++ b/server/app/services/program/ProgramDefinition.java
@@ -767,7 +767,7 @@ public abstract class ProgramDefinition {
   }
 
   @JsonIgnore
-  public boolean isCommonIntakeForm() {
+  public boolean isPreScreenerForm() {
     return this.programType() == ProgramType.COMMON_INTAKE_FORM;
   }
 

--- a/server/app/services/program/ProgramService.java
+++ b/server/app/services/program/ProgramService.java
@@ -697,7 +697,7 @@ public final class ProgramService {
         programRepository.getShallowProgramDefinition(
             programRepository.createOrUpdateDraft(maybePreScreenerForm.get().toProgram()));
     ProgramModel preScreenerProgram =
-      draftPreScreenerProgramDefinition.toBuilder()
+        draftPreScreenerProgramDefinition.toBuilder()
             .setProgramType(ProgramType.DEFAULT)
             .build()
             .toProgram();
@@ -1012,8 +1012,7 @@ public final class ProgramService {
       ImmutableSet.Builder<CiviFormError> errorsBuilder,
       LocalizationUpdate localizationUpdate,
       ProgramDefinition programDefinition) {
-    if (!programDefinition.isPreScreenerForm()
-        && !programDefinition.applicationSteps().isEmpty()) {
+    if (!programDefinition.isPreScreenerForm() && !programDefinition.applicationSteps().isEmpty()) {
       IntStream.range(0, programDefinition.applicationSteps().size())
           .forEach(
               i -> {

--- a/server/app/services/program/ProgramService.java
+++ b/server/app/services/program/ProgramService.java
@@ -175,7 +175,7 @@ public final class ProgramService {
 
   /*
    * Looks at the most recent version of each program and returns the program marked as the
-   * common intake form if it exists. The most recent version may be in the draft or active stage.
+   * pre-screener form if it exists. The most recent version may be in the draft or active stage.
    */
   public Optional<ProgramDefinition> getCommonIntakeForm() {
     return getActiveAndDraftPrograms().getMostRecentProgramDefinitions().stream()
@@ -682,7 +682,7 @@ public final class ProgramService {
   }
 
   /**
-   * Clears the common intake form if it exists.
+   * Clears the pre-screener form if it exists.
    *
    * <p>If there is a program among the most recent versions of all programs marked as the common
    * intake form, this changes its ProgramType to DEFAULT, creating a new draft to do so if
@@ -822,7 +822,7 @@ public final class ProgramService {
       ProgramType programType,
       ImmutableSet.Builder<CiviFormError> errorsBuilder,
       ImmutableList<ApplicationStep> applicationSteps) {
-    // Common intake and external programs don't have application steps.
+    // Pre-screener and external programs don't have application steps.
     if (programType == ProgramType.COMMON_INTAKE_FORM || programType == ProgramType.EXTERNAL) {
       return errorsBuilder;
     }
@@ -1005,7 +1005,7 @@ public final class ProgramService {
   }
 
   /**
-   * If the program is not a common intake program and has application steps, validate that all the
+   * If the program is not a pre-screener program and has application steps, validate that all the
    * existing application steps have translations
    */
   private void validateApplicationSteps(

--- a/server/app/services/program/ProgramService.java
+++ b/server/app/services/program/ProgramService.java
@@ -177,7 +177,7 @@ public final class ProgramService {
    * Looks at the most recent version of each program and returns the program marked as the
    * pre-screener form if it exists. The most recent version may be in the draft or active stage.
    */
-  public Optional<ProgramDefinition> getCommonIntakeForm() {
+  public Optional<ProgramDefinition> getPreScreenerForm() {
     return getActiveAndDraftPrograms().getMostRecentProgramDefinitions().stream()
         .filter(ProgramDefinition::isCommonIntakeForm)
         .findFirst();
@@ -403,8 +403,8 @@ public final class ProgramService {
       return ErrorAnd.error(maybeEmptyBlock.getErrors());
     }
 
-    if (programType.equals(ProgramType.COMMON_INTAKE_FORM) && getCommonIntakeForm().isPresent()) {
-      clearCommonIntakeForm();
+    if (programType.equals(ProgramType.COMMON_INTAKE_FORM) && getPreScreenerForm().isPresent()) {
+      clearPreScreenerForm();
     }
     ProgramAcls programAcls = new ProgramAcls(new HashSet<>(tiGroups));
     ImmutableList<ProgramNotificationPreference> notificationPreferencesAsEnums =
@@ -569,10 +569,10 @@ public final class ProgramService {
     }
 
     if (programType.equals(ProgramType.COMMON_INTAKE_FORM)) {
-      Optional<ProgramDefinition> maybeCommonIntakeForm = getCommonIntakeForm();
+      Optional<ProgramDefinition> maybeCommonIntakeForm = getPreScreenerForm();
       if (maybeCommonIntakeForm.isPresent()
           && !programDefinition.adminName().equals(maybeCommonIntakeForm.get().adminName())) {
-        clearCommonIntakeForm();
+        clearPreScreenerForm();
       }
     }
 
@@ -688,20 +688,20 @@ public final class ProgramService {
    * intake form, this changes its ProgramType to DEFAULT, creating a new draft to do so if
    * necessary.
    */
-  private void clearCommonIntakeForm() {
-    Optional<ProgramDefinition> maybeCommonIntakeForm = getCommonIntakeForm();
-    if (!maybeCommonIntakeForm.isPresent()) {
+  private void clearPreScreenerForm() {
+    Optional<ProgramDefinition> maybePreScreenerForm = getPreScreenerForm();
+    if (!maybePreScreenerForm.isPresent()) {
       return;
     }
-    ProgramDefinition draftCommonIntakeProgramDefinition =
+    ProgramDefinition draftPreScreenerProgramDefinition =
         programRepository.getShallowProgramDefinition(
-            programRepository.createOrUpdateDraft(maybeCommonIntakeForm.get().toProgram()));
-    ProgramModel commonIntakeProgram =
-        draftCommonIntakeProgramDefinition.toBuilder()
+            programRepository.createOrUpdateDraft(maybePreScreenerForm.get().toProgram()));
+    ProgramModel preScreenerProgram =
+      draftPreScreenerProgramDefinition.toBuilder()
             .setProgramType(ProgramType.DEFAULT)
             .build()
             .toProgram();
-    programRepository.updateProgramSync(commonIntakeProgram);
+    programRepository.updateProgramSync(preScreenerProgram);
   }
 
   /**

--- a/server/app/services/program/ProgramService.java
+++ b/server/app/services/program/ProgramService.java
@@ -179,7 +179,7 @@ public final class ProgramService {
    */
   public Optional<ProgramDefinition> getPreScreenerForm() {
     return getActiveAndDraftPrograms().getMostRecentProgramDefinitions().stream()
-        .filter(ProgramDefinition::isCommonIntakeForm)
+        .filter(ProgramDefinition::isPreScreenerForm)
         .findFirst();
   }
 
@@ -583,7 +583,7 @@ public final class ProgramService {
         preserveApplicationStepTranslations(applicationSteps, programDefinition.applicationSteps());
 
     if (programType.equals(ProgramType.COMMON_INTAKE_FORM)
-        && !programDefinition.isCommonIntakeForm()) {
+        && !programDefinition.isPreScreenerForm()) {
       programDefinition = removeAllEligibilityPredicates(programDefinition);
     }
     ImmutableList<ProgramNotificationPreference> notificationPreferencesAsEnums =
@@ -1012,7 +1012,7 @@ public final class ProgramService {
       ImmutableSet.Builder<CiviFormError> errorsBuilder,
       LocalizationUpdate localizationUpdate,
       ProgramDefinition programDefinition) {
-    if (!programDefinition.isCommonIntakeForm()
+    if (!programDefinition.isPreScreenerForm()
         && !programDefinition.applicationSteps().isEmpty()) {
       IntStream.range(0, programDefinition.applicationSteps().size())
           .forEach(
@@ -1476,7 +1476,7 @@ public final class ProgramService {
           EligibilityNotValidForProgramTypeException {
     ProgramDefinition programDefinition = getFullProgramDefinition(programId);
 
-    if (programDefinition.isCommonIntakeForm() && eligibility.isPresent()) {
+    if (programDefinition.isPreScreenerForm() && eligibility.isPresent()) {
       throw new EligibilityNotValidForProgramTypeException(programDefinition.programType());
     }
 

--- a/server/app/views/admin/programs/ProgramAdministratorProgramListView.java
+++ b/server/app/views/admin/programs/ProgramAdministratorProgramListView.java
@@ -107,7 +107,7 @@ public final class ProgramAdministratorProgramListView extends BaseHtmlView {
                 /* message= */ Optional.empty())
             .url();
 
-    String buttonText = activeProgram.isCommonIntakeForm() ? "Forms" : "Applications";
+    String buttonText = activeProgram.isPreScreenerForm() ? "Forms" : "Applications";
     ButtonTag button =
         makeSvgTextButton(buttonText, Icons.TEXT_SNIPPET).withClass(ButtonStyles.CLEAR_WITH_ICON);
     return asRedirectElement(button, viewApplicationsLink);

--- a/server/app/views/admin/programs/ProgramFormBuilder.java
+++ b/server/app/views/admin/programs/ProgramFormBuilder.java
@@ -162,8 +162,7 @@ abstract class ProgramFormBuilder extends BaseHtmlView {
     boolean isNorthStarEnabled = settingsManifest.getNorthStarApplicantUi(request);
 
     boolean disableProgramEligibility = isPreScreenerForm || isExternalProgram;
-    boolean disableLongDescription =
-        (isPreScreenerForm || isExternalProgram) && isNorthStarEnabled;
+    boolean disableLongDescription = (isPreScreenerForm || isExternalProgram) && isNorthStarEnabled;
     boolean disableExternalLink = (isDefaultProgram || isPreScreenerForm) && isNorthStarEnabled;
     boolean disableEmailNotifications = isExternalProgram;
     boolean disableApplicationSteps = isPreScreenerForm || isExternalProgram;

--- a/server/app/views/admin/programs/ProgramFormBuilder.java
+++ b/server/app/views/admin/programs/ProgramFormBuilder.java
@@ -381,9 +381,9 @@ abstract class ProgramFormBuilder extends BaseHtmlView {
       boolean externalProgramFieldDisabled = false;
 
       // When editing a program:
-      //   - external program field is disabled when program type is default or common intake form,
+      //   - external program field is disabled when program type is default or pre-screener form,
       // since a program can be changed to external after creation.
-      //   - common intake and default program fields are disabled when program type is external
+      //   - pre-screener and default program fields are disabled when program type is external
       // program, since an external program cannot change type after creation.
       if (programEditStatus.equals(ProgramEditStatus.EDIT)) {
         switch (programType) {
@@ -467,7 +467,7 @@ abstract class ProgramFormBuilder extends BaseHtmlView {
     return each(
         programTypeFieldset,
         // Hidden checkbox used to signal whether or not the user has confirmed they want to
-        // change which program is marked as the common intake form.
+        // change which program is marked as the pre-screener form.
         FieldWithLabel.checkbox()
             .setId("confirmed-change-common-intake-checkbox")
             .setFieldName("confirmedChangeCommonIntakeForm")

--- a/server/app/views/admin/programs/ProgramFormBuilder.java
+++ b/server/app/views/admin/programs/ProgramFormBuilder.java
@@ -155,18 +155,18 @@ abstract class ProgramFormBuilder extends BaseHtmlView {
       ImmutableList<Long> categories,
       ImmutableList<Map<String, String>> applicationSteps) {
     boolean isDefaultProgram = programType.equals(ProgramType.DEFAULT);
-    boolean isCommonIntakeForm = programType.equals(ProgramType.COMMON_INTAKE_FORM);
+    boolean isPreScreenerForm = programType.equals(ProgramType.COMMON_INTAKE_FORM);
     boolean isExternalProgram = programType.equals(ProgramType.EXTERNAL);
     boolean isExternalProgramCardsEnabled =
         settingsManifest.getExternalProgramCardsEnabled(request);
     boolean isNorthStarEnabled = settingsManifest.getNorthStarApplicantUi(request);
 
-    boolean disableProgramEligibility = isCommonIntakeForm || isExternalProgram;
+    boolean disableProgramEligibility = isPreScreenerForm || isExternalProgram;
     boolean disableLongDescription =
-        (isCommonIntakeForm || isExternalProgram) && isNorthStarEnabled;
-    boolean disableExternalLink = (isDefaultProgram || isCommonIntakeForm) && isNorthStarEnabled;
+        (isPreScreenerForm || isExternalProgram) && isNorthStarEnabled;
+    boolean disableExternalLink = (isDefaultProgram || isPreScreenerForm) && isNorthStarEnabled;
     boolean disableEmailNotifications = isExternalProgram;
-    boolean disableApplicationSteps = isCommonIntakeForm || isExternalProgram;
+    boolean disableApplicationSteps = isPreScreenerForm || isExternalProgram;
     boolean disableConfirmationMessage = isExternalProgram;
 
     List<CategoryModel> categoryOptions = categoryRepository.listCategories();
@@ -244,7 +244,7 @@ abstract class ProgramFormBuilder extends BaseHtmlView {
         // Program categories
         iff(
             settingsManifest.getProgramFilteringEnabled(request) && !categoryOptions.isEmpty(),
-            showCategoryCheckboxes(categoryOptions, categories, isCommonIntakeForm)),
+            showCategoryCheckboxes(categoryOptions, categories, isPreScreenerForm)),
         // Program visibility
         fieldset(
                 legend("Program visibility")
@@ -377,7 +377,7 @@ abstract class ProgramFormBuilder extends BaseHtmlView {
     if (isExternalProgramCardsEnabled) {
       // When creating a program, program type fields (if visible) are never disabled.
       boolean defaultProgramFieldDisabled = false;
-      boolean commonIntakeFieldDisabled = false;
+      boolean preScreenerFieldDisabled = false;
       boolean externalProgramFieldDisabled = false;
 
       // When editing a program:
@@ -390,12 +390,12 @@ abstract class ProgramFormBuilder extends BaseHtmlView {
           case DEFAULT:
           case COMMON_INTAKE_FORM:
             defaultProgramFieldDisabled = false;
-            commonIntakeFieldDisabled = false;
+            preScreenerFieldDisabled = false;
             externalProgramFieldDisabled = true;
             break;
           case EXTERNAL:
             defaultProgramFieldDisabled = true;
-            commonIntakeFieldDisabled = true;
+            preScreenerFieldDisabled = true;
             externalProgramFieldDisabled = false;
             break;
         }
@@ -432,7 +432,7 @@ abstract class ProgramFormBuilder extends BaseHtmlView {
                       /* name= */ PROGRAM_TYPE_FIELD_NAME,
                       /* value= */ ProgramType.COMMON_INTAKE_FORM.getValue(),
                       /* isChecked= */ programType.equals(ProgramType.COMMON_INTAKE_FORM),
-                      /* isDisabled= */ commonIntakeFieldDisabled,
+                      /* isDisabled= */ preScreenerFieldDisabled,
                       /* label= */ "Pre-screener",
                       /* description */ Optional.of(
                           "This program informational card will always appear at the top of the"
@@ -634,13 +634,13 @@ abstract class ProgramFormBuilder extends BaseHtmlView {
             p(fieldText).withClasses(BaseStyles.FORM_FIELD));
   }
 
-  protected Modal buildConfirmCommonIntakeChangeModal(String existingCommonIntakeFormDisplayName) {
+  protected Modal buildConfirmPreScreenerChangeModal(String existingPreScreenerFormDisplayName) {
     DivTag content =
         div()
             .withClasses("flex-row", "space-y-6")
             .with(
                 p("The pre-screener will be updated from ")
-                    .with(span(existingCommonIntakeFormDisplayName).withClass("font-bold"))
+                    .with(span(existingPreScreenerFormDisplayName).withClass("font-bold"))
                     .withText(" to the current program."))
             .with(p("Would you like to confirm the change?"))
             .with(

--- a/server/app/views/admin/programs/ProgramMetaDataEditView.java
+++ b/server/app/views/admin/programs/ProgramMetaDataEditView.java
@@ -71,7 +71,7 @@ public final class ProgramMetaDataEditView extends ProgramFormBuilder {
 
   /**
    * Renders the edit form with a modal that confirms whether or not the user wants to change which
-   * program is set to be the common intake form. Fields are pre-populated based on the content of
+   * program is set to be the pre-screener form. Fields are pre-populated based on the content of
    * programForm.
    */
   public Content renderChangeCommonIntakeConfirmation(

--- a/server/app/views/admin/programs/ProgramMetaDataEditView.java
+++ b/server/app/views/admin/programs/ProgramMetaDataEditView.java
@@ -86,7 +86,7 @@ public final class ProgramMetaDataEditView extends ProgramFormBuilder {
         programEditStatus,
         Optional.of(programForm),
         Optional.empty(),
-        Optional.of(buildConfirmCommonIntakeChangeModal(existingCommonIntakeFormDisplayName)));
+        Optional.of(buildConfirmPreScreenerChangeModal(existingCommonIntakeFormDisplayName)));
   }
 
   private Content render(

--- a/server/app/views/admin/programs/ProgramMetaDataEditView.java
+++ b/server/app/views/admin/programs/ProgramMetaDataEditView.java
@@ -74,19 +74,19 @@ public final class ProgramMetaDataEditView extends ProgramFormBuilder {
    * program is set to be the pre-screener form. Fields are pre-populated based on the content of
    * programForm.
    */
-  public Content renderChangeCommonIntakeConfirmation(
+  public Content renderChangePreScreenerConfirmation(
       Request request,
       ProgramDefinition existingProgram,
       ProgramEditStatus programEditStatus,
       ProgramForm programForm,
-      String existingCommonIntakeFormDisplayName) {
+      String existingPreScreenerFormDisplayName) {
     return render(
         request,
         existingProgram,
         programEditStatus,
         Optional.of(programForm),
         Optional.empty(),
-        Optional.of(buildConfirmPreScreenerChangeModal(existingCommonIntakeFormDisplayName)));
+        Optional.of(buildConfirmPreScreenerChangeModal(existingPreScreenerFormDisplayName)));
   }
 
   private Content render(

--- a/server/app/views/admin/programs/ProgramNewOneView.java
+++ b/server/app/views/admin/programs/ProgramNewOneView.java
@@ -58,8 +58,8 @@ public final class ProgramNewOneView extends ProgramFormBuilder {
 
   /**
    * Renders the create form with a modal that confirms whether or not the user wants to change
-   * which program is set to be the pre-screener form. Fields are pre-populated based on the
-   * content of programForm.
+   * which program is set to be the pre-screener form. Fields are pre-populated based on the content
+   * of programForm.
    */
   public Content renderChangePreScreenerConfirmation(
       Request request, ProgramForm programForm, String existingPreScreenerFormDisplayName) {

--- a/server/app/views/admin/programs/ProgramNewOneView.java
+++ b/server/app/views/admin/programs/ProgramNewOneView.java
@@ -58,7 +58,7 @@ public final class ProgramNewOneView extends ProgramFormBuilder {
 
   /**
    * Renders the create form with a modal that confirms whether or not the user wants to change
-   * which program is set to be the common intake form. Fields are pre-populated based on the
+   * which program is set to be the pre-screener form. Fields are pre-populated based on the
    * content of programForm.
    */
   public Content renderChangeCommonIntakeConfirmation(

--- a/server/app/views/admin/programs/ProgramNewOneView.java
+++ b/server/app/views/admin/programs/ProgramNewOneView.java
@@ -61,13 +61,13 @@ public final class ProgramNewOneView extends ProgramFormBuilder {
    * which program is set to be the pre-screener form. Fields are pre-populated based on the
    * content of programForm.
    */
-  public Content renderChangeCommonIntakeConfirmation(
-      Request request, ProgramForm programForm, String existingCommonIntakeFormDisplayName) {
+  public Content renderChangePreScreenerConfirmation(
+      Request request, ProgramForm programForm, String existingPreScreenerFormDisplayName) {
     return render(
         request,
         programForm,
         /* toastMessage= */ Optional.empty(),
-        Optional.of(buildConfirmCommonIntakeChangeModal(existingCommonIntakeFormDisplayName)));
+        Optional.of(buildConfirmCommonIntakeChangeModal(existingPreScreenerFormDisplayName)));
   }
 
   private Content render(

--- a/server/app/views/admin/programs/ProgramNewOneView.java
+++ b/server/app/views/admin/programs/ProgramNewOneView.java
@@ -67,7 +67,7 @@ public final class ProgramNewOneView extends ProgramFormBuilder {
         request,
         programForm,
         /* toastMessage= */ Optional.empty(),
-        Optional.of(buildConfirmCommonIntakeChangeModal(existingPreScreenerFormDisplayName)));
+        Optional.of(buildConfirmPreScreenerChangeModal(existingPreScreenerFormDisplayName)));
   }
 
   private Content render(

--- a/server/app/views/admin/programs/ProgramTranslationView.java
+++ b/server/app/views/admin/programs/ProgramTranslationView.java
@@ -293,7 +293,7 @@ public final class ProgramTranslationView extends TranslationFormView {
     // If north star is enabled, only show the long description field if the program is not a common
     // intake program
     boolean northStarIsOff = !settingsManifest.getNorthStarApplicantUi(request);
-    boolean isNotCommonIntake = !program.isCommonIntakeForm();
+    boolean isNotCommonIntake = !program.isPreScreenerForm();
     if (northStarIsOff || isNotCommonIntake) {
       applicantVisibleDetails.add(
           fieldWithDefaultLocaleTextHint(

--- a/server/test/controllers/admin/AdminProgramControllerTest.java
+++ b/server/test/controllers/admin/AdminProgramControllerTest.java
@@ -392,7 +392,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
 
   @Test
   public void create_showsErrorsBeforePromptingUserToConfirmCommonIntakeChange() {
-    ProgramBuilder.newActiveCommonIntakeForm("Old common intake").build();
+    ProgramBuilder.newActiveCommonIntakeForm("Old pre-screener").build();
     RequestBuilder requestBuilder =
         fakeRequestBuilder()
             .bodyForm(
@@ -427,7 +427,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
 
   @Test
   public void create_promptsUserToConfirmCommonIntakeChange() {
-    ProgramBuilder.newActiveCommonIntakeForm("Old common intake").build();
+    ProgramBuilder.newActiveCommonIntakeForm("Old pre-screener").build();
     RequestBuilder requestBuilder =
         fakeRequestBuilder()
             .bodyForm(
@@ -508,7 +508,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
 
   @Test
   public void create_allowsChangingCommonIntakeAfterConfirming() {
-    ProgramBuilder.newActiveCommonIntakeForm("Old common intake").build();
+    ProgramBuilder.newActiveCommonIntakeForm("Old pre-screener").build();
 
     String adminName = "internal-program-name";
     String programName = "External program name";
@@ -824,7 +824,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
   public void update_showsErrorsBeforePromptingUserToConfirmCommonIntakeChange() throws Exception {
     ProgramModel program =
         ProgramBuilder.newDraftProgram("Existing One", "old description").build();
-    ProgramBuilder.newActiveCommonIntakeForm("Old common intake").build();
+    ProgramBuilder.newActiveCommonIntakeForm("Old pre-screener").build();
 
     RequestBuilder requestBuilder =
         fakeRequestBuilder()
@@ -863,7 +863,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
   public void update_promptsUserToConfirmCommonIntakeChange() throws Exception {
     ProgramModel program =
         ProgramBuilder.newDraftProgram("Existing One", "old description").build();
-    ProgramBuilder.newActiveCommonIntakeForm("Old common intake").build();
+    ProgramBuilder.newActiveCommonIntakeForm("Old pre-screener").build();
 
     RequestBuilder requestBuilder =
         fakeRequestBuilder()
@@ -949,7 +949,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
   public void update_allowsChangingCommonIntakeAfterConfirming() throws Exception {
     ProgramModel program =
         ProgramBuilder.newDraftProgram("Existing One", "old description").build();
-    ProgramBuilder.newActiveCommonIntakeForm("Old common intake").build();
+    ProgramBuilder.newActiveCommonIntakeForm("Old pre-screener").build();
 
     String newProgramName = "External program name";
     String newProgramDescription = "New external program description";

--- a/server/test/controllers/admin/AdminProgramControllerTest.java
+++ b/server/test/controllers/admin/AdminProgramControllerTest.java
@@ -543,7 +543,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
         versionRepository.getProgramByNameForVersion(
             adminName, versionRepository.getDraftVersionOrCreate());
     assertThat(newProgram).isPresent();
-    assertThat(newProgram.get().getProgramDefinition().isCommonIntakeForm()).isTrue();
+    assertThat(newProgram.get().getProgramDefinition().isPreScreenerForm()).isTrue();
 
     Result programDashboard = controller.index(fakeRequest());
     assertThat(contentAsString(programDashboard)).contains(programName);

--- a/server/test/services/applicant/ApplicantServiceTest.java
+++ b/server/test/services/applicant/ApplicantServiceTest.java
@@ -3311,7 +3311,7 @@ public class ApplicantServiceTest extends ResetPostgres {
     EligibilityDefinition unansweredQuestionEligibilityDefinition =
         createEligibilityDefinition(unansweredQuestion, "Sza");
 
-    // Setup program for answering questions (not necessarily a common intake program)
+    // Setup program for answering questions (not necessarily a pre-screener program)
     ProgramModel programForAnsweringQuestions =
         ProgramBuilder.newDraftProgram("other program")
             .withBlock()
@@ -3571,7 +3571,7 @@ public class ApplicantServiceTest extends ResetPostgres {
     applicant.setAccount(resourceCreator.insertAccount());
     applicant.save();
 
-    // Set up common intake form
+    // Set up pre-screener form
     NameQuestionDefinition question = createNameQuestion("question");
     ProgramModel commonIntakeForm =
         ProgramBuilder.newDraftProgram(

--- a/server/test/services/program/ProgramServiceTest.java
+++ b/server/test/services/program/ProgramServiceTest.java
@@ -3239,8 +3239,8 @@ public class ProgramServiceTest extends ResetPostgres {
 
   @Test
   public void getCommonIntakeForm_ignoresObsoletePrograms() {
-    // No common intake form in the most recent version of any program, although some programs
-    // were previously marked as common intake.
+    // No pre-screener form in the most recent version of any program, although some programs
+    // were previously marked as pre-screener.
     ProgramBuilder.newObsoleteProgram("one")
         .withProgramType(ProgramType.COMMON_INTAKE_FORM)
         .build();

--- a/server/test/services/program/ProgramServiceTest.java
+++ b/server/test/services/program/ProgramServiceTest.java
@@ -585,7 +585,7 @@ public class ProgramServiceTest extends ResetPostgres {
         /* categoryIds= */ ImmutableList.of(),
         ImmutableList.of(new ApplicationStep("title", "description")));
 
-    Optional<ProgramDefinition> commonIntakeForm = ps.getCommonIntakeForm();
+    Optional<ProgramDefinition> commonIntakeForm = ps.getPreScreenerForm();
     assertThat(commonIntakeForm).isPresent();
     assertThat(commonIntakeForm.get().adminName()).isEqualTo("name-one");
 
@@ -609,7 +609,7 @@ public class ProgramServiceTest extends ResetPostgres {
     assertThat(result.isError()).isFalse();
     assertThat(result.getResult().programType()).isEqualTo(ProgramType.COMMON_INTAKE_FORM);
 
-    commonIntakeForm = ps.getCommonIntakeForm();
+    commonIntakeForm = ps.getPreScreenerForm();
     assertThat(commonIntakeForm).isPresent();
     assertThat(commonIntakeForm.get().adminName()).isEqualTo("name-two");
     Optional<ProgramDefinition> oldCommonIntake =
@@ -1167,7 +1167,7 @@ public class ProgramServiceTest extends ResetPostgres {
         /* categoryIds= */ ImmutableList.of(),
         ImmutableList.of(new ApplicationStep("title", "description")));
 
-    Optional<ProgramDefinition> commonIntakeForm = ps.getCommonIntakeForm();
+    Optional<ProgramDefinition> commonIntakeForm = ps.getPreScreenerForm();
     assertThat(commonIntakeForm).isPresent();
     assertThat(commonIntakeForm.get().adminName()).isEqualTo("name-one");
 
@@ -1193,7 +1193,7 @@ public class ProgramServiceTest extends ResetPostgres {
     assertThat(result.hasResult()).isTrue();
     assertThat(result.isError()).isFalse();
     assertThat(result.getResult().programType()).isEqualTo(ProgramType.COMMON_INTAKE_FORM);
-    commonIntakeForm = ps.getCommonIntakeForm();
+    commonIntakeForm = ps.getPreScreenerForm();
     assertThat(commonIntakeForm).isPresent();
     assertThat(commonIntakeForm.get().adminName()).isEqualTo(program.adminName());
     Optional<ProgramDefinition> oldCommonIntake =
@@ -3238,7 +3238,7 @@ public class ProgramServiceTest extends ResetPostgres {
   }
 
   @Test
-  public void getCommonIntakeForm_ignoresObsoletePrograms() {
+  public void getPreScreenerForm_ignoresObsoletePrograms() {
     // No pre-screener form in the most recent version of any program, although some programs
     // were previously marked as pre-screener.
     ProgramBuilder.newObsoleteProgram("one")
@@ -3247,30 +3247,30 @@ public class ProgramServiceTest extends ResetPostgres {
     ProgramBuilder.newActiveProgram("two").withProgramType(ProgramType.COMMON_INTAKE_FORM).build();
     ProgramBuilder.newDraftProgram("two").withProgramType(ProgramType.DEFAULT).build();
 
-    assertThat(ps.getCommonIntakeForm()).isNotPresent();
+    assertThat(ps.getPreScreenerForm()).isNotPresent();
   }
 
   @Test
-  public void getCommonIntakeForm_activeCommonIntake() {
+  public void getPreScreenerForm_activePreScreener() {
     ProgramBuilder.newObsoleteProgram("one")
         .withProgramType(ProgramType.COMMON_INTAKE_FORM)
         .build();
     ProgramBuilder.newActiveProgram("two").withProgramType(ProgramType.COMMON_INTAKE_FORM).build();
 
-    assertThat(ps.getCommonIntakeForm()).isPresent();
-    assertThat(ps.getCommonIntakeForm().get().adminName()).isEqualTo("two");
+    assertThat(ps.getPreScreenerForm()).isPresent();
+    assertThat(ps.getPreScreenerForm().get().adminName()).isEqualTo("two");
   }
 
   @Test
-  public void getCommonIntakeForm_draftCommonIntake() {
+  public void getPreScreenerForm_draftPreScreener() {
     ProgramBuilder.newObsoleteProgram("one")
         .withProgramType(ProgramType.COMMON_INTAKE_FORM)
         .build();
     ProgramBuilder.newActiveProgram("two").withProgramType(ProgramType.DEFAULT).build();
     ProgramBuilder.newDraftProgram("two").withProgramType(ProgramType.COMMON_INTAKE_FORM).build();
 
-    assertThat(ps.getCommonIntakeForm()).isPresent();
-    assertThat(ps.getCommonIntakeForm().get().adminName()).isEqualTo("two");
+    assertThat(ps.getPreScreenerForm()).isPresent();
+    assertThat(ps.getPreScreenerForm().get().adminName()).isEqualTo("two");
   }
 
   @Test


### PR DESCRIPTION
### Description

Please explain the changes you made here.

## Release notes

Remove this section if the title of the pull request can be used as the default release notes description. If more detail is needed to communicate to partners the scope of the PR's changes, use this release notes section (and remove this placeholder text).

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [ ] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [ ] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

#### Database evolutions

Read the guidelines [here](https://github.com/civiform/civiform/wiki/Database#writing-database-evolutions)

- [ ] Assigned two reviewers
- [ ] Guarded against already existing resources using `IF NOT EXISTS` and `IF EXISTS`
- [ ] Downs created to undo changes in Ups
- [ ] Every comment in script should begin with -- and not # --- unless it denotes Ups or Downs. See [here](https://www.playframework.com/documentation/2.9.x/Evolutions) for details.
- [ ] Tested both the Downs and the Ups scripts manually (When testing, include all comments from the evolution in your test script to ensure any syntax errors in the comments are caught.)
- [ ] Data migrations aren't being done (please use a [Durable Job](https://github.com/civiform/civiform/wiki/Database#durable-jobs-for-data-updates) if doing a data migration)
- [ ] Update the model documentation in our [wiki](https://github.com/civiform/civiform/wiki/Database) if necessary

#### Durable jobs

Read the docs [here](https://github.com/civiform/civiform/wiki/Database#durable-jobs-for-data-updates)

- [ ] Assigned two reviewers
- [ ] Included a rollback plan and a job to undo the data changes if appropriate

#### User visible changes

- [ ] Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
  - [ ] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [ ] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Made equivalent changes in Thymeleaf for applicant-facing features and changes (or created an issue in the [Northstar epic](https://github.com/orgs/civiform/projects/1/views/94) to track that it's missing from Thymeleaf)
- [ ] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order
- [ ] Manually tested with a screen reader if the feature is applicant-facing. See [screen reader testing](https://github.com/civiform/civiform/wiki/Testing#screen-reader-testing)

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/helper/feature-flags.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://github.com/civiform/civiform/wiki/Feature-Flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Instructions for manual testing

If instructions are needed for manual testing by reviewers, include them here.

### Issue(s) this completes

Fixes #<issue_number>; Fixes #<issue_number>...
