### PR TITLE
[Maps] Add feature flag for map question

### DIFF
--- a/server/app/services/settings/SettingsManifest.java
+++ b/server/app/services/settings/SettingsManifest.java
@@ -2360,13 +2360,6 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                           SettingType.BOOLEAN,
                           SettingMode.ADMIN_WRITEABLE),
                       SettingDescription.create(
-                          "MAP_QUESTION_ENABLED",
-                          "(NOT FOR PRODUCTION USE) Enable allowing CiviForm admins to add a map"
-                              + " question to their programs.",
-                          /* isRequired= */ false,
-                          SettingType.BOOLEAN,
-                          SettingMode.ADMIN_READABLE),
-                      SettingDescription.create(
                           "DATE_VALIDATION_ENABLED",
                           "(NOT FOR PRODUCTION USE) Enables admin validation settings for date"
                               + " questions.",
@@ -2377,6 +2370,13 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                           "YES_NO_QUESTION_ENABLED",
                           "(NOT FOR PRODUCTION USE) Enables being able to add a new yes/no"
                               + " question.",
+                          /* isRequired= */ false,
+                          SettingType.BOOLEAN,
+                          SettingMode.ADMIN_READABLE),
+                      SettingDescription.create(
+                          "MAP_QUESTION_ENABLED",
+                          "(NOT FOR PRODUCTION USE) Enable allowing CiviForm admins to add a map"
+                              + " question to their programs.",
                           /* isRequired= */ false,
                           SettingType.BOOLEAN,
                           SettingMode.ADMIN_READABLE))))

--- a/server/app/services/settings/SettingsManifest.java
+++ b/server/app/services/settings/SettingsManifest.java
@@ -1111,6 +1111,14 @@ public final class SettingsManifest extends AbstractSettingsManifest {
     return getBool("YES_NO_QUESTION_ENABLED");
   }
 
+  /**
+   * (NOT FOR PRODUCTION USE) Enable allowing CiviForm admins to add a map question to their
+   * programs.
+   */
+  public boolean getMapQuestionEnabled(RequestHeader request) {
+    return getBool("MAP_QUESTION_ENABLED", request);
+  }
+
   private static final ImmutableMap<String, SettingsSection> GENERATED_SECTIONS =
       ImmutableMap.<String, SettingsSection>builder()
           .put(
@@ -2348,6 +2356,13 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                           "PROGRAM_SLUG_URLS_ENABLED",
                           "(NOT FOR PRODUCTION USE) Use program slugs instead of program IDs in"
                               + " URLs.",
+                          /* isRequired= */ false,
+                          SettingType.BOOLEAN,
+                          SettingMode.ADMIN_WRITEABLE),
+                      SettingDescription.create(
+                          "MAP_QUESTION_ENABLED",
+                          "(NOT FOR PRODUCTION USE) Enable allowing CiviForm admins to add a map"
+                              + " question to their programs.",
                           /* isRequired= */ false,
                           SettingType.BOOLEAN,
                           SettingMode.ADMIN_WRITEABLE),

--- a/server/app/services/settings/SettingsManifest.java
+++ b/server/app/services/settings/SettingsManifest.java
@@ -2379,7 +2379,7 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                               + " question to their programs.",
                           /* isRequired= */ false,
                           SettingType.BOOLEAN,
-                          SettingMode.ADMIN_READABLE))))
+                          SettingMode.HIDDEN))))
           .put(
               "Miscellaneous",
               SettingsSection.create(

--- a/server/app/services/settings/SettingsManifest.java
+++ b/server/app/services/settings/SettingsManifest.java
@@ -1115,8 +1115,8 @@ public final class SettingsManifest extends AbstractSettingsManifest {
    * (NOT FOR PRODUCTION USE) Enable allowing CiviForm admins to add a map question to their
    * programs.
    */
-  public boolean getMapQuestionEnabled(RequestHeader request) {
-    return getBool("MAP_QUESTION_ENABLED", request);
+  public boolean getMapQuestionEnabled() {
+    return getBool("MAP_QUESTION_ENABLED");
   }
 
   private static final ImmutableMap<String, SettingsSection> GENERATED_SECTIONS =
@@ -2365,7 +2365,7 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                               + " question to their programs.",
                           /* isRequired= */ false,
                           SettingType.BOOLEAN,
-                          SettingMode.ADMIN_WRITEABLE),
+                          SettingMode.ADMIN_READABLE),
                       SettingDescription.create(
                           "DATE_VALIDATION_ENABLED",
                           "(NOT FOR PRODUCTION USE) Enables admin validation settings for date"

--- a/server/conf/env-var-docs.json
+++ b/server/conf/env-var-docs.json
@@ -973,7 +973,7 @@
         "required": false
       },
       "MAP_QUESTION_ENABLED": {
-        "mode": "ADMIN_READABLE",
+        "mode": "HIDDEN",
         "description": "(NOT FOR PRODUCTION USE) Enable allowing CiviForm admins to add a map question to their programs.",
         "type": "bool",
         "required": false

--- a/server/conf/env-var-docs.json
+++ b/server/conf/env-var-docs.json
@@ -971,6 +971,12 @@
         "description": "(NOT FOR PRODUCTION USE) Enables being able to add a new yes/no question.",
         "type": "bool",
         "required": false
+      },
+      "MAP_QUESTION_ENABLED": {
+        "mode": "ADMIN_WRITEABLE",
+        "description": "(NOT FOR PRODUCTION USE) Enable allowing CiviForm admins to add a map question to their programs.",
+        "type": "bool",
+        "required": false
       }
     }
   }

--- a/server/conf/env-var-docs.json
+++ b/server/conf/env-var-docs.json
@@ -973,7 +973,7 @@
         "required": false
       },
       "MAP_QUESTION_ENABLED": {
-        "mode": "ADMIN_WRITEABLE",
+        "mode": "ADMIN_READABLE",
         "description": "(NOT FOR PRODUCTION USE) Enable allowing CiviForm admins to add a map question to their programs.",
         "type": "bool",
         "required": false

--- a/server/conf/helper/feature-flags.conf
+++ b/server/conf/helper/feature-flags.conf
@@ -90,3 +90,7 @@ yes_no_question_enabled = ${?YES_NO_QUESTION_ENABLED}
 # Date question validation settings
 date_validation_enabled = false
 date_validation_enabled = ${?DATE_VALIDATION_ENABLED}
+
+# Allow admins to add a map question to their programs
+map_question_enabled = false
+map_question_enabled = ${?MAP_QUESTION_ENABLED}


### PR DESCRIPTION
### Description

Adds an admin readable feature flag, MAP_QUESTION_ENABLED, for development of new map question.

### Issue(s) this completes

Fixes #10713; 
