### PR TITLE
Remove NO_DUPLICATE_QUESTIONS_FOR_MIGRATION flag

### DIFF
--- a/server/app/services/settings/SettingsManifest.java
+++ b/server/app/services/settings/SettingsManifest.java
@@ -1070,15 +1070,6 @@ public final class SettingsManifest extends AbstractSettingsManifest {
   }
 
   /**
-   * (NOT FOR PRODUCTION USE) Ensures duplicate questions aren't created when migrating programs
-   * between deployed environments. Note: this should only be used on new environments, since
-   * existing programs will be modified if a program with the same question gets imported.
-   */
-  public boolean getNoDuplicateQuestionsForMigrationEnabled() {
-    return getBool("NO_DUPLICATE_QUESTIONS_FOR_MIGRATION_ENABLED");
-  }
-
-  /**
    * (NOT FOR PRODUCTION USE) Enable session replay protection, so that a session cookie cannot be
    * replayed if the user logs out
    */
@@ -2324,16 +2315,6 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                       + " enable or disable in-development features.",
                   ImmutableList.of(),
                   ImmutableList.of(
-                      SettingDescription.create(
-                          "NO_DUPLICATE_QUESTIONS_FOR_MIGRATION_ENABLED",
-                          "(NOT FOR PRODUCTION USE) Ensures duplicate questions aren't created when"
-                              + " migrating programs between deployed environments. Note: this"
-                              + " should only be used on new environments, since existing programs"
-                              + " will be modified if a program with the same question gets"
-                              + " imported.",
-                          /* isRequired= */ false,
-                          SettingType.BOOLEAN,
-                          SettingMode.ADMIN_READABLE),
                       SettingDescription.create(
                           "SESSION_REPLAY_PROTECTION_ENABLED",
                           "(NOT FOR PRODUCTION USE) Enable session replay protection, so that a"

--- a/server/conf/env-var-docs.json
+++ b/server/conf/env-var-docs.json
@@ -933,11 +933,6 @@
   "Experimental": {
     "group_description": "These are __NOT READY FOR PRODUCTION USE__. Use these configuration options to enable or disable in-development features.",
     "members": {
-      "NO_DUPLICATE_QUESTIONS_FOR_MIGRATION_ENABLED": {
-        "mode": "ADMIN_READABLE",
-        "description": "(NOT FOR PRODUCTION USE) Ensures duplicate questions aren't created when migrating programs between deployed environments. Note: this should only be used on new environments, since existing programs will be modified if a program with the same question gets imported.",
-        "type": "bool"
-      },
       "SESSION_REPLAY_PROTECTION_ENABLED": {
         "mode": "ADMIN_READABLE",
         "description": "(NOT FOR PRODUCTION USE) Enable session replay protection, so that a session cookie cannot be replayed if the user logs out",

--- a/server/conf/helper/feature-flags.conf
+++ b/server/conf/helper/feature-flags.conf
@@ -43,10 +43,6 @@ suggest_programs_on_application_confirmation_page = ${?SUGGEST_PROGRAMS_ON_APPLI
 north_star_applicant_ui = false
 north_star_applicant_ui = ${?NORTH_STAR_APPLICANT_UI}
 
-# Ensure no duplicate questions during program migration
-no_duplicate_questions_for_migration_enabled = false
-no_duplicate_questions_for_migration_enabled = ${?NO_DUPLICATE_QUESTIONS_FOR_MIGRATION_ENABLED}
-
 # Enable to show a banner that tells users this is not a production site
 show_not_production_banner_enabled = false
 show_not_production_banner_enabled = ${?SHOW_NOT_PRODUCTION_BANNER_ENABLED}


### PR DESCRIPTION
### Description

Removes the default-off and currently clobbered `NO_DUPLICATE_QUESTIONS_FOR_MIGRATION` feature flag. #9628 

## Release notes

Removes the default-off and currently clobbered `NO_DUPLICATE_QUESTIONS_FOR_MIGRATION` feature flag.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if the primary reviewer is not an admin and this PR includes functionality changes)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.