### PR TITLE
[draft] pre-populating yes and no answer options for yes/no question

### DIFF
--- a/server/app/controllers/dev/seeding/SampleQuestionDefinitions.java
+++ b/server/app/controllers/dev/seeding/SampleQuestionDefinitions.java
@@ -511,7 +511,9 @@ public final class SampleQuestionDefinitions {
       case STATIC -> STATIC_CONTENT_QUESTION_DEFINITION.withPopulatedTestId();
       case TEXT -> TEXT_QUESTION_DEFINITION.withPopulatedTestId();
       case PHONE -> PHONE_QUESTION_DEFINITION.withPopulatedTestId();
-      case NULL_QUESTION -> new NullQuestionDefinition(1);
+        // Fall through to Null Question for now since Yes/No is not fully implemented.
+        // TODO: Create a Yes/No question instead.
+      case YES_NO, NULL_QUESTION -> new NullQuestionDefinition(1);
     };
   }
 }

--- a/server/app/forms/QuestionFormBuilder.java
+++ b/server/app/forms/QuestionFormBuilder.java
@@ -45,6 +45,7 @@ public final class QuestionFormBuilder {
           formFactory.form(StaticContentQuestionForm.class).bindFromRequest(request).get();
       case TEXT -> formFactory.form(TextQuestionForm.class).bindFromRequest(request).get();
       case PHONE -> formFactory.form(PhoneQuestionForm.class).bindFromRequest(request).get();
+      case YES_NO -> formFactory.form(YesNoQuestionForm.class).bindFromRequest(request).get();
       default -> throw new InvalidQuestionTypeException(questionType.toString());
     };
   }
@@ -67,6 +68,7 @@ public final class QuestionFormBuilder {
       case STATIC -> new StaticContentQuestionForm();
       case TEXT -> new TextQuestionForm();
       case PHONE -> new PhoneQuestionForm();
+      case YES_NO -> new YesNoQuestionForm();
       default -> throw new UnsupportedQuestionTypeException(questionType);
     };
   }
@@ -94,6 +96,8 @@ public final class QuestionFormBuilder {
           new StaticContentQuestionForm((StaticContentQuestionDefinition) questionDefinition);
       case TEXT -> new TextQuestionForm((TextQuestionDefinition) questionDefinition);
       case PHONE -> new PhoneQuestionForm((PhoneQuestionDefinition) questionDefinition);
+      case YES_NO ->
+          new RadioButtonQuestionForm((MultiOptionQuestionDefinition) questionDefinition);
       default -> throw new InvalidQuestionTypeException(questionType.toString());
     };
   }

--- a/server/app/forms/QuestionFormBuilder.java
+++ b/server/app/forms/QuestionFormBuilder.java
@@ -96,8 +96,7 @@ public final class QuestionFormBuilder {
           new StaticContentQuestionForm((StaticContentQuestionDefinition) questionDefinition);
       case TEXT -> new TextQuestionForm((TextQuestionDefinition) questionDefinition);
       case PHONE -> new PhoneQuestionForm((PhoneQuestionDefinition) questionDefinition);
-      case YES_NO ->
-          new RadioButtonQuestionForm((MultiOptionQuestionDefinition) questionDefinition);
+      case YES_NO -> new YesNoQuestionForm((MultiOptionQuestionDefinition) questionDefinition);
       default -> throw new InvalidQuestionTypeException(questionType.toString());
     };
   }

--- a/server/app/forms/YesNoQuestionForm.java
+++ b/server/app/forms/YesNoQuestionForm.java
@@ -1,0 +1,21 @@
+package forms;
+
+import services.question.types.MultiOptionQuestionDefinition;
+import services.question.types.QuestionType;
+
+/** Form for updating a yes/no question. */
+public class YesNoQuestionForm extends MultiOptionQuestionForm {
+
+  public YesNoQuestionForm() {
+    super();
+  }
+
+  public YesNoQuestionForm(MultiOptionQuestionDefinition qd) {
+    super(qd);
+  }
+
+  @Override
+  public QuestionType getQuestionType() {
+    return QuestionType.YES_NO;
+  }
+}

