### PR TITLE
[DateValidation] Add validation checks to ensure admin provided date validation parameters create possible date ranges

### DIFF
--- a/server/test/services/question/types/DateQuestionDefinitionTest.java
+++ b/server/test/services/question/types/DateQuestionDefinitionTest.java
@@ -1,0 +1,157 @@
+package services.question.types;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import java.time.Clock;
+import java.time.LocalDate;
+import java.util.Locale;
+import java.util.Optional;
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import services.CiviFormError;
+import services.LocalizedStrings;
+import services.question.types.DateQuestionDefinition.DateValidationOption;
+import services.question.types.DateQuestionDefinition.DateValidationOption.DateType;
+import services.question.types.DateQuestionDefinition.DateValidationPredicates;
+
+@RunWith(JUnitParamsRunner.class)
+public class DateQuestionDefinitionTest {
+  private static final DateValidationOption ANY_DATE =
+      DateValidationOption.builder().setDateType(DateType.ANY).build();
+  private static final DateValidationOption APPLICATION_DATE =
+      DateValidationOption.builder().setDateType(DateType.APPLICATION_DATE).build();
+  private static final DateValidationOption EMPTY_CUSTOM_DATE =
+      DateValidationOption.builder().setDateType(DateType.CUSTOM).build();
+  private static final DateValidationOption INVALID_CUSTOM_DATE =
+      DateValidationOption.builder()
+          .setDateType(DateType.ANY)
+          .setCustomDate(Optional.of(LocalDate.of(2025, 1, 1)))
+          .build();
+
+  @SuppressWarnings({"JavaTimeDefaultTimeZone", "TimeInStaticInitializer"})
+  private static final DateValidationOption CUSTOM_PAST_DATE =
+      DateValidationOption.builder()
+          .setDateType(DateType.CUSTOM)
+          .setCustomDate(Optional.of(LocalDate.now(Clock.systemDefaultZone()).minusDays(10)))
+          .build();
+
+  @SuppressWarnings({"JavaTimeDefaultTimeZone", "TimeInStaticInitializer"})
+  private static final DateValidationOption CUSTOM_FUTURE_DATE =
+      DateValidationOption.builder()
+          .setDateType(DateType.CUSTOM)
+          .setCustomDate(Optional.of(LocalDate.now(Clock.systemDefaultZone()).plusDays(10)))
+          .build();
+
+  @SuppressWarnings("unused") // Is used via reflection by the @Parameters annotation below
+  private static ImmutableList<Object[]> getValidationTestData() {
+    return ImmutableList.of(
+        new Object[] {Optional.empty(), Optional.empty(), Optional.<String>empty()},
+        new Object[] {
+          Optional.empty(),
+          Optional.of(ANY_DATE),
+          Optional.of("Both start and end date are required")
+        },
+        new Object[] {
+          Optional.of(ANY_DATE),
+          Optional.empty(),
+          Optional.of("Both start and end date are required")
+        },
+        new Object[] {Optional.of(ANY_DATE), Optional.of(ANY_DATE), Optional.<String>empty()},
+        new Object[] {
+          Optional.of(ANY_DATE), Optional.of(APPLICATION_DATE), Optional.<String>empty()
+        },
+        new Object[] {
+          Optional.of(ANY_DATE),
+          Optional.of(EMPTY_CUSTOM_DATE),
+          Optional.of("A valid date is required for custom start and end dates")
+        },
+        new Object[] {
+          Optional.of(ANY_DATE),
+          Optional.of(INVALID_CUSTOM_DATE),
+          Optional.of("Specific date must be empty if start and end date are not \"Custom date\"")
+        },
+        new Object[] {
+          Optional.of(ANY_DATE), Optional.of(CUSTOM_PAST_DATE), Optional.<String>empty()
+        },
+        new Object[] {
+          Optional.of(ANY_DATE), Optional.of(CUSTOM_FUTURE_DATE), Optional.<String>empty()
+        },
+        new Object[] {
+          Optional.of(APPLICATION_DATE), Optional.of(ANY_DATE), Optional.<String>empty()
+        },
+        new Object[] {
+          Optional.of(APPLICATION_DATE), Optional.of(APPLICATION_DATE), Optional.<String>empty()
+        },
+        new Object[] {
+          Optional.of(APPLICATION_DATE),
+          Optional.of(CUSTOM_PAST_DATE),
+          Optional.of("End date cannot be before today's date")
+        },
+        new Object[] {
+          Optional.of(APPLICATION_DATE), Optional.of(CUSTOM_FUTURE_DATE), Optional.<String>empty()
+        },
+        new Object[] {
+          Optional.of(EMPTY_CUSTOM_DATE),
+          Optional.of(ANY_DATE),
+          Optional.of("A valid date is required for custom start and end dates")
+        },
+        new Object[] {
+          Optional.of(INVALID_CUSTOM_DATE),
+          Optional.of(ANY_DATE),
+          Optional.of("Specific date must be empty if start and end date are not \"Custom date\"")
+        },
+        new Object[] {
+          Optional.of(CUSTOM_PAST_DATE), Optional.of(ANY_DATE), Optional.<String>empty()
+        },
+        new Object[] {
+          Optional.of(CUSTOM_PAST_DATE), Optional.of(APPLICATION_DATE), Optional.<String>empty()
+        },
+        new Object[] {
+          Optional.of(CUSTOM_PAST_DATE), Optional.of(CUSTOM_FUTURE_DATE), Optional.<String>empty()
+        },
+        new Object[] {
+          Optional.of(CUSTOM_FUTURE_DATE),
+          Optional.of(APPLICATION_DATE),
+          Optional.of("Start date cannot be after today's date")
+        },
+        new Object[] {
+          Optional.of(CUSTOM_FUTURE_DATE),
+          Optional.of(CUSTOM_PAST_DATE),
+          Optional.of("Start date cannot be after end date")
+        });
+  }
+
+  @Test
+  @Parameters(method = "getValidationTestData")
+  public void validate_settingConstraints(
+      Optional<DateValidationOption> minDate,
+      Optional<DateValidationOption> maxDate,
+      Optional<String> expectedErrorMessage) {
+    QuestionDefinitionConfig config =
+        makeConfigBuilder()
+            .setValidationPredicates(
+                DateValidationPredicates.builder().setMinDate(minDate).setMaxDate(maxDate).build())
+            .build();
+    QuestionDefinition question = new DateQuestionDefinition(config);
+
+    ImmutableSet<CiviFormError> errors = question.validate();
+
+    assertThat(errors)
+        .isEqualTo(
+            expectedErrorMessage
+                .map(CiviFormError::of)
+                .map(ImmutableSet::of)
+                .orElse(ImmutableSet.of()));
+  }
+
+  private QuestionDefinitionConfig.Builder makeConfigBuilder() {
+    return QuestionDefinitionConfig.builder()
+        .setName("name")
+        .setDescription("description")
+        .setQuestionText(LocalizedStrings.of(Locale.US, "question?"));
+  }
+}


