### PR TITLE
Don't return API docs for external programs

### DIFF
--- a/server/app/controllers/docs/ApiDocsController.java
+++ b/server/app/controllers/docs/ApiDocsController.java
@@ -57,11 +57,16 @@ public final class ApiDocsController {
       return notFound("API Docs are not enabled.");
     }
 
-    ImmutableSet<String> allProgramSlugs = programService.getAllNonExternalProgramSlugs();
+    ImmutableSet<String> allNonExternalProgramSlugs =
+        programService.getAllNonExternalProgramSlugs();
     Optional<ProgramDefinition> programDefinition =
-        getProgramDefinition(selectedProgramSlug, useActiveVersion);
+        allNonExternalProgramSlugs.contains(selectedProgramSlug)
+            ? getProgramDefinition(selectedProgramSlug, useActiveVersion)
+            : Optional.empty();
 
-    return ok(docsView.render(request, selectedProgramSlug, programDefinition, allProgramSlugs));
+    return ok(
+        docsView.render(
+            request, selectedProgramSlug, programDefinition, allNonExternalProgramSlugs));
   }
 
   private Optional<ProgramDefinition> getProgramDefinition(

--- a/server/test/controllers/docs/ApiDocsControllerTest.java
+++ b/server/test/controllers/docs/ApiDocsControllerTest.java
@@ -74,6 +74,19 @@ public class ApiDocsControllerTest extends ResetPostgres {
   }
 
   @Test
+  public void activeDocsForSlug_externalProgram_doesNotExist() {
+    ProgramBuilder.newActiveProgram("Test External Program")
+        .withProgramType(ProgramType.EXTERNAL)
+        .buildDefinition();
+    Request request = fakeRequest();
+    Result result =
+        instanceOf(ApiDocsController.class).activeDocsForSlug(request, "test-external-program");
+
+    assertThat(result.status()).isEqualTo(OK);
+    assertThat(contentAsString(result)).contains(PROGRAM_OR_VERSION_NOT_FOUND_ERROR);
+  }
+
+  @Test
   public void draftDocsForSlug_noDraftAvailable() {
     Request request = fakeRequest();
     Result result = instanceOf(ApiDocsController.class).draftDocsForSlug(request, "test-program-1");


### PR DESCRIPTION
### Description

External programs are not available via the API so they should return not found in API docs when accessed by program slug directly in the url. This is a followup to #10728 which removed them from the UI program dropdowns.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

#### User visible changes

- [ ] Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
  - [ ] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [ ] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Made equivalent changes in Thymeleaf for applicant-facing features and changes (or created an issue in the [Northstar epic](https://github.com/orgs/civiform/projects/1/views/94) to track that it's missing from Thymeleaf)
- [x] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [x] Manually tested at 200% size
- [ ] Manually evaluated tab order
- [ ] Manually tested with a screen reader if the feature is applicant-facing. See [screen reader testing](https://github.com/civiform/civiform/wiki/Testing#screen-reader-testing)

### Issue(s) this completes

Fixes #10755 
