### PR TITLE
Adding wsclient retry capabilities

### DIFF
--- a/mock-web-services/apibridge/__init__.py
+++ b/mock-web-services/apibridge/__init__.py
@@ -27,8 +27,13 @@ def healthcheck() -> tuple[Response, int]:
         response_code = int(request.headers.get("Emulate-Response-Code", 200))
 
         match response_code:
-            case 400 | 401 | 429 | 500:
+            case 400 | 401 | 500:
                 response = create_problem_detail(response_code)
+            case 429:
+                response = create_problem_detail(response_code)
+                http_response = jsonify(response)
+                http_response.headers["Retry-After"] = "1"
+                return http_response, response_code
             case _:
                 response = HealthcheckResponse(
                     timestamp=int(time.time() + 1000))
@@ -47,8 +52,13 @@ def discovery() -> tuple[Response, int]:
         response_code = int(request.headers.get("Emulate-Response-Code", 200))
 
         match response_code:
-            case 400 | 401 | 429 | 500:
+            case 400 | 401 | 500:
                 response = create_problem_detail(response_code)
+            case 429:
+                response = create_problem_detail(response_code)
+                http_response = jsonify(response)
+                http_response.headers["Retry-After"] = "1"
+                return http_response, response_code
             case _:
                 response = DiscoveryResponse(
                     endpoints={
@@ -77,10 +87,15 @@ def bridge(slug: str) -> tuple[Response, int]:
         response_code = int(request.headers.get("Emulate-Response-Code", 200))
 
         match response_code:
-            case 400 | 401 | 404 | 429 | 500:
+            case 400 | 401 | 404 | 500:
                 response = create_problem_detail(response_code)
             case 422:
                 response = create_val_problem_detail()
+            case 429:
+                response = create_problem_detail(response_code)
+                http_response = jsonify(response)
+                http_response.headers["Retry-After"] = "1"
+                return http_response, response_code
             case _:
                 response = BridgeResponse(
                     compatibility_level=CompatibilityLevel.V1,

--- a/server/app/services/apibridge/RetryAfterHeaderParser.java
+++ b/server/app/services/apibridge/RetryAfterHeaderParser.java
@@ -1,0 +1,69 @@
+package services.apibridge;
+
+import static com.google.api.client.util.Preconditions.checkNotNull;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+/** Provides string parsing of the value from a Retry-After http header */
+@Singleton
+public final class RetryAfterHeaderParser {
+  private final Clock clock;
+
+  @Inject
+  public RetryAfterHeaderParser(Clock clock) {
+    this.clock = checkNotNull(clock);
+  }
+
+  /**
+   * Attempts to parse the value of a <a
+   * href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Retry-After">Retry-After</a>
+   * HTTP header.
+   *
+   * <p>The Retry-After could be in one of two formats
+   *
+   * <ul>
+   *   <li>http-date - See {@link DateTimeFormatter#RFC_1123_DATE_TIME}
+   *   <li>delay-seconds - See {@link Long}
+   * </ul>
+   *
+   * @param value Value from Retry-After http header
+   * @return The amount of time to wait before making next attempt or a Duration of 0 if the value
+   *     cannot be successfully parsed.
+   */
+  public Duration parse(String value) {
+    if (value == null || value.isBlank()) {
+      return Duration.ZERO;
+    }
+
+    value = value.trim();
+
+    // Attempt to parse as a number
+    try {
+      long seconds = Long.parseLong(value);
+      return Duration.ofSeconds(seconds);
+    } catch (NumberFormatException ignored) {
+      // no-op
+    }
+
+    // Attempt to parse as a date
+    try {
+      ZonedDateTime retryTime = ZonedDateTime.parse(value, DateTimeFormatter.RFC_1123_DATE_TIME);
+      ZonedDateTime now = ZonedDateTime.now(clock);
+      Duration duration = Duration.between(now, retryTime);
+
+      // Negative duration means the date is already in the past so run now
+      return duration.isNegative() ? Duration.ZERO : duration;
+
+    } catch (DateTimeParseException ignored) {
+      // no-op
+    }
+
+    return Duration.ZERO;
+  }
+}

--- a/server/app/services/apibridge/RetryingWSClient.java
+++ b/server/app/services/apibridge/RetryingWSClient.java
@@ -1,0 +1,171 @@
+package services.apibridge;
+
+import static autovalue.shaded.com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import javax.inject.Inject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import play.libs.ws.WSClient;
+import play.libs.ws.WSRequest;
+import play.libs.ws.WSResponse;
+
+/** Decorator class to wrap a {@link WSClient} to add retry capabilities */
+public final class RetryingWSClient implements WSClient {
+  private static final Logger logger = LoggerFactory.getLogger(RetryingWSClient.class);
+
+  private static final int MAX_RETRIES = 3;
+  private static final long DEFAULT_BASE_DELAY_MS = 500L;
+
+  private final WSClient wsClient;
+  private final RetryAfterHeaderParser retryAfterHeaderParser;
+  private final long baseDelayInMs;
+  private final ScheduledExecutorService scheduler;
+  private final Executor executionContext;
+
+  @Inject
+  public RetryingWSClient(
+      WSClient wsClient,
+      RetryAfterHeaderParser retryAfterHeaderParser,
+      ScheduledExecutorService scheduledExecutorService,
+      Executor executionContext) {
+    this(
+        wsClient,
+        retryAfterHeaderParser,
+        scheduledExecutorService,
+        executionContext,
+        DEFAULT_BASE_DELAY_MS);
+  }
+
+  @VisibleForTesting
+  public RetryingWSClient(
+      WSClient wsClient,
+      RetryAfterHeaderParser retryAfterHeaderParser,
+      ScheduledExecutorService scheduledExecutorService,
+      Executor executionContext,
+      long baseDelayInMs) {
+    this.wsClient = checkNotNull(wsClient);
+    this.retryAfterHeaderParser = checkNotNull(retryAfterHeaderParser);
+    this.executionContext = checkNotNull(executionContext);
+    this.baseDelayInMs = baseDelayInMs;
+    this.scheduler = scheduledExecutorService;
+  }
+
+  @Override
+  public Object getUnderlying() {
+    return wsClient.getUnderlying();
+  }
+
+  @Override
+  public play.api.libs.ws.WSClient asScala() {
+    return wsClient.asScala();
+  }
+
+  @Override
+  public WSRequest url(String url) {
+    return wsClient.url(url);
+  }
+
+  @Override
+  public void close() throws IOException {
+    wsClient.close();
+  }
+
+  /** Perform a GET on the request asynchronously. */
+  public CompletionStage<WSResponse> get(String url) {
+    return getWithRetry(url, 0);
+  }
+
+  /** Perform a GET on the request asynchronously with retry */
+  private CompletionStage<WSResponse> getWithRetry(String url, int retryCount) {
+    return this.url(url)
+        .get()
+        .thenComposeAsync(
+            wsResponse ->
+                handleResponse(wsResponse, retryCount, () -> getWithRetry(url, retryCount + 1)),
+            executionContext)
+        .exceptionallyAsync(
+            error -> {
+              throw new RuntimeException(String.format("Request failed for URL: %s", url), error);
+            },
+            executionContext);
+  }
+
+  /** Perform a POST on the request asynchronously */
+  public CompletionStage<WSResponse> post(String url, String jsonBody) {
+    return postWithRetry(url, jsonBody, 0);
+  }
+
+  /** Perform a POST on the request asynchronously with retry */
+  private CompletionStage<WSResponse> postWithRetry(String url, String jsonBody, int retryCount) {
+    return this.url(url)
+        .setContentType("application/json")
+        .post(jsonBody)
+        .thenComposeAsync(
+            wsResponse ->
+                handleResponse(
+                    wsResponse, retryCount, () -> postWithRetry(url, jsonBody, retryCount + 1)),
+            executionContext)
+        .exceptionallyAsync(
+            error -> {
+              throw new RuntimeException(String.format("Request failed for URL: %s", url), error);
+            },
+            executionContext);
+  }
+
+  /** Handles an HTTP response with retry */
+  @VisibleForTesting
+  CompletionStage<WSResponse> handleResponse(
+      WSResponse wsResponse, int retryCount, Supplier<CompletionStage<WSResponse>> retryAction) {
+    // Return immediately if successful http request or max retries exceeded
+    if (wsResponse.getStatus() == 200 || retryCount >= MAX_RETRIES) {
+      return CompletableFuture.completedFuture(wsResponse);
+    }
+
+    // Calculate timeout
+    Duration retryDelayDuration = Duration.ofMillis(baseDelayInMs * retryCount);
+
+    if (wsResponse.getStatus() == 429 && wsResponse.getSingleHeader("Retry-After").isPresent()) {
+      retryDelayDuration =
+          retryAfterHeaderParser.parse(wsResponse.getSingleHeader("Retry-After").get());
+    }
+
+    // Schedule retry
+    logger.debug(
+        "Retrying... URL={} Status={} Delay={}ms Retries={}",
+        wsResponse.getUri().toString(),
+        wsResponse.getStatus(),
+        retryDelayDuration.toMillis(),
+        retryCount);
+
+    CompletableFuture<WSResponse> retryFuture = new CompletableFuture<>();
+
+    var unused =
+        scheduler.schedule(
+            () -> {
+              retryAction
+                  .get()
+                  .whenCompleteAsync(
+                      (retryResult, retryError) -> {
+                        if (retryError != null) {
+                          retryFuture.completeExceptionally(retryError);
+                        } else {
+                          retryFuture.complete(retryResult);
+                        }
+                      },
+                      executionContext);
+            },
+            retryDelayDuration.toMillis(),
+            TimeUnit.MILLISECONDS);
+
+    return retryFuture;
+  }
+}

--- a/server/test/services/apibridge/RetryAfterHeaderParserTest.java
+++ b/server/test/services/apibridge/RetryAfterHeaderParserTest.java
@@ -1,0 +1,56 @@
+package services.apibridge;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import org.junit.Test;
+
+public class RetryAfterHeaderParserTest {
+  private final Clock clock = Clock.fixed(Instant.parse("2015-10-21T07:28:00Z"), ZoneId.of("UTC"));
+
+  @Test
+  public void defaults_to_zero_when_argument_null_or_blank() {
+    var parser = new RetryAfterHeaderParser(clock);
+    assertThat(parser.parse(null)).isEqualTo(Duration.ZERO);
+    assertThat(parser.parse("")).isEqualTo(Duration.ZERO);
+  }
+
+  @Test
+  public void parses_delay_seconds_format_successfully() {
+    var parser = new RetryAfterHeaderParser(clock);
+    Duration expected = Duration.ofSeconds(30);
+    assertThat(parser.parse("30")).isEqualTo(expected);
+    assertThat(parser.parse("   30")).isEqualTo(expected);
+    assertThat(parser.parse("30   ")).isEqualTo(expected);
+  }
+
+  @Test
+  public void defaults_to_zero_when_delay_seconds_format_is_invalid() {
+    var parser = new RetryAfterHeaderParser(clock);
+    assertThat(parser.parse("3 0")).isEqualTo(Duration.ZERO);
+  }
+
+  @Test
+  public void parses_http_date_format_successfully() {
+    var parser = new RetryAfterHeaderParser(clock);
+
+    String retryAfterHeaderValue = "Wed, 21 Oct 2015 07:28:30 GMT";
+    Duration expected = Duration.ofSeconds(30);
+    assertThat(parser.parse(retryAfterHeaderValue)).isEqualTo(expected);
+  }
+
+  @Test
+  public void defaults_to_zero_when_http_date_format_is_invalid() {
+    var parser = new RetryAfterHeaderParser(clock);
+    assertThat(parser.parse("Wed, 40 Oct 2015 07:28:30 GMT")).isEqualTo(Duration.ZERO);
+  }
+
+  @Test
+  public void defaults_to_zero_when_http_date_is_in_the_past() {
+    var parser = new RetryAfterHeaderParser(clock);
+    assertThat(parser.parse("Wed, 14 Oct 2015 07:28:30 GMT")).isEqualTo(Duration.ZERO);
+  }
+}

--- a/server/test/services/apibridge/RetryingWSClientTest.java
+++ b/server/test/services/apibridge/RetryingWSClientTest.java
@@ -1,0 +1,109 @@
+package services.apibridge;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import org.junit.AfterClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Spy;
+import org.mockito.junit.MockitoJUnitRunner;
+import play.libs.ws.WSClient;
+import play.libs.ws.WSResponse;
+import repository.ResetPostgres;
+import support.WSClientWithHttpHeader;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RetryingWSClientTest extends ResetPostgres {
+  private static final String GET_URL = "http://mock-web-services:8000/api-bridge/health-check";
+  private static final String POST_URL = "http://mock-web-services:8000/api-bridge/bridge/success";
+  private static final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
+
+  @Spy
+  private RetryAfterHeaderParser retryAfterHeaderParser = instanceOf(RetryAfterHeaderParser.class);
+
+  @AfterClass
+  public static void shutdown() {
+    scheduler.shutdown();
+  }
+
+  private RetryingWSClient createWSClient(Integer emulatedResponseCode) {
+    WSClient wsClient = instanceOf(WSClient.class);
+
+    WSClientWithHttpHeader wsClientWithHttpHeader =
+        new WSClientWithHttpHeader(wsClient)
+            .setHeaders(Map.of("Emulate-Response-Code", List.of(emulatedResponseCode.toString())));
+
+    ApiBridgeExecutionContext executionContext = instanceOf(ApiBridgeExecutionContext.class);
+
+    return new RetryingWSClient(
+        wsClientWithHttpHeader, retryAfterHeaderParser, scheduler, executionContext, 1L);
+  }
+
+  @Test
+  public void successful_get_response_does_not_retry() {
+    int expectedHttpResponseCode = 200;
+    RetryingWSClient wsClient = spy(createWSClient(expectedHttpResponseCode));
+    WSResponse wsResponse = wsClient.get(GET_URL).toCompletableFuture().join();
+
+    assertExpectedMethodsCalled(wsClient, 1, 0);
+    assertThat(wsResponse.getStatus()).isEqualTo(expectedHttpResponseCode);
+  }
+
+  @Test
+  public void successful_post_response_does_not_retry() {
+    int expectedHttpResponseCode = 200;
+    RetryingWSClient wsClient = spy(createWSClient(expectedHttpResponseCode));
+    String jsonBody = "{\"payload\": { \"accountNumber\": 1 }}";
+    WSResponse wsResponse = wsClient.post(POST_URL, jsonBody).toCompletableFuture().join();
+
+    assertExpectedMethodsCalled(wsClient, 1, 0);
+    assertThat(wsResponse.getStatus()).isEqualTo(expectedHttpResponseCode);
+  }
+
+  @Test
+  public void http_429_response_retries_using_retry_after_interval() {
+    int expectedHttpResponseCode = 429;
+    RetryingWSClient wsClient = spy(createWSClient(expectedHttpResponseCode));
+    WSResponse wsResponse = wsClient.get(GET_URL).toCompletableFuture().join();
+
+    assertExpectedMethodsCalled(wsClient, 4, 3);
+    assertThat(wsResponse.getStatus()).isEqualTo(expectedHttpResponseCode);
+  }
+
+  @Test
+  public void unsuccessful_response_retries() {
+    int expectedHttpResponseCode = 500;
+    RetryingWSClient wsClient = spy(createWSClient(expectedHttpResponseCode));
+    WSResponse wsResponse = wsClient.get(GET_URL).toCompletableFuture().join();
+
+    assertExpectedMethodsCalled(wsClient, 4, 0);
+    assertThat(wsResponse.getStatus()).isEqualTo(expectedHttpResponseCode);
+  }
+
+  /**
+   * Assert that certain methods are called the number of times we expect them to be called
+   *
+   * @param wsClient Just the wsClient
+   * @param handleResponseCount Number of calls we expect the {@link
+   *     RetryingWSClient#handleResponse} to receive. This gets called once when successful or the
+   *     retry count + 1.
+   * @param retryHeaderParseCount Number of calls we expect the {@link RetryAfterHeaderParser#parse}
+   *     to receive. This gets called each attempt only when there is an http 429 with a retry-after
+   *     header present.
+   */
+  private void assertExpectedMethodsCalled(
+      RetryingWSClient wsClient, int handleResponseCount, int retryHeaderParseCount) {
+    verify(wsClient, times(handleResponseCount)).handleResponse(any(), anyInt(), any());
+    verify(retryAfterHeaderParser, times(retryHeaderParseCount)).parse(anyString());
+  }
+}


### PR DESCRIPTION
### Description

Creates a new WSClient class that will retry on errors or handle the retry-after header for on throttled http 429 calls. Fully async future based.

Updates the mock web services to return a retry-after header when calling generates a 429 response.

Creates a class that can appropriately parse the value from the retry-after header as it can be either a date or number of seconds.


### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.


Related to [#10555](https://github.com/civiform/civiform/issues/10555)
