### PR TITLE
[External Program Cards] Show required indicator for external link on external program creation

### DIFF
--- a/browser-test/src/admin/admin_program_creation.test.ts
+++ b/browser-test/src/admin/admin_program_creation.test.ts
@@ -1462,6 +1462,7 @@ test.describe('program creation', () => {
 
           await adminPrograms.expectFormFieldEnabled(
             FormField.PROGRAM_EXTERNAL_LINK,
+            ProgramType.EXTERNAL,
           )
 
           // Changing the program type is allowed during program creation.
@@ -1525,6 +1526,7 @@ test.describe('program creation', () => {
 
           await adminPrograms.expectFormFieldEnabled(
             FormField.PROGRAM_EXTERNAL_LINK,
+            ProgramType.EXTERNAL,
           )
 
           // Changing the program type of an external program is disallowed

--- a/browser-test/src/support/admin_programs.ts
+++ b/browser-test/src/support/admin_programs.ts
@@ -471,6 +471,8 @@ export class AdminPrograms {
         const externalLink = this.getExternalLinkField()
         await expect(externalLink).toBeDisabled()
         expect(await externalLink.getAttribute('readonly')).not.toBeNull()
+        const requiredIndicator = this.getExternalLinkFieldRequiredIndicator()
+        await expect(requiredIndicator).toBeHidden()
         break
       }
 
@@ -482,14 +484,19 @@ export class AdminPrograms {
   }
 
   /**
-   * Verifies whether the given form field ais enabled.
+   * Verifies whether the given form field is enabled.
    *
    * @param formField - The specific form field type to verify (from FormField enum)
+   * @param programType - Optional program type to specify context (from ProgramType enum).
+   *                      Not all form fields require a program type for verification.
    *
    * @throws Will throw an error if the elements' states don't match the expected enabled state
    * @throws Will throw an error if an invalid or unsupported form field type is provided
    */
-  async expectFormFieldEnabled(formField: FormField) {
+  async expectFormFieldEnabled(
+    formField: FormField,
+    programType?: ProgramType,
+  ) {
     switch (formField) {
       case FormField.APPLICATION_STEPS: {
         for (let i = 0; i < 5; i++) {
@@ -556,6 +563,17 @@ export class AdminPrograms {
         const externalLink = this.getExternalLinkField()
         await expect(externalLink).toBeEnabled()
         expect(await externalLink.getAttribute('readonly')).toBeNull()
+        // In pre - North Star, the external link field is optional for
+        // 'default' and 'pre-screeners'. In North Star, the external link field
+        // is disabled for 'default' and 'pre-screeners' and required for
+        // 'external programs'. Therefore, required indicator is dependent on
+        // program type. This condition can be removed once North Star is fully
+        // launched, since the required indicator will always be present if the
+        // field is enabled.
+        if (programType && programType === ProgramType.EXTERNAL) {
+          const requiredIndicator = this.getExternalLinkFieldRequiredIndicator()
+          await expect(requiredIndicator).toBeVisible()
+        }
         break
       }
 
@@ -1829,6 +1847,12 @@ export class AdminPrograms {
     return this.page.getByRole('textbox', {
       name: 'Link to program website',
     })
+  }
+
+  getExternalLinkFieldRequiredIndicator(): Locator {
+    return this.page.locator(
+      'label[for="program-external-link-input"] span.required-indicator',
+    )
   }
 
   getLongDescriptionField(): Locator {

--- a/server/app/assets/javascripts/admin_programs.ts
+++ b/server/app/assets/javascripts/admin_programs.ts
@@ -109,6 +109,10 @@ class AdminPrograms {
       /* fieldElement= */ externalLink,
       /* shouldDisable= */ disableExternalLink,
     )
+    this.updateRequiredIndicatorState(
+      /* fieldSelector= */ 'label[for="program-external-link-input"]',
+      /* shouldHide= */ programType !== ProgramType.EXTERNAL,
+    )
 
     // Notification preferences
     const disableNotificationPreferences = programType === ProgramType.EXTERNAL


### PR DESCRIPTION
### Description

Add the required indicator ('`*`') to the 'external link' field in the program form creation for external programs. This was already handled for program form edit by adding it on the [ProgramFormBuilder](https://github.com/civiform/civiform/blob/49534291f328cb274d6562de4e46e9e18f823c03/server/app/views/admin/programs/ProgramFormBuilder.java#L299). However, we were missing showing/hidding it when the program type is selected on the create form.

### Checklist

#### General

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if the primary reviewer is not an admin and this PR includes functionality changes)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

#### User visible changes

- [ ] Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
  - [ ] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [ ] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Made equivalent changes in Thymeleaf for applicant-facing features and changes (or created an issue in the [Northstar epic](https://github.com/orgs/civiform/projects/1/views/94) to track that it's missing from Thymeleaf)
- [x] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [x] Manually tested at 200% size
- [ ] Manually evaluated tab order
- [ ] Manually tested with a screen reader if the feature is applicant-facing. See [screen reader testing](https://github.com/civiform/civiform/wiki/Testing#screen-reader-testing)

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/helper/feature-flags.conf`
- [x] Conditioned new functionality on a [FeatureFlag](https://github.com/civiform/civiform/wiki/Feature-Flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Instructions for manual testing

As a CiviForm admin
1. Enable external program feature
2. Start program creation
3. Select 'external program' type
=> external link should be marked as required
4. Submit 'external program' with no short description and no external link
5. Edit external program
=> external link is marked as required

### Issue(s) this completes

Fixes #10830