### PR DESCRIPTION
### Description

Now that admin can create date questions with validation parameters, we need to validate that the provided parameters represent a valid date range.

This change adds a `validateInternal` method to `DateQuestionDefinition` which performs the following checks:
- if at least one of start/end is provided then both must be present
- a custom date is provided iff date type is custom
- if minDate is custom and maxDate is application date, then minDate < today
- if maxDate is custom and minDate is application date, then maxDate > today
- if minDate and maxDate are both custom, then minDate < maxDate
- custom dates are valid dates -> in `DateQuestionDefinition` this is done by checking that the date is non-empty, since at this point the date has already been converted to `LocalDate` which has to represent a valid date. Invalid dates are instead handled earlier in `DateQuestionForm`, which handles empty fields and impossible dates (e.g. day of month > 31) and returns an empty optional if the separate input fields can't be converted into a `LocalDate`.

Note: The datepicker already validates that the month and year inputs are numeric, and that the date is 4 digits, so these checks aren't needed.


See [TDD section](https://docs.google.com/document/d/1mxw5G7L8DOiYR_m95Q4B9ocQ2qiWkkV2RfZ1TDewD8k/edit?tab=t.0#heading=h.dekiu9vkr8c8)

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if the primary reviewer is not an admin and this PR includes functionality changes)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.


### Issue(s) this completes

Fixes #10996 
