### PR TITLE
Redirect to review or edit when changing language during submit/update

### DIFF
--- a/browser-test/src/applicant/northstar_ineligible.test.ts
+++ b/browser-test/src/applicant/northstar_ineligible.test.ts
@@ -278,7 +278,81 @@ test.describe('North Star Ineligible Page Tests', {tag: ['@northstar']}, () => {
     await validateAccessibility(page)
   })
 
-  test('Changing language on ineligible page redirects to review', async ({
+  test('Changing language on ineligible page after block edit redirects to block edit', async ({
+    page,
+    applicantQuestions,
+  }) => {
+    await loginAsTestUser(page)
+    await enableFeatureFlag(page, 'north_star_applicant_ui')
+
+    await test.step('Setup: start application', async () => {
+      await applicantQuestions.applyProgram(
+        programName,
+        /* northStarEnabled=*/ true,
+      )
+      await applicantQuestions.answerNumberQuestion('0')
+      await applicantQuestions.clickContinue()
+    })
+
+    await test.step('Expect ineligible page', async () => {
+      await applicantQuestions.expectIneligiblePage(/* northStar= */ true)
+      await expect(page.getByText(questionText)).toBeVisible()
+    })
+
+    await test.step('Setup: set language to French', async () => {
+      await selectApplicantLanguageNorthstar(page, 'fr')
+    })
+
+    await test.step('Expect first block edit', async () => {
+      await applicantQuestions.validateQuestionIsOnPage(questionText)
+      expect(page.url().split('/').pop()).toEqual('edit')
+    })
+  })
+
+  test('Changing language on ineligible page after block review redirects to block review', async ({
+    page,
+    applicantQuestions,
+  }) => {
+    await loginAsTestUser(page)
+    await enableFeatureFlag(page, 'north_star_applicant_ui')
+
+    await test.step('Setup: start application', async () => {
+      await applicantQuestions.applyProgram(
+        programName,
+        /* northStarEnabled=*/ true,
+      )
+      await applicantQuestions.answerNumberQuestion('0')
+      await applicantQuestions.clickContinue()
+    })
+
+    await test.step('Expect ineligible page', async () => {
+      await applicantQuestions.expectIneligiblePage(/* northStar= */ true)
+      await expect(page.getByText(questionText)).toBeVisible()
+    })
+
+    await test.step('Go back to the review page and re-submit first block', async () => {
+      await applicantQuestions.clickEditMyResponses()
+      // Review and submit first question
+      await applicantQuestions.clickEdit()
+      await applicantQuestions.clickContinue()
+    })
+
+    await test.step('Expect ineligible page again', async () => {
+      await applicantQuestions.expectIneligiblePage(/* northStar= */ true)
+      await expect(page.getByText(questionText)).toBeVisible()
+    })
+
+    await test.step('Setup: set language to French', async () => {
+      await selectApplicantLanguageNorthstar(page, 'fr')
+    })
+
+    await test.step('Expect block review page', async () => {
+      await applicantQuestions.validateQuestionIsOnPage(questionText)
+      expect(page.url().split('/').pop()).toEqual('review')
+    })
+  })
+
+  test('Changing language on ineligible page after application submit redirects to review', async ({
     page,
     applicantQuestions,
   }) => {
@@ -290,12 +364,21 @@ test.describe('North Star Ineligible Page Tests', {tag: ['@northstar']}, () => {
         programName,
         /* northStarEnabled=*/ true,
       )
-
       await applicantQuestions.answerNumberQuestion('0')
       await applicantQuestions.clickContinue()
     })
 
-    await test.step('Expect ineligible page part 1', async () => {
+    await test.step('Expect ineligible page', async () => {
+      await applicantQuestions.expectIneligiblePage(/* northStar= */ true)
+      await expect(page.getByText(questionText)).toBeVisible()
+    })
+
+    await test.step('Go back to the review page and submit', async () => {
+      await applicantQuestions.clickEditMyResponses()
+      await applicantQuestions.clickSubmitApplication()
+    })
+
+    await test.step('Expect ineligible page again', async () => {
       await applicantQuestions.expectIneligiblePage(/* northStar= */ true)
       await expect(page.getByText(questionText)).toBeVisible()
     })
@@ -305,7 +388,7 @@ test.describe('North Star Ineligible Page Tests', {tag: ['@northstar']}, () => {
     })
 
     await test.step('Expect review page', async () => {
-      await applicantQuestions.validateQuestionIsOnPage(questionText)
+      await applicantQuestions.expectReviewPage(/* northStarEnabled= */ true)
     })
   })
 })

--- a/browser-test/src/applicant/northstar_ineligible.test.ts
+++ b/browser-test/src/applicant/northstar_ineligible.test.ts
@@ -300,7 +300,7 @@ test.describe('North Star Ineligible Page Tests', {tag: ['@northstar']}, () => {
       await expect(page.getByText(questionText)).toBeVisible()
     })
 
-    await test.step('Setup: set language to Chinese', async () => {
+    await test.step('Setup: set language to French', async () => {
       await selectApplicantLanguageNorthstar(page, 'fr')
     })
 

--- a/browser-test/src/applicant/northstar_ineligible.test.ts
+++ b/browser-test/src/applicant/northstar_ineligible.test.ts
@@ -277,4 +277,35 @@ test.describe('North Star Ineligible Page Tests', {tag: ['@northstar']}, () => {
 
     await validateAccessibility(page)
   })
+
+  test('Changing language on ineligible page redirects to review', async ({
+    page,
+    applicantQuestions,
+  }) => {
+    await loginAsTestUser(page)
+    await enableFeatureFlag(page, 'north_star_applicant_ui')
+
+    await test.step('Setup: submit application', async () => {
+      await applicantQuestions.applyProgram(
+        programName,
+        /* northStarEnabled=*/ true,
+      )
+
+      await applicantQuestions.answerNumberQuestion('0')
+      await applicantQuestions.clickContinue()
+    })
+
+    await test.step('Expect ineligible page part 1', async () => {
+      await applicantQuestions.expectIneligiblePage(/* northStar= */ true)
+      await expect(page.getByText(questionText)).toBeVisible()
+    })
+
+    await test.step('Setup: set language to Chinese', async () => {
+      await selectApplicantLanguageNorthstar(page, 'fr')
+    })
+
+    await test.step('Expect review page', async () => {
+      await applicantQuestions.validateQuestionIsOnPage(questionText)
+    })
+  })
 })

--- a/server/app/actions/RouteExtractor.java
+++ b/server/app/actions/RouteExtractor.java
@@ -122,6 +122,19 @@ public final class RouteExtractor {
   }
 
   /**
+   * The given key's string value.
+   *
+   * @param key Path parameter key name as defined in the routes file.
+   * @return the given key's string value.
+   */
+  public String getParamStringValue(String key) {
+    if (!routeParameters.containsKey(key)) {
+      throw new RuntimeException(String.format("Could not find '%s' in route '%s'", key, path));
+    }
+    return routeParameters.get(key);
+  }
+
+  /**
    * Returns {@code true} if this contains a mapping for the specified key.
    *
    * @param key Path parameter key name as defined in the routes file.

--- a/server/app/views/NorthStarBaseView.java
+++ b/server/app/views/NorthStarBaseView.java
@@ -260,13 +260,16 @@ public abstract class NorthStarBaseView {
     }
     // If the language was changed during a block update, redirect to /block/edit or /block/review
     if (routeExtractor.containsKey("blockId") && profile.isPresent() && applicantId.isPresent()) {
+      boolean inReview =
+          routeExtractor.containsKey("inReview")
+              && Boolean.valueOf(routeExtractor.getParamStringValue("inReview"));
       return applicantRoutes
           .blockEditOrBlockReview(
               profile.get(),
               applicantId.get(),
               programId,
-              String.valueOf(routeExtractor.getParamLongValue("blockId")),
-              routeExtractor.containsKey("inReview"))
+              routeExtractor.getParamStringValue("blockId"),
+              inReview)
           .url();
     }
     return request.uri();

--- a/server/app/views/NorthStarBaseView.java
+++ b/server/app/views/NorthStarBaseView.java
@@ -18,6 +18,7 @@ import org.thymeleaf.TemplateEngine;
 import play.i18n.Lang;
 import play.i18n.Messages;
 import play.mvc.Http.Request;
+import play.routing.Router;
 import services.AlertSettings;
 import services.AlertType;
 import services.DeploymentType;
@@ -238,9 +239,13 @@ public abstract class NorthStarBaseView {
    */
   private String getUpdateLanguageRedirectUri(
       Request request, Optional<CiviFormProfile> profile, Optional<Long> applicantId) {
+    // Default to the current request if it is not a POST or a redirect can't be constructed.
+    if (!request.method().equals("POST")
+        || !request.attrs().containsKey(Router.Attrs.HANDLER_DEF)) {
+      return request.uri();
+    }
     RouteExtractor routeExtractor = new RouteExtractor(request);
-    // Use the current request if it is not a POST.
-    if (!request.method().equals("POST") || !routeExtractor.containsKey("programId")) {
+    if (!routeExtractor.containsKey("programId")) {
       return request.uri();
     }
 

--- a/server/app/views/applicant/ApplicantLayout.java
+++ b/server/app/views/applicant/ApplicantLayout.java
@@ -336,13 +336,16 @@ public class ApplicantLayout extends BaseHtmlLayout {
     }
     // If the language was changed during a block update, redirect to /block/edit or /block/review
     if (routeExtractor.containsKey("blockId") && profile.isPresent() && applicantId.isPresent()) {
+      boolean inReview =
+          routeExtractor.containsKey("inReview")
+              && Boolean.valueOf(routeExtractor.getParamStringValue("inReview"));
       return applicantRoutes
           .blockEditOrBlockReview(
               profile.get(),
               applicantId.get(),
               programId,
-              String.valueOf(routeExtractor.getParamLongValue("blockId")),
-              routeExtractor.containsKey("inReview"))
+              routeExtractor.getParamStringValue("blockId"),
+              inReview)
           .url();
     }
     return request.uri();

--- a/server/app/views/applicant/ApplicantLayout.java
+++ b/server/app/views/applicant/ApplicantLayout.java
@@ -46,6 +46,7 @@ import play.i18n.Messages;
 import play.i18n.MessagesApi;
 import play.mvc.Http;
 import play.mvc.Http.Request;
+import play.routing.Router;
 import play.twirl.api.Content;
 import services.DeploymentType;
 import services.MessageKey;
@@ -314,9 +315,13 @@ public class ApplicantLayout extends BaseHtmlLayout {
    */
   private String getUpdateLanguageRedirectUri(
       Request request, Optional<CiviFormProfile> profile, Optional<Long> applicantId) {
+    // Default to the current request if it is not a POST or a redirect can't be constructed.
+    if (!request.method().equals("POST")
+        || !request.attrs().containsKey(Router.Attrs.HANDLER_DEF)) {
+      return request.uri();
+    }
     RouteExtractor routeExtractor = new RouteExtractor(request);
-    // Use the current request if it is not a POST.
-    if (!request.method().equals("POST") || !routeExtractor.containsKey("programId")) {
+    if (!routeExtractor.containsKey("programId")) {
       return request.uri();
     }
 

--- a/server/app/views/applicant/ApplicantLayout.java
+++ b/server/app/views/applicant/ApplicantLayout.java
@@ -16,10 +16,12 @@ import static j2html.TagCreator.span;
 import static j2html.TagCreator.text;
 import static services.applicant.ApplicantPersonalInfo.ApplicantType.GUEST;
 
+import actions.RouteExtractor;
 import auth.CiviFormProfile;
 import auth.ProfileUtils;
 import controllers.AssetsFinder;
 import controllers.LanguageUtils;
+import controllers.applicant.ApplicantRoutes;
 import controllers.routes;
 import io.jsonwebtoken.lang.Strings;
 import j2html.TagCreator;
@@ -43,6 +45,7 @@ import org.slf4j.LoggerFactory;
 import play.i18n.Messages;
 import play.i18n.MessagesApi;
 import play.mvc.Http;
+import play.mvc.Http.Request;
 import play.twirl.api.Content;
 import services.DeploymentType;
 import services.MessageKey;
@@ -87,6 +90,7 @@ public class ApplicantLayout extends BaseHtmlLayout {
   private final PageNotProductionBanner pageNotProductionBanner;
   private String tiDashboardHref = getTiDashboardHref();
   private final MessagesApi messagesApi;
+  private final ApplicantRoutes applicantRoutes;
 
   @Inject
   public ApplicantLayout(
@@ -99,7 +103,8 @@ public class ApplicantLayout extends BaseHtmlLayout {
       DeploymentType deploymentType,
       AssetsFinder assetsFinder,
       PageNotProductionBanner pageNotProductionBanner,
-      MessagesApi messagesApi) {
+      MessagesApi messagesApi,
+      ApplicantRoutes applicantRoutes) {
     super(viewUtils, settingsManifest, deploymentType, assetsFinder);
     this.layout = layout;
     this.profileUtils = checkNotNull(profileUtils);
@@ -108,6 +113,7 @@ public class ApplicantLayout extends BaseHtmlLayout {
     this.isDevOrStaging = deploymentType.isDevOrStaging();
     this.pageNotProductionBanner = checkNotNull(pageNotProductionBanner);
     this.messagesApi = checkNotNull(messagesApi);
+    this.applicantRoutes = checkNotNull(applicantRoutes);
   }
 
   @Override
@@ -247,7 +253,7 @@ public class ApplicantLayout extends BaseHtmlLayout {
                                     StyleUtils.joinStyles(ApplicantStyles.LINK, "cursor-pointer"))))
                 .with(
                     div(
-                            getLanguageForm(request, messages, applicantId),
+                            getLanguageForm(request, messages, profile, applicantId),
                             authDisplaySection(applicantPersonalInfo, profile, messages))
                         .withClasses(
                             "flex",
@@ -263,7 +269,10 @@ public class ApplicantLayout extends BaseHtmlLayout {
   }
 
   private ContainerTag<?> getLanguageForm(
-      Http.Request request, Messages messages, Optional<Long> applicantId) {
+      Http.Request request,
+      Messages messages,
+      Optional<CiviFormProfile> profile,
+      Optional<Long> applicantId) {
     ContainerTag<?> languageFormDiv = div().withClasses("flex", "flex-col", "justify-center");
 
     String updateLanguageAction =
@@ -277,7 +286,11 @@ public class ApplicantLayout extends BaseHtmlLayout {
 
     String csrfToken = CSRF.getToken(request.asScala()).value();
     InputTag csrfInput = input().isHidden().withValue(csrfToken).withName("csrfToken");
-    InputTag redirectInput = input().isHidden().withValue(request.uri()).withName("redirectLink");
+    InputTag redirectInput =
+        input()
+            .isHidden()
+            .withValue(getUpdateLanguageRedirectUri(request, profile, applicantId))
+            .withName("redirectLink");
     String preferredLanguage = languageUtils.getPreferredLanguage(request).code();
     SelectTag languageDropdown =
         languageSelector
@@ -293,6 +306,41 @@ public class ApplicantLayout extends BaseHtmlLayout {
                 .with(languageDropdown)
                 .with(TagCreator.button().withId("cf-update-lang").withType("submit").isHidden()));
     return languageFormDiv;
+  }
+
+  /**
+   * Calculate the redirect location after the language is changed. If the current request is a
+   * POST, the redirect is be mapped to the associated GET uri.
+   */
+  private String getUpdateLanguageRedirectUri(
+      Request request, Optional<CiviFormProfile> profile, Optional<Long> applicantId) {
+    RouteExtractor routeExtractor = new RouteExtractor(request);
+    // Use the current request if it is not a POST.
+    if (!request.method().equals("POST") || !routeExtractor.containsKey("programId")) {
+      return request.uri();
+    }
+
+    long programId = routeExtractor.getParamLongValue("programId");
+    // If the language was changed during /submit, redirect to /review
+    if (request.path().contains("submit")) {
+      String submitRedirectUri =
+          applicantId.isPresent() && profile.isPresent()
+              ? applicantRoutes.review(profile.get(), applicantId.get(), programId).url()
+              : applicantRoutes.review(programId).url();
+      return submitRedirectUri;
+    }
+    // If the language was changed during a block update, redirect to /block/edit or /block/review
+    if (routeExtractor.containsKey("blockId") && profile.isPresent() && applicantId.isPresent()) {
+      return applicantRoutes
+          .blockEditOrBlockReview(
+              profile.get(),
+              applicantId.get(),
+              programId,
+              String.valueOf(routeExtractor.getParamLongValue("blockId")),
+              routeExtractor.containsKey("inReview"))
+          .url();
+    }
+    return request.uri();
   }
 
   private ATag branding(Http.Request request) {

--- a/server/app/views/applicant/NavigationFragment.html
+++ b/server/app/views/applicant/NavigationFragment.html
@@ -270,7 +270,7 @@
 <div th:fragment="languageSelector">
   <form th:action="${updateLanguageAction}" method="POST">
     <input hidden th:value="${csrfToken}" name="csrfToken" />
-    <input hidden th:value="${requestUri}" name="redirectLink" />
+    <input hidden th:value="${redirectUri}" name="redirectLink" />
 
     <ul class="usa-language__primary usa-accordion">
       <li class="usa-language__primary-item">

--- a/server/test/views/applicant/ApplicantLayoutTest.java
+++ b/server/test/views/applicant/ApplicantLayoutTest.java
@@ -10,6 +10,7 @@ import auth.CiviFormProfile;
 import auth.ProfileUtils;
 import controllers.AssetsFinder;
 import controllers.LanguageUtils;
+import controllers.applicant.ApplicantRoutes;
 import java.util.Optional;
 import org.junit.Before;
 import org.junit.Test;
@@ -57,7 +58,8 @@ public class ApplicantLayoutTest extends ResetPostgres {
             instanceOf(DeploymentType.class),
             instanceOf(AssetsFinder.class),
             instanceOf(PageNotProductionBanner.class),
-            messagesApi);
+            messagesApi,
+            instanceOf(ApplicantRoutes.class));
   }
 
   @Test


### PR DESCRIPTION
### Description

Changing the language on an eligibility alert page currently throws an error. This is because the eligibility page is shown after POST requests to submit an application or page and redirecting back to a POST endpoint results in a 404.

This change fixes the issue by checking if the current request is a submit/update url and replaces it with the associated GET endpoint instead. Ex: `/submit` redirects to `/review` and `/blocks/:blockId/../` redirects to `/blocks/:blockId/review` or `/blocks/:blockId/edit`. See [applicant routes](https://github.com/civiform/civiform/blob/bd055a1627d14503d01d1cb075f938c4c1b0dfca/server/conf/routes#L178-L187). This duplicates the logic in both NS and legacy for consistency but this seems acceptable since it's a relatively simple change and legacy paths may be cleaned up soon.

https://github.com/user-attachments/assets/fb776fb2-f78c-405b-9e89-e79417c405b7

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if the primary reviewer is not an admin and this PR includes functionality changes)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

#### User visible changes

- [ ] Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
  - [ ] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [ ] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [x] Made equivalent changes in Thymeleaf for applicant-facing features and changes (or created an issue in the [Northstar epic](https://github.com/orgs/civiform/projects/1/views/94) to track that it's missing from Thymeleaf)
- [x] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [x] Manually tested at 200% size
- [ ] Manually evaluated tab order
- [ ] Manually tested with a screen reader if the feature is applicant-facing. See [screen reader testing](https://github.com/civiform/civiform/wiki/Testing#screen-reader-testing)

### Issue(s) this completes

Fixes #10476
