### PR TITLE
Remove the program filtering feature flag and all of its uses

### DIFF
--- a/server/app/services/settings/SettingsManifest.java
+++ b/server/app/services/settings/SettingsManifest.java
@@ -1046,11 +1046,6 @@ public final class SettingsManifest extends AbstractSettingsManifest {
     return getBool("NORTH_STAR_APPLICANT_UI", request);
   }
 
-  /** Enables filtering programs by category on the homepage */
-  public boolean getProgramFilteringEnabled() {
-    return getBool("PROGRAM_FILTERING_ENABLED");
-  }
-
   /** Enable using custom theme colors on North Star applicant UI. */
   public boolean getCustomThemeColorsEnabled(RequestHeader request) {
     return getBool("CUSTOM_THEME_COLORS_ENABLED", request);
@@ -2295,12 +2290,6 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                           /* isRequired= */ false,
                           SettingType.BOOLEAN,
                           SettingMode.ADMIN_WRITEABLE),
-                      SettingDescription.create(
-                          "PROGRAM_FILTERING_ENABLED",
-                          "Enables filtering programs by category on the homepage",
-                          /* isRequired= */ false,
-                          SettingType.BOOLEAN,
-                          SettingMode.ADMIN_READABLE),
                       SettingDescription.create(
                           "CUSTOM_THEME_COLORS_ENABLED",
                           "Enable using custom theme colors on North Star applicant UI.",

--- a/server/app/views/ProgramImageUtils.java
+++ b/server/app/views/ProgramImageUtils.java
@@ -29,10 +29,7 @@ public final class ProgramImageUtils {
    *     card we show to applicants and false if this image will be shown on its own.
    */
   public Optional<ImgTag> createProgramImage(
-      ProgramDefinition program,
-      Locale preferredLocale,
-      boolean isWithinProgramCard,
-      boolean isProgramFilteringEnabled) {
+      ProgramDefinition program, Locale preferredLocale, boolean isWithinProgramCard) {
     if (program.summaryImageFileKey().isEmpty()) {
       return Optional.empty();
     }
@@ -43,13 +40,8 @@ public final class ProgramImageUtils {
 
     String styleClasses = StyleUtils.joinStyles("w-full", "aspect-video", "object-cover");
     if (isWithinProgramCard) {
-      if (isProgramFilteringEnabled) {
-        // Round all corners when showing the image in context of a program card with filtering.
-        styleClasses = StyleUtils.joinStyles(styleClasses, "rounded-lg");
-      } else {
-        // Only round the bottom corners when showing the image in context of a program card.
-        styleClasses = StyleUtils.joinStyles(styleClasses, "rounded-b-lg");
-      }
+      // Round all corners when showing the image in context of a program card with filtering.
+      styleClasses = StyleUtils.joinStyles(styleClasses, "rounded-lg");
     }
 
     return Optional.of(

--- a/server/app/views/admin/programs/ProgramBaseView.java
+++ b/server/app/views/admin/programs/ProgramBaseView.java
@@ -2,7 +2,6 @@ package views.admin.programs;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static j2html.TagCreator.div;
-import static j2html.TagCreator.iff;
 import static j2html.TagCreator.iffElse;
 import static j2html.TagCreator.li;
 import static j2html.TagCreator.span;
@@ -116,7 +115,7 @@ abstract class ProgramBaseView extends BaseHtmlView {
             title,
             description,
             adminNote,
-            iff(settingsManifest.getProgramFilteringEnabled(), categoriesDiv),
+            categoriesDiv,
             headerButtonsDiv)
         .withClasses("bg-gray-100", "text-gray-800", "shadow-md", "p-8", "pt-4", "-mx-2");
   }

--- a/server/app/views/admin/programs/ProgramFormBuilder.java
+++ b/server/app/views/admin/programs/ProgramFormBuilder.java
@@ -236,7 +236,7 @@ abstract class ProgramFormBuilder extends BaseHtmlView {
             .withClasses("usa-fieldset", SPACE_BETWEEN_FORM_ELEMENTS),
         // Program categories
         iff(
-            settingsManifest.getProgramFilteringEnabled() && !categoryOptions.isEmpty(),
+            !categoryOptions.isEmpty(),
             showCategoryCheckboxes(categoryOptions, categories, isCommonIntakeForm)),
         // Program visibility
         fieldset(

--- a/server/app/views/admin/programs/ProgramImageView.java
+++ b/server/app/views/admin/programs/ProgramImageView.java
@@ -357,7 +357,6 @@ public final class ProgramImageView extends BaseHtmlView {
             messages.lang().toLocale(),
             MessageKey.BUTTON_APPLY,
             MessageKey.BUTTON_APPLY_SR,
-            /* nestedUnderSubheading= */ false,
             layout.getBundle(request),
             profile,
             zoneId,

--- a/server/app/views/applicant/ProgramIndexView.java
+++ b/server/app/views/applicant/ProgramIndexView.java
@@ -91,34 +91,18 @@ public final class ProgramIndexView extends BaseHtmlView {
             .setCondOnStorageKey("session_just_ended")
             .setDuration(5000));
 
-    // TODO(#7610): When the program filtering flag is removed, we can remove this conditional
-    // statement.
-    if (settingsManifest.getProgramFilteringEnabled()) {
-      bundle.addMainContent(
-          topContent(request, messages, personalInfo),
-          mainContentWithProgramFiltersEnabled(
-              request,
-              messages,
-              personalInfo,
-              applicationPrograms,
-              selectedCategoriesFromParams,
-              applicantId,
-              messages.lang().toLocale(),
-              bundle,
-              profile));
-    } else {
-      bundle.addMainContent(
-          topContent(request, messages, personalInfo),
-          mainContent(
-              request,
-              messages,
-              personalInfo,
-              applicationPrograms,
-              applicantId,
-              messages.lang().toLocale(),
-              bundle,
-              profile));
-    }
+    bundle.addMainContent(
+        topContent(request, messages, personalInfo),
+        mainContent(
+            request,
+            messages,
+            personalInfo,
+            applicationPrograms,
+            selectedCategoriesFromParams,
+            applicantId,
+            messages.lang().toLocale(),
+            bundle,
+            profile));
 
     return layout.renderWithNav(
         request, personalInfo, messages, bundle, /* includeAdminLogin= */ true, applicantId);
@@ -225,104 +209,6 @@ public final class ProgramIndexView extends BaseHtmlView {
       Messages messages,
       ApplicantPersonalInfo personalInfo,
       ApplicantService.ApplicationPrograms relevantPrograms,
-      Optional<Long> applicantId,
-      Locale preferredLocale,
-      HtmlBundle bundle,
-      Optional<CiviFormProfile> profile) {
-    DivTag content =
-        div().withId("main-content").withClasses(ApplicantStyles.PROGRAM_CARDS_PARENT_CONTAINER);
-
-    // The different program card containers should have the same styling, by using the program
-    // count of the larger set of programs
-    String cardContainerStyles =
-        programCardViewRenderer.programCardsContainerStyles(
-            Math.max(
-                Math.max(relevantPrograms.unapplied().size(), relevantPrograms.submitted().size()),
-                relevantPrograms.inProgress().size()));
-
-    if (relevantPrograms.preScreenerForm().isPresent()) {
-      content.with(
-          findServicesSection(
-              request,
-              messages,
-              personalInfo,
-              relevantPrograms,
-              cardContainerStyles,
-              applicantId,
-              preferredLocale,
-              bundle,
-              profile),
-          div().withClass("mb-12"),
-          programSectionTitle(
-              messages.at(
-                  MessageKey.TITLE_ALL_PROGRAMS_SECTION.getKeyName(),
-                  relevantPrograms.inProgress().size()
-                      + relevantPrograms.submitted().size()
-                      + relevantPrograms.unapplied().size())));
-    } else {
-      content.with(programSectionTitle(messages.at(MessageKey.TITLE_PROGRAMS.getKeyName())));
-    }
-
-    if (!relevantPrograms.inProgress().isEmpty()) {
-      content.with(
-          programCardViewRenderer.programCardsSection(
-              request,
-              messages,
-              personalInfo,
-              Optional.of(MessageKey.TITLE_PROGRAMS_IN_PROGRESS_UPDATED),
-              cardContainerStyles,
-              applicantId,
-              preferredLocale,
-              relevantPrograms.inProgress(),
-              MessageKey.BUTTON_CONTINUE,
-              MessageKey.BUTTON_CONTINUE_SR,
-              bundle,
-              profile,
-              /* isMyApplicationsSection= */ false));
-    }
-    if (!relevantPrograms.submitted().isEmpty()) {
-      content.with(
-          programCardViewRenderer.programCardsSection(
-              request,
-              messages,
-              personalInfo,
-              Optional.of(MessageKey.TITLE_PROGRAMS_SUBMITTED),
-              cardContainerStyles,
-              applicantId,
-              preferredLocale,
-              relevantPrograms.submitted(),
-              MessageKey.BUTTON_EDIT,
-              MessageKey.BUTTON_EDIT_SR,
-              bundle,
-              profile,
-              /* isMyApplicationsSection= */ false));
-    }
-    if (!relevantPrograms.unapplied().isEmpty()) {
-      content.with(
-          programCardViewRenderer.programCardsSection(
-              request,
-              messages,
-              personalInfo,
-              Optional.of(MessageKey.TITLE_PROGRAMS_ACTIVE_UPDATED),
-              cardContainerStyles,
-              applicantId,
-              preferredLocale,
-              relevantPrograms.unapplied(),
-              MessageKey.BUTTON_APPLY,
-              MessageKey.BUTTON_APPLY_SR,
-              bundle,
-              profile,
-              /* isMyApplicationsSection= */ false));
-    }
-
-    return div().withClasses(ApplicantStyles.PROGRAM_CARDS_GRANDPARENT_CONTAINER).with(content);
-  }
-
-  private DivTag mainContentWithProgramFiltersEnabled(
-      Http.Request request,
-      Messages messages,
-      ApplicantPersonalInfo personalInfo,
-      ApplicantService.ApplicationPrograms relevantPrograms,
       ImmutableList<String> selectedCategoriesFromParams,
       Optional<Long> applicantId,
       Locale preferredLocale,
@@ -396,7 +282,7 @@ public final class ProgramIndexView extends BaseHtmlView {
     }
 
     // The category buttons
-    if (settingsManifest.getProgramFilteringEnabled() && !relevantCategories.isEmpty()) {
+    if (!relevantCategories.isEmpty()) {
       content.with(
           renderCategoryFilterChips(
               profile, applicantId, relevantCategories, selectedCategoriesFromParams, messages));
@@ -559,10 +445,7 @@ public final class ProgramIndexView extends BaseHtmlView {
       }
     }
 
-    String titleMessage =
-        settingsManifest.getProgramFilteringEnabled()
-            ? messages.at(MessageKey.TITLE_BENEFITS_FINDER_SECTION_V2.getKeyName())
-            : messages.at(MessageKey.TITLE_FIND_SERVICES_SECTION.getKeyName());
+    String titleMessage = messages.at(MessageKey.TITLE_BENEFITS_FINDER_SECTION_V2.getKeyName());
 
     return div()
         .withClass(ReferenceClasses.APPLICATION_PROGRAM_SECTION)

--- a/server/app/views/components/ProgramCardFactory.java
+++ b/server/app/views/components/ProgramCardFactory.java
@@ -44,7 +44,6 @@ public final class ProgramCardFactory {
 
   public DivTag renderCard(ProgramCardData cardData, Http.Request request) {
     ProgramDefinition displayProgram = getDisplayProgram(cardData);
-    boolean showCategories = settingsManifest.getProgramFilteringEnabled();
     boolean northStarEnabled = settingsManifest.getNorthStarApplicantUi(request);
 
     String programTitleText = displayProgram.localizedName().getDefault();
@@ -117,16 +116,14 @@ public final class ProgramCardFactory {
                                 span("Visibility state: ").withClasses("font-semibold"),
                                 span(displayProgram.displayMode().visibilityState))
                             .withClasses(
-                                "text-sm", StyleUtils.responsiveLarge("text-base"), "mb-4"))
-                    .condWith(
-                        showCategories,
-                        p(
-                                span("Categories:  ").withClasses("font-semibold"),
-                                iffElse(
-                                    programCategoryNames.isEmpty(),
-                                    span("None"),
-                                    span(String.join(", ", programCategoryNames))))
-                            .withClasses("text-sm", StyleUtils.responsiveLarge("text-base"))),
+                                "text-sm", StyleUtils.responsiveLarge("text-base"), "mb-4")),
+                p(
+                        span("Categories:  ").withClasses("font-semibold"),
+                        iffElse(
+                            programCategoryNames.isEmpty(),
+                            span("None"),
+                            span(String.join(", ", programCategoryNames))))
+                    .withClasses("text-sm", StyleUtils.responsiveLarge("text-base")),
                 statusDiv.withClasses(
                     "flex-grow", "text-sm", StyleUtils.responsiveLarge("text-base")));
 
@@ -255,12 +252,7 @@ public final class ProgramCardFactory {
 
     Optional<ImgTag> image =
         programImageUtils.createProgramImage(
-            program,
-            Locale.getDefault(),
-            /* isWithinProgramCard= */ false,
-            /* isProgramFilteringEnabled= */ false); // Hardcoded to false because
-    // if isWithProgramCard is false, we never reach the code that evaluates
-    // isProgramFilteringEnabled.
+            program, Locale.getDefault(), /* isWithinProgramCard= */ false);
     if (image.isPresent()) {
       return div().withClasses("w-16", "h-9").with(image.get());
     }

--- a/server/app/views/components/ProgramCardFactory.java
+++ b/server/app/views/components/ProgramCardFactory.java
@@ -116,14 +116,15 @@ public final class ProgramCardFactory {
                                 span("Visibility state: ").withClasses("font-semibold"),
                                 span(displayProgram.displayMode().visibilityState))
                             .withClasses(
-                                "text-sm", StyleUtils.responsiveLarge("text-base"), "mb-4")),
-                p(
-                        span("Categories:  ").withClasses("font-semibold"),
-                        iffElse(
-                            programCategoryNames.isEmpty(),
-                            span("None"),
-                            span(String.join(", ", programCategoryNames))))
-                    .withClasses("text-sm", StyleUtils.responsiveLarge("text-base")),
+                                "text-sm", StyleUtils.responsiveLarge("text-base"), "mb-4"))
+                    .with(
+                        p(
+                                span("Categories:  ").withClasses("font-semibold"),
+                                iffElse(
+                                    programCategoryNames.isEmpty(),
+                                    span("None"),
+                                    span(String.join(", ", programCategoryNames))))
+                            .withClasses("text-sm", StyleUtils.responsiveLarge("text-base"))),
                 statusDiv.withClasses(
                     "flex-grow", "text-sm", StyleUtils.responsiveLarge("text-base")));
 

--- a/server/conf/env-var-docs.json
+++ b/server/conf/env-var-docs.json
@@ -905,11 +905,6 @@
         "description": "Enables showing new UI with an updated user experience in Applicant flows",
         "type": "bool"
       },
-      "PROGRAM_FILTERING_ENABLED": {
-        "mode": "ADMIN_READABLE",
-        "description": "Enables filtering programs by category on the homepage",
-        "type": "bool"
-      },
       "CUSTOM_THEME_COLORS_ENABLED": {
         "mode": "ADMIN_WRITEABLE",
         "description": "Enable using custom theme colors on North Star applicant UI.",

--- a/server/conf/helper/feature-flags.conf
+++ b/server/conf/helper/feature-flags.conf
@@ -43,10 +43,6 @@ suggest_programs_on_application_confirmation_page = ${?SUGGEST_PROGRAMS_ON_APPLI
 north_star_applicant_ui = false
 north_star_applicant_ui = ${?NORTH_STAR_APPLICANT_UI}
 
-# Program filtering
-program_filtering_enabled = true
-program_filtering_enabled = ${?PROGRAM_FILTERING_ENABLED}
-
 # Ensure no duplicate questions during program migration
 no_duplicate_questions_for_migration_enabled = false
 no_duplicate_questions_for_migration_enabled = ${?NO_DUPLICATE_QUESTIONS_FOR_MIGRATION_ENABLED}

--- a/server/test/views/ProgramImageUtilsTest.java
+++ b/server/test/views/ProgramImageUtilsTest.java
@@ -31,10 +31,7 @@ public class ProgramImageUtilsTest extends ResetPostgres {
 
     Optional<ImgTag> result =
         programImageUtils.createProgramImage(
-            program,
-            Locale.getDefault(),
-            /* isWithinProgramCard= */ true,
-            /* isProgramFilteringEnabled= */ false);
+            program, Locale.getDefault(), /* isWithinProgramCard= */ true);
 
     assertThat(result).isEmpty();
   }
@@ -49,10 +46,7 @@ public class ProgramImageUtilsTest extends ResetPostgres {
 
     Optional<ImgTag> result =
         programImageUtils.createProgramImage(
-            program,
-            Locale.getDefault(),
-            /* isWithinProgramCard= */ true,
-            /* isProgramFilteringEnabled= */ false);
+            program, Locale.getDefault(), /* isWithinProgramCard= */ true);
 
     assertThat(result).isEmpty();
   }
@@ -67,10 +61,7 @@ public class ProgramImageUtilsTest extends ResetPostgres {
 
     Optional<ImgTag> result =
         programImageUtils.createProgramImage(
-            program,
-            Locale.getDefault(),
-            /* isWithinProgramCard= */ true,
-            /* isProgramFilteringEnabled= */ false);
+            program, Locale.getDefault(), /* isWithinProgramCard= */ true);
 
     assertThat(result).isNotEmpty();
   }
@@ -85,10 +76,7 @@ public class ProgramImageUtilsTest extends ResetPostgres {
 
     Optional<ImgTag> result =
         programImageUtils.createProgramImage(
-            program,
-            Locale.getDefault(),
-            /* isWithinProgramCard= */ true,
-            /* isProgramFilteringEnabled= */ false);
+            program, Locale.getDefault(), /* isWithinProgramCard= */ true);
 
     assertThat(result).isNotEmpty();
     String renderedImage = result.get().render();
@@ -107,10 +95,7 @@ public class ProgramImageUtilsTest extends ResetPostgres {
 
     Optional<ImgTag> result =
         programImageUtils.createProgramImage(
-            program,
-            Locale.CHINESE,
-            /* isWithinProgramCard= */ true,
-            /* isProgramFilteringEnabled= */ false);
+            program, Locale.CHINESE, /* isWithinProgramCard= */ true);
 
     assertThat(result).isNotEmpty();
     String renderedImage = result.get().render();
@@ -130,10 +115,7 @@ public class ProgramImageUtilsTest extends ResetPostgres {
 
     Optional<ImgTag> result =
         programImageUtils.createProgramImage(
-            program,
-            Locale.CHINESE,
-            /* isWithinProgramCard= */ true,
-            /* isProgramFilteringEnabled= */ false);
+            program, Locale.CHINESE, /* isWithinProgramCard= */ true);
 
     assertThat(result).isNotEmpty();
     String renderedImage = result.get().render();


### PR DESCRIPTION
### Description

The program filtering feature is complete.  This PR removes the feature flag entirely.

## Release notes

Program filtering is now always available in CiviForm.  It is no longer behind a feature flag.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if the primary reviewer is not an admin and this PR includes functionality changes)
- [ ] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.
