### PR TITLE
[Date validation] Add server validation for admin start/end year settings

### DIFF
--- a/server/app/services/question/types/DateQuestionDefinition.java
+++ b/server/app/services/question/types/DateQuestionDefinition.java
@@ -141,10 +141,8 @@ public final class DateQuestionDefinition extends QuestionDefinition {
           CiviFormError.of(
               "Specific date must be empty if start and end date are not \"Custom date\""));
     }
-    // Custom date may be empty if any of the date parts were missing, or if they did not represent
-    // a valid LocalDate
-    if ((minDateOption.dateType() == CUSTOM && !hasValidCustomDate(minDateOption))
-        || (maxDateOption.dateType() == CUSTOM && !hasValidCustomDate(maxDateOption))) {
+    if ((minDateOption.dateType() == CUSTOM && !hasValidDate(minDateOption))
+        || (maxDateOption.dateType() == CUSTOM && !hasValidDate(maxDateOption))) {
       errors.add(CiviFormError.of("A valid date is required for custom start and end dates"));
     } else {
       // At least one custom date is present. Check that custom dates represent valid date ranges.
@@ -167,10 +165,11 @@ public final class DateQuestionDefinition extends QuestionDefinition {
     return errors.build();
   }
 
-  private boolean hasValidCustomDate(DateValidationOption option) {
-    // Year must be a positive 4-digit number
+  private boolean hasValidDate(DateValidationOption option) {
+    // Date may be empty if any of the date parts were missing, or if they did not represent a valid
+    // LocalDate
     return option.customDate().isPresent()
-        && option.customDate().get().getYear() > 999
+        && option.customDate().get().getYear() > 999 // Year must be a positive 4-digit number
         && option.customDate().get().getYear() < 10000;
   }
 

--- a/server/app/services/question/types/DateQuestionDefinition.java
+++ b/server/app/services/question/types/DateQuestionDefinition.java
@@ -143,8 +143,12 @@ public final class DateQuestionDefinition extends QuestionDefinition {
     }
     // Custom date may be empty if any of the date parts were missing, or if they did not represent
     // a valid LocalDate
-    if ((minDateOption.dateType() == CUSTOM && minDateOption.customDate().isEmpty())
-        || (maxDateOption.dateType() == CUSTOM && maxDateOption.customDate().isEmpty())) {
+    if ((minDateOption.dateType() == CUSTOM
+            && (minDateOption.customDate().isEmpty()
+                || !hasValidYear(minDateOption.customDate().get())))
+        || (maxDateOption.dateType() == CUSTOM
+            && (maxDateOption.customDate().isEmpty()
+                || !hasValidYear(maxDateOption.customDate().get())))) {
       errors.add(CiviFormError.of("A valid date is required for custom start and end dates"));
     } else {
       // At least one custom date is present. Check that custom dates represent valid date ranges.
@@ -165,6 +169,11 @@ public final class DateQuestionDefinition extends QuestionDefinition {
       }
     }
     return errors.build();
+  }
+
+  /* Year must be a positive 4-digit number */
+  private boolean hasValidYear(LocalDate date) {
+    return date.getYear() > 999 && date.getYear() < 10000;
   }
 
   @JsonIgnore

--- a/server/app/services/question/types/DateQuestionDefinition.java
+++ b/server/app/services/question/types/DateQuestionDefinition.java
@@ -143,12 +143,8 @@ public final class DateQuestionDefinition extends QuestionDefinition {
     }
     // Custom date may be empty if any of the date parts were missing, or if they did not represent
     // a valid LocalDate
-    if ((minDateOption.dateType() == CUSTOM
-            && (minDateOption.customDate().isEmpty()
-                || !hasValidYear(minDateOption.customDate().get())))
-        || (maxDateOption.dateType() == CUSTOM
-            && (maxDateOption.customDate().isEmpty()
-                || !hasValidYear(maxDateOption.customDate().get())))) {
+    if ((minDateOption.dateType() == CUSTOM && !hasValidCustomDate(minDateOption))
+        || (maxDateOption.dateType() == CUSTOM && !hasValidCustomDate(maxDateOption))) {
       errors.add(CiviFormError.of("A valid date is required for custom start and end dates"));
     } else {
       // At least one custom date is present. Check that custom dates represent valid date ranges.
@@ -171,9 +167,11 @@ public final class DateQuestionDefinition extends QuestionDefinition {
     return errors.build();
   }
 
-  /* Year must be a positive 4-digit number */
-  private boolean hasValidYear(LocalDate date) {
-    return date.getYear() > 999 && date.getYear() < 10000;
+  private boolean hasValidCustomDate(DateValidationOption option) {
+    // Year must be a positive 4-digit number
+    return option.customDate().isPresent()
+        && option.customDate().get().getYear() > 999
+        && option.customDate().get().getYear() < 10000;
   }
 
   @JsonIgnore

--- a/server/test/services/question/types/DateQuestionDefinitionTest.java
+++ b/server/test/services/question/types/DateQuestionDefinitionTest.java
@@ -26,10 +26,15 @@ public class DateQuestionDefinitionTest {
       DateValidationOption.builder().setDateType(DateType.APPLICATION_DATE).build();
   private static final DateValidationOption EMPTY_CUSTOM_DATE =
       DateValidationOption.builder().setDateType(DateType.CUSTOM).build();
-  private static final DateValidationOption INVALID_CUSTOM_DATE =
+  private static final DateValidationOption CUSTOM_DATE_INVALID_TYPE =
       DateValidationOption.builder()
           .setDateType(DateType.ANY)
           .setCustomDate(Optional.of(LocalDate.of(2025, 1, 1)))
+          .build();
+  private static final DateValidationOption CUSTOM_DATE_INVALID_YEAR =
+      DateValidationOption.builder()
+          .setDateType(DateType.CUSTOM)
+          .setCustomDate(Optional.of(LocalDate.of(999999, 1, 1)))
           .build();
 
   @SuppressWarnings({"JavaTimeDefaultTimeZone", "TimeInStaticInitializer"})
@@ -71,7 +76,12 @@ public class DateQuestionDefinitionTest {
         },
         new Object[] {
           Optional.of(ANY_DATE),
-          Optional.of(INVALID_CUSTOM_DATE),
+          Optional.of(CUSTOM_DATE_INVALID_YEAR),
+          Optional.of("A valid date is required for custom start and end dates")
+        },
+        new Object[] {
+          Optional.of(ANY_DATE),
+          Optional.of(CUSTOM_DATE_INVALID_TYPE),
           Optional.of("Specific date must be empty if start and end date are not \"Custom date\"")
         },
         new Object[] {
@@ -100,7 +110,12 @@ public class DateQuestionDefinitionTest {
           Optional.of("A valid date is required for custom start and end dates")
         },
         new Object[] {
-          Optional.of(INVALID_CUSTOM_DATE),
+          Optional.of(CUSTOM_DATE_INVALID_YEAR),
+          Optional.of(ANY_DATE),
+          Optional.of("A valid date is required for custom start and end dates")
+        },
+        new Object[] {
+          Optional.of(CUSTOM_DATE_INVALID_TYPE),
           Optional.of(ANY_DATE),
           Optional.of("Specific date must be empty if start and end date are not \"Custom date\"")
         },


### PR DESCRIPTION
### Description

Add server validation for admin year values. This is currently done in the client, but it's possible to remove the client validation and still enter and submit a non 4 digit year.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if the primary reviewer is not an admin and this PR includes functionality changes)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.


### Issue(s) this completes

Part of #5677