--- a/server/app/services/applicant/question/ApplicantQuestion.java
+++ b/server/app/services/applicant/question/ApplicantQuestion.java
@@ -335,7 +335,7 @@ public final class ApplicantQuestion {
       case ID -> createIdQuestion();
       case NAME -> createNameQuestion();
       case NUMBER -> createNumberQuestion(); // fallthrough to RADIO_BUTTON
-      case DROPDOWN, RADIO_BUTTON -> createSingleSelectQuestion();
+      case DROPDOWN, RADIO_BUTTON, YES_NO -> createSingleSelectQuestion();
       case ENUMERATOR -> createEnumeratorQuestion();
       case TEXT -> createTextQuestion();
       case STATIC -> createStaticContentQuestion();

--- a/server/app/services/question/types/MultiOptionQuestionDefinition.java
+++ b/server/app/services/question/types/MultiOptionQuestionDefinition.java
@@ -26,7 +26,8 @@ public final class MultiOptionQuestionDefinition extends QuestionDefinition {
   public enum MultiOptionQuestionType {
     CHECKBOX,
     DROPDOWN,
-    RADIO_BUTTON
+    RADIO_BUTTON,
+    YES_NO
   }
 
   private static final MultiOptionValidationPredicates SINGLE_SELECT_PREDICATE =
@@ -70,6 +71,7 @@ public final class MultiOptionQuestionDefinition extends QuestionDefinition {
       case CHECKBOX -> QuestionType.CHECKBOX;
       case DROPDOWN -> QuestionType.DROPDOWN;
       case RADIO_BUTTON -> QuestionType.RADIO_BUTTON;
+      case YES_NO -> QuestionType.YES_NO;
     };
   }
 

--- a/server/app/services/question/types/QuestionDefinitionBuilder.java
+++ b/server/app/services/question/types/QuestionDefinitionBuilder.java
@@ -276,6 +276,10 @@ public final class QuestionDefinitionBuilder {
         }
         return new PhoneQuestionDefinition(builder.build());
 
+      case YES_NO:
+        return new MultiOptionQuestionDefinition(
+            builder.build(), questionOptions, MultiOptionQuestionType.YES_NO);
+
       default:
         throw new UnsupportedQuestionTypeException(this.questionType);
     }

--- a/server/app/services/question/types/QuestionDefinitionBuilder.java
+++ b/server/app/services/question/types/QuestionDefinitionBuilder.java
@@ -279,7 +279,7 @@ public final class QuestionDefinitionBuilder {
       case YES_NO:
         return new MultiOptionQuestionDefinition(
             builder.build(), questionOptions, MultiOptionQuestionType.YES_NO);
-
+            
       default:
         throw new UnsupportedQuestionTypeException(this.questionType);
     }

--- a/server/app/services/question/types/QuestionDefinitionBuilder.java
+++ b/server/app/services/question/types/QuestionDefinitionBuilder.java
@@ -279,7 +279,7 @@ public final class QuestionDefinitionBuilder {
       case YES_NO:
         return new MultiOptionQuestionDefinition(
             builder.build(), questionOptions, MultiOptionQuestionType.YES_NO);
-            
+
       default:
         throw new UnsupportedQuestionTypeException(this.questionType);
     }

