### PR TITLE
[Refactor] Use getByRole in admin_predicates.ts

### DIFF
--- a/browser-test/src/support/admin_predicates.ts
+++ b/browser-test/src/support/admin_predicates.ts
@@ -71,11 +71,11 @@ export class AdminPredicates {
   }
 
   async clickAddConditionButton() {
-    await this.page.click('button:has-text("Add condition")')
+    await this.page.getByRole('button', {name: 'Add condition'}).click()
   }
 
   async clickSaveConditionButton() {
-    await this.page.click('button:visible:has-text("Save condition")')
+    await this.page.getByRole('button', {name: 'Save condition'}).click()
   }
 
   async expectPredicateErrorToast(type: string) {


### PR DESCRIPTION
### Description

Use `getByRole` instead of `[getByText](button:has-text)` because it tests elements the way users (including those using assistive technologies) actually interact with them, making tests  more accessible and robust against UI changes.

### Issue(s) this completes

None
