### PR TITLE
Consolidate question-card rendering into helper method

### DIFF
--- a/server/app/views/admin/AdminLayout.java
+++ b/server/app/views/admin/AdminLayout.java
@@ -3,34 +3,48 @@ package views.admin;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static j2html.TagCreator.a;
 import static j2html.TagCreator.div;
+import static j2html.TagCreator.iff;
+import static j2html.TagCreator.iffElse;
+import static j2html.TagCreator.li;
 import static j2html.TagCreator.nav;
+import static j2html.TagCreator.p;
 import static j2html.TagCreator.span;
 import static j2html.TagCreator.text;
+import static j2html.TagCreator.ul;
 import static views.BaseHtmlView.asRedirectElement;
 import static views.ViewUtils.makeSvgTextButton;
 
 import auth.CiviFormProfile;
+import com.google.common.collect.ImmutableList;
 import controllers.AssetsFinder;
 import controllers.admin.routes;
 import j2html.tags.DomContent;
 import j2html.tags.specialized.ATag;
 import j2html.tags.specialized.ButtonTag;
 import j2html.tags.specialized.DivTag;
+import j2html.tags.specialized.FieldsetTag;
 import j2html.tags.specialized.NavTag;
+import j2html.tags.specialized.UlTag;
 import java.util.Optional;
 import play.i18n.MessagesApi;
 import play.mvc.Http;
 import play.twirl.api.Content;
 import services.DeploymentType;
 import services.TranslationLocales;
+import services.question.QuestionOption;
+import services.question.types.MultiOptionQuestionDefinition;
+import services.question.types.QuestionDefinition;
 import services.settings.SettingsManifest;
 import views.BaseHtmlLayout;
 import views.HtmlBundle;
 import views.JsBundle;
 import views.ViewUtils;
 import views.components.Icons;
+import views.components.SvgTag;
+import views.components.TextFormatter;
 import views.style.AdminStyles;
 import views.style.BaseStyles;
+import views.style.ReferenceClasses;
 import views.style.StyleUtils;
 
 /** Contains methods rendering common compoments used across admin pages. */