--- a/server/app/services/question/types/QuestionType.java
+++ b/server/app/services/question/types/QuestionType.java
@@ -32,10 +32,11 @@ public enum QuestionType {
   ID("ID", IdQuestion.class),
   NAME("Name", NameQuestion.class),
   NUMBER("Number", NumberQuestion.class),
+  PHONE("Phone Number", PhoneQuestion.class),
   RADIO_BUTTON("Radio Button", SingleSelectQuestion.class),
   STATIC("Static Text", StaticContentQuestion.class),
   TEXT("Text", TextQuestion.class),
-  PHONE("Phone Number", PhoneQuestion.class),
+  YES_NO("Yes/No", SingleSelectQuestion.class),
   NULL_QUESTION("Missing Question", NullQuestion.class);
 
   private final String label;

--- a/server/app/views/admin/questions/QuestionConfig.java
+++ b/server/app/views/admin/questions/QuestionConfig.java
@@ -201,6 +201,71 @@ public final class QuestionConfig {
     return multiOptionQuestionField(Optional.empty(), messages, /* isForNewOption= */ true);
   }
 
+  private static DivTag multiOptionQuestionFieldAdminName(
+      Optional<LocalizedQuestionOption> existingOption,
+      Messages messages,
+      boolean isForNewOption,
+      boolean readOnly) {
+    return FieldWithLabel.input()
+        .setFieldName(isForNewOption ? "newOptionAdminNames[]" : "optionAdminNames[]")
+        .setLabelText("Admin ID")
+        .setRequired(true)
+        .addReferenceClass(ReferenceClasses.MULTI_OPTION_ADMIN_INPUT)
+        .setValue(existingOption.map(LocalizedQuestionOption::adminName))
+        .setFieldErrors(
+            messages,
+            ImmutableSet.of(
+                ValidationErrorMessage.create(MessageKey.MULTI_OPTION_ADMIN_VALIDATION)))
+        .showFieldErrors(false)
+        .setReadOnly(readOnly || !isForNewOption)
+        .getInputTag()
+        .withClasses(
+            ReferenceClasses.MULTI_OPTION_ADMIN_INPUT,
+            "col-start-1",
+            "col-span-5",
+            "mb-2",
+            "ml-2",
+            "row-start-1",
+            "row-span-2");
+  }
+
+  private static DivTag multiOptionQuestionFieldOptionInput(
+      Optional<LocalizedQuestionOption> existingOption,
+      Messages messages,
+      boolean isForNewOption,
+      boolean readOnly,
+      boolean markdownSupported) {
+    FieldWithLabel fieldOptionInput =
+        FieldWithLabel.input()
+            .setFieldName(isForNewOption ? "newOptions[]" : "options[]")
+            .setLabelText("Option Text")
+            .setRequired(true)
+            .addReferenceClass(ReferenceClasses.MULTI_OPTION_INPUT)
+            .setValue(existingOption.map(LocalizedQuestionOption::optionText))
+            .setReadOnly(readOnly)
+            .setFieldErrors(
+                messages,
+                ImmutableSet.of(ValidationErrorMessage.create(MessageKey.MULTI_OPTION_VALIDATION)))
+            .showFieldErrors(false);
+    if (markdownSupported) {
+      fieldOptionInput =
+          fieldOptionInput
+              .setMarkdownSupported(true)
+              .setMarkdownText("Some markdown is supported, ")
+              .setMarkdownLinkText("see how it works");
+    }
+    return fieldOptionInput
+        .getInputTag()
+        .withClasses(
+            ReferenceClasses.MULTI_OPTION_INPUT,
+            "col-start-1",
+            "col-span-5",
+            "mb-2",
+            "ml-2",
+            "row-start-3",
+            "row-span-2");
+  }
+
   /**
    * Creates an individual text field where an admin can enter a single multi-option question
    * answer, along with a button to remove the option.
@@ -208,27 +273,8 @@ public final class QuestionConfig {
   private static DivTag multiOptionQuestionField(
       Optional<LocalizedQuestionOption> existingOption, Messages messages, boolean isForNewOption) {
     DivTag optionAdminName =
-        FieldWithLabel.input()
-            .setFieldName(isForNewOption ? "newOptionAdminNames[]" : "optionAdminNames[]")
-            .setLabelText("Admin ID")
-            .setRequired(true)
-            .addReferenceClass(ReferenceClasses.MULTI_OPTION_ADMIN_INPUT)
-            .setValue(existingOption.map(LocalizedQuestionOption::adminName))
-            .setFieldErrors(
-                messages,
-                ImmutableSet.of(
-                    ValidationErrorMessage.create(MessageKey.MULTI_OPTION_ADMIN_VALIDATION)))
-            .showFieldErrors(false)
-            .setReadOnly(!isForNewOption)
-            .getInputTag()
-            .withClasses(
-                ReferenceClasses.MULTI_OPTION_ADMIN_INPUT,
-                "col-start-1",
-                "col-span-5",
-                "mb-2",
-                "ml-2",
-                "row-start-1",
-                "row-span-2");
+        multiOptionQuestionFieldAdminName(
+            existingOption, messages, isForNewOption, /* readOnly= */ false);
     DivTag optionIndexInput =
         isForNewOption
             ? div()
