### PR TITLE
feat: filter out programs with external links from API key creation view

### DIFF
--- a/server/app/controllers/admin/AdminApiKeysController.java
+++ b/server/app/controllers/admin/AdminApiKeysController.java
@@ -17,6 +17,8 @@ import play.mvc.Result;
 import repository.VersionRepository;
 import services.apikey.ApiKeyCreationResult;
 import services.apikey.ApiKeyService;
+import services.program.ActiveAndDraftPrograms;
+import services.program.ProgramDefinition;
 import services.program.ProgramService;
 import views.admin.apikeys.ApiKeyCredentialsView;
 import views.admin.apikeys.ApiKeyIndexView;
@@ -92,7 +94,12 @@ public class AdminApiKeysController extends CiviFormController {
 
   @Secure(authorizers = Authorizers.Labels.CIVIFORM_ADMIN)
   public Result newOne(Http.Request request) {
-    ImmutableSet<String> programNames = programService.getActiveProgramNames();
+    ActiveAndDraftPrograms allPrograms = programService.getActiveAndDraftPrograms();
+
+    ImmutableSet<String> programNames = allPrograms.getActivePrograms().stream()
+        .filter(program -> program.externalLink() == null || program.externalLink().isBlank())
+        .map(ProgramDefinition::adminName)
+        .collect(ImmutableSet.toImmutableSet());
 
     if (programNames.isEmpty()) {
       return ok(newOneView.renderNoPrograms(request));

--- a/server/test/controllers/admin/AdminApiKeysControllerTest.java
+++ b/server/test/controllers/admin/AdminApiKeysControllerTest.java
@@ -1,0 +1,168 @@
+package controllers.admin;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static play.test.Helpers.fakeRequest;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import org.junit.Test;
+import play.Application;
+import play.inject.guice.GuiceApplicationBuilder;
+import play.mvc.Http;
+import play.mvc.Result;
+import play.twirl.api.Content;
+import repository.VersionRepository;
+import services.apikey.ApiKeyService;
+import services.program.ActiveAndDraftPrograms;
+import services.program.ProgramDefinition;
+import services.program.ProgramService;
+import support.ProgramBuilder;
+import auth.ProfileUtils;
+import views.admin.apikeys.ApiKeyCredentialsView;
+import views.admin.apikeys.ApiKeyIndexView;
+import views.admin.apikeys.ApiKeyNewOneView;
+import org.junit.Before;
+import play.data.FormFactory;
+import play.inject.Injector;
+import play.test.WithApplication;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AdminApiKeysControllerTest extends WithApplication {
+
+        private ApiKeyService apiKeyService;
+        private ApiKeyIndexView indexView;
+        private ApiKeyNewOneView apiKeyNewOneView;
+        private ApiKeyCredentialsView apiKeyCredentialsView;
+        private ProgramService programService;
+        private FormFactory formFactory;
+        private ProfileUtils profileUtils;
+        private VersionRepository versionRepository;
+        private AdminApiKeysController controller;
+
+        @Override
+        protected Application provideApplication() {
+                return new GuiceApplicationBuilder().build();
+        }
+
+        @Before
+        public void setUp() {
+                Injector injector = app.injector();
+                ProgramBuilder.setInjector(injector);
+
+                apiKeyService = mock(ApiKeyService.class);
+                indexView = mock(ApiKeyIndexView.class);
+                apiKeyNewOneView = mock(ApiKeyNewOneView.class);
+                apiKeyCredentialsView = mock(ApiKeyCredentialsView.class);
+                programService = mock(ProgramService.class);
+                formFactory = mock(FormFactory.class);
+                profileUtils = mock(ProfileUtils.class);
+                versionRepository = mock(VersionRepository.class);
+
+                controller = new AdminApiKeysController(
+                                apiKeyService,
+                                indexView,
+                                apiKeyNewOneView,
+                                apiKeyCredentialsView,
+                                programService,
+                                formFactory,
+                                profileUtils,
+                                versionRepository);
+        }
+
+        @Test
+        public void newOne_rendersInternalProgramsOnly() {
+                ProgramDefinition internalProgram1 = ProgramBuilder.newActiveProgram("Internal One", "desc1")
+                                .buildDefinition();
+                ProgramDefinition externalProgram = ProgramBuilder.newActiveProgram("External", "desc2")
+                                .buildDefinition().toBuilder().setExternalLink("https://external.com").build();
+                ProgramDefinition internalProgram2 = ProgramBuilder.newActiveProgram("Internal Two", "desc3")
+                                .buildDefinition();
+
+                ImmutableList<ProgramDefinition> activePrograms = ImmutableList.of(internalProgram1, externalProgram,
+                                internalProgram2);
+                ActiveAndDraftPrograms allPrograms = mock(ActiveAndDraftPrograms.class);
+                when(allPrograms.getActivePrograms()).thenReturn(activePrograms);
+                when(programService.getActiveAndDraftPrograms()).thenReturn(allPrograms);
+
+                ImmutableSet<String> expectedProgramNames = activePrograms.stream()
+                                .filter(program -> program.externalLink() == null || program.externalLink().isBlank())
+                                .map(ProgramDefinition::adminName)
+                                .collect(ImmutableSet.toImmutableSet());
+
+                Content mockContent = mock(Content.class);
+                when(mockContent.body()).thenReturn("Mocked content body");
+
+                when(apiKeyNewOneView.render(any(Http.Request.class), eq(expectedProgramNames)))
+                                .thenReturn(mockContent);
+
+                Result result = controller.newOne(fakeRequest().build());
+
+                assertThat(result.status()).isEqualTo(200);
+                verify(apiKeyNewOneView).render(any(Http.Request.class), eq(expectedProgramNames));
+                verify(apiKeyNewOneView, never()).renderNoPrograms(any());
+        }
+
+        @Test
+        public void newOne_rendersNoProgramsIfAllAreExternal() {
+                ProgramDefinition externalProgram1 = ProgramBuilder.newActiveProgram("External 1", "desc1")
+                                .buildDefinition().toBuilder().setExternalLink("https://link1").build();
+                ProgramDefinition externalProgram2 = ProgramBuilder.newActiveProgram("External 2", "desc2")
+                                .buildDefinition().toBuilder().setExternalLink("https://link2").build();
+
+                ImmutableList<ProgramDefinition> activePrograms = ImmutableList.of(externalProgram1, externalProgram2);
+                ActiveAndDraftPrograms allPrograms = mock(ActiveAndDraftPrograms.class);
+                when(allPrograms.getActivePrograms()).thenReturn(activePrograms);
+                when(programService.getActiveAndDraftPrograms()).thenReturn(allPrograms);
+
+                ImmutableSet<String> programNames = activePrograms.stream()
+                                .filter(program -> program.externalLink() == null || program.externalLink().isBlank())
+                                .map(ProgramDefinition::adminName)
+                                .collect(ImmutableSet.toImmutableSet());
+                assert programNames.isEmpty();
+
+                Content mockContent = mock(Content.class);
+                when(mockContent.body()).thenReturn("Mocked content body");
+
+                when(apiKeyNewOneView.renderNoPrograms(any(Http.Request.class))).thenReturn(mockContent);
+
+                Result result = controller.newOne(fakeRequest().build());
+
+                assertThat(result.status()).isEqualTo(200);
+                verify(apiKeyNewOneView).renderNoPrograms(any(Http.Request.class));
+                verify(apiKeyNewOneView, never()).render(any(), any());
+        }
+
+        @Test
+        public void newOne_rendersAllInternalIfNoneAreExternal() {
+                ProgramDefinition internal1 = ProgramBuilder.newActiveProgram("Alpha", "desc").buildDefinition();
+                ProgramDefinition internal2 = ProgramBuilder.newActiveProgram("Beta", "desc").buildDefinition();
+
+                ImmutableList<ProgramDefinition> activePrograms = ImmutableList.of(internal1, internal2);
+                ActiveAndDraftPrograms allPrograms = mock(ActiveAndDraftPrograms.class);
+                when(allPrograms.getActivePrograms()).thenReturn(activePrograms);
+                when(programService.getActiveAndDraftPrograms()).thenReturn(allPrograms);
+
+                ImmutableSet<String> expectedProgramNames = activePrograms.stream()
+                                .filter(program -> program.externalLink() == null || program.externalLink().isBlank())
+                                .map(ProgramDefinition::adminName)
+                                .collect(ImmutableSet.toImmutableSet());
+
+                Content mockContent = mock(Content.class);
+                when(mockContent.body()).thenReturn("Mocked content body");
+
+                when(apiKeyNewOneView.render(any(Http.Request.class), eq(expectedProgramNames)))
+                                .thenReturn(mockContent);
+
+                Result result = controller.newOne(fakeRequest().build());
+
+                assertThat(result.status()).isEqualTo(200);
+                verify(apiKeyNewOneView).render(any(Http.Request.class), eq(expectedProgramNames));
+                verify(apiKeyNewOneView, never()).renderNoPrograms(any());
+        }
+}


### PR DESCRIPTION
- Updates `AdminApiKeysController#newOne` to exclude programs with external links.
- Ensures only internal programs are selectable when creating new API keys.
- Adds unit tests for:
  - Excluding external programs
  - Showing 'no programs' view if all are external
  - Rendering all programs when none are external

### Description

Please explain the changes you made here.

## Release notes

Remove this section if the title of the pull request can be used as the default release notes description. If more detail is needed to communicate to partners the scope of the PR's changes, use this release notes section (and remove this placeholder text).

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [ ] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [ ] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

#### Database evolutions

Read the guidelines [here](https://github.com/civiform/civiform/wiki/Database#writing-database-evolutions)

- [ ] Assigned two reviewers
- [ ] Guarded against already existing resources using `IF NOT EXISTS` and `IF EXISTS`
- [ ] Downs created to undo changes in Ups
- [ ] Every comment in script should begin with -- and not # --- unless it denotes Ups or Downs. See [here](https://www.playframework.com/documentation/2.9.x/Evolutions) for details.
- [ ] Tested both the Downs and the Ups scripts manually (When testing, include all comments from the evolution in your test script to ensure any syntax errors in the comments are caught.)
- [ ] Data migrations aren't being done (please use a [Durable Job](https://github.com/civiform/civiform/wiki/Database#durable-jobs-for-data-updates) if doing a data migration)
- [ ] Update the model documentation in our [wiki](https://github.com/civiform/civiform/wiki/Database) if necessary

#### Durable jobs

Read the docs [here](https://github.com/civiform/civiform/wiki/Database#durable-jobs-for-data-updates)

- [ ] Assigned two reviewers
- [ ] Included a rollback plan and a job to undo the data changes if appropriate

#### User visible changes

- [ ] Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
  - [ ] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [ ] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Made equivalent changes in Thymeleaf for applicant-facing features and changes (or created an issue in the [Northstar epic](https://github.com/orgs/civiform/projects/1/views/94) to track that it's missing from Thymeleaf)
- [ ] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order
- [ ] Manually tested with a screen reader if the feature is applicant-facing. See [screen reader testing](https://github.com/civiform/civiform/wiki/Testing#screen-reader-testing)

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/helper/feature-flags.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://github.com/civiform/civiform/wiki/Feature-Flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Instructions for manual testing

If instructions are needed for manual testing by reviewers, include them here.

### Issue(s) this completes

Fixes #<issue_number>; Fixes #<issue_number>...
