### PR TITLE
[ProgramSlugUrl] Add metrics to /edit

### DIFF
--- a/server/app/services/monitoring/MonitoringMetricCounters.java
+++ b/server/app/services/monitoring/MonitoringMetricCounters.java
@@ -10,6 +10,7 @@ public final class MonitoringMetricCounters {
   private final Counter queryMetricMeanLatency;
   private final Counter queryMetricMaxLatency;
   private final Counter queryMetricTotalLatency;
+  private final Counter urlWithProgramIdCall;
 
   @Inject
   public MonitoringMetricCounters() {
@@ -40,6 +41,13 @@ public final class MonitoringMetricCounters {
             .help("Total latency of database queries in micros")
             .labelNames("name", "location", "className")
             .register();
+
+    urlWithProgramIdCall =
+        Counter.build()
+            .name("url_with_program_id_call_total")
+            .help("Count of calls to program-related URLs")
+            .labelNames("route")
+            .register();
   }
 
   public Counter getQueryMetricCount() {
@@ -56,5 +64,9 @@ public final class MonitoringMetricCounters {
 
   public Counter getQueryMetricTotalLatency() {
     return queryMetricTotalLatency;
+  }
+
+  public Counter getUrlWithProgramIdCall() {
+    return urlWithProgramIdCall;
   }
 }

--- a/server/test/controllers/applicant/ApplicantProgramsControllerTest.java
+++ b/server/test/controllers/applicant/ApplicantProgramsControllerTest.java
@@ -41,6 +41,7 @@ import repository.VersionRepository;
 import services.Path;
 import services.applicant.ApplicantData;
 import services.applicant.ApplicantService;
+import services.monitoring.MonitoringMetricCounters;
 import services.question.QuestionAnswerer;
 import services.question.types.QuestionDefinition;
 import services.settings.SettingsManifest;
@@ -79,7 +80,8 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
             instanceOf(ApplicantRoutes.class),
             settingsManifest,
             instanceOf(NorthStarProgramIndexView.class),
-            instanceOf(NorthStarFilteredProgramsViewPartial.class));
+            instanceOf(NorthStarFilteredProgramsViewPartial.class),
+            instanceOf(MonitoringMetricCounters.class));
   }
 
   /**


### PR DESCRIPTION
### Description

#10763 is introducing a feature where URLs use programSlug instead of programId. When the feature is enabled, we redirect to the main page if programId is used on the public facing URL. To decide whether we should make such URL invalid, we are adding metrics for this.

This PR adds metrics to the `/edit` route. 

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if the primary reviewer is not an admin and this PR includes functionality changes)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/helper/feature-flags.conf`
- [x] Conditioned new functionality on a [FeatureFlag](https://github.com/civiform/civiform/wiki/Feature-Flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Issue(s) this completes

Part of #10763