### PR TITLE
Fix tooltip hover issues with pointer-events-none labels

### DIFF
--- a/server/app/assets/stylesheets/styles.css
+++ b/server/app/assets/stylesheets/styles.css
@@ -14,6 +14,14 @@
     @apply text-xl;
   }
 
+  /* Fix for tooltip hover events being blocked by pointer-events-none */
+  label .group,
+  label span .group,
+  .group svg,
+  .group span {
+    pointer-events: auto !important;
+  }
+
   /* Must define the body color explicitly rather than relying on the browser default because,
   if left undefined, USWDS will apply its slightly lighter color */
   body {


### PR DESCRIPTION
# Description
for Issue #10593 
Fixes tooltip hover functionality that was broken due to pointer-events-none CSS class blocking mouse events on labels. This affected multiple form fields including "Question enumerator" and "Administrative identifier" fields. 

## Solution
Added CSS rules to ensure tooltips within labels can receive hover events while maintaining the existing tooltip implementation:
```css
/* Fix for tooltip hover events being blocked by pointer-events-none */
label .group,
label span .group,
.group svg,
.group span {
  pointer-events: auto !important;
}
```

## Manual Testing Instructions
1. Go to Questions page
2. Create a new question or edit an existing one
3. Hover over the info icon (ⓘ) next to "Question enumerator" field
4. Verify that the tooltip appears
5. Test in both Chrome and Firefox browsers

## AI assistance
Used Cursor AI(Claude 3.5/7) for my IDE, and Gemini for additional information.