### PR TITLE
[API] Add lifecycleStages to SubmittedApplicationFilter

### DIFF
--- a/server/app/controllers/admin/AdminApplicationController.java
+++ b/server/app/controllers/admin/AdminApplicationController.java
@@ -26,6 +26,7 @@ import java.util.Optional;
 import java.util.concurrent.CompletionException;
 import javax.inject.Inject;
 import models.ApplicationModel;
+import models.LifecycleStage;
 import org.pac4j.play.java.Secure;
 import play.data.Form;
 import play.data.FormFactory;
@@ -159,6 +160,7 @@ public final class AdminApplicationController extends CiviFormController {
                           parseDateTimeFromQuery(dateConverter, untilDate, RelativeTimeOfDay.END))
                       .build())
               .setApplicationStatus(applicationStatus)
+              .setLifecycleStages(ImmutableList.of(LifecycleStage.ACTIVE, LifecycleStage.OBSOLETE))
               .build();
     }
 
@@ -200,6 +202,8 @@ public final class AdminApplicationController extends CiviFormController {
                             parseDateTimeFromQuery(dateConverter, untilDate, RelativeTimeOfDay.END))
                         .build())
                 .setApplicationStatus(applicationStatus)
+                .setLifecycleStages(
+                    ImmutableList.of(LifecycleStage.ACTIVE, LifecycleStage.OBSOLETE))
                 .build();
       }
       ProgramDefinition program = programService.getFullProgramDefinition(programId);
@@ -479,6 +483,7 @@ public final class AdminApplicationController extends CiviFormController {
                         parseDateTimeFromQuery(dateConverter, untilDate, RelativeTimeOfDay.END))
                     .build())
             .setApplicationStatus(applicationStatus)
+            .setLifecycleStages(ImmutableList.of(LifecycleStage.ACTIVE, LifecycleStage.OBSOLETE))
             .build();
 
     final ProgramDefinition program;

--- a/server/app/controllers/api/ProgramApplicationsApiController.java
+++ b/server/app/controllers/api/ProgramApplicationsApiController.java
@@ -3,6 +3,7 @@ package controllers.api;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import auth.ProfileUtils;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.inject.Inject;
@@ -15,6 +16,7 @@ import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 import javax.annotation.Nullable;
 import models.ApplicationModel;
+import models.LifecycleStage;
 import play.libs.concurrent.ClassLoaderExecutionContext;
 import play.mvc.Http;
 import play.mvc.Result;
@@ -90,6 +92,7 @@ public final class ProgramApplicationsApiController extends CiviFormApiControlle
                     .setUntilTime(
                         resolveDateParam(paginationToken, UNTIL_DATE_PARAM_NAME, toDateParam))
                     .build())
+            .setLifecycleStages(ImmutableList.of(LifecycleStage.ACTIVE, LifecycleStage.OBSOLETE))
             .build();
     int pageSize = resolvePageSize(paginationToken, pageSizeParam);
 

