### PR TITLE
Add test.slow to fast forward tests

### DIFF
--- a/browser-test/src/applicant/application_version_fast_forward.test.ts
+++ b/browser-test/src/applicant/application_version_fast_forward.test.ts
@@ -22,6 +22,8 @@ test.describe('Application Version Fast-Forward Flow', () => {
   })
 
   test('all major steps', async ({browser}) => {
+    test.slow()
+
     const programName = 'program-fastforward-example'
 
     const civiformAdminActor = await FastForwardCiviformAdminActor.create(

--- a/browser-test/src/applicant/northstar_application_version_fast_forward.test.ts
+++ b/browser-test/src/applicant/northstar_application_version_fast_forward.test.ts
@@ -29,6 +29,8 @@ test.describe(
     })
 
     test('all major steps', async ({browser}) => {
+      test.slow()
+
       const programName = 'program-fastforward-example'
 
       const civiformAdminActor = await FastForwardCiviformAdminActor.create(


### PR DESCRIPTION
Adding test.slow to a couple of tests that were timing out in aws staging prober tests.