### PR TITLE
[Date Validation] Add DateValidationOption to date question definition and form

### DIFF
--- a/server/app/forms/DateQuestionForm.java
+++ b/server/app/forms/DateQuestionForm.java
@@ -1,21 +1,77 @@
 package forms;
 
+import java.time.LocalDate;
+import java.util.Optional;
 import services.question.types.DateQuestionDefinition;
+import services.question.types.DateQuestionDefinition.DateValidationOption;
+import services.question.types.DateQuestionDefinition.DateValidationOption.DateType;
+import services.question.types.QuestionDefinitionBuilder;
 import services.question.types.QuestionType;
 
 /** Form for updating a date question. */
 public class DateQuestionForm extends QuestionForm {
+  private Optional<DateType> minDateType;
+  private Optional<LocalDate> minCustomDate;
+  private Optional<DateType> maxDateType;
+  private Optional<LocalDate> maxCustomDate;
 
   public DateQuestionForm() {
     super();
+    this.minDateType = Optional.empty();
+    this.maxDateType = Optional.empty();
+    this.minCustomDate = Optional.empty();
+    this.maxCustomDate = Optional.empty();
   }
 
   public DateQuestionForm(DateQuestionDefinition qd) {
     super(qd);
+    this.minDateType = qd.getMinDate().map(DateValidationOption::dateType);
+    this.minCustomDate = qd.getMinDate().flatMap(DateValidationOption::customDate);
+    this.maxDateType = qd.getMaxDate().map(DateValidationOption::dateType);
+    this.maxCustomDate = qd.getMaxDate().flatMap(DateValidationOption::customDate);
   }
 
   @Override
   public QuestionType getQuestionType() {
     return QuestionType.DATE;
+  }
+
+  public Optional<DateType> getMinDateType() {
+    return minDateType;
+  }
+
+  public Optional<LocalDate> getMinCustomDate() {
+    return minCustomDate;
+  }
+
+  public Optional<DateType> getMaxDateType() {
+    return maxDateType;
+  }
+
+  public Optional<LocalDate> getMaxCustomDate() {
+    return maxCustomDate;
+  }
+
+  @Override
+  public QuestionDefinitionBuilder getBuilder() {
+    DateQuestionDefinition.DateValidationPredicates.Builder dateValidationPredicatesBuilder =
+        DateQuestionDefinition.DateValidationPredicates.builder();
+
+    if (getMinDateType().isPresent()) {
+      dateValidationPredicatesBuilder.setMinDate(
+          DateValidationOption.builder()
+              .setDateType(getMinDateType().get())
+              .setCustomDate(getMinCustomDate())
+              .build());
+    }
+    if (getMaxDateType().isPresent()) {
+      dateValidationPredicatesBuilder.setMaxDate(
+          DateValidationOption.builder()
+              .setDateType(getMaxDateType().get())
+              .setCustomDate(getMaxCustomDate())
+              .build());
+    }
+
+    return super.getBuilder().setValidationPredicates(dateValidationPredicatesBuilder.build());
   }
 }

--- a/server/app/services/question/types/DateQuestionDefinition.java
+++ b/server/app/services/question/types/DateQuestionDefinition.java
@@ -1,8 +1,12 @@
 package services.question.types;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
