### PR TITLE
Remove scripts from NorthStarQuestionPreview

### DIFF
--- a/server/app/views/admin/questions/QuestionPreviewFragment.html
+++ b/server/app/views/admin/questions/QuestionPreviewFragment.html
@@ -9,7 +9,11 @@
     th:if="${question.getType().getLabel() != 'File Upload'}"
     th:replace="~{questiontypes/QuestionFragment :: applicant-question(${question}, ${questionRendererParams}, ${stateAbbreviations}, ${enumMaxEntityCount})}"
   ></div>
-  <div
-    th:replace="~{applicant/ApplicantBaseFragment :: pageFooterScripts}"
-  ></div>
+
+  <script
+    th:nonce="${cspNonce}"
+    th:src="${uswdsJsBundle}"
+    type="text/javascript"
+  ></script>
+
 </div>


### PR DESCRIPTION
### Description

Removing the `pageFooterScripts` from the `NorthStarQuestionPreview` Thymeleaf template. They are adding uswds to the page twice along with the applicant scripts which is causing unexpected behavior with the admin Question create/edit page.

Right now if you run Firefox with Northstar enabled saving the question results in an unneeded modal briefly flashing on the screen. It saves correctly, but is confusing and elicits feelings of dreads that it is broken.

After removing the extra scripts the preview still updates as you type when the question info is changed.


## Release notes

Preventing an unneeded modal from flashing on the screen when editing a question when using Firefox.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if the primary reviewer is not an admin and this PR includes functionality changes)
- [ ] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.
