### PR TITLE
Exclude external programs from API docs

### DIFF
--- a/browser-test/src/api_docs.test.ts
+++ b/browser-test/src/api_docs.test.ts
@@ -6,6 +6,7 @@ import {
   validateScreenshot,
   waitForPageJsLoad,
 } from './support'
+import {ProgramVisibility} from './support/admin_programs'
 
 test.describe('Viewing API docs', () => {
   test.beforeEach(async ({page, seeding}) => {
@@ -151,7 +152,6 @@ test.describe('Viewing API docs', () => {
   }) => {
     await page.goto('/')
     await loginAsAdmin(page)
-
     await adminPrograms.publishAllDrafts()
 
     await page.getByRole('link', {name: 'API docs'}).click()
@@ -194,5 +194,28 @@ test.describe('Viewing API docs', () => {
       page.locator('.cf-accordion'),
       'api-docs-page-accordion-open',
     )
+  })
+
+  test('External programs are not shown in program options', async ({
+    page,
+    adminPrograms,
+  }) => {
+    await page.goto('/')
+    await loginAsAdmin(page)
+    await enableFeatureFlag(page, 'external_program_cards_enabled')
+
+    await adminPrograms.addExternalProgram(
+      'External Program Name',
+      'short program description',
+      'https://usa.gov',
+      ProgramVisibility.PUBLIC,
+    )
+
+    await page.getByRole('link', {name: 'API docs'}).click()
+    await waitForPageJsLoad(page)
+
+    await expect(
+      page.getByRole('combobox', {name: 'Program'}),
+    ).not.toContainText('external-program-name')
   })
 })

--- a/browser-test/src/api_docs_schema_viewer.test.ts
+++ b/browser-test/src/api_docs_schema_viewer.test.ts
@@ -1,5 +1,6 @@
 import {test, expect} from './support/civiform_fixtures'
 import {enableFeatureFlag, loginAsAdmin, waitForPageJsLoad} from './support'
+import {ProgramVisibility} from './support/admin_programs'
 
 test.describe('Viewing API docs', () => {
   const program1 = 'comprehensive-sample-program'
@@ -53,6 +54,22 @@ test.describe('Viewing API docs', () => {
         .selectOption('swagger-v2')
       await waitForPageJsLoad(page)
       await expect(page.getByRole('heading', {name: program2})).toBeAttached()
+    })
+
+    await test.step('Add external program does not show in program options', async () => {
+      await enableFeatureFlag(page, 'external_program_cards_enabled')
+      await adminPrograms.addExternalProgram(
+        'External Program Name',
+        'short program description',
+        'https://usa.gov',
+        ProgramVisibility.PUBLIC,
+      )
+      await page.goto('/docs/api/schemas')
+      await waitForPageJsLoad(page)
+
+      await expect(
+        page.getByRole('combobox', {name: 'Program'}),
+      ).not.toContainText('external-program-name')
     })
   })
 })

