### PR TITLE
[Cleanup] Use versionRepository class variable in ApplicantProgramsControllerTest

### DIFF
--- a/server/test/controllers/applicant/ApplicantProgramsControllerTest.java
+++ b/server/test/controllers/applicant/ApplicantProgramsControllerTest.java
@@ -66,6 +66,7 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
     applicantWithoutProfile = createApplicant();
 
     settingsManifest = mock(SettingsManifest.class);
+    versionRepository = mock(VersionRepository.class);
     controller =
         new ApplicantProgramsController(
             instanceOf(ClassLoaderExecutionContext.class),
@@ -74,7 +75,7 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
             instanceOf(ProgramIndexView.class),
             instanceOf(ApplicantDisabledProgramView.class),
             instanceOf(ProfileUtils.class),
-            instanceOf(VersionRepository.class),
+            versionRepository,
             instanceOf(ProgramSlugHandler.class),
             instanceOf(ApplicantRoutes.class),
             settingsManifest,
@@ -180,7 +181,6 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
 
   @Test
   public void test_deduplicate_inProgressProgram() {
-    versionRepository = instanceOf(VersionRepository.class);
     String programName = "In Progress Program";
     ProgramModel program = resourceCreator().insertActiveProgram(programName);
 


### PR DESCRIPTION
### Description

In `ApplicantProgramsControllerTest`, `VersionRepository` is instantiated twice: in the setup and by one of the tests. Store the one from the setup and use it on the test.

No functionality changed

### Issue(s) this completes

None