+import java.time.LocalDate;
+import java.util.Optional;
 
 /** Defines a date question. */
 public final class DateQuestionDefinition extends QuestionDefinition {
@@ -11,6 +15,8 @@ public final class DateQuestionDefinition extends QuestionDefinition {
     super(config);
   }
 
+  @JsonDeserialize(
+      builder = AutoValue_DateQuestionDefinition_DateValidationPredicates.Builder.class)
   @AutoValue
   public abstract static class DateValidationPredicates extends ValidationPredicates {
 
@@ -23,8 +29,71 @@ public final class DateQuestionDefinition extends QuestionDefinition {
       }
     }
 
-    public static DateQuestionDefinition.DateValidationPredicates create() {
-      return new AutoValue_DateQuestionDefinition_DateValidationPredicates();
+    public static DateValidationPredicates create() {
+      return builder().build();
+    }
+
+    public static DateValidationPredicates create(
+        Optional<DateValidationOption> minDate, Optional<DateValidationOption> maxDate) {
+      return builder().setMinDate(minDate).setMaxDate(maxDate).build();
+    }
+
+    @JsonProperty("minDate")
+    public abstract Optional<DateValidationOption> minDate();
+
+    @JsonProperty("maxDate")
+    public abstract Optional<DateValidationOption> maxDate();
+
+    public static Builder builder() {
+      return new AutoValue_DateQuestionDefinition_DateValidationPredicates.Builder();
+    }
+
+    @AutoValue.Builder
+    public abstract static class Builder {
+      @JsonProperty("minDate")
+      public abstract Builder setMinDate(Optional<DateValidationOption> minDate);
+
+      public abstract Builder setMinDate(DateValidationOption minDate);
+
+      @JsonProperty("maxDate")
+      public abstract Builder setMaxDate(Optional<DateValidationOption> maxDate);
+
+      public abstract Builder setMaxDate(DateValidationOption maxDate);
+
+      public abstract DateValidationPredicates build();
+    }
+  }
+
+  @JsonDeserialize(builder = AutoValue_DateQuestionDefinition_DateValidationOption.Builder.class)
+  @AutoValue
+  public abstract static class DateValidationOption {
+    @JsonProperty("dateType")
+    public abstract DateType dateType();
+
+    // Required and used iff dateType is CUSTOM.
+    // Dates serialized to ISO-8601 date without time zone format. "Ex: 2025-06-25"
+    @JsonProperty("customDate")
+    public abstract Optional<LocalDate> customDate();
+
+    public enum DateType {
+      ANY, // Any min or max date
+      APPLICATION_DATE, // The current date that the applicant is applying
+      CUSTOM // A custom date specified in the customDate field
+    }
+
+    public static Builder builder() {
+      return new AutoValue_DateQuestionDefinition_DateValidationOption.Builder();
+    }
+
+    @AutoValue.Builder
+    public abstract static class Builder {
+      @JsonProperty("dateType")
+      public abstract Builder setDateType(DateType dateType);
+
+      @JsonProperty("customDate")
+      public abstract Builder setCustomDate(Optional<LocalDate> customDate);
+
+      public abstract DateValidationOption build();
     }
   }
 
@@ -36,5 +105,20 @@ public final class DateQuestionDefinition extends QuestionDefinition {
   @Override
   ValidationPredicates getDefaultValidationPredicates() {
     return DateValidationPredicates.create();
+  }
+
+  @JsonIgnore
+  public Optional<DateValidationOption> getMinDate() {
+    return getDateValidationPredicates().minDate();
+  }
+
+  @JsonIgnore
+  public Optional<DateValidationOption> getMaxDate() {
+    return getDateValidationPredicates().maxDate();
+  }
+
+  @JsonIgnore
+  private DateValidationPredicates getDateValidationPredicates() {
+    return (DateValidationPredicates) getValidationPredicates();
   }
 }

--- a/server/app/services/question/types/QuestionDefinitionBuilder.java
+++ b/server/app/services/question/types/QuestionDefinitionBuilder.java
@@ -12,6 +12,7 @@ import services.question.PrimaryApplicantInfoTag;
 import services.question.QuestionOption;
 import services.question.exceptions.UnsupportedQuestionTypeException;
 import services.question.types.AddressQuestionDefinition.AddressValidationPredicates;
+import services.question.types.DateQuestionDefinition.DateValidationPredicates;
 import services.question.types.EnumeratorQuestionDefinition.EnumeratorValidationPredicates;
 import services.question.types.FileUploadQuestionDefinition.FileUploadValidationPredicates;
 import services.question.types.IdQuestionDefinition.IdValidationPredicates;
@@ -206,6 +207,10 @@ public final class QuestionDefinitionBuilder {
         return new CurrencyQuestionDefinition(builder.build());
 
       case DATE:
+        if (!validationPredicatesString.isEmpty()) {
+          builder.setValidationPredicates(
+              DateValidationPredicates.parse(validationPredicatesString));
+        }
         return new DateQuestionDefinition(builder.build());
 
       case DROPDOWN:

--- a/server/test/forms/DateQuestionFormTest.java
+++ b/server/test/forms/DateQuestionFormTest.java
@@ -1,0 +1,72 @@
+package forms;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static services.question.types.DateQuestionDefinition.DateValidationOption.DateType.ANY;
+import static services.question.types.DateQuestionDefinition.DateValidationOption.DateType.APPLICATION_DATE;
+
+import java.util.Locale;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.Test;
+import services.LocalizedStrings;
+import services.question.types.DateQuestionDefinition;
+import services.question.types.DateQuestionDefinition.DateValidationOption;
+import services.question.types.DateQuestionDefinition.DateValidationPredicates;
+import services.question.types.QuestionDefinition;
+import services.question.types.QuestionDefinitionBuilder;
+import services.question.types.QuestionDefinitionConfig;
+
+public class DateQuestionFormTest {
+
+  @Test
+  public void getBuilder_returnsCompleteBuilder() throws Exception {
+    UUID initialToken = UUID.randomUUID();
+    DateQuestionForm form = new DateQuestionForm();
+    form.setQuestionName("name");
+    form.setQuestionDescription("description");
+    form.setQuestionText("What is the question text?");
+    form.setQuestionHelpText("");
+    form.setConcurrencyToken(initialToken);
+    QuestionDefinitionBuilder builder = form.getBuilder();
+
+    DateQuestionDefinition expected =
+        new DateQuestionDefinition(
+            QuestionDefinitionConfig.builder()
+                .setName("name")
+                .setDescription("description")
+                .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
+                .setQuestionHelpText(LocalizedStrings.empty())
+                .setConcurrencyToken(initialToken)
+                .build());
+
+    QuestionDefinition actual = builder.build();
+
+    assertThat(actual).isEqualTo(expected);
+  }
+
+  @Test
+  public void getBuilder_withQdConstructor_returnsCompleteBuilder() throws Exception {
+    DateValidationOption minDate =
+        DateValidationOption.builder().setDateType(APPLICATION_DATE).build();
+    DateValidationOption maxDate = DateValidationOption.builder().setDateType(ANY).build();
+    DateValidationPredicates validationPredicates =
+        DateValidationPredicates.create(Optional.of(minDate), Optional.of(maxDate));
+    DateQuestionDefinition originalQd =
+        new DateQuestionDefinition(
+            QuestionDefinitionConfig.builder()
+                .setName("name")
+                .setDescription("description")
+                .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
+                .setQuestionHelpText(LocalizedStrings.empty())
+                .setConcurrencyToken(UUID.randomUUID())
+                .setValidationPredicates(validationPredicates)
+                .build());
+
+    DateQuestionForm form = new DateQuestionForm(originalQd);
+    QuestionDefinitionBuilder builder = form.getBuilder();
+
+    QuestionDefinition actual = builder.build();
+
+    assertThat(actual).isEqualTo(originalQd);
+  }
+}


### PR DESCRIPTION
### Description

This change adds validation predicates for min/max dates to the date question definition and admin edit form:

1. Add min/maxDate fields to `DateQuestionDefinition`. Define new`DateValidationOption` which encapsulates a pair of `DateType` and optional LocalDate for custom dates.
2. Add min/max date type and custom date fields to `DateQuestionForm`. These are separated out to correspond with each input field (select for date type and date picker for custom date).
3. Populate `DateQuestionForm` fields from `DateQuestionDefinition` and, vice versa, build `DateQuestionDefinition.DateValidationPredicates` from the form fields.

This change defines the new fields but does not yet expose them in any UI or support setting them in the admin form. Verified no change to date question behavior locally.

[TDD](https://docs.google.com/document/d/1mxw5G7L8DOiYR_m95Q4B9ocQ2qiWkkV2RfZ1TDewD8k/edit?tab=t.0#heading=h.bknox3ib8wpb)

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if the primary reviewer is not an admin and this PR includes functionality changes)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

### Issue(s) this completes

Fixes #[10917](https://github.com/civiform/civiform/issues/10917)
