### PR TITLE
Add browser test that publishes programs

### DIFF
--- a/browser-test/src/admin/admin_program_migration.test.ts
+++ b/browser-test/src/admin/admin_program_migration.test.ts
@@ -1189,6 +1189,26 @@ test.describe('program migration', () => {
         page.getByTestId('question-admin-name-Sample Text Question'),
       ).not.toContainText('What is your LEAST favorite color?')
     })
+
+    await test.step('publish all programs', async () => {
+      // Check that other program is in DRAFT
+      await adminPrograms.gotoAdminProgramsPage()
+      await adminPrograms.expectDraftProgram('Comprehensive Sample Program')
+
+      // Confirm that we are able to publish all drafts
+      await adminPrograms.publishAllDrafts()
+      await adminPrograms.expectAdminProgramsPage()
+      await adminPrograms.expectDoesNotHaveDraftProgram(
+        'Comprehensive Sample Program',
+      )
+      await adminPrograms.expectActiveProgram('Comprehensive Sample Program')
+      await adminPrograms.expectDoesNotHaveDraftProgram(
+        'Comprehensive Sample Program New',
+      )
+      await adminPrograms.expectActiveProgram(
+        'Comprehensive Sample Program New',
+      )
+    })
   })
 
   test('Importing with duplicate enumerators and repeated questions', async ({

--- a/browser-test/src/support/admin_programs.ts
+++ b/browser-test/src/support/admin_programs.ts
@@ -1856,7 +1856,7 @@ export class AdminPrograms {
   getProgramCard(programName: string, lifecycle: string): Locator {
     return this.page
       .locator('div.cf-admin-program-card')
-      .filter({has: this.page.getByText(programName)})
+      .filter({has: this.page.getByText(programName, {exact: true})})
       .filter({has: this.page.getByText(lifecycle)})
   }
 


### PR DESCRIPTION
### Description

Adds a browser test specifically to test the publish-all functionality after an import (that includes an overwritten Q). This should ensure no regressions in transaction/version semantics that interplay with the program import feature. #9628 

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from `civiform/eng-admin` as FYI (if the primary reviewer is not an admin and this PR includes functionality changes)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.