### PR TITLE
[North Star] Write North Star tests for AdminProgramControllerTest.java

### DIFF
--- a/server/test/controllers/admin/AdminProgramControllerTest.java
+++ b/server/test/controllers/admin/AdminProgramControllerTest.java
@@ -109,6 +109,9 @@ public class AdminProgramControllerTest extends ResetPostgres {
     assertThat(contentAsString(result)).contains(CSRF.getToken(request.asScala()).value());
   }
 
+  /**
+   * @deprecated todo: Remove the test after NORTH_STAR_APPLICANT_UI is fully enabled
+   */
   @Test
   public void create_showsNewProgramInList() {
     RequestBuilder requestBuilder =
@@ -218,6 +221,9 @@ public class AdminProgramControllerTest extends ResetPostgres {
                 .url());
   }
 
+  /**
+   * @deprecated todo: Remove the test after NORTH_STAR_APPLICANT_UI is fully enabled
+   */
   @Test
   public void create_returnsNewProgramWithAcls() {
     RequestBuilder requestBuilder =
@@ -391,6 +397,9 @@ public class AdminProgramControllerTest extends ResetPostgres {
     assertThat(updatedDraft.getProgramDefinition().eligibilityIsGating()).isTrue();
   }
 
+  /**
+   * @deprecated todo: Remove the test after NORTH_STAR_APPLICANT_UI is fully enabled
+   */
   @Test
   public void create_includesNewAndExistingProgramsInList() {
     ProgramBuilder.newActiveProgram("Existing One").build();
@@ -557,6 +566,9 @@ public class AdminProgramControllerTest extends ResetPostgres {
     assertThat(contentAsString(result)).contains("confirm-common-intake-change");
   }
 
+  /**
+   * @deprecated todo: Remove the test after NORTH_STAR_APPLICANT_UI is fully enabled
+   */
   @Test
   public void create_doesNotPromptUserToConfirmCommonIntakeChangeIfNoneExists() {
     RequestBuilder requestBuilder =
@@ -817,6 +829,9 @@ public class AdminProgramControllerTest extends ResetPostgres {
     assertThat(contentAsString(result)).contains(CSRF.getToken(request.asScala()).value());
   }
 
+  /**
+   * @deprecated todo: Remove the test after NORTH_STAR_APPLICANT_UI is fully enabled
+   */
   @Test
   public void update_overwritesExistingProgram() throws Exception {
     ProgramModel program =
@@ -826,11 +841,11 @@ public class AdminProgramControllerTest extends ResetPostgres {
             .bodyForm(
                 ImmutableMap.of(
                     "adminDescription",
-                    "New internal program description",
+                    "New program slug",
                     "localizedDisplayName",
-                    "New external program name",
+                    "New program name",
                     "localizedDisplayDescription",
-                    "New external program description",
+                    "New program description",
                     "localizedShortDescription",
                     "New external short program description",
                     "externalLink",
@@ -852,7 +867,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
     Result indexResult = controller.index(request);
     assertThat(contentAsString(indexResult))
         .contains(
-            "Create new program", "New external program name", "New external program description");
+            "Create new program", "New program name", "New program description");
     assertThat(contentAsString(indexResult)).doesNotContain("Existing one", "short description");
   }
 
@@ -865,11 +880,11 @@ public class AdminProgramControllerTest extends ResetPostgres {
             .bodyForm(
                 ImmutableMap.of(
                     "adminDescription",
-                    "New internal program description",
+                    "New program slug",
                     "localizedDisplayName",
-                    "New external program name",
+                    "New program name",
                     "localizedDisplayDescription",
-                    "New external program description",
+                    "New program description",
                     "localizedShortDescription",
                     "New external short program description",
                     "externalLink",
@@ -891,7 +906,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
     assertThat(contentAsString(indexResult))
         .contains(
             "Create new program",
-            "New external program name",
+            "New program name",
             "New external short program description");
     assertThat(contentAsString(indexResult)).doesNotContain("Existing one", "short description");
   }
@@ -1021,13 +1036,13 @@ public class AdminProgramControllerTest extends ResetPostgres {
             .bodyForm(
                 ImmutableMap.of(
                     "adminDescription",
-                    "New internal program description",
+                    "New program slug",
                     "localizedDisplayName",
                     "",
                     "localizedDisplayDescription",
-                    "New external program description",
+                    "New program description",
                     "localizedShortDescription",
-                    "External short program description",
+                    "New short program description",
                     "externalLink",
                     "https://external.program.link",
                     "displayMode",
@@ -1060,13 +1075,13 @@ public class AdminProgramControllerTest extends ResetPostgres {
             .bodyForm(
                 ImmutableMap.of(
                     "adminDescription",
-                    "New internal program description",
+                    "New program slug",
                     "localizedDisplayName",
-                    "New external program name",
+                    "New program name",
                     "localizedDisplayDescription",
-                    "New external program description",
+                    "New program description",
                     "localizedShortDescription",
-                    "External short program description",
+                    "Short program description",
                     "externalLink",
                     "https://external.program.link",
                     "displayMode",
@@ -1097,11 +1112,11 @@ public class AdminProgramControllerTest extends ResetPostgres {
             .bodyForm(
                 ImmutableMap.of(
                     "adminDescription",
-                    "New internal program description",
+                    "New program slug",
                     "localizedDisplayName",
-                    "New external program name",
+                    "New program name",
                     "localizedDisplayDescription",
-                    "New external program description",
+                    "New program description",
                     "localizedShortDescription",
                     "New short program description",
                     "externalLink",
@@ -1132,9 +1147,12 @@ public class AdminProgramControllerTest extends ResetPostgres {
         .hasValue(routes.AdminProgramBlocksController.index(programId).url());
 
     Result redirectResult = controller.index(fakeRequest());
-    assertThat(contentAsString(redirectResult)).contains("New external program name");
+    assertThat(contentAsString(redirectResult)).contains("New program name");
   }
 
+  /**
+   * @deprecated todo: Remove the test after NORTH_STAR_APPLICANT_UI is fully enabled
+   */
   @Test
   public void update_allowsChangingCommonIntakeAfterConfirming() throws Exception {
     ProgramModel program =
@@ -1142,17 +1160,17 @@ public class AdminProgramControllerTest extends ResetPostgres {
     ProgramBuilder.newActiveCommonIntakeForm("Old common intake").build();
 
     String newProgramName = "External program name";
-    String newProgramDescription = "New external program description";
+    String newProgramDescription = "New program description";
     RequestBuilder requestBuilder =
         fakeRequestBuilder()
             .bodyForm(
                 ImmutableMap.of(
                     "adminDescription",
-                    "New internal program description",
+                    "New program slug",
                     "localizedDisplayName",
                     newProgramName,
                     "localizedDisplayDescription",
-                    "New external program description",
+                    "New program description",
                     "localizedShortDescription",
                     "External program short description",
                     "externalLink",
@@ -1200,11 +1218,11 @@ public class AdminProgramControllerTest extends ResetPostgres {
             .bodyForm(
                 ImmutableMap.of(
                     "adminDescription",
-                    "New internal program description",
+                    "New program slug",
                     "localizedDisplayName",
                     newProgramName,
                     "localizedDisplayDescription",
-                    "New external program description",
+                    "New program description",
                     "localizedShortDescription",
                     newProgramShortDescription,
                     "externalLink",

--- a/server/test/controllers/admin/AdminProgramControllerTest.java
+++ b/server/test/controllers/admin/AdminProgramControllerTest.java
@@ -112,6 +112,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
   /**
    * @deprecated todo: Remove the test after NORTH_STAR_APPLICANT_UI is fully enabled
    */
+  @Deprecated
   @Test
   public void create_showsNewProgramInList() {
     RequestBuilder requestBuilder =
@@ -224,6 +225,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
   /**
    * @deprecated todo: Remove the test after NORTH_STAR_APPLICANT_UI is fully enabled
    */
+  @Deprecated
   @Test
   public void create_returnsNewProgramWithAcls() {
     RequestBuilder requestBuilder =
@@ -400,6 +402,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
   /**
    * @deprecated todo: Remove the test after NORTH_STAR_APPLICANT_UI is fully enabled
    */
+  @Deprecated
   @Test
   public void create_includesNewAndExistingProgramsInList() {
     ProgramBuilder.newActiveProgram("Existing One").build();
@@ -569,6 +572,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
   /**
    * @deprecated todo: Remove the test after NORTH_STAR_APPLICANT_UI is fully enabled
    */
+  @Deprecated
   @Test
   public void create_doesNotPromptUserToConfirmCommonIntakeChangeIfNoneExists() {
     RequestBuilder requestBuilder =
@@ -832,6 +836,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
   /**
    * @deprecated todo: Remove the test after NORTH_STAR_APPLICANT_UI is fully enabled
    */
+  @Deprecated
   @Test
   public void update_overwritesExistingProgram() throws Exception {
     ProgramModel program =
@@ -1150,6 +1155,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
   /**
    * @deprecated todo: Remove the test after NORTH_STAR_APPLICANT_UI is fully enabled
    */
+  @Deprecated
   @Test
   public void update_allowsChangingCommonIntakeAfterConfirming() throws Exception {
     ProgramModel program =

--- a/server/test/controllers/admin/AdminProgramControllerTest.java
+++ b/server/test/controllers/admin/AdminProgramControllerTest.java
@@ -890,7 +890,9 @@ public class AdminProgramControllerTest extends ResetPostgres {
     Result indexResult = controller.index(request);
     assertThat(contentAsString(indexResult))
         .contains(
-            "Create new program", "New external program name", "New external short program description");
+            "Create new program",
+            "New external program name",
+            "New external short program description");
     assertThat(contentAsString(indexResult)).doesNotContain("Existing one", "short description");
   }
 
@@ -1187,7 +1189,8 @@ public class AdminProgramControllerTest extends ResetPostgres {
   @Test
   public void update_northStar_allowsChangingCommonIntakeAfterConfirming() throws Exception {
     ProgramModel program =
-        ProgramBuilder.newDraftProgram("Existing One", "old description", "old short description").build();
+        ProgramBuilder.newDraftProgram("Existing One", "old description", "old short description")
+            .build();
     ProgramBuilder.newActiveCommonIntakeForm("Old common intake").build();
 
     String newProgramName = "External program name";

--- a/server/test/controllers/admin/AdminProgramControllerTest.java
+++ b/server/test/controllers/admin/AdminProgramControllerTest.java
@@ -170,8 +170,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
 
     controller.create(requestBuilder.build());
 
-    Request request =
-        fakeRequestBuilder().addCiviFormSetting("NORTH_STAR_APPLICANT_UI", "true").build();
+    Request request = fakeRequestBuilder().build();
     Result programDashboardResult = controller.index(request);
     assertThat(contentAsString(programDashboardResult)).contains("External program name");
     assertThat(contentAsString(programDashboardResult))
@@ -263,6 +262,51 @@ public class AdminProgramControllerTest extends ResetPostgres {
     assertThat(contentAsString(programDashboard)).contains("External program name with acls");
     assertThat(contentAsString(programDashboard))
         .contains("External program description with acls");
+  }
+
+  @Test
+  public void create_northStar_returnsNewProgramWithAcls() {
+    RequestBuilder requestBuilder =
+        fakeRequestBuilder()
+            .bodyForm(
+                ImmutableMap.of(
+                    "adminName",
+                    "internal-program-with-acls",
+                    "adminDescription",
+                    "Internal program description with acls",
+                    "localizedDisplayName",
+                    "External program name with acls",
+                    "localizedDisplayDescription",
+                    "External program description with acls",
+                    "localizedShortDescription",
+                    "External short program description with acls",
+                    "externalLink",
+                    "https://external.program.link",
+                    "displayMode",
+                    DisplayMode.SELECT_TI.getValue(),
+                    "tiGroups[]",
+                    "1",
+                    "applicationSteps[0][title]",
+                    "step one title",
+                    "applicationSteps[0][description]",
+                    "step one description"));
+
+    Result result = controller.create(requestBuilder.build());
+
+    assertThat(result.status()).isEqualTo(SEE_OTHER);
+
+    Optional<ProgramModel> newProgram =
+        versionRepository.getProgramByNameForVersion(
+            "internal-program-with-acls", versionRepository.getDraftVersionOrCreate());
+    assertThat(newProgram).isPresent();
+    assertThat(newProgram.get().getProgramDefinition().acls().getTiProgramViewAcls())
+        .containsExactly(1L);
+
+    Request request = fakeRequestBuilder().build();
+    Result programDashboard = controller.index(request);
+    assertThat(contentAsString(programDashboard)).contains("External program name with acls");
+    assertThat(contentAsString(programDashboard))
+        .contains("External short program description with acls");
   }
 
   @Test
@@ -397,6 +441,54 @@ public class AdminProgramControllerTest extends ResetPostgres {
   }
 
   @Test
+  public void create_northStar_includesNewAndExistingProgramsInList() {
+    ProgramBuilder.newActiveProgram("Existing One").build();
+    RequestBuilder requestBuilder =
+        fakeRequestBuilder()
+            .bodyForm(
+                ImmutableMap.of(
+                    "adminName",
+                    "internal-program-name",
+                    "adminDescription",
+                    "Internal program description",
+                    "localizedDisplayName",
+                    "External program name",
+                    "localizedDisplayDescription",
+                    "External program description",
+                    "localizedShortDescription",
+                    "External short program description",
+                    "externalLink",
+                    "https://external.program.link",
+                    "displayMode",
+                    DisplayMode.PUBLIC.getValue(),
+                    "applicationSteps[0][title]",
+                    "step one title",
+                    "applicationSteps[0][description]",
+                    "step one description"));
+
+    Result result = controller.create(requestBuilder.build());
+
+    assertThat(result.status()).isEqualTo(SEE_OTHER);
+    long programId =
+        versionRepository
+            .getDraftVersionOrCreate()
+            .getPrograms()
+            .get(0)
+            .getProgramDefinition()
+            .id();
+    assertThat(result.redirectLocation())
+        .hasValue(
+            routes.AdminProgramImageController.index(programId, ProgramEditStatus.CREATION.name())
+                .url());
+
+    Request request = fakeRequestBuilder().build();
+    Result programDashboard = controller.index(request);
+    assertThat(contentAsString(programDashboard)).contains("Existing One");
+    assertThat(contentAsString(programDashboard)).contains("External program name");
+    assertThat(contentAsString(programDashboard)).contains("External short program description");
+  }
+
+  @Test
   public void create_showsErrorsBeforePromptingUserToConfirmCommonIntakeChange() {
     ProgramBuilder.newActiveCommonIntakeForm("Old common intake").build();
     RequestBuilder requestBuilder =
@@ -512,6 +604,54 @@ public class AdminProgramControllerTest extends ResetPostgres {
     Result programDashboard = controller.index(request);
     assertThat(contentAsString(programDashboard)).contains("External program name");
     assertThat(contentAsString(programDashboard)).contains("External program description");
+  }
+
+  @Test
+  public void create_northStar_doesNotPromptUserToConfirmCommonIntakeChangeIfNoneExists() {
+    RequestBuilder requestBuilder =
+        fakeRequestBuilder()
+            .bodyForm(
+                ImmutableMap.of(
+                    "adminName",
+                    "internal-program-name",
+                    "adminDescription",
+                    "Internal program description",
+                    "localizedDisplayName",
+                    "External program name",
+                    "localizedDisplayDescription",
+                    "External program description",
+                    "localizedShortDescription",
+                    "External short program description",
+                    "displayMode",
+                    DisplayMode.PUBLIC.getValue(),
+                    "programTypeValue",
+                    ProgramType.COMMON_INTAKE_FORM.getValue(),
+                    "confirmedChangeCommonIntakeForm",
+                    "false",
+                    "applicationSteps[0][title]",
+                    "step one title",
+                    "applicationSteps[0][description]",
+                    "step one description"));
+
+    Result result = controller.create(requestBuilder.build());
+
+    assertThat(result.status()).isEqualTo(SEE_OTHER);
+    long programId =
+        versionRepository
+            .getDraftVersionOrCreate()
+            .getPrograms()
+            .get(0)
+            .getProgramDefinition()
+            .id();
+    assertThat(result.redirectLocation())
+        .hasValue(
+            routes.AdminProgramImageController.index(programId, ProgramEditStatus.CREATION.name())
+                .url());
+
+    Request request = fakeRequestBuilder().build();
+    Result programDashboard = controller.index(request);
+    assertThat(contentAsString(programDashboard)).contains("External program name");
+    assertThat(contentAsString(programDashboard)).contains("External short program description");
   }
 
   @Test
@@ -713,6 +853,44 @@ public class AdminProgramControllerTest extends ResetPostgres {
     assertThat(contentAsString(indexResult))
         .contains(
             "Create new program", "New external program name", "New external program description");
+    assertThat(contentAsString(indexResult)).doesNotContain("Existing one", "short description");
+  }
+
+  @Test
+  public void update_northStar_overwritesExistingProgram() throws Exception {
+    ProgramModel program =
+        ProgramBuilder.newDraftProgram("Existing One", "old description").build();
+    RequestBuilder requestBuilder =
+        fakeRequestBuilder()
+            .bodyForm(
+                ImmutableMap.of(
+                    "adminDescription",
+                    "New internal program description",
+                    "localizedDisplayName",
+                    "New external program name",
+                    "localizedDisplayDescription",
+                    "New external program description",
+                    "localizedShortDescription",
+                    "New external short program description",
+                    "externalLink",
+                    "https://external.program.link",
+                    "displayMode",
+                    DisplayMode.PUBLIC.getValue(),
+                    "programTypeValue",
+                    ProgramType.COMMON_INTAKE_FORM.getValue(),
+                    "tiGroups[]",
+                    "1",
+                    "applicationSteps[0][title]",
+                    "step one title",
+                    "applicationSteps[0][description]",
+                    "step one description"));
+    controller.update(requestBuilder.build(), program.id, ProgramEditStatus.EDIT.name());
+
+    Request request = fakeRequestBuilder().build();
+    Result indexResult = controller.index(request);
+    assertThat(contentAsString(indexResult))
+        .contains(
+            "Create new program", "New external program name", "New external short program description");
     assertThat(contentAsString(indexResult)).doesNotContain("Existing one", "short description");
   }
 
@@ -1004,6 +1182,56 @@ public class AdminProgramControllerTest extends ResetPostgres {
     Result redirectResult = controller.index(request);
     assertThat(contentAsString(redirectResult)).contains(newProgramName);
     assertThat(contentAsString(redirectResult)).contains(newProgramDescription);
+  }
+
+  @Test
+  public void update_northStar_allowsChangingCommonIntakeAfterConfirming() throws Exception {
+    ProgramModel program =
+        ProgramBuilder.newDraftProgram("Existing One", "old description", "old short description").build();
+    ProgramBuilder.newActiveCommonIntakeForm("Old common intake").build();
+
+    String newProgramName = "External program name";
+    String newProgramShortDescription = "External program short description";
+    RequestBuilder requestBuilder =
+        fakeRequestBuilder()
+            .bodyForm(
+                ImmutableMap.of(
+                    "adminDescription",
+                    "New internal program description",
+                    "localizedDisplayName",
+                    newProgramName,
+                    "localizedDisplayDescription",
+                    "New external program description",
+                    "localizedShortDescription",
+                    newProgramShortDescription,
+                    "externalLink",
+                    "https://external.program.link",
+                    "displayMode",
+                    DisplayMode.PUBLIC.getValue(),
+                    "programTypeValue",
+                    ProgramType.COMMON_INTAKE_FORM.getValue(),
+                    "confirmedChangeCommonIntakeForm",
+                    "true",
+                    "applicationSteps[0][title]",
+                    "step one title",
+                    "applicationSteps[0][description]",
+                    "step one description"));
+
+    Result result =
+        controller.update(requestBuilder.build(), program.id, ProgramEditStatus.EDIT.name());
+
+    assertThat(result.status()).isEqualTo(SEE_OTHER);
+    Optional<ProgramModel> newProgram =
+        versionRepository.getProgramByNameForVersion(
+            "Existing One", versionRepository.getDraftVersionOrCreate());
+    assertThat(newProgram).isPresent();
+    assertThat(result.redirectLocation())
+        .hasValue(routes.AdminProgramBlocksController.index(newProgram.get().id).url());
+
+    Request request = fakeRequestBuilder().build();
+    Result redirectResult = controller.index(request);
+    assertThat(contentAsString(redirectResult)).contains(newProgramName);
+    assertThat(contentAsString(redirectResult)).contains(newProgramShortDescription);
   }
 
   @Test

--- a/server/test/controllers/admin/AdminProgramControllerTest.java
+++ b/server/test/controllers/admin/AdminProgramControllerTest.java
@@ -866,8 +866,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
         fakeRequestBuilder().addCiviFormSetting("NORTH_STAR_APPLICANT_UI", "false").build();
     Result indexResult = controller.index(request);
     assertThat(contentAsString(indexResult))
-        .contains(
-            "Create new program", "New program name", "New program description");
+        .contains("Create new program", "New program name", "New program description");
     assertThat(contentAsString(indexResult)).doesNotContain("Existing one", "short description");
   }
 
@@ -905,9 +904,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
     Result indexResult = controller.index(request);
     assertThat(contentAsString(indexResult))
         .contains(
-            "Create new program",
-            "New program name",
-            "New external short program description");
+            "Create new program", "New program name", "New external short program description");
     assertThat(contentAsString(indexResult)).doesNotContain("Existing one", "short description");
   }
 


### PR DESCRIPTION
### Description

Creates North Star counterparts for the tests for which NORTH_STAR_APPLICANT_UI had to be disabled for them to pass.

### Issue(s) this completes

Part of #10971 ;
