### PR TITLE
Reinstate programservice test

### DIFF
--- a/server/test/services/program/ProgramServiceTest.java
+++ b/server/test/services/program/ProgramServiceTest.java
@@ -2504,7 +2504,8 @@ public class ProgramServiceTest extends ResetPostgres {
 
   @Test
   public void setBlockEligibilityMessage_updatesExistingEligibilityMessage() throws Exception {
-    ProgramDefinition programDefinition = ProgramBuilder.newDraftProgram().withBlock("Screen 1").buildDefinition();
+    ProgramDefinition programDefinition =
+        ProgramBuilder.newDraftProgram().withBlock("Screen 1").buildDefinition();
     ErrorAnd<ProgramBlockAdditionResult, CiviFormError> result =
         ps.addBlockToProgram(programDefinition.id());
     Optional<LocalizedStrings> firstEligibilityMsg =
@@ -2522,7 +2523,7 @@ public class ProgramServiceTest extends ResetPostgres {
     BlockDefinition blockWithSetEligibilityMessage =
         programAfterEligibilityMessageSet.getBlockDefinition(addedBlock.id());
     assertThat(blockWithSetEligibilityMessage.localizedEligibilityMessage())
-        .isEqualTo(firstEligibilityMsg); 
+        .isEqualTo(firstEligibilityMsg);
 
     ProgramDefinition programAfterEligibilityMessageUpdate =
         ps.setBlockEligibilityMessage(


### PR DESCRIPTION
### Description

The test were failing because it was referring to the original `BlockDefinition` before the eligibility message was set/updated. To fix this, we retrieve the updated `ProgramDefinition` and `BlockDefinition`.


### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if the primary reviewer is not an admin and this PR includes functionality changes)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

### Issue(s) this completes

Fixes #10492
