### PR TITLE
Fixing formatter to call the local docker image

### DIFF
--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -30,7 +30,7 @@ jobs:
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3
 
       - name: Re-build formatter if needed
-        if: contains(toJSON(steps.file_changes.outputs.all_changed_files), 'formatter/')
+        if: contains(toJSON(steps.file_changes.outputs.all_changed_files), 'formatter/') || contains(toJSON(steps.file_changes.outputs.all_changed_files), 'bin/fmt')
         id: formatter_rebuild
         run: bin/build-formatter
 

--- a/bin/fmt
+++ b/bin/fmt
@@ -50,7 +50,7 @@ fi
 if [[ "${repo_type}" == "not-worktree" ]]; then
   docker run --rm ${interactive_flag} \
     -v "$(pwd):/code" \
-    civiform/formatter \
+    civiform-formatter \
     "$@"
 
 # If repo_type is a file then the current folder was created with the command `git worktree add` which
@@ -68,7 +68,7 @@ elif [[ "${repo_type}" == "worktree" ]]; then
   docker run --rm ${interactive_flag} \
     -v "$(pwd):/code" \
     -v "${worktree_root}:${worktree_root}" \
-    civiform/formatter \
+    civiform-formatter \
     "$@"
 else
   echo "Could not find the git work tree for ${GIT_DIR}"


### PR DESCRIPTION
The `bin/fmt` script was running based off the docker hub tag version. Our scripts should reference the local tag, that is the one without the `/`. 

:+1:  `civiform-formatter`
:no_good: `civiform/formatter`

This also makes it so that changes to the `bin/fmt` script will trigger the `format` github action to re-build the formatter to take into account any changes that may have happened.

This should now always run the formatter based on the latest changes.


