### PR TITLE
Use IT email address for internal server errors

### DIFF
--- a/browser-test/src/error_pages.test.ts
+++ b/browser-test/src/error_pages.test.ts
@@ -55,18 +55,42 @@ test.describe('Error pages', {tag: ['@parallel-candidate']}, () => {
       ).toBeAttached()
     })
 
-    await test.step('Updating the support email address updates the error page', async () => {
+    await test.step('Updating the support email address updates the error page when IT email is unset', async () => {
       await loginAsAdmin(page)
       await adminSettings.gotoAdminSettings()
       await adminSettings.setStringSetting(
         'SUPPORT_EMAIL_ADDRESS',
-        'help@email.com',
+        'support@email.com',
       )
       await adminSettings.saveChanges()
       await page.goto('/error?exceptionId=1')
       await expect(
         page.getByRole('link', {
-          name: 'help@email.com',
+          name: 'support@email.com',
+        }),
+      ).toBeAttached()
+    })
+
+    await test.step('Updating the IT email address updates the error page when both are set', async () => {
+      await adminSettings.gotoAdminSettings()
+      await adminSettings.setStringSetting('IT_EMAIL_ADDRESS', 'it@email.com')
+      await adminSettings.saveChanges()
+      await page.goto('/error?exceptionId=1')
+      await expect(
+        page.getByRole('link', {
+          name: 'it@email.com',
+        }),
+      ).toBeAttached()
+    })
+
+    await test.step('Removing the IT email address updates the error page with fallback to support', async () => {
+      await adminSettings.gotoAdminSettings()
+      await adminSettings.setStringSetting('IT_EMAIL_ADDRESS', '')
+      await adminSettings.saveChanges()
+      await page.goto('/error?exceptionId=1')
+      await expect(
+        page.getByRole('link', {
+          name: 'support@email.com',
         }),
       ).toBeAttached()
     })

--- a/server/app/services/settings/SettingsManifest.java
+++ b/server/app/services/settings/SettingsManifest.java
@@ -721,7 +721,10 @@ public final class SettingsManifest extends AbstractSettingsManifest {
     return getString("SUPPORT_EMAIL_ADDRESS", request);
   }
 
-  /** This email address receives error notifications from CiviForm when things break. */
+  /**
+   * This email address receives error notifications from CiviForm when there is an internal server
+   * error or a durable job fails.
+   */
   public Optional<String> getItEmailAddress(RequestHeader request) {
     return getString("IT_EMAIL_ADDRESS", request);
   }
@@ -1984,8 +1987,8 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                           SettingMode.ADMIN_WRITEABLE),
                       SettingDescription.create(
                           "IT_EMAIL_ADDRESS",
-                          "This email address receives error notifications from CiviForm when"
-                              + " things break.",
+                          "This email address receives error notifications from CiviForm when there"
+                              + " is an internal server error or a durable job fails.",
                           /* isRequired= */ false,
                           SettingType.STRING,
                           SettingMode.ADMIN_WRITEABLE),

--- a/server/app/views/errors/InternalServerError.java
+++ b/server/app/views/errors/InternalServerError.java
@@ -65,12 +65,12 @@ public final class InternalServerError extends BaseHtmlView {
 
   private UnescapedText buildAdditionalInfo(
       Http.RequestHeader requestHeader, Messages messages, String exceptionId) {
-    String supportEmail = settingsManifest.getSupportEmailAddress(requestHeader).get();
+    String emailAddress = getEmailAddress(requestHeader);
     String emailLinkHref =
-        String.format("mailto:%s?body=[CiviForm Error ID: %s]", supportEmail, exceptionId);
+        String.format("mailto:%s?body=[CiviForm Error ID: %s]", emailAddress, exceptionId);
     ATag emailAction =
         new LinkElement()
-            .setText(supportEmail)
+            .setText(emailAddress)
             .setHref(emailLinkHref)
             .asAnchorText()
             .withClasses(ApplicantStyles.LINK);
@@ -81,5 +81,12 @@ public final class InternalServerError extends BaseHtmlView {
     String sanitizedDescription =
         TextFormatter.sanitizeHtml(String.format(descriptionText, emailAction.render()));
     return rawHtml(sanitizedDescription);
+  }
+
+  /** Get either the IT email address or the support email address */
+  private String getEmailAddress(Http.RequestHeader requestHeader) {
+    Optional<String> itEmail =
+        settingsManifest.getItEmailAddress(requestHeader).filter(email -> !email.isBlank());
+    return itEmail.or(() -> settingsManifest.getSupportEmailAddress(requestHeader)).orElse("");
   }
 }

--- a/server/conf/env-var-docs.json
+++ b/server/conf/env-var-docs.json
@@ -634,7 +634,7 @@
       },
       "IT_EMAIL_ADDRESS": {
         "mode": "ADMIN_WRITEABLE",
-        "description": "This email address receives error notifications from CiviForm when things break.",
+        "description": "This email address receives error notifications from CiviForm when there is an internal server error or a durable job fails.",
         "type": "string"
       },
       "STAGING_PROGRAM_ADMIN_NOTIFICATION_MAILING_LIST": {


### PR DESCRIPTION
### Description

Use IT email address for internal server errors with fallback to support email and update description of IT email setting.

Demo: 
<img width="819" alt="Screenshot 2025-06-04 at 10 33 12" src="https://github.com/user-attachments/assets/38a17210-2d69-47eb-a7ac-9b47be2597c7" />

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

### Issue(s) this completes

Fixes #8372
