### PR TITLE
[ProgramSlugUrls]: Fix label value in metrics

### DIFF
--- a/server/app/controllers/applicant/ApplicantProgramBlocksController.java
+++ b/server/app/controllers/applicant/ApplicantProgramBlocksController.java
@@ -183,7 +183,8 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
     if (programSlugUrlEnabled && isFromUrlCall && StringUtils.isNumeric(programParam)) {
       metricCounters
           .getUrlWithProgramIdCall()
-          .labels("/programs/:programParam/blocks/:blockId/review", programParam)
+          .labels(
+              "/applicants/:applicantId/programs/:programParam/blocks/:blockId/edit", programParam)
           .inc();
       return CompletableFuture.completedFuture(redirectToHome());
     }
@@ -282,7 +283,9 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
     if (programSlugUrlEnabled && isFromUrlCall && StringUtils.isNumeric(programParam)) {
       metricCounters
           .getUrlWithProgramIdCall()
-          .labels("/programs/:programParam/blocks/:blockId/review", programParam)
+          .labels(
+              "/applicants/:applicantId/programs/:programParam/blocks/:blockId/review",
+              programParam)
           .inc();
       return CompletableFuture.completedFuture(redirectToHome());
     }


### PR DESCRIPTION
### Description

Fix the label value for some of the program slug URL metrics, which were using the wrong path.

### Checklist

#### General

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if the primary reviewer is not an admin and this PR includes functionality changes)
- [ ] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

### Issue(s) this completes

Part of #/10763