@@ -257,28 +303,12 @@ public final class QuestionConfig {
                 "row-start-2")
             .attr("aria-label", "move down");
     DivTag optionInput =
-        FieldWithLabel.input()
-            .setFieldName(isForNewOption ? "newOptions[]" : "options[]")
-            .setLabelText("Option Text")
-            .setRequired(true)
-            .addReferenceClass(ReferenceClasses.MULTI_OPTION_INPUT)
-            .setMarkdownSupported(true)
-            .setMarkdownText("Some markdown is supported, ")
-            .setMarkdownLinkText("see how it works")
-            .setValue(existingOption.map(LocalizedQuestionOption::optionText))
-            .setFieldErrors(
-                messages,
-                ImmutableSet.of(ValidationErrorMessage.create(MessageKey.MULTI_OPTION_VALIDATION)))
-            .showFieldErrors(false)
-            .getInputTag()
-            .withClasses(
-                ReferenceClasses.MULTI_OPTION_INPUT,
-                "col-start-1",
-                "col-span-5",
-                "mb-2",
-                "ml-2",
-                "row-start-3",
-                "row-span-2");
+        multiOptionQuestionFieldOptionInput(
+            existingOption,
+            messages,
+            isForNewOption,
+            /* readOnly= */ false,
+            /* markdownSupported= */ true);
     ButtonTag removeOptionButton =
         button()
             .with(Icons.svg(Icons.DELETE).withClasses("w-6", "h-6"))