@@ -261,5 +275,135 @@ public final class AdminLayout extends BaseHtmlLayout {
         .withHref(href)
         .withClasses(
             "px-3", "opacity-75", StyleUtils.hover("opacity-100"), StyleUtils.joinStyles(styles));
+  }
+
+  // maybeBadgeForImport = empty, maybeDuplicateHandlingForImport = empty
+
+  /**
+   * Renders a question for import, including info about the question and possibly its
+   * duplicate-handling options
+   *
+   * @param questionDefinition the question definition to render
+   * @param badgeForImport a badge indicating if the question is new or a duplicate
+   * @param maybeDuplicateHandlingForImport a div tag containing the duplicate handling options, if
+   *     this question is a duplicate
+   * @return a div tag containing the rendered question
+   */
+  public static DivTag renderQuestionForImport(
+      QuestionDefinition questionDefinition,
+      DivTag badgeForImport,
+      Optional<FieldsetTag> maybeDuplicateHandlingForImport) {
+    return renderQuestion(
+        questionDefinition,
+        /* malformedQuestionDefinition= */ false,
+        /* editButtonsForProgramPage= */ ImmutableList.of(),
+        Optional.of(badgeForImport),
+        maybeDuplicateHandlingForImport);
+  }
+
+  /**
+   * Renders a question for a program, including info about the question and possibly some editing
+   * controls
+   *
+   * @param questionDefinition the question definition to render
+   * @param malformedQuestionDefinition whether there is an issue with the definition
+   * @param editButtonsForProgramPage the div tags containing buttons/icons showing the options to
+   *     edit the question
+   * @return a div tag containing the rendered question
+   */
+  public static DivTag renderQuestionForProgramPage(
+      QuestionDefinition questionDefinition,
+      boolean malformedQuestionDefinition,
+      ImmutableList<DomContent> editButtonsForProgramPage) {
+    return renderQuestion(
+        questionDefinition,
+        malformedQuestionDefinition,
+        editButtonsForProgramPage,
+        /* maybeBadgeForImport= */ Optional.empty(),
+        /* maybeDuplicateHandlingForImport= */ Optional.empty());
+  }
+
+  /**
+   * Renders an individual question, including the description and any toggles or tags that should
+   * be shown next to the question in the list of questions.
+   */
+  private static DivTag renderQuestion(
+      QuestionDefinition questionDefinition,
+      boolean malformedQuestionDefinition,
+      ImmutableList<DomContent> editButtonsForProgramPage,
+      Optional<DivTag> maybeBadgeForImport,
+      Optional<FieldsetTag> maybeDuplicateHandlingForImport) {
+    DivTag cardDiv =
+        div()
+            .withData("testid", "question-admin-name-" + questionDefinition.getName())
+            .withClasses(
+                ReferenceClasses.PROGRAM_QUESTION,
+                "my-2",
+                iffElse(malformedQuestionDefinition, "border-2", "border"),
+                iffElse(malformedQuestionDefinition, "border-red-500", "border-gray-200"),
+                "px-4",
+                "py-2",
+                "items-center",
+                "rounded-md",
+                StyleUtils.hover("text-gray-800", "bg-gray-100"))
+            .with(
+                div()
+                    .withClasses("flex", "mt-2", "mb-4")
+                    .condWith(
+                        !malformedQuestionDefinition && questionDefinition.isUniversal(),
+                        ViewUtils.makeUniversalBadge(questionDefinition, "mr-2"))
+                    .condWith(maybeBadgeForImport.isPresent(), maybeBadgeForImport.get()));
+    SvgTag icon =
+        Icons.questionTypeSvg(questionDefinition.getQuestionType())
+            .withClasses("shrink-0", "h-12", "w-6");
+    String questionHelpText =
+        questionDefinition.getQuestionHelpText().isEmpty()
+            ? ""
+            : questionDefinition.getQuestionHelpText().getDefault();
+
+    DivTag content =
+        div()
+            .withClass("flex-grow")
+            .with(
+                iff(
+                    malformedQuestionDefinition,
+                    p("This is not pointing at the latest version")
+                        .withClasses("text-red-500", "font-bold")),
+                iff(
+                    malformedQuestionDefinition,
+                    p("Edit the program and try republishing").withClass("text-red-500")),
+                div()
+                    .with(
+                        TextFormatter.formatTextForAdmins(
+                            questionDefinition.getQuestionText().getDefault()))
+                    .withData("testid", "question-div"),
+                div()
+                    .with(TextFormatter.formatTextForAdmins(questionHelpText))
+                    .withClasses("mt-1", "text-sm"),
+                p(String.format("Admin ID: %s", questionDefinition.getName()))
+                    .withClasses("mt-1", "text-sm"),
+                iff(
+                    // Only show multi-option text during program import
+                    maybeDuplicateHandlingForImport.isPresent()
+                        && questionDefinition.getQuestionType().isMultiOptionType(),
+                    getOptions((MultiOptionQuestionDefinition) questionDefinition)));
+
+    DivTag row =
+        div()
+            .withClasses("flex", "gap-4", "items-center")
+            .with(icon, content)
+            .condWith(
+                maybeDuplicateHandlingForImport.isPresent(), maybeDuplicateHandlingForImport.get())
+            .with(editButtonsForProgramPage);
+
+    return cardDiv.with(row);
+  }
+
+  private static UlTag getOptions(MultiOptionQuestionDefinition question) {
+    UlTag options = ul().withClasses("list-disc", "mx-4", "mt-2");
+    for (QuestionOption option : question.getOptions()) {
+      options.with(li(option.optionText().getDefault()));
+    }
+    return options;
   }
 }

--- a/server/app/views/admin/migration/AdminImportViewPartial.java
+++ b/server/app/views/admin/migration/AdminImportViewPartial.java
@@ -40,15 +40,12 @@ import services.question.types.QuestionDefinition;
 import services.settings.SettingsManifest;
 import views.AlertComponent;
 import views.BaseHtmlView;
-import views.ViewUtils;
+import views.admin.AdminLayout;
 import views.components.FieldWithLabel;
 import views.components.Icons;
 import views.components.LinkElement;