--- a/server/app/repository/ProgramRepository.java
+++ b/server/app/repository/ProgramRepository.java
@@ -432,8 +432,8 @@ public final class ProgramRepository {
 
   /**
    * Get all submitted applications for this program and all other previous and future versions of
-   * it where the application matches the specified filters. Does not include drafts or deleted
-   * applications. Results returned in reverse order that the applications were created.
+   * it where the application matches the specified filters. Results returned in reverse order that
+   * the applications were created.
    *
    * <p>Pagination is supported via the passed {@link BasePaginationSpec} object.
    */
@@ -449,9 +449,7 @@ public final class ProgramRepository {
             .fetch("applicant.account.managedByGroup")
             .where()
             .in("program_id", allProgramVersionsQuery(programId))
-            .in(
-                "lifecycle_stage",
-                ImmutableList.of(LifecycleStage.ACTIVE, LifecycleStage.OBSOLETE));
+            .in("lifecycle_stage", filters.lifecycleStages());
 
     if (filters.submitTimeFilter().fromTime().isPresent()) {
       query = query.where().ge("submit_time", filters.submitTimeFilter().fromTime().get());

--- a/server/app/repository/SubmittedApplicationFilter.java
+++ b/server/app/repository/SubmittedApplicationFilter.java
@@ -1,7 +1,9 @@
 package repository;
 
 import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableList;
 import java.util.Optional;
+import models.LifecycleStage;
 
 /**
  * Filters that can be applied to retrieve a list of submitted applications matching all of the
@@ -12,7 +14,11 @@ public abstract class SubmittedApplicationFilter {
   public static final String NO_STATUS_FILTERS_OPTION_UUID = "ad80b347-5ae4-43c3-8578-e503b043be12";
 
   public static final SubmittedApplicationFilter EMPTY =
-      SubmittedApplicationFilter.builder().setSubmitTimeFilter(TimeFilter.EMPTY).build();
+      SubmittedApplicationFilter.builder()
+          .setSubmitTimeFilter(TimeFilter.EMPTY)
+          // By default, retrieves all submitted applications.
+          .setLifecycleStages(ImmutableList.of(LifecycleStage.ACTIVE, LifecycleStage.OBSOLETE))
+          .build();
 
   /**
    * If provided and is an unsigned integer, the query will filter to applications with an applicant
@@ -30,6 +36,9 @@ public abstract class SubmittedApplicationFilter {
    */
   public abstract Optional<String> applicationStatus();
 
+  /** Filters to applications with the specified lifecycle stages. */
+  public abstract ImmutableList<LifecycleStage> lifecycleStages();
+
   public static Builder builder() {
     return new AutoValue_SubmittedApplicationFilter.Builder();
   }
@@ -41,6 +50,8 @@ public abstract class SubmittedApplicationFilter {
     public abstract Builder setSubmitTimeFilter(TimeFilter v);
 
     public abstract Builder setApplicationStatus(Optional<String> v);
+
+    public abstract Builder setLifecycleStages(ImmutableList<LifecycleStage> v);
 
     public abstract SubmittedApplicationFilter build();
   }

--- a/server/test/repository/ProgramRepositoryTest.java
+++ b/server/test/repository/ProgramRepositoryTest.java
@@ -17,6 +17,7 @@ import models.ApplicantModel;
 import models.ApplicationModel;
 import models.ApplicationStep;
 import models.DisplayMode;
+import models.LifecycleStage;
 import models.ProgramModel;
 import models.QuestionModel;
 import models.VersionModel;
@@ -405,6 +406,8 @@ public class ProgramRepositoryTest extends ResetPostgres {
             SubmittedApplicationFilter.builder()
                 .setSearchNameFragment(Optional.of(bobApp.id.toString()))
                 .setSubmitTimeFilter(TimeFilter.EMPTY)
+                .setLifecycleStages(
+                    ImmutableList.of(LifecycleStage.ACTIVE, LifecycleStage.OBSOLETE))
                 .build());
 
     assertThat(
@@ -432,6 +435,8 @@ public class ProgramRepositoryTest extends ResetPostgres {
             SubmittedApplicationFilter.builder()
                 .setSearchNameFragment(Optional.of("One"))
                 .setSubmitTimeFilter(TimeFilter.EMPTY)
+                .setLifecycleStages(
+                    ImmutableList.of(LifecycleStage.ACTIVE, LifecycleStage.OBSOLETE))
                 .build());
 
     assertThat(
@@ -448,6 +453,8 @@ public class ProgramRepositoryTest extends ResetPostgres {
             SubmittedApplicationFilter.builder()
                 .setSearchNameFragment(Optional.of("Last"))
                 .setSubmitTimeFilter(TimeFilter.EMPTY)
+                .setLifecycleStages(
+                    ImmutableList.of(LifecycleStage.ACTIVE, LifecycleStage.OBSOLETE))
                 .build());
 
     assertThat(
@@ -464,6 +471,8 @@ public class ProgramRepositoryTest extends ResetPostgres {
             SubmittedApplicationFilter.builder()
                 .setSearchNameFragment(Optional.of(emailTwo))
                 .setSubmitTimeFilter(TimeFilter.EMPTY)
+                .setLifecycleStages(
+                    ImmutableList.of(LifecycleStage.ACTIVE, LifecycleStage.OBSOLETE))
                 .build());
 
     assertThat(
@@ -480,6 +489,8 @@ public class ProgramRepositoryTest extends ResetPostgres {
             SubmittedApplicationFilter.builder()
                 .setSearchNameFragment(Optional.of("1234"))
                 .setSubmitTimeFilter(TimeFilter.EMPTY)
+                .setLifecycleStages(
+                    ImmutableList.of(LifecycleStage.ACTIVE, LifecycleStage.OBSOLETE))
                 .build());
 
     assertThat(
@@ -496,6 +507,8 @@ public class ProgramRepositoryTest extends ResetPostgres {
             SubmittedApplicationFilter.builder()
                 .setSearchNameFragment(Optional.of("(1.23)- 456"))
                 .setSubmitTimeFilter(TimeFilter.EMPTY)
+                .setLifecycleStages(
+                    ImmutableList.of(LifecycleStage.ACTIVE, LifecycleStage.OBSOLETE))
                 .build());
 
     assertThat(
@@ -617,6 +630,8 @@ public class ProgramRepositoryTest extends ResetPostgres {
                 SubmittedApplicationFilter.builder()
                     .setApplicationStatus(Optional.of(""))
                     .setSubmitTimeFilter(TimeFilter.EMPTY)
+                    .setLifecycleStages(
+                        ImmutableList.of(LifecycleStage.ACTIVE, LifecycleStage.OBSOLETE))
                     .build()))
         .isEqualTo(
             ImmutableSet.of(
@@ -633,6 +648,8 @@ public class ProgramRepositoryTest extends ResetPostgres {
                 SubmittedApplicationFilter.builder()
                     .setApplicationStatus(Optional.of(SECOND_STATUS.statusText()))
                     .setSubmitTimeFilter(TimeFilter.EMPTY)
+                    .setLifecycleStages(
+                        ImmutableList.of(LifecycleStage.ACTIVE, LifecycleStage.OBSOLETE))
                     .build()))
         .isEqualTo(ImmutableSet.of(secondStatusApplication.id));
 
@@ -644,6 +661,8 @@ public class ProgramRepositoryTest extends ResetPostgres {
                     .setApplicationStatus(
                         Optional.of(SubmittedApplicationFilter.NO_STATUS_FILTERS_OPTION_UUID))
                     .setSubmitTimeFilter(TimeFilter.EMPTY)
+                    .setLifecycleStages(
+                        ImmutableList.of(LifecycleStage.ACTIVE, LifecycleStage.OBSOLETE))
                     .build()))
         .isEqualTo(ImmutableSet.of(noStatusApplication.id, backToNoStatusApplication.id));
 
@@ -654,8 +673,60 @@ public class ProgramRepositoryTest extends ResetPostgres {
                 SubmittedApplicationFilter.builder()
                     .setApplicationStatus(Optional.of("some-random-status"))
                     .setSubmitTimeFilter(TimeFilter.EMPTY)
+                    .setLifecycleStages(
+                        ImmutableList.of(LifecycleStage.ACTIVE, LifecycleStage.OBSOLETE))
                     .build()))
         .isEqualTo(ImmutableSet.of());
+  }
+
+  @Test
+  public void getApplicationsForAllProgramVersions_filterByLifecycleStage() {
+    ProgramModel program = resourceCreator.insertActiveProgram("test program");
+    ApplicantModel applicant =
+        resourceCreator.insertApplicantWithAccount(Optional.of("applicant@example.com"));
+    ApplicationModel obsoleteApplication =
+        resourceCreator.insertApplication(applicant, program, LifecycleStage.OBSOLETE);
+    ApplicationModel activeApplication =
+        resourceCreator.insertActiveApplication(applicant, program);
+
+    // Test filtering for a specific stage. Should return only the active application
+    PaginationResult<ApplicationModel> result =
+        repo.getApplicationsForAllProgramVersions(
+            program.id,
+            RowIdSequentialAccessPaginationSpec.APPLICATION_MODEL_MAX_PAGE_SIZE_SPEC,
+            SubmittedApplicationFilter.builder()
+                .setSubmitTimeFilter(TimeFilter.EMPTY)
+                .setLifecycleStages(ImmutableList.of(LifecycleStage.ACTIVE))
+                .build());
+    assertThat(
+            result.getPageContents().stream().map(a -> a.id).collect(ImmutableSet.toImmutableSet()))
+        .containsExactly(activeApplication.id);
+
+    // Test filtering for multiple stages. Should return the active and obsolete applications
+    result =
+        repo.getApplicationsForAllProgramVersions(
+            program.id,
+            RowIdSequentialAccessPaginationSpec.APPLICATION_MODEL_MAX_PAGE_SIZE_SPEC,
+            SubmittedApplicationFilter.builder()
+                .setSubmitTimeFilter(TimeFilter.EMPTY)
+                .setLifecycleStages(
+                    ImmutableList.of(LifecycleStage.ACTIVE, LifecycleStage.OBSOLETE))
+                .build());
+
+    assertThat(
+            result.getPageContents().stream().map(a -> a.id).collect(ImmutableSet.toImmutableSet()))
+        .containsExactly(activeApplication.id, obsoleteApplication.id);
+
+    // Test filtering for a specific stage with no matches. Should return no results
+    result =
+        repo.getApplicationsForAllProgramVersions(
+            program.id,
+            RowIdSequentialAccessPaginationSpec.APPLICATION_MODEL_MAX_PAGE_SIZE_SPEC,
+            SubmittedApplicationFilter.builder()
+                .setSubmitTimeFilter(TimeFilter.EMPTY)
+                .setLifecycleStages(ImmutableList.of(LifecycleStage.DRAFT))
+                .build());
+    assertThat(result.getPageContents()).isEmpty();
   }
 
   private ImmutableSet<Long> applicationIdsForProgramAndFilter(
@@ -741,6 +812,8 @@ public class ProgramRepositoryTest extends ResetPostgres {
                         .setFromTime(Optional.of(Instant.parse("2022-01-25T00:00:00Z")))
                         .setUntilTime(Optional.of(Instant.parse("2022-02-10T00:00:00Z")))
                         .build())
+                .setLifecycleStages(
+                    ImmutableList.of(LifecycleStage.ACTIVE, LifecycleStage.OBSOLETE))
                 .build());
 
     assertThat(paginationResult.hasMorePages()).isFalse();


### PR DESCRIPTION
### Description

When retrieving applications with `getApplicationsForAllProgramVersions()`, all applications matching `ACTIVE` and `OBSOLETE` lifecycle stage are [returned](https://sourcegraph.com/github.com/civiform/civiform@519ec3bf4c4ddd0b24838d28c9c377fb53a5b7f8/-/blob/server/app/repository/ProgramRepository.java?L453-454). 

To support #499, we need to introduce retrieving application by lifecycle stage. Therefore, this PR 
- adds a list of lifecycle stages to `SubmittedApplicationFilter`. 
- moves the default value (active and obsolete applications) to the caller. While now all the callers have the same stages, this allows each controller to decide the stages (which could also add more granularity to the other places, like downloading JSON)

**Potential future improvements**
`SubmittedApplicationFilter.EMPTY` sets default values, which includes active and obsolete for the lifecycle stages. This is used in two places:
(1) AdminApplicationController
(2) various tests
More than "empty", this should be "default". Can also look into removing the use in the controller, and directly setting the needed values

### Checklist

#### General

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [ ] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.


### Issue(s) this completes

Part of #499
