### PR TITLE
Rename common intake to pre screener in ApplicantService.java

### DIFF
--- a/server/app/services/applicant/ApplicantService.java
+++ b/server/app/services/applicant/ApplicantService.java
@@ -1113,7 +1113,7 @@ public final class ApplicantService {
    * @return All unsubmitted programs that are appropriate to serve to an applicant and that they
    *     may be eligible for. Includes programs with matching eligibility criteria or no eligibility
    *     criteria.
-   *     <p>Does not include the Common Intake Form.
+   *     <p>Does not include the Pre-Screener Form.
    *     <p>"Appropriate programs" those returned by {@link #relevantProgramsForApplicant(long,
    *     auth.CiviFormProfile)}.
    */
@@ -1232,7 +1232,7 @@ public final class ApplicantService {
                 getApplicantMayBeEligibleStatus(draftApp.getApplicant(), programDefinition));
 
             if (programDefinition.isCommonIntakeForm()) {
-              relevantPrograms.setCommonIntakeForm(applicantProgramDataBuilder.build());
+              relevantPrograms.setPreScreenerForm(applicantProgramDataBuilder.build());
             } else {
               inProgressPrograms.add(applicantProgramDataBuilder.build());
             }
@@ -1312,7 +1312,7 @@ public final class ApplicantService {
 
           ProgramType programType = program.programType();
           if (programType.equals(ProgramType.COMMON_INTAKE_FORM)) {
-            relevantPrograms.setCommonIntakeForm(applicantProgramDataBuilder.build());
+            relevantPrograms.setPreScreenerForm(applicantProgramDataBuilder.build());
           } else if (programType.equals(ProgramType.DEFAULT)
               || (programType.equals(ProgramType.EXTERNAL)
                   && settingsManifest.getExternalProgramCardsEnabled(request)
@@ -1750,7 +1750,7 @@ public final class ApplicantService {
      * Common Intake Form, if it exists and hasn't been submitted, is populated here and not in
      * inProgress or unapplied, regardless of its application status.
      */
-    public abstract Optional<ApplicantProgramData> commonIntakeForm();
+    public abstract Optional<ApplicantProgramData> preScreenerForm();
 
     public abstract ImmutableList<ApplicantProgramData> inProgress();
 
@@ -1776,7 +1776,7 @@ public final class ApplicantService {
 
     @AutoValue.Builder
     abstract static class Builder {
-      abstract Builder setCommonIntakeForm(ApplicantProgramData value);
+      abstract Builder setPreScreenerForm(ApplicantProgramData value);
 
       abstract Builder setInProgress(ImmutableList<ApplicantProgramData> value);
 
@@ -1792,8 +1792,8 @@ public final class ApplicantService {
       ImmutableList.Builder<ApplicantProgramData> allPrograms =
           new ImmutableList.Builder<ApplicantProgramData>();
 
-      if (commonIntakeForm().isPresent()) {
-        allPrograms.add(commonIntakeForm().get());
+      if (preScreenerForm().isPresent()) {
+        allPrograms.add(preScreenerForm().get());
       }
       allPrograms.addAll(inProgress());
       allPrograms.addAll(submitted());
@@ -1809,10 +1809,10 @@ public final class ApplicantService {
       ImmutableList.Builder<ApplicantProgramData> inProgress =
           new ImmutableList.Builder<ApplicantProgramData>();
 
-      commonIntakeForm()
+      preScreenerForm()
           .flatMap(ApplicantProgramData::latestApplicationLifecycleStage)
           .filter(stage -> stage.equals(LifecycleStage.DRAFT))
-          .ifPresent(programData -> inProgress.add(commonIntakeForm().get()));
+          .ifPresent(programData -> inProgress.add(preScreenerForm().get()));
 
       inProgress.addAll(inProgress());
       return inProgress.build();

--- a/server/app/services/applicant/ApplicantService.java
+++ b/server/app/services/applicant/ApplicantService.java
@@ -1747,7 +1747,7 @@ public final class ApplicantService {
   @AutoValue
   public abstract static class ApplicationPrograms {
     /**
-     * Common Intake Form, if it exists and hasn't been submitted, is populated here and not in
+     * Pre-Screener Form, if it exists and hasn't been submitted, is populated here and not in
      * inProgress or unapplied, regardless of its application status.
      */
     public abstract Optional<ApplicantProgramData> preScreenerForm();
@@ -1802,10 +1802,10 @@ public final class ApplicantService {
     }
 
     /**
-     * Returns all programs that are in progress, including the Common Intake Form, which usually is
+     * Returns all programs that are in progress, including the Pre-Screener Form, which usually is
      * not included in the inProgress list.
      */
-    public ImmutableList<ApplicantProgramData> inProgressIncludingCommonIntake() {
+    public ImmutableList<ApplicantProgramData> inProgressIncludingPreScreener() {
       ImmutableList.Builder<ApplicantProgramData> inProgress =
           new ImmutableList.Builder<ApplicantProgramData>();
 

--- a/server/app/views/applicant/NorthStarProgramIndexView.java
+++ b/server/app/views/applicant/NorthStarProgramIndexView.java
@@ -81,13 +81,13 @@ public class NorthStarProgramIndexView extends NorthStarBaseView {
             .sorted()
             .collect(ImmutableList.toImmutableList());
 
-    if (isUnstartedCommonIntakeForm(applicationPrograms.commonIntakeForm())) {
+    if (isUnstartedCommonIntakeForm(applicationPrograms.preScreenerForm())) {
       intakeSection =
           Optional.of(
               getCommonIntakeFormSection(
                   messages,
                   request,
-                  applicationPrograms.commonIntakeForm().get(),
+                  applicationPrograms.preScreenerForm().get(),
                   profile,
                   applicantId,
                   personalInfo));

--- a/server/app/views/applicant/NorthStarProgramIndexView.java
+++ b/server/app/views/applicant/NorthStarProgramIndexView.java
@@ -93,7 +93,7 @@ public class NorthStarProgramIndexView extends NorthStarBaseView {
                   personalInfo));
     }
 
-    if (!applicationPrograms.inProgressIncludingCommonIntake().isEmpty()
+    if (!applicationPrograms.inProgressIncludingPreScreener().isEmpty()
         || !applicationPrograms.submitted().isEmpty()) {
       myApplicationsSection =
           Optional.of(
@@ -103,7 +103,7 @@ public class NorthStarProgramIndexView extends NorthStarBaseView {
                   Optional.of(MessageKey.TITLE_MY_APPLICATIONS_SECTION_V2),
                   MessageKey.BUTTON_EDIT,
                   Stream.concat(
-                          applicationPrograms.inProgressIncludingCommonIntake().stream(),
+                          applicationPrograms.inProgressIncludingPreScreener().stream(),
                           applicationPrograms.submitted().stream())
                       .collect(ImmutableList.toImmutableList()),
                   /* preferredLocale= */ messages.lang().toLocale(),

--- a/server/app/views/applicant/ProgramIndexView.java
+++ b/server/app/views/applicant/ProgramIndexView.java
@@ -240,7 +240,7 @@ public final class ProgramIndexView extends BaseHtmlView {
                 Math.max(relevantPrograms.unapplied().size(), relevantPrograms.submitted().size()),
                 relevantPrograms.inProgress().size()));
 
-    if (relevantPrograms.commonIntakeForm().isPresent()) {
+    if (relevantPrograms.preScreenerForm().isPresent()) {
       content.with(
           findServicesSection(
               request,
@@ -496,7 +496,7 @@ public final class ProgramIndexView extends BaseHtmlView {
       DivTag content,
       String cardContainerStyles) {
     // Intake form
-    if (relevantPrograms.commonIntakeForm().isPresent()) {
+    if (relevantPrograms.preScreenerForm().isPresent()) {
       content.with(
           findServicesSection(
               request,
@@ -541,7 +541,7 @@ public final class ProgramIndexView extends BaseHtmlView {
       HtmlBundle bundle,
       Optional<CiviFormProfile> profile) {
     Optional<LifecycleStage> commonIntakeFormApplicationStatus =
-        relevantPrograms.commonIntakeForm().get().latestApplicationLifecycleStage();
+        relevantPrograms.preScreenerForm().get().latestApplicationLifecycleStage();
     MessageKey buttonText = MessageKey.BUTTON_START_HERE;
     MessageKey buttonScreenReaderText = MessageKey.BUTTON_START_HERE_PRE_SCREENER_SR;
     if (commonIntakeFormApplicationStatus.isPresent()) {
@@ -576,7 +576,7 @@ public final class ProgramIndexView extends BaseHtmlView {
                 cardContainerStyles,
                 applicantId,
                 preferredLocale,
-                ImmutableList.of(relevantPrograms.commonIntakeForm().get()),
+                ImmutableList.of(relevantPrograms.preScreenerForm().get()),
                 buttonText,
                 buttonScreenReaderText,
                 bundle,

--- a/server/test/services/applicant/ApplicantServiceTest.java
+++ b/server/test/services/applicant/ApplicantServiceTest.java
@@ -2183,7 +2183,7 @@ public class ApplicantServiceTest extends ResetPostgres {
             result.submitted().get(0),
             result.unapplied().get(0),
             result.unapplied().get(1));
-    assertThat(result.inProgressIncludingCommonIntake().stream().map(p -> p.program().id()))
+    assertThat(result.inProgressIncludingPreScreener().stream().map(p -> p.program().id()))
         .containsExactlyInAnyOrder(commonIntakeForm.id, programForDraft.id);
   }
 

--- a/server/test/services/applicant/ApplicantServiceTest.java
+++ b/server/test/services/applicant/ApplicantServiceTest.java
@@ -2174,11 +2174,11 @@ public class ApplicantServiceTest extends ResetPostgres {
     assertThat(
             result.unapplied().stream().map(ApplicantProgramData::latestSubmittedApplicationStatus))
         .containsExactly(Optional.empty(), Optional.empty());
-    assertThat(result.commonIntakeForm().isPresent()).isTrue();
-    assertThat(result.commonIntakeForm().get().program().id()).isEqualTo(commonIntakeForm.id);
+    assertThat(result.preScreenerForm().isPresent()).isTrue();
+    assertThat(result.preScreenerForm().get().program().id()).isEqualTo(commonIntakeForm.id);
     assertThat(result.allPrograms())
         .containsExactlyInAnyOrder(
-            result.commonIntakeForm().get(),
+            result.preScreenerForm().get(),
             result.inProgress().get(0),
             result.submitted().get(0),
             result.unapplied().get(0),
@@ -2218,8 +2218,8 @@ public class ApplicantServiceTest extends ResetPostgres {
     assertThat(
             result.unapplied().stream().map(ApplicantProgramData::latestSubmittedApplicationStatus))
         .containsExactly(Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
-    assertThat(result.commonIntakeForm().isPresent()).isTrue();
-    assertThat(result.commonIntakeForm().get().program().id()).isEqualTo(commonIntakeForm.id);
+    assertThat(result.preScreenerForm().isPresent()).isTrue();
+    assertThat(result.preScreenerForm().get().program().id()).isEqualTo(commonIntakeForm.id);
     assertThat(result.allPrograms().stream().map(p -> p.program().id()))
         .containsExactlyInAnyOrder(
             commonIntakeForm.id, program1.id, program2.id, program3.id, programDefinition.id());
@@ -2276,7 +2276,7 @@ public class ApplicantServiceTest extends ResetPostgres {
     assertThat(
             result.unapplied().stream().map(ApplicantProgramData::latestSubmittedApplicationStatus))
         .containsExactly(Optional.empty(), Optional.empty());
-    assertThat(result.commonIntakeForm().isPresent()).isFalse();
+    assertThat(result.preScreenerForm().isPresent()).isFalse();
     assertThat(result.allPrograms())
         .containsExactlyInAnyOrder(
             result.inProgress().get(0),
@@ -2304,9 +2304,9 @@ public class ApplicantServiceTest extends ResetPostgres {
     assertThat(result.submitted()).isEmpty();
     assertThat(result.unapplied().stream().map(p -> p.program().id()))
         .containsExactlyInAnyOrder(programDefinition.id());
-    assertThat(result.commonIntakeForm().isPresent()).isTrue();
-    assertThat(result.commonIntakeForm().get().program().id()).isEqualTo(commonIntakeForm.id);
-    assertThat(result.commonIntakeForm().get().latestApplicationLifecycleStage().isPresent())
+    assertThat(result.preScreenerForm().isPresent()).isTrue();
+    assertThat(result.preScreenerForm().get().program().id()).isEqualTo(commonIntakeForm.id);
+    assertThat(result.preScreenerForm().get().latestApplicationLifecycleStage().isPresent())
         .isFalse();
 
     // CIF application in progress.
@@ -2323,11 +2323,11 @@ public class ApplicantServiceTest extends ResetPostgres {
     assertThat(result.submitted()).isEmpty();
     assertThat(result.unapplied().stream().map(p -> p.program().id()))
         .containsExactlyInAnyOrder(programDefinition.id());
-    assertThat(result.commonIntakeForm().isPresent()).isTrue();
-    assertThat(result.commonIntakeForm().get().program().id()).isEqualTo(commonIntakeForm.id);
-    assertThat(result.commonIntakeForm().get().latestApplicationLifecycleStage().isPresent())
+    assertThat(result.preScreenerForm().isPresent()).isTrue();
+    assertThat(result.preScreenerForm().get().program().id()).isEqualTo(commonIntakeForm.id);
+    assertThat(result.preScreenerForm().get().latestApplicationLifecycleStage().isPresent())
         .isTrue();
-    assertThat(result.commonIntakeForm().get().latestApplicationLifecycleStage().get())
+    assertThat(result.preScreenerForm().get().latestApplicationLifecycleStage().get())
         .isEqualTo(LifecycleStage.DRAFT);
 
     // CIF application submitted.


### PR DESCRIPTION
### Description

Updating to use pre-screener rather than common intake in the Applicant service methods to minimize confusion.