@@ -387,27 +417,8 @@ public final class QuestionConfig {
   private static DivTag yesNoOptionQuestionField(
       Optional<LocalizedQuestionOption> existingOption, Messages messages, boolean isForNewOption) {
     DivTag optionAdminName =
-        FieldWithLabel.input()
-            .setFieldName(isForNewOption ? "newOptionAdminNames[]" : "optionAdminNames[]")
-            .setLabelText("Admin ID")
-            .setRequired(true)
-            .addReferenceClass(ReferenceClasses.MULTI_OPTION_ADMIN_INPUT)
-            .setValue(existingOption.map(LocalizedQuestionOption::adminName))
-            .setFieldErrors(
-                messages,
-                ImmutableSet.of(
-                    ValidationErrorMessage.create(MessageKey.MULTI_OPTION_ADMIN_VALIDATION)))
-            .showFieldErrors(false)
-            .setReadOnly(true)
-            .getInputTag()
-            .withClasses(
-                ReferenceClasses.MULTI_OPTION_ADMIN_INPUT,
-                "col-start-1",
-                "col-span-5",
-                "mb-2",
-                "ml-2",
-                "row-start-1",
-                "row-span-2");
+        multiOptionQuestionFieldAdminName(
+            existingOption, messages, isForNewOption, /* readOnly= */ true);
     DivTag optionIndexInput =
         isForNewOption
             ? div()
@@ -418,48 +429,22 @@ public final class QuestionConfig {
                 .getInputTag()
                 .withClasses("hidden");
     DivTag optionInput =
-        FieldWithLabel.input()
-            .setFieldName(isForNewOption ? "newOptions[]" : "options[]")
-            .setLabelText("Option Text")
-            .setRequired(true)
-            .addReferenceClass(ReferenceClasses.MULTI_OPTION_INPUT)
-            .setMarkdownSupported(true)
-            .setMarkdownText("Some markdown is supported, ")
-            .setMarkdownLinkText("see how it works")
-            .setValue(existingOption.map(LocalizedQuestionOption::optionText))
-            .setFieldErrors(
-                messages,
-                ImmutableSet.of(ValidationErrorMessage.create(MessageKey.MULTI_OPTION_VALIDATION)))
-            .showFieldErrors(false)
-            .setReadOnly(!isForNewOption)
-            .getInputTag()
-            .withClasses(
-                ReferenceClasses.MULTI_OPTION_INPUT,
-                "col-start-1",
-                "col-span-5",
-                "mb-2",
-                "ml-2",
-                "row-start-3",
-                "row-span-2");
+        multiOptionQuestionFieldOptionInput(
+            existingOption,
+            messages,
+            isForNewOption,
+            /* readOnly= */ true,
+            /* markdownSupported= */ false);
+    // TODO(#10778): Add checkbox allowing admins to control which options to display.
     return div()
         .withClasses(
             ReferenceClasses.MULTI_OPTION_QUESTION_OPTION,
-            ReferenceClasses.MULTI_OPTION_QUESTION_OPTION_EDITABLE,
             "grid",
             "grid-cols-8",
             "grid-rows-4",
             "items-center",
             "mb-4")
-        .with(
-            optionIndexInput,
-            optionAdminName,
-            optionInput,
-            FieldWithLabel.checkbox()
-                .setFieldName("include")
-                .setLabelText("include")
-                .setValue("true")
-                .setChecked(!isForNewOption)
-                .getCheckboxTag());
+        .with(optionIndexInput, optionAdminName, optionInput);
   }
 
   /**

--- a/server/app/views/admin/questions/QuestionConfig.java
+++ b/server/app/views/admin/questions/QuestionConfig.java
@@ -75,6 +75,7 @@ public final class QuestionConfig {
       case PHONE:
         return Optional.of(config.addPhoneConfig().getContainer());
       case DROPDOWN: // fallthrough to RADIO_BUTTON
+      case YES_NO: // fallthrough to RADIO_BUTTON
       case RADIO_BUTTON:
         return Optional.of(
             config

--- a/server/app/views/components/CreateQuestionButton.java
+++ b/server/app/views/components/CreateQuestionButton.java
@@ -51,6 +51,10 @@ public final class CreateQuestionButton {
       if (type == QuestionType.NULL_QUESTION) {
         continue;
       }
+      if (type == QuestionType.YES_NO) {
+        // Do not attempt to render a YES_NO question unless the experiment is enabled.
+        continue;
+      }
 
       String typeString = type.toString().toLowerCase(Locale.ROOT);
       String link =

--- a/server/app/views/components/CreateQuestionButton.java
+++ b/server/app/views/components/CreateQuestionButton.java
@@ -51,10 +51,6 @@ public final class CreateQuestionButton {
       if (type == QuestionType.NULL_QUESTION) {
         continue;
       }
-      if (type == QuestionType.YES_NO) {
-        // Do not attempt to render a YES_NO question unless the experiment is enabled.
-        continue;
-      }
 
       String typeString = type.toString().toLowerCase(Locale.ROOT);
       String link =

--- a/server/test/services/export/AbstractExporterTest.java
+++ b/server/test/services/export/AbstractExporterTest.java
@@ -157,6 +157,8 @@ public abstract class AbstractExporterTest extends ResetPostgres {
       case PHONE:
         QuestionAnswerer.answerPhoneQuestion(applicantDataOne, answerPath, "US", "(615) 757-1010");
         break;
+      case YES_NO:
+        // Do nothing for now.
       case STATIC:
         // Do nothing.
         break;

--- a/server/test/views/admin/question/QuestionConfigTest.java
+++ b/server/test/views/admin/question/QuestionConfigTest.java
@@ -9,6 +9,7 @@ import com.google.common.collect.ImmutableSet;
 import forms.CheckboxQuestionForm;
 import forms.QuestionForm;
 import forms.QuestionFormBuilder;
+import forms.YesNoQuestionForm;
 import j2html.tags.specialized.DivTag;
 import java.util.Optional;
 import junitparams.JUnitParamsRunner;
@@ -97,6 +98,10 @@ public class QuestionConfigTest {
         assertThat(maybeConfig).isPresent();
         assertThat(maybeConfig.get().renderFormatted()).contains("Minimum length");
         break;
+      case YES_NO:
+        assertThat(maybeConfig).isPresent();
+        assertThat(maybeConfig.get().renderFormatted()).contains("Yes");
+        break;
       default:
         fail(
             "Unhandled question type: %s. Please add a configuration in"
@@ -128,5 +133,16 @@ public class QuestionConfigTest {
     assertThat(result).contains("existing-option-admin-b");
     assertThat(result).contains("new-option-admin-c");
     assertThat(result).contains("new-option-admin-d");
+  }
+
+  @Test
+  public void yesNoForm_prepopulatesOptions() {
+    YesNoQuestionForm form = new YesNoQuestionForm();
+    Optional<DivTag> maybeConfig = QuestionConfig.buildQuestionConfig(form, messages);
+    assertThat(maybeConfig).isPresent();
+    String result = maybeConfig.get().renderFormatted();
+
+    assertThat(result).contains("yes");
+    assertThat(result).contains("no");
   }
 }

--- a/server/test/views/questiontypes/ApplicantQuestionRendererFactoryTest.java
+++ b/server/test/views/questiontypes/ApplicantQuestionRendererFactoryTest.java
@@ -91,6 +91,7 @@ public class ApplicantQuestionRendererFactoryTest {
       case ENUMERATOR:
       case NAME:
       case RADIO_BUTTON:
+      case YES_NO:
         assertThat(renderedContent).contains("fieldset");
         break;
       case CURRENCY:


### PR DESCRIPTION
### Description

Please explain the changes you made here.

## Release notes

Remove this section if the title of the pull request can be used as the default release notes description. If more detail is needed to communicate to partners the scope of the PR's changes, use this release notes section (and remove this placeholder text).

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [ ] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if the primary reviewer is not an admin and this PR includes functionality changes)
- [ ] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

#### Database evolutions

Read the guidelines [here](https://github.com/civiform/civiform/wiki/Database#writing-database-evolutions)

- [ ] Assigned two reviewers
- [ ] Guarded against already existing resources using `IF NOT EXISTS` and `IF EXISTS`
- [ ] Downs created to undo changes in Ups
- [ ] Every comment in script should begin with -- and not # --- unless it denotes Ups or Downs. See [here](https://www.playframework.com/documentation/2.9.x/Evolutions) for details.
- [ ] Tested both the Downs and the Ups scripts manually (When testing, include all comments from the evolution in your test script to ensure any syntax errors in the comments are caught.)
- [ ] Data migrations aren't being done (please use a [Durable Job](https://github.com/civiform/civiform/wiki/Database#durable-jobs-for-data-updates) if doing a data migration)
- [ ] Update the model documentation in our [wiki](https://github.com/civiform/civiform/wiki/Database) if necessary

#### Durable jobs

Read the docs [here](https://github.com/civiform/civiform/wiki/Database#durable-jobs-for-data-updates)

- [ ] Assigned two reviewers
- [ ] Included a rollback plan and a job to undo the data changes if appropriate

#### User visible changes

- [ ] Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
  - [ ] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [ ] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Made equivalent changes in Thymeleaf for applicant-facing features and changes (or created an issue in the [Northstar epic](https://github.com/orgs/civiform/projects/1/views/94) to track that it's missing from Thymeleaf)
- [ ] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order
- [ ] Manually tested with a screen reader if the feature is applicant-facing. See [screen reader testing](https://github.com/civiform/civiform/wiki/Testing#screen-reader-testing)

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/helper/feature-flags.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://github.com/civiform/civiform/wiki/Feature-Flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Instructions for manual testing

If instructions are needed for manual testing by reviewers, include them here.

### Issue(s) this completes

Fixes #<issue_number>; Fixes #<issue_number>...