-import views.components.SvgTag;
 import views.components.TextFormatter;
 import views.questiontypes.RadioButtonQuestionRenderer;
-import views.style.ReferenceClasses;
-import views.style.StyleUtils;
 
 /** An HTMX partial for portions of the page rendered by {@link AdminImportView}. */
 public final class AdminImportViewPartial extends BaseHtmlView {
@@ -451,82 +448,19 @@ public final class AdminImportViewPartial extends BaseHtmlView {
    */
   private DivTag renderQuestionCard(
       QuestionDefinition questionDefinition, ImmutableList<String> duplicateQuestionNames) {
+    // We use the old admin name (the one inputted by the admin) rather than the de-duped
+    // suffixed name, since the admin has not yet decided how to handle this duplicate
+    // question. In the event they choose to create a new duplicate, then the de-duped
+    // suffixed name will be used by the backend to create a new question.
     String adminName = questionDefinition.getName();
-    boolean questionIsUniversal = questionDefinition.isUniversal();
     boolean questionIsDuplicate = duplicateQuestionNames.contains(adminName);
 
-    // TODO: #9628 - The classes below are copied from the Question Card-rendering method in
-    // ProgramBlockView. We should consider factoring out the card rendering logic to a common
-    // helper method to limit the potential for diverging styles.
-    DivTag cardDiv =
-        div()
-            // We use the old admin name (the one inputted by the admin) rather than the de-duped
-            // suffixed name, since the admin has not yet decided how to handle this duplicate
-            // question. In the event they choose to create a new duplicate, then the de-duped
-            // suffixed name will be used by the backend to create a new question.
-            .withData("testid", "question-admin-name-" + adminName)
-            .withClasses(
-                ReferenceClasses.PROGRAM_QUESTION,
-                "my-2",
-                "px-4",
-                "py-2",
-                "items-center",
-                "rounded-md",
-                "border",
-                StyleUtils.hover("text-gray-800", "bg-gray-100"))
-            .with(
-                div()
-                    .condWith(
-                        questionIsUniversal,
-                        ViewUtils.makeUniversalBadge(questionDefinition, "mr-2"))
-                    .with(
-                        questionIsDuplicate ? makeDuplicateQuestionBadge() : makeNewQuestionBadge())
-                    .withClasses("flex", "mt-2", "mb-4"));
-
-    SvgTag icon =
-        Icons.questionTypeSvg(questionDefinition.getQuestionType())
-            .withClasses("shrink-0", "h-12", "w-6");
-    String questionHelpText =
-        questionDefinition.getQuestionHelpText().isEmpty()
-            ? ""
-            : questionDefinition.getQuestionHelpText().getDefault();
-
-    DivTag content =
-        div()
-            .withClass("flex-grow")
-            .with(
-                div()
-                    .with(
-                        TextFormatter.formatTextForAdmins(
-                            questionDefinition.getQuestionText().getDefault()))
-                    .withData("testid", "question-div"),
-                div()
-                    .with(TextFormatter.formatTextForAdmins(questionHelpText))
-                    .withClasses("mt-1", "text-sm"),
-                p(String.format("Admin ID: %s", adminName)).withClasses("mt-1", "text-sm"))
-            .condWith(
-                questionDefinition.getQuestionType().isMultiOptionType(),
-                questionDefinition.getQuestionType().isMultiOptionType()
-                    ? getOptions((MultiOptionQuestionDefinition) questionDefinition)
-                    : null);
-
-    // TODO: #9628 - If this is a repeated Q, and its parent is a duplicate for which the admin opts
-    // to create a new admin name, then we should dynamically add a badge here that indicates this
-    // Q's parent will *not* be the existing parent, but rather this new duplicated enumerator Q.
-    DivTag row =
-        div()
-            .withClasses("flex", "gap-4", "items-center")
-            .with(icon, content)
-            .condWith(questionIsDuplicate, renderDuplicateQuestionHandlingOptions(adminName));
-    return cardDiv.with(row);
-  }
-
-  private static UlTag getOptions(MultiOptionQuestionDefinition question) {
-    UlTag options = ul().withClasses("list-disc", "mx-4", "mt-2");
-    for (QuestionOption option : question.getOptions()) {
-      options.with(li(option.optionText().getDefault()));
-    }
-    return options;
+    return AdminLayout.renderQuestionForImport(
+        questionDefinition,
+        questionIsDuplicate ? makeDuplicateQuestionBadge() : makeNewQuestionBadge(),
+        questionIsDuplicate
+            ? Optional.of(renderDuplicateQuestionHandlingOptions(adminName))
+            : Optional.empty());
   }
 
   private static DivTag makeDuplicateQuestionBadge(String... classes) {

--- a/server/app/views/admin/programs/ProgramBlocksView.java
+++ b/server/app/views/admin/programs/ProgramBlocksView.java
@@ -7,7 +7,6 @@ import static j2html.TagCreator.div;
 import static j2html.TagCreator.form;
 import static j2html.TagCreator.h1;
 import static j2html.TagCreator.iff;
-import static j2html.TagCreator.iffElse;
 import static j2html.TagCreator.input;
 import static j2html.TagCreator.join;
 import static j2html.TagCreator.p;
@@ -55,8 +54,6 @@ import views.components.FieldWithLabel;
 import views.components.Icons;
 import views.components.Modal;
 import views.components.ProgramQuestionBank;
-import views.components.SvgTag;
-import views.components.TextFormatter;
 import views.components.ToastMessage;
 import views.style.AdminStyles;
 import views.style.BaseStyles;
@@ -700,57 +697,7 @@ public final class ProgramBlocksView extends ProgramBaseView {
       int questionsCount,
       boolean malformedQuestionDefinition,
       Request request) {
-    DivTag ret =
-        div()
-            .withData("testid", "question-admin-name-" + questionDefinition.getName())
-            .withClasses(
-                ReferenceClasses.PROGRAM_QUESTION,
-                "my-2",
-                iffElse(malformedQuestionDefinition, "border-2", "border"),
-                iffElse(malformedQuestionDefinition, "border-red-500", "border-gray-200"),
-                "px-4",
-                "py-2",
-                "items-center",
-                "rounded-md",
-                StyleUtils.hover("text-gray-800", "bg-gray-100"));
-    ret.condWith(
-        !malformedQuestionDefinition && questionDefinition.isUniversal(),
-        ViewUtils.makeUniversalBadge(questionDefinition, "mt-2", "mb-4"));
-
-    DivTag row = div().withClasses("flex", "gap-4", "items-center");
-    SvgTag icon =
-        Icons.questionTypeSvg(questionDefinition.getQuestionType())
-            .withClasses("shrink-0", "h-12", "w-6");
-    String questionHelpText =
-        questionDefinition.getQuestionHelpText().isEmpty()
-            ? ""
-            : questionDefinition.getQuestionHelpText().getDefault();
-
-    DivTag content =
-        div()
-            .withClass("flex-grow")
-            .with(
-                iff(
-                    malformedQuestionDefinition,
-                    p("This is not pointing at the latest version")
-                        .withClasses("text-red-500", "font-bold")),
-                iff(
-                    malformedQuestionDefinition,
-                    p("Edit the program and try republishing").withClass("text-red-500")),
-                div()
-                    .with(
-                        TextFormatter.formatTextForAdmins(
-                            questionDefinition.getQuestionText().getDefault())),
-                div()
-                    .with(TextFormatter.formatTextForAdmins(questionHelpText))
-                    .withClasses("mt-1", "text-sm"),
-                p(String.format("Admin ID: %s", questionDefinition.getName()))
-                    .withClasses("mt-1", "text-sm"));
-
-    Optional<FormTag> maybeOptionalToggle =
-        renderOptionalToggle(
-            csrfTag, programDefinition.id(), blockDefinition.id(), questionDefinition, isOptional);
-
+    ImmutableList.Builder<DomContent> rowContent = ImmutableList.builder();
     Optional<FormTag> maybeAddressCorrectionEnabledToggle =
         renderAddressCorrectionEnabledToggle(
             request,
@@ -759,13 +706,18 @@ public final class ProgramBlocksView extends ProgramBaseView {
             blockDefinition,
             questionDefinition,
             addressCorrectionEnabled);
-
-    row.with(icon, content);
+    Optional<FormTag> maybeOptionalToggle =
+        renderOptionalToggle(
+            csrfTag, programDefinition.id(), blockDefinition.id(), questionDefinition, isOptional);
     // UI for editing is only added if we are viewing a draft.
     if (viewAllowsEditingProgram()) {
-      maybeAddressCorrectionEnabledToggle.ifPresent(toggle -> row.with(toggle));
-      maybeOptionalToggle.ifPresent(row::with);
-      row.with(
+      if (maybeAddressCorrectionEnabledToggle.isPresent()) {
+        rowContent.add(maybeAddressCorrectionEnabledToggle.get());
+      }
+      if (maybeOptionalToggle.isPresent()) {
+        rowContent.add(maybeOptionalToggle.get());
+      }
+      rowContent.add(
           this.renderMoveQuestionButtonsSection(
               csrfTag,
               programDefinition.id(),
@@ -773,7 +725,7 @@ public final class ProgramBlocksView extends ProgramBaseView {
               questionDefinition,
               questionIndex,
               questionsCount));
-      row.with(
+      rowContent.add(
           renderDeleteQuestionForm(
               csrfTag,
               programDefinition.id(),
@@ -787,14 +739,15 @@ public final class ProgramBlocksView extends ProgramBaseView {
             addressCorrectionEnabled
                 ? "Address correction: enabled"
                 : "Address correction: disabled";
-        row.with(renderReadOnlyLabel(label));
+        rowContent.add(renderReadOnlyLabel(label));
       }
       if (maybeOptionalToggle.isPresent()) {
         String label = isOptional ? "optional question" : "required question";
-        row.with(renderReadOnlyLabel(label));
+        rowContent.add(renderReadOnlyLabel(label));
       }
     }
-    return ret.with(row);
+    return AdminLayout.renderQuestionForProgramPage(
+        questionDefinition, malformedQuestionDefinition, rowContent.build());
   }
 
   /**


### PR DESCRIPTION
### Description

Please explain the changes you made here.

## Release notes

Remove this section if the title of the pull request can be used as the default release notes description. If more detail is needed to communicate to partners the scope of the PR's changes, use this release notes section (and remove this placeholder text).

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [ ] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [ ] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

#### Database evolutions

Read the guidelines [here](https://github.com/civiform/civiform/wiki/Database#writing-database-evolutions)

- [ ] Assigned two reviewers
- [ ] Guarded against already existing resources using `IF NOT EXISTS` and `IF EXISTS`
- [ ] Downs created to undo changes in Ups
- [ ] Every comment in script should begin with -- and not # --- unless it denotes Ups or Downs. See [here](https://www.playframework.com/documentation/2.9.x/Evolutions) for details.
- [ ] Tested both the Downs and the Ups scripts manually (When testing, include all comments from the evolution in your test script to ensure any syntax errors in the comments are caught.)
- [ ] Data migrations aren't being done (please use a [Durable Job](https://github.com/civiform/civiform/wiki/Database#durable-jobs-for-data-updates) if doing a data migration)
- [ ] Update the model documentation in our [wiki](https://github.com/civiform/civiform/wiki/Database) if necessary

#### Durable jobs

Read the docs [here](https://github.com/civiform/civiform/wiki/Database#durable-jobs-for-data-updates)

- [ ] Assigned two reviewers
- [ ] Included a rollback plan and a job to undo the data changes if appropriate

#### User visible changes

- [ ] Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
  - [ ] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [ ] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Made equivalent changes in Thymeleaf for applicant-facing features and changes (or created an issue in the [Northstar epic](https://github.com/orgs/civiform/projects/1/views/94) to track that it's missing from Thymeleaf)
- [ ] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order
- [ ] Manually tested with a screen reader if the feature is applicant-facing. See [screen reader testing](https://github.com/civiform/civiform/wiki/Testing#screen-reader-testing)

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/helper/feature-flags.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://github.com/civiform/civiform/wiki/Feature-Flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Instructions for manual testing

If instructions are needed for manual testing by reviewers, include them here.

### Issue(s) this completes

Fixes #<issue_number>; Fixes #<issue_number>...
