### PR TITLE
[ProgramSlugUrl] Retrieve slug from programParam in ProgramDisabledAction

### DIFF
--- a/browser-test/src/applicant/northstar_application_version_fast_forward.test.ts
+++ b/browser-test/src/applicant/northstar_application_version_fast_forward.test.ts
@@ -851,7 +851,7 @@ test.describe(
             ])
           })
 
-          return await test.step('add questions to program and republish program', async () => {
+          await test.step('add questions to program', async () => {
             await civiformAdminActor.addQuestionsToExistingBlocks([
               {
                 block: Block.Fourth,
@@ -859,7 +859,9 @@ test.describe(
                 eligibilityValue: `${Question.H}-text-answer`,
               },
             ])
+          })
 
+          return await test.step('disable and republish program', async () => {
             const programIdV3 =
               civiformAdminActor.getProgramIdFromEditProgramUrl()
 
@@ -879,7 +881,8 @@ test.describe(
         'Verify Program v2 ID is less than Program v3 ID.',
       ).toBeLessThan(programIdV3)
 
-      // Applicant submits application for program v1; it does not change to program v3
+      // Applicant submits application for program v1; it does not change to
+      // program v3 because program is disabled
       await test.step('As applicant - active program v3', async () => {
         await applicantActor.getPage().reload()
         await applicantActor.waitForDisabledPage()

--- a/server/app/actions/ProgramDisabledAction.java
+++ b/server/app/actions/ProgramDisabledAction.java
@@ -8,6 +8,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import javax.inject.Inject;
 import models.DisplayMode;
+import org.apache.commons.lang3.StringUtils;
 import play.mvc.Action;
 import play.mvc.Http.Request;
 import play.mvc.Result;
@@ -31,6 +32,81 @@ public class ProgramDisabledAction extends Action.Simple {
     this.programService = checkNotNull(programService);
   }
 
+  @Override
+  public CompletionStage<Result> call(Request req) {
+
+    Optional<String> programSlugOptional = getProgramSlug(req);
+
+    if (programSlugOptional.isPresent() && programIsDisabled(programSlugOptional.get())) {
+      return CompletableFuture.completedFuture(
+          redirect(
+              controllers.applicant.routes.ApplicantProgramsController.showInfoDisabledProgram(
+                  programSlugOptional.get())));
+    }
+
+    // Program is not disabled or not found - continue with normal processing
+    return delegate.call(req);
+  }
+
+  /** Extracts the program slug from the HTTP request flash key or route parameter. */
+  private Optional<String> getProgramSlug(Request request) {
+    Optional<String> programSlugOptional =
+        request.flash().get(FlashKey.REDIRECTED_FROM_PROGRAM_SLUG);
+    if (programSlugOptional.isPresent()) {
+      return programSlugOptional;
+    }
+
+    if (!request.attrs().containsKey(Router.Attrs.HANDLER_DEF)) {
+      return Optional.empty();
+    }
+
+    String routePattern = request.attrs().get(Router.Attrs.HANDLER_DEF).path();
+    RouteExtractor routeExtractor = new RouteExtractor(routePattern, request.path());
+
+    if (routeExtractor.containsKey("programParam")) {
+      return extractSlugFromProgramParam(routeExtractor);
+    }
+
+    if (routeExtractor.containsKey("programId")) {
+      return extractSlugFromProgramId(routeExtractor);
+    }
+
+    return Optional.empty();
+  }
+
+  /**
+   * Extracts program slug from the programParam route parameter. Handles both string slugs and
+   * numeric IDs.
+   */
+  private Optional<String> extractSlugFromProgramParam(RouteExtractor routeExtractor) {
+    try {
+      String programParam = routeExtractor.getParamStringValue("programParam");
+
+      if (StringUtils.isNumeric(programParam)) {
+        long programId = Long.parseLong(programParam);
+        ProgramDefinition program = programService.getFullProgramDefinition(programId);
+        return Optional.of(program.slug());
+      }
+
+      return Optional.of(programParam);
+
+    } catch (ProgramNotFoundException | RuntimeException e) {
+      return Optional.empty();
+    }
+  }
+
+  /** Extracts program slug from the programId route parameter. */
+  private Optional<String> extractSlugFromProgramId(RouteExtractor routeExtractor) {
+    try {
+      Long programId = routeExtractor.getParamLongValue("programId");
+      ProgramDefinition program = programService.getFullProgramDefinition(programId);
+      return Optional.of(program.slug());
+    } catch (ProgramNotFoundException | RuntimeException e) {
+      return Optional.empty();
+    }
+  }
+
+  /** Returns whether the program is disabled. */
   private boolean programIsDisabled(String programSlug) {
     try {
       ProgramDefinition programDefiniton =
@@ -46,53 +122,5 @@ public class ProgramDisabledAction extends Action.Simple {
       // that are missing or only have a draft version
       return false;
     }
-  }
-
-  private ProgramDefinition getProgram(long programId) {
-    try {
-      return programService.getFullProgramDefinition(programId);
-    } catch (ProgramNotFoundException e) {
-      throw new RuntimeException(e);
-    }
-  }
-
-  @Override
-  public CompletionStage<Result> call(Request req) {
-
-    Optional<String> programSlugOptional = getProgramSlug(req);
-
-    if (programSlugOptional.isPresent() && programIsDisabled(programSlugOptional.get())) {
-      return CompletableFuture.completedFuture(
-          redirect(
-              controllers.applicant.routes.ApplicantProgramsController.showInfoDisabledProgram(
-                  programSlugOptional.get())));
-    }
-
-    return delegate.call(req); // continute processing next step
-  }
-
-  /** Get the program slug from flash key or from programId */
-  private Optional<String> getProgramSlug(Request request) {
-    Optional<String> programSlugOptional =
-        request.flash().get(FlashKey.REDIRECTED_FROM_PROGRAM_SLUG);
-
-    if (programSlugOptional.isPresent()) {
-      return programSlugOptional;
-    }
-
-    if (!request.attrs().containsKey(Router.Attrs.HANDLER_DEF)) {
-      return Optional.empty();
-    }
-
-    String routePattern = request.attrs().get(Router.Attrs.HANDLER_DEF).path();
-    RouteExtractor routeExtractor = new RouteExtractor(routePattern, request.path());
-    Optional<Long> programId = routeExtractor.getParamOptionalLongValue("programId");
-
-    if (programId.isPresent()) {
-      ProgramDefinition program = getProgram(programId.get());
-      return Optional.of(program.slug());
-    }
-
-    return Optional.empty();
   }
 }

--- a/server/test/actions/ProgramDisabledActionTest.java
+++ b/server/test/actions/ProgramDisabledActionTest.java
@@ -151,6 +151,56 @@ public class ProgramDisabledActionTest extends ResetPostgres {
   }
 
   @Test
+  public void testDisabledProgramFromUriPathProgramParamWithProgramId() {
+    ProgramModel program = createProgram(DisplayMode.DISABLED, LifecycleStage.ACTIVE);
+
+    var routePattern = "/programs/$programParam<[^/]+>/edit";
+    var path = String.format("/programs/%d/edit", program.id);
+
+    Request request =
+        fakeRequestBuilder()
+            .location("GET", path)
+            .build()
+            .addAttr(
+                Router.Attrs.HANDLER_DEF,
+                createHandlerDef(getClass().getClassLoader(), routePattern));
+
+    ProgramDisabledAction action = instanceOf(ProgramDisabledAction.class);
+
+    Result result = action.call(request).toCompletableFuture().join();
+    assertEquals(
+        result.redirectLocation().get(),
+        controllers.applicant.routes.ApplicantProgramsController.showInfoDisabledProgram(
+                program.getSlug())
+            .url());
+  }
+
+  @Test
+  public void testDisabledProgramFromUriPathProgramParamWithProgramSlug() {
+    ProgramModel program = createProgram(DisplayMode.DISABLED, LifecycleStage.ACTIVE);
+
+    var routePattern = "/programs/$programParam<[^/]+>/edit";
+    var path = String.format("/programs/%s/edit", program.getSlug());
+
+    Request request =
+        fakeRequestBuilder()
+            .location("GET", path)
+            .build()
+            .addAttr(
+                Router.Attrs.HANDLER_DEF,
+                createHandlerDef(getClass().getClassLoader(), routePattern));
+
+    ProgramDisabledAction action = instanceOf(ProgramDisabledAction.class);
+
+    Result result = action.call(request).toCompletableFuture().join();
+    assertEquals(
+        result.redirectLocation().get(),
+        controllers.applicant.routes.ApplicantProgramsController.showInfoDisabledProgram(
+                program.getSlug())
+            .url());
+  }
+
+  @Test
   public void testNonDisabledProgramFromFlashKey() {
     ProgramModel program = createProgram(DisplayMode.PUBLIC, LifecycleStage.ACTIVE);
 


### PR DESCRIPTION
### Description

`ProgramDisabledAction` is an action filter that intercepts requests for disabled programs and redirects users
to an appropriate disabled program info page. As part of #10763, URLs are being changed to use `programParam` instead of `programId`, where program param can be the program id or the program slug.

This PR adds functionality to extract the program slug from the request's programParam (if existent), since we want to keep the same redirect functionality for disabled programs.

### Checklist

#### General


- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if the primary reviewer is not an admin and this PR includes functionality changes)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.


### Issue(s) this completes
Part of #10763