### PR TITLE
Only run eslint when needed

### DIFF
--- a/formatter/fmt
+++ b/formatter/fmt
@@ -153,25 +153,36 @@ else
   eslint_app_file_list="$(printf "%s" "${modified_ts}" | (grep -E "^server/app" || true) | sed 's/^/ ..\//' | tr -d '\n')"
   eslint_browsertest_file_list="$(printf "%s" "${modified_ts}" | (grep -E "^browser-test" || true) | sed 's/^/ ..\//' | tr -d '\n')"
 
-  echo "Run eslint on /server"
-  cd server
-  npm install --silent
+  if [[ -z "${eslint_app_file_list}" ]]; then
+    echo "No modified files for /server. Skipping eslint."
+  else
+    echo "Run eslint on /server"
+    cd server
+    npm install --silent
 
-  # The eslint_app_file_list array should not be surrounded by quotes, in this case
-  # we want word splitting to occur so eslint will operate in each file. If
-  # quoted it gets treated as a single path.
-  npx eslint --fix ${eslint_app_file_list[@]}
+    # The eslint_app_file_list array should not be surrounded by quotes, in this case
+    # we want word splitting to occur so eslint will operate in each file. If
+    # quoted it gets treated as a single path.
+    npx eslint --fix ${eslint_app_file_list[@]}
 
-  echo "Run eslint on /browser-test"
-  cd ../browser-test
-  npm install --silent
+    cd ..
+  fi
 
-  # The eslint_browsertest_file_list array should not be surrounded by quotes, in this case
-  # we want word splitting to occur so eslint will operate in each file. If
-  # quoted it gets treated as a single path.
-  npx eslint --fix ${eslint_browsertest_file_list[@]}
+  if [[ -z "${eslint_browsertest_file_list}" ]]; then
+    echo "No modified files for /browser-test. Skipping eslint."
+  else
+    echo "Run eslint on /browser-test"
+    cd browser-test
+    npm install --silent
 
-  cd ..
+    # The eslint_browsertest_file_list array should not be surrounded by quotes, in this case
+    # we want word splitting to occur so eslint will operate in each file. If
+    # quoted it gets treated as a single path.
+    npx eslint --fix ${eslint_browsertest_file_list[@]}
+
+    cd ..
+  fi
+
   echo 'Done formatting with eslint'
 fi
 


### PR DESCRIPTION
### Description

Only run eslint when needed.

/server was running against all files which was slow. So I fixed it.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if the primary reviewer is not an admin and this PR includes functionality changes)
- [ ] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

