### PR TITLE
[Date validation] Render date picker for custom min/max date validation

### DIFF
--- a/server/app/assets/stylesheets/uswds/_uswds-theme-custom-styles.scss
+++ b/server/app/assets/stylesheets/uswds/_uswds-theme-custom-styles.scss
@@ -79,7 +79,8 @@ See the radio-option below as an example.
  * Remove top margin because other surrounding elements add this margin.
  */
 .usa-legend,
-.cf-question-date .usa-memorable-date .usa-form-group {
+.cf-question-date .usa-memorable-date .usa-form-group,
+.cf-question-config .usa-memorable-date .usa-form-group {
   margin-top: 0;
 }
 

--- a/server/app/forms/DateQuestionForm.java
+++ b/server/app/forms/DateQuestionForm.java
@@ -11,24 +11,63 @@ import services.question.types.QuestionType;
 /** Form for updating a date question. */
 public class DateQuestionForm extends QuestionForm {
   private Optional<DateType> minDateType;
-  private Optional<LocalDate> minCustomDate;
+  private Optional<String> minCustomDay;
+  private Optional<String> minCustomMonth;
+  private Optional<String> minCustomYear;
+
   private Optional<DateType> maxDateType;
-  private Optional<LocalDate> maxCustomDate;
+  private Optional<String> maxCustomDay;
+  private Optional<String> maxCustomMonth;
+  private Optional<String> maxCustomYear;
 
   public DateQuestionForm() {
     super();
     this.minDateType = Optional.empty();
+    this.minCustomDay = Optional.empty();
+    this.minCustomMonth = Optional.empty();
+    this.minCustomYear = Optional.empty();
+
     this.maxDateType = Optional.empty();
-    this.minCustomDate = Optional.empty();
-    this.maxCustomDate = Optional.empty();
+    this.maxCustomDay = Optional.empty();
+    this.maxCustomMonth = Optional.empty();
+    this.maxCustomYear = Optional.empty();
   }
 
   public DateQuestionForm(DateQuestionDefinition qd) {
     super(qd);
     this.minDateType = qd.getMinDate().map(DateValidationOption::dateType);
-    this.minCustomDate = qd.getMinDate().flatMap(DateValidationOption::customDate);
+    this.minCustomDay =
+        qd.getMinDate()
+            .flatMap(DateValidationOption::customDate)
+            .map(LocalDate::getDayOfMonth)
+            .map(day -> String.valueOf(day));
+    this.minCustomMonth =
+        qd.getMinDate()
+            .flatMap(DateValidationOption::customDate)
+            .map(LocalDate::getMonthValue)
+            .map(month -> String.valueOf(month));
+    this.minCustomYear =
+        qd.getMinDate()
+            .flatMap(DateValidationOption::customDate)
+            .map(LocalDate::getYear)
+            .map(year -> String.valueOf(year));
+
     this.maxDateType = qd.getMaxDate().map(DateValidationOption::dateType);
-    this.maxCustomDate = qd.getMaxDate().flatMap(DateValidationOption::customDate);
+    this.maxCustomDay =
+        qd.getMaxDate()
+            .flatMap(DateValidationOption::customDate)
+            .map(LocalDate::getDayOfMonth)
+            .map(day -> String.valueOf(day));
+    this.maxCustomMonth =
+        qd.getMaxDate()
+            .flatMap(DateValidationOption::customDate)
+            .map(LocalDate::getMonthValue)
+            .map(month -> String.valueOf(month));
+    this.maxCustomYear =
+        qd.getMaxDate()
+            .flatMap(DateValidationOption::customDate)
+            .map(LocalDate::getYear)
+            .map(year -> String.valueOf(year));
   }
 
   @Override
@@ -40,16 +79,64 @@ public class DateQuestionForm extends QuestionForm {
     return minDateType;
   }
 
-  public Optional<LocalDate> getMinCustomDate() {
-    return minCustomDate;
+  public void setMinDateType(String minDateType) {
+    this.minDateType = Optional.of(DateType.valueOf(minDateType));
+  }
+
+  public Optional<String> getMinCustomDay() {
+    return minCustomDay;
+  }
+
+  public void setMinCustomDay(String minCustomDay) {
+    this.minCustomDay = Optional.of(minCustomDay);
+  }
+
+  public Optional<String> getMinCustomMonth() {
+    return minCustomMonth;
+  }
+
+  public void setMinCustomMonth(String minCustomMonth) {
+    this.minCustomMonth = Optional.of(minCustomMonth);
+  }
+
+  public Optional<String> getMinCustomYear() {
+    return minCustomYear;
+  }
+
+  public void setMinCustomYear(String minCustomYear) {
+    this.minCustomYear = Optional.of(minCustomYear);
   }
 
   public Optional<DateType> getMaxDateType() {
     return maxDateType;
   }
 
-  public Optional<LocalDate> getMaxCustomDate() {
-    return maxCustomDate;
+  public void setMaxDateType(String maxDateType) {
+    this.maxDateType = Optional.of(DateType.valueOf(maxDateType));
+  }
+
+  public Optional<String> getMaxCustomDay() {
+    return maxCustomDay;
+  }
+
+  public void setMaxCustomDay(String maxCustomDay) {
+    this.maxCustomDay = Optional.of(maxCustomDay);
+  }
+
+  public Optional<String> getMaxCustomMonth() {
+    return maxCustomMonth;
+  }
+
+  public void setMaxCustomMonth(String maxCustomMonth) {
+    this.maxCustomMonth = Optional.of(maxCustomMonth);
+  }
+
+  public Optional<String> getMaxCustomYear() {
+    return maxCustomYear;
+  }
+
+  public void setMaxCustomYear(String maxCustomYear) {
+    this.maxCustomYear = Optional.of(maxCustomYear);
   }
 
   @Override
@@ -73,5 +160,31 @@ public class DateQuestionForm extends QuestionForm {
     }
 
     return super.getBuilder().setValidationPredicates(dateValidationPredicatesBuilder.build());
+  }
+
+  private Optional<LocalDate> getMinCustomDate() {
+    if (getMinCustomDay().isEmpty()
+        || getMinCustomMonth().isEmpty()
+        || getMinCustomYear().isEmpty()) {
+      return Optional.empty();
+    }
+    return Optional.of(
+        LocalDate.of(
+            Integer.valueOf(getMinCustomYear().get()),
+            Integer.valueOf(getMinCustomMonth().get()),
+            Integer.valueOf(getMinCustomDay().get())));
+  }
+
+  private Optional<LocalDate> getMaxCustomDate() {
+    if (getMaxCustomDay().isEmpty()
+        || getMaxCustomMonth().isEmpty()
+        || getMaxCustomYear().isEmpty()) {
+      return Optional.empty();
+    }
+    return Optional.of(
+        LocalDate.of(
+            Integer.valueOf(getMaxCustomYear().get()),
+            Integer.valueOf(getMaxCustomMonth().get()),
+            Integer.valueOf(getMaxCustomDay().get())));
   }
 }

--- a/server/app/services/question/types/QuestionDefinition.java
+++ b/server/app/services/question/types/QuestionDefinition.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
@@ -118,7 +119,10 @@ public abstract class QuestionDefinition {
   })
   public abstract static class ValidationPredicates {
     protected static final ObjectMapper mapper =
-        new ObjectMapper().registerModule(new GuavaModule()).registerModule(new Jdk8Module());
+        new ObjectMapper()
+            .registerModule(new GuavaModule())
+            .registerModule(new Jdk8Module())
+            .registerModule(new JavaTimeModule());
 
     static {
       mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);

--- a/server/test/views/admin/question/QuestionConfigTest.java
+++ b/server/test/views/admin/question/QuestionConfigTest.java
@@ -10,11 +10,14 @@ import static play.test.Helpers.stubMessagesApi;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import forms.CheckboxQuestionForm;
+import forms.DateQuestionForm;
 import forms.QuestionForm;
 import forms.QuestionFormBuilder;
 import forms.YesNoQuestionForm;
 import j2html.tags.specialized.DivTag;
 import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.junit.Before;
@@ -23,6 +26,7 @@ import org.junit.runner.RunWith;
 import play.i18n.Lang;
 import play.i18n.Messages;
 import play.mvc.Http.Request;
+import services.question.types.DateQuestionDefinition.DateValidationOption.DateType;
 import services.question.types.QuestionType;
 import services.settings.SettingsManifest;
 import views.admin.questions.QuestionConfig;
@@ -69,7 +73,10 @@ public class QuestionConfigTest {
         break;
       case DATE:
         assertThat(maybeConfig).isPresent();
-        assertThat(maybeConfig.get().renderFormatted()).contains("Validation parameters");
+        String dateConfig = maybeConfig.get().renderFormatted();
+        assertThat(dateConfig).contains("Validation parameters");
+        assertThat(dateConfig).contains("Start date");
+        assertThat(dateConfig).contains("End date");
         break;
       case DROPDOWN:
         assertThat(maybeConfig).isPresent();
@@ -175,5 +182,48 @@ public class QuestionConfigTest {
     Optional<DivTag> maybeConfig =
         QuestionConfig.buildQuestionConfig(questionForm, messages, settingsManifest, request);
     assertThat(maybeConfig).isEmpty();
+  }
+
+  @Test
+  public void buildDateConfig_rendersDefaultMinMaxDateOptions() throws Exception {
+    QuestionForm questionForm = QuestionFormBuilder.create(QuestionType.DATE);
+    Optional<DivTag> maybeConfig =
+        QuestionConfig.buildQuestionConfig(questionForm, messages, settingsManifest, request);
+    assertThat(maybeConfig).isPresent();
+    String result = maybeConfig.get().renderFormatted();
+
+    // Verify date type options are rendered
+    assertThat(result).contains("Any past date");
+    assertThat(result).contains("Any future date");
+    assertThat(result).contains("Current date of application");
+    assertThat(result).contains("Custom date");
+    // Verify ANY is selected by default
+    Pattern dateTypeAnySelectedPattern = Pattern.compile("<option[^>]*value=\"ANY\" selected>");
+    Matcher matcher = dateTypeAnySelectedPattern.matcher(result);
+    assertThat(matcher.results().count()).isEqualTo(2);
+    // Verify custom date pickers are present
+    assertThat(result).contains("min-date-month");
+    assertThat(result).contains("max-date-month");
+  }
+
+  @Test
+  public void buildDateConfig_prepopulatesFormMinMaxDates() throws Exception {
+    DateQuestionForm form = new DateQuestionForm();
+    form.setMinDateType(DateType.APPLICATION_DATE.toString());
+    form.setMaxDateType(DateType.CUSTOM.toString());
+    form.setMaxCustomDay("1");
+    form.setMaxCustomMonth("2");
+    form.setMaxCustomYear("2025");
+
+    Optional<DivTag> maybeConfig =
+        QuestionConfig.buildQuestionConfig(form, messages, settingsManifest, request);
+    assertThat(maybeConfig).isPresent();
+    String result = maybeConfig.get().renderFormatted();
+
+    assertThat(result).containsPattern("<option[^>]*value=\"APPLICATION_DATE\" selected>");
+    assertThat(result).containsPattern("<option[^>]*value=\"CUSTOM\" selected>");
+    assertThat(result).containsPattern("input[^>]*id=\"max-date-day\"[^>]*value=\"1\"");
+    assertThat(result).containsPattern("<option value=\"2\" selected>");
+    assertThat(result).containsPattern("input[^>]*id=\"max-date-year\"[^>]*value=\"2025\"");
   }
 }


### PR DESCRIPTION
### Description

Add Memorable datepickers for min/max date validation to date question config. Also includes fix to DateQuestionForm to include separate day/month/year params and getters/setters since these are separate input fields in the Memorable date component. This adds the datepicker elements but does not yet handle toggling show/hide interactions based on whether the date type dropdown is "custom".

Changes:

- Add min/max MemorableDate to Date `QuestionConfig`
- Populate with values from `DateQuestionForm` if present
- Set initial hidden tag if question's saved date type is not `CUSTOM`
- Expand min/maxDate in `DateQuestionForm` to handle individual day/month/year fields
- Register missing JavaTimeModule for json parsing
- Adds tests for QuestionConfig, intend to add browser tests when full interactive functionality is implemented in followup PR.

![Screenshot 2025-07-09 at 14 25 06](https://github.com/user-attachments/assets/daee49ee-90c2-4a89-a7e9-cea8a7aaf75b)

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if the primary reviewer is not an admin and this PR includes functionality changes)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

#### User visible changes

- [ ] Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
  - [ ] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [ ] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Made equivalent changes in Thymeleaf for applicant-facing features and changes (or created an issue in the [Northstar epic](https://github.com/orgs/civiform/projects/1/views/94) to track that it's missing from Thymeleaf)
- [x] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [x] Manually tested at 200% size
- [ ] Manually evaluated tab order
- [ ] Manually tested with a screen reader if the feature is applicant-facing. See [screen reader testing](https://github.com/civiform/civiform/wiki/Testing#screen-reader-testing)
- [ ] Manually tested with a right-to-left language

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/helper/feature-flags.conf`
- [x] Conditioned new functionality on a [FeatureFlag](https://github.com/civiform/civiform/wiki/Feature-Flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Issue(s) this completes

Part of #10938