### PR TITLE
bug:center align toast message

### DIFF
--- a/server/app/assets/javascripts/toast.ts
+++ b/server/app/assets/javascripts/toast.ts
@@ -72,6 +72,7 @@ export class ToastController {
       'duration-300',
       'flex',
       'flex-row',
+      'items-center',
       'max-w-md',
       'px-2',
       'py-2',


### PR DESCRIPTION
## Description

This PR addresses the toast message alignment issue #9224  by vertically centering the icon and message text within toast messages.

### Before:
Toast icons and text were slightly misaligned, causing visual imbalance.

### After:
Toast messages now use  `items-center` to ensure the icon and message are vertically aligned.

## How Can This Be Tested/Reviewed?

1. Go to the Applicant Homepage
2. Click `View and apply` on a program
3. Click `End your session`
4. Confirm that the green toast message appears with the icon and text properly aligned

## Author Checklist:

- [x] Reviewed in a desktop view
- [x] Verified vertical alignment of toast content
- [x] Ran `bin/run-dev` to test changes locally

<img width="757" alt="Screenshot 2025-06-17 at 10 57 02 AM" src="https://github.com/user-attachments/assets/4fa1a460-4e38-43e5-a1f2-6e89109b87c4" />