--- a/server/app/controllers/docs/ApiDocsController.java
+++ b/server/app/controllers/docs/ApiDocsController.java
@@ -33,7 +33,8 @@ public final class ApiDocsController {
    * Like {@link #docsForSlug}, but defaults to an arbitrary program when one is not set in the URL.
    */
   public Result index(Http.Request request) {
-    Optional<String> firstProgramSlug = programService.getAllProgramSlugs().stream().findFirst();
+    Optional<String> firstProgramSlug =
+        programService.getAllNonExternalProgramSlugs().stream().findFirst();
     return firstProgramSlug
         .map(slug -> redirect(routes.ApiDocsController.activeDocsForSlug(slug)))
         .orElse(
@@ -56,7 +57,7 @@ public final class ApiDocsController {
       return notFound("API Docs are not enabled.");
     }
 
-    ImmutableSet<String> allProgramSlugs = programService.getAllProgramSlugs();
+    ImmutableSet<String> allProgramSlugs = programService.getAllNonExternalProgramSlugs();
     Optional<ProgramDefinition> programDefinition =
         getProgramDefinition(selectedProgramSlug, useActiveVersion);
 

--- a/server/app/controllers/docs/OpenApiSchemaController.java
+++ b/server/app/controllers/docs/OpenApiSchemaController.java
@@ -139,7 +139,7 @@ public final class OpenApiSchemaController {
     }
 
     if (programSlug.isEmpty()) {
-      programSlug = programService.getAllProgramSlugs().stream().findFirst().orElse("");
+      programSlug = programService.getAllNonExternalProgramSlugs().stream().findFirst().orElse("");
     }
 
     // This will only happen if there are no programs at all in the system
@@ -157,7 +157,8 @@ public final class OpenApiSchemaController {
 
       SchemaView.Form form = new SchemaView.Form(programSlug, stage, openApiVersion);
 
-      return ok(schemaView.render(request, form, url, programService.getAllProgramSlugs()));
+      return ok(
+          schemaView.render(request, form, url, programService.getAllNonExternalProgramSlugs()));
     } catch (RuntimeException ex) {
       return internalServerError();
     }

--- a/server/app/repository/ProgramRepository.java
+++ b/server/app/repository/ProgramRepository.java
@@ -140,6 +140,20 @@ public final class ProgramRepository {
     return names.build();
   }
 
+  public ImmutableSet<String> getAllNonExternalProgramNames() {
+    ImmutableSet.Builder<String> names = ImmutableSet.builder();
+    List<SqlRow> rows =
+        database
+            .sqlQuery("SELECT DISTINCT name FROM programs WHERE program_type <> 'external'")
+            .findList();
+
+    for (SqlRow row : rows) {
+      names.add(row.getString("name"));
+    }
+
+    return names.build();
+  }
+
   /**
    * Retrieves the program definition for the given program.
    *

--- a/server/app/services/apikey/ApiKeyService.java
+++ b/server/app/services/apikey/ApiKeyService.java
@@ -286,7 +286,7 @@ public final class ApiKeyService {
 
   private ApiKeyGrants resolveGrants(DynamicForm form) {
     ApiKeyGrants grants = new ApiKeyGrants();
-    ImmutableSet<String> programSlugs = programService.getAllProgramSlugs();
+    ImmutableSet<String> programSlugs = programService.getAllNonExternalProgramSlugs();
 
     for (String formDataKey : form.rawData().keySet()) {
       Matcher matcher = GRANT_PROGRAM_READ_PATTERN.matcher(formDataKey);

--- a/server/app/services/program/ProgramService.java
+++ b/server/app/services/program/ProgramService.java
@@ -120,14 +120,19 @@ public final class ProgramService {
     return programRepository.getAllProgramNames();
   }
 
+  /** Get the names for all programs excluding external programs. */
+  public ImmutableSet<String> getAllNonExternalProgramNames() {
+    return programRepository.getAllNonExternalProgramNames();
+  }
+
   /** Get the slug of {@code} programId. */
   public String getSlug(long programId) throws ProgramNotFoundException {
     return programRepository.getSlug(programId);
   }
 
-  /** Get the slugs for all programs. */
-  public ImmutableSet<String> getAllProgramSlugs() {
-    return getAllProgramNames().stream()
+  /** Get the slugs for all programs excluding external programs. */
+  public ImmutableSet<String> getAllNonExternalProgramSlugs() {
+    return getAllNonExternalProgramNames().stream()
         .map(MainModule.SLUGIFIER::slugify)
         .sorted()
         .collect(ImmutableSet.toImmutableSet());

--- a/server/test/controllers/docs/ApiDocsControllerTest.java
+++ b/server/test/controllers/docs/ApiDocsControllerTest.java
@@ -1,6 +1,7 @@
 package controllers.docs;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static play.mvc.Http.Status.NOT_FOUND;
 import static play.mvc.Http.Status.OK;
 import static play.mvc.Http.Status.SEE_OTHER;
 import static play.test.Helpers.contentAsString;
@@ -12,6 +13,7 @@ import org.junit.Test;
 import play.mvc.Http.Request;
 import play.mvc.Result;
 import repository.ResetPostgres;
+import services.program.ProgramType;
 import support.ProgramBuilder;
 
 public class ApiDocsControllerTest extends ResetPostgres {
@@ -35,6 +37,20 @@ public class ApiDocsControllerTest extends ResetPostgres {
     assertThat(result.status()).isEqualTo(SEE_OTHER);
     assertThat(result.redirectLocation())
         .isEqualTo(Optional.of("/docs/api/programs/test-program-1/active"));
+  }
+
+  @Test
+  public void index_externalProgramOnly_notFound() {
+    resetTables();
+    ProgramBuilder.newActiveProgram("Test External Program 1")
+        .withProgramType(ProgramType.EXTERNAL)
+        .buildDefinition();
+
+    Request request = fakeRequest();
+    Result result = instanceOf(ApiDocsController.class).index(request);
+
+    assertThat(result.status()).isEqualTo(NOT_FOUND);
+    assertThat(contentAsString(result)).contains("No programs found");
   }
 
   @Test

--- a/server/test/controllers/docs/OpenApiSchemaControllerTest.java
+++ b/server/test/controllers/docs/OpenApiSchemaControllerTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static play.mvc.Http.Status.BAD_REQUEST;
 import static play.mvc.Http.Status.NOT_FOUND;
 import static play.mvc.Http.Status.OK;
+import static play.test.Helpers.contentAsString;
 import static support.FakeRequestBuilder.fakeRequest;
 
 import java.util.Optional;
@@ -14,9 +15,13 @@ import play.mvc.Http.Request;
 import play.mvc.Result;
 import repository.ResetPostgres;
 import services.openapi.OpenApiVersion;
+import services.program.ProgramType;
 import support.ProgramBuilder;
 
 public class OpenApiSchemaControllerTest extends ResetPostgres {
+
+  private static final String SCHEMA_UI_NO_PROGRAM_FOUND_ERROR = "Please add a program";
+
   @Before
   public void setUp() {
     resetTables();
@@ -98,16 +103,37 @@ public class OpenApiSchemaControllerTest extends ResetPostgres {
   }
 
   @Test
-  public void getSchemaUI_cannotFindProgram() {
+  public void getSchemaUI_noProgram_loadsFirstActive() {
     Request request = fakeRequest();
     Result result =
         instanceOf(OpenApiSchemaController.class)
-            .getSchemaByProgramSlug(
+            .getSchemaUI(
                 request,
                 "test-program-2",
                 Optional.of(LifecycleStage.ACTIVE.getValue()),
                 Optional.of(OpenApiVersion.SWAGGER_V2.toString()));
 
-    assertThat(result.status()).isEqualTo(NOT_FOUND);
+    assertThat(result.status()).isEqualTo(OK);
+    assertThat(contentAsString(result)).doesNotContain(SCHEMA_UI_NO_PROGRAM_FOUND_ERROR);
+  }
+
+  @Test
+  public void getSchemaUI_externalProgramsOnly_noProgramFound() {
+    resetTables();
+    ProgramBuilder.newActiveProgram("Test External Program 1")
+        .withProgramType(ProgramType.EXTERNAL)
+        .buildDefinition();
+
+    Request request = fakeRequest();
+    Result result =
+        instanceOf(OpenApiSchemaController.class)
+            .getSchemaUI(
+                request,
+                "",
+                Optional.of(LifecycleStage.ACTIVE.getValue()),
+                Optional.of(OpenApiVersion.SWAGGER_V2.toString()));
+
+    assertThat(result.status()).isEqualTo(OK);
+    assertThat(contentAsString(result)).contains(SCHEMA_UI_NO_PROGRAM_FOUND_ERROR);
   }
 }

--- a/server/test/repository/ProgramRepositoryTest.java
+++ b/server/test/repository/ProgramRepositoryTest.java
@@ -353,6 +353,16 @@ public class ProgramRepositoryTest extends ResetPostgres {
   }
 
   @Test
+  public void getAllNonExternalProgramNames() {
+    resourceCreator.insertActiveExternalProgram("external program name");
+    resourceCreator.insertActiveProgram("default program name");
+
+    ImmutableSet<String> result = repo.getAllNonExternalProgramNames();
+
+    assertThat(result).isEqualTo(ImmutableSet.of("default program name"));
+  }
+
+  @Test
   public void getVersionsForProgram() {
     ProgramModel program = resourceCreator.insertActiveProgram("old name");
 

--- a/server/test/support/ResourceCreator.java
+++ b/server/test/support/ResourceCreator.java
@@ -26,6 +26,7 @@ import play.Mode;
 import play.inject.Injector;
 import services.LocalizedStrings;
 import services.apikey.ApiKeyService;
+import services.program.ProgramType;
 import services.question.types.QuestionDefinition;
 import services.question.types.QuestionDefinitionConfig;
 import services.question.types.TextQuestionDefinition;
@@ -151,6 +152,10 @@ public class ResourceCreator {
 
   public ProgramModel insertActiveCommonIntakeForm(String name) {
     return ProgramBuilder.newActiveCommonIntakeForm(name).build();
+  }
+
+  public ProgramModel insertActiveExternalProgram(String name) {
+    return ProgramBuilder.newActiveProgram().withProgramType(ProgramType.EXTERNAL).build();
   }
 
   public ProgramModel insertDraftProgram(String name) {


### PR DESCRIPTION
### Description

External programs are not available via the API so they should be removed as options from the dropdown on both pages of the API docs. If only external programs exist, "program not found" treatment is shown.

This approach replaces getAllProgramSlugs with getAllNonExternalProgramSlugs as the only usage was in API docs. Another approach considered was to allow passing in flexible program types as input: getProgramSlugsForType(programType), but this seemed unnecessary if filtering out external only would be the standard use case.

Also makes a small fix to an existing schema test that intended to test the schema root ui but was calling schemaBySlug instead (duplicate of another test).

Note: It's still possible to access external program docs directly via url, in which case the experience isn't ideal since the external program's data is shown, but the dropdown is still filtered and its selected value will not match. If this is a concern, happy to address as part of this change or in a followup.


[Demo](https://github.com/user-attachments/assets/b234d486-f10a-43ac-8963-e4599adccad6)

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

#### User visible changes

- [ ] Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
  - [ ] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [ ] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Made equivalent changes in Thymeleaf for applicant-facing features and changes (or created an issue in the [Northstar epic](https://github.com/orgs/civiform/projects/1/views/94) to track that it's missing from Thymeleaf)
- [x] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [x] Manually tested at 200% size
- [ ] Manually evaluated tab order
- [ ] Manually tested with a screen reader if the feature is applicant-facing. See [screen reader testing](https://github.com/civiform/civiform/wiki/Testing#screen-reader-testing)

### Issue(s) this completes

Fixes #10598 
