### PR TITLE
Deprecate NO_DUPLICATE_QUESTIONS_FOR_MIGRATION_ENABLED flag

### DIFF
--- a/server/app/controllers/admin/AdminImportController.java
+++ b/server/app/controllers/admin/AdminImportController.java
@@ -197,8 +197,7 @@ public class AdminImportController extends CiviFormController {
                 .render());
       }
 
-      boolean withDuplicates =
-          !settingsManifest.getNoDuplicateQuestionsForMigrationEnabled(request);
+      boolean withDuplicates = !settingsManifest.getNoDuplicateQuestionsForMigrationEnabled();
 
       // When we are importing without duplicate questions, we expect all drafts to be published
       // before the import process begins.
@@ -312,8 +311,7 @@ public class AdminImportController extends CiviFormController {
       ImmutableMap<String, ProgramMigrationWrapper.DuplicateQuestionHandlingOption>
           duplicateHandlingOptions = programMigrationWrapper.getDuplicateQuestionHandlingOptions();
 
-      boolean withDuplicates =
-          !settingsManifest.getNoDuplicateQuestionsForMigrationEnabled(request);
+      boolean withDuplicates = !settingsManifest.getNoDuplicateQuestionsForMigrationEnabled();
       boolean duplicateHandlingEnabled =
           settingsManifest.getImportDuplicateHandlingOptionsEnabled();
 
@@ -337,8 +335,7 @@ public class AdminImportController extends CiviFormController {
 
       return ok(
           adminImportViewPartial
-              .renderProgramSaved(
-                  request, savedProgramDefinition.adminName(), savedProgramDefinition.id())
+              .renderProgramSaved(savedProgramDefinition.adminName(), savedProgramDefinition.id())
               .render());
     } catch (RuntimeException error) {
       logger.error("Error saving program", error);

--- a/server/app/services/settings/SettingsManifest.java
+++ b/server/app/services/settings/SettingsManifest.java
@@ -1074,8 +1074,8 @@ public final class SettingsManifest extends AbstractSettingsManifest {
    * between deployed environments. Note: this should only be used on new environments, since
    * existing programs will be modified if a program with the same question gets imported.
    */
-  public boolean getNoDuplicateQuestionsForMigrationEnabled(RequestHeader request) {
-    return getBool("NO_DUPLICATE_QUESTIONS_FOR_MIGRATION_ENABLED", request);
+  public boolean getNoDuplicateQuestionsForMigrationEnabled() {
+    return getBool("NO_DUPLICATE_QUESTIONS_FOR_MIGRATION_ENABLED");
   }
 
   /**
@@ -2330,7 +2330,7 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                               + " imported.",
                           /* isRequired= */ false,
                           SettingType.BOOLEAN,
-                          SettingMode.ADMIN_WRITEABLE),
+                          SettingMode.ADMIN_READABLE),
                       SettingDescription.create(
                           "SESSION_REPLAY_PROTECTION_ENABLED",
                           "(NOT FOR PRODUCTION USE) Enable session replay protection, so that a"

--- a/server/app/views/admin/migration/AdminImportViewPartial.java
+++ b/server/app/views/admin/migration/AdminImportViewPartial.java
@@ -224,12 +224,12 @@ public final class AdminImportViewPartial extends BaseHtmlView {
   }
 
   /** Renders a message saying the program was successfully saved. */
-  public DomContent renderProgramSaved(Http.Request request, String programName, Long programId) {
+  public DomContent renderProgramSaved(String programName, Long programId) {
     String successText =
         programName
             + " and its questions have been imported to your program dashboard. To view it,  visit"
             + " the program dashboard.";
-    if (settingsManifest.getNoDuplicateQuestionsForMigrationEnabled(request)) {
+    if (settingsManifest.getNoDuplicateQuestionsForMigrationEnabled()) {
       successText += " Before you import another program, you will need to publish all drafts.";
     }
     return div()
@@ -247,7 +247,7 @@ public final class AdminImportViewPartial extends BaseHtmlView {
                             routes.AdminProgramBlocksController.index(programId).url())
                         .withClasses("usa-button", "mr-2"))
                 .condWith(
-                    !settingsManifest.getNoDuplicateQuestionsForMigrationEnabled(request),
+                    !settingsManifest.getNoDuplicateQuestionsForMigrationEnabled(),
                     asRedirectElement(
                             button("Import another program"),
                             routes.AdminImportController.index().url())

--- a/server/conf/env-var-docs.json
+++ b/server/conf/env-var-docs.json
@@ -933,7 +933,7 @@
     "group_description": "These are __NOT READY FOR PRODUCTION USE__. Use these configuration options to enable or disable in-development features.",
     "members": {
       "NO_DUPLICATE_QUESTIONS_FOR_MIGRATION_ENABLED": {
-        "mode": "ADMIN_WRITEABLE",
+        "mode": "ADMIN_READABLE",
         "description": "(NOT FOR PRODUCTION USE) Ensures duplicate questions aren't created when migrating programs between deployed environments. Note: this should only be used on new environments, since existing programs will be modified if a program with the same question gets imported.",
         "type": "bool"
       },

--- a/server/test/controllers/admin/AdminImportControllerTest.java
+++ b/server/test/controllers/admin/AdminImportControllerTest.java
@@ -1,7 +1,6 @@
 package controllers.admin;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static play.mvc.Http.Status.OK;
@@ -99,7 +98,7 @@ public class AdminImportControllerTest extends ResetPostgres {
 
   @Test
   public void hxImportProgram_noDuplicatesEnabled_malformattedJson_error() {
-    when(mockSettingsManifest.getNoDuplicateQuestionsForMigrationEnabled(any())).thenReturn(true);
+    when(mockSettingsManifest.getNoDuplicateQuestionsForMigrationEnabled()).thenReturn(true);
 
     Result result =
         controller.hxImportProgram(
@@ -134,7 +133,7 @@ public class AdminImportControllerTest extends ResetPostgres {
 
   @Test
   public void hxImportProgram_noDuplicatesEnabled_noTopLevelProgramFieldInJson_error() {
-    when(mockSettingsManifest.getNoDuplicateQuestionsForMigrationEnabled(any())).thenReturn(true);
+    when(mockSettingsManifest.getNoDuplicateQuestionsForMigrationEnabled()).thenReturn(true);
 
     Result result =
         controller.hxImportProgram(
@@ -173,7 +172,7 @@ public class AdminImportControllerTest extends ResetPostgres {
 
   @Test
   public void hxImportProgram_noDuplicatesEnabled_notEnoughInfoToCreateProgramDef_error() {
-    when(mockSettingsManifest.getNoDuplicateQuestionsForMigrationEnabled(any())).thenReturn(true);
+    when(mockSettingsManifest.getNoDuplicateQuestionsForMigrationEnabled()).thenReturn(true);
 
     Result result =
         controller.hxImportProgram(
@@ -216,7 +215,7 @@ public class AdminImportControllerTest extends ResetPostgres {
 
   @Test
   public void hxImportProgram_noDuplicatesEnabled_programAlreadyExists_error() {
-    when(mockSettingsManifest.getNoDuplicateQuestionsForMigrationEnabled(any())).thenReturn(true);
+    when(mockSettingsManifest.getNoDuplicateQuestionsForMigrationEnabled()).thenReturn(true);
 
     // save a program
     controller.hxSaveProgram(
@@ -296,7 +295,7 @@ public class AdminImportControllerTest extends ResetPostgres {
 
   @Test
   public void hxImportProgram_noDuplicatesEnabled_draftProgramExists_error() {
-    when(mockSettingsManifest.getNoDuplicateQuestionsForMigrationEnabled(any())).thenReturn(true);
+    when(mockSettingsManifest.getNoDuplicateQuestionsForMigrationEnabled()).thenReturn(true);
 
     // Create a draft program, so that there are unpublished programs
     ProgramBuilder.newDraftProgram("draft-program").build();
@@ -318,7 +317,7 @@ public class AdminImportControllerTest extends ResetPostgres {
 
   @Test
   public void hxImportProgram_noDuplicatesEnabled_draftQuestionExists_error() {
-    when(mockSettingsManifest.getNoDuplicateQuestionsForMigrationEnabled(any())).thenReturn(true);
+    when(mockSettingsManifest.getNoDuplicateQuestionsForMigrationEnabled()).thenReturn(true);
 
     // Create a draft question, so there is an unpublished question
     versionRepository
@@ -360,7 +359,7 @@ public class AdminImportControllerTest extends ResetPostgres {
   @Test
   public void
       hxImportProgram_noDuplicatesEnabled_jsonHasAllProgramInfo_resultHasProgramAndQuestionInfo() {
-    when(mockSettingsManifest.getNoDuplicateQuestionsForMigrationEnabled(any())).thenReturn(true);
+    when(mockSettingsManifest.getNoDuplicateQuestionsForMigrationEnabled()).thenReturn(true);
 
     Result result =
         controller.hxImportProgram(
@@ -400,7 +399,7 @@ public class AdminImportControllerTest extends ResetPostgres {
 
   @Test
   public void hxSaveProgram_noDuplicatesEnabled_savesTheProgramWithoutQuestions() {
-    when(mockSettingsManifest.getNoDuplicateQuestionsForMigrationEnabled(any())).thenReturn(true);
+    when(mockSettingsManifest.getNoDuplicateQuestionsForMigrationEnabled()).thenReturn(true);
 
     Result result =
         controller.hxSaveProgram(
@@ -456,7 +455,7 @@ public class AdminImportControllerTest extends ResetPostgres {
 
   @Test
   public void hxSaveProgram_noDuplicatesEnabled_savesTheProgramWithQuestions() {
-    when(mockSettingsManifest.getNoDuplicateQuestionsForMigrationEnabled(any())).thenReturn(true);
+    when(mockSettingsManifest.getNoDuplicateQuestionsForMigrationEnabled()).thenReturn(true);
 
     Result result =
         controller.hxSaveProgram(
@@ -531,7 +530,7 @@ public class AdminImportControllerTest extends ResetPostgres {
 
   @Test
   public void hxSaveProgram_noDuplicatesEnabled_handlesNestEnumeratorQuestions() {
-    when(mockSettingsManifest.getNoDuplicateQuestionsForMigrationEnabled(any())).thenReturn(true);
+    when(mockSettingsManifest.getNoDuplicateQuestionsForMigrationEnabled()).thenReturn(true);
 
     Result result =
         controller.hxSaveProgram(
@@ -670,7 +669,7 @@ public class AdminImportControllerTest extends ResetPostgres {
   @Test
   public void hxSaveProgram_noDuplicatesEnabled_savesUpdatedQuestionIdsOnPredicates()
       throws ProgramBlockDefinitionNotFoundException {
-    when(mockSettingsManifest.getNoDuplicateQuestionsForMigrationEnabled(any())).thenReturn(true);
+    when(mockSettingsManifest.getNoDuplicateQuestionsForMigrationEnabled()).thenReturn(true);
 
     Result result =
         controller.hxSaveProgram(
@@ -788,7 +787,7 @@ public class AdminImportControllerTest extends ResetPostgres {
 
   @Test
   public void hxSaveProgram_noDuplicatesEnabled_discardsPaiTagsOnImportedQuestions() {
-    when(mockSettingsManifest.getNoDuplicateQuestionsForMigrationEnabled(any())).thenReturn(true);
+    when(mockSettingsManifest.getNoDuplicateQuestionsForMigrationEnabled()).thenReturn(true);
 
     Result result =
         controller.hxSaveProgram(
@@ -836,7 +835,7 @@ public class AdminImportControllerTest extends ResetPostgres {
 
   @Test
   public void hxSaveProgram_noDuplicatesEnabled_preservesUniversalSettingOnImportedQuestions() {
-    when(mockSettingsManifest.getNoDuplicateQuestionsForMigrationEnabled(any())).thenReturn(true);
+    when(mockSettingsManifest.getNoDuplicateQuestionsForMigrationEnabled()).thenReturn(true);
 
     Result result =
         controller.hxSaveProgram(
@@ -961,7 +960,7 @@ public class AdminImportControllerTest extends ResetPostgres {
 
   @Test
   public void hxSaveProgram_noDuplicatesEnabled_addsAnEmptyStatus() {
-    when(mockSettingsManifest.getNoDuplicateQuestionsForMigrationEnabled(any())).thenReturn(true);
+    when(mockSettingsManifest.getNoDuplicateQuestionsForMigrationEnabled()).thenReturn(true);
 
     controller.hxSaveProgram(
         fakeRequestBuilder()


### PR DESCRIPTION
### Description

The NO_DUPLICATE_QUESTIONS_FOR_MIGRATION_ENABLED is clobbered by the IMPORT_DUPLICATE_HANDLING_OPTIONS_ENABLED flag, which was deprecated and defaulted to true in #10993. It can be safely deprecated with a default value of false, since it was seldom used, and is clobbered by another flag that is default-true. Flag was originally introduced in #8532.

## Release notes

Makes the NO_DUPLICATE_QUESTIONS_FOR_MIGRATION_ENABLED admin-readable with a default value of `false`. This flag is clobbered by the IMPORT_DUPLICATE_HANDLING_OPTIONS_ENABLED flag, which is default-true.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from `civiform/eng-admin` as FYI (if the primary reviewer is not an admin and this PR includes functionality changes)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.