### PR TITLE
Adding Display Mode to QuestionModel

### DIFF
--- a/server/app/models/QuestionDisplayMode.java
+++ b/server/app/models/QuestionDisplayMode.java
@@ -1,0 +1,21 @@
+package models;
+
+import io.ebean.annotation.DbEnumType;
+import io.ebean.annotation.DbEnumValue;
+
+/** Represents the display mode for a {@link QuestionModel} */
+public enum QuestionDisplayMode {
+  VISIBLE("Visible"),
+  HIDDEN("Hidden");
+
+  @DbEnumValue(storage = DbEnumType.VARCHAR)
+  public String getValue() {
+    return this.name();
+  }
+
+  public final String displayMode;
+
+  QuestionDisplayMode(String displayMode) {
+    this.displayMode = displayMode;
+  }
+}

--- a/server/app/models/QuestionModel.java
+++ b/server/app/models/QuestionModel.java
@@ -85,6 +85,8 @@ public class QuestionModel extends BaseModel {
   /** When the question was last modified. */
   @WhenModified private Instant lastModifiedTime;
 
+  private @Constraints.Required QuestionDisplayMode displayMode;
+
   private UUID concurrencyToken;
 
   @ManyToMany(mappedBy = "questions")
@@ -179,6 +181,7 @@ public class QuestionModel extends BaseModel {
             .setValidationPredicatesString(validationPredicates)
             .setLastModifiedTime(Optional.ofNullable(lastModifiedTime))
             .setUniversal(questionTags.contains(QuestionTag.UNIVERSAL))
+            .setDisplayMode(displayMode)
             .setPrimaryApplicantInfoTags(getPrimaryApplicantInfoTagsFromQuestionTags(questionTags));
 
     if (concurrencyToken != null) {
@@ -255,6 +258,7 @@ public class QuestionModel extends BaseModel {
     questionText = questionDefinition.getQuestionText();
     questionHelpText = questionDefinition.getQuestionHelpText();
     questionType = questionDefinition.getQuestionType().toString();
+    displayMode = questionDefinition.getDisplayMode();
     validationPredicates = questionDefinition.getValidationPredicatesAsString();
 
     if (questionDefinition.getQuestionType().isMultiOptionType()) {
@@ -331,5 +335,14 @@ public class QuestionModel extends BaseModel {
 
   public UUID getConcurrencyToken() {
     return this.concurrencyToken;
+  }
+
+  public QuestionDisplayMode getDisplayMode() {
+    return this.displayMode;
+  }
+
+  public QuestionModel setDisplayMode(QuestionDisplayMode displayMode) {
+    this.displayMode = displayMode;
+    return this;
   }
 }

--- a/server/app/services/question/types/NullQuestionDefinitionConfig.java
+++ b/server/app/services/question/types/NullQuestionDefinitionConfig.java
@@ -6,6 +6,7 @@ import java.util.Locale;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.UUID;
+import models.QuestionDisplayMode;
 import services.LocalizedStrings;
 import services.question.PrimaryApplicantInfoTag;
 
@@ -71,6 +72,11 @@ public class NullQuestionDefinitionConfig extends QuestionDefinitionConfig {
   @Override
   Optional<UUID> concurrencyToken() {
     return Optional.empty();
+  }
+
+  @Override
+  public QuestionDisplayMode displayMode() {
+    return QuestionDisplayMode.VISIBLE;
   }
 
   @Override
@@ -140,6 +146,11 @@ public class NullQuestionDefinitionConfig extends QuestionDefinitionConfig {
 
     @Override
     public QuestionDefinitionConfig.Builder setConcurrencyToken(UUID concurrencyToken) {
+      return this;
+    }
+
+    @Override
+    public QuestionDefinitionConfig.Builder setDisplayMode(QuestionDisplayMode display) {
       return this;
     }
 

--- a/server/app/services/question/types/QuestionDefinition.java
+++ b/server/app/services/question/types/QuestionDefinition.java
@@ -21,6 +21,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Random;
 import java.util.UUID;
+import models.QuestionDisplayMode;
 import services.CiviFormError;
 import services.LocalizedStrings;
 import services.Path;
@@ -68,6 +69,11 @@ public abstract class QuestionDefinition {
     }
 
     this.config = config;
+  }
+
+  @JsonIgnore
+  public QuestionDisplayMode getDisplayMode() {
+    return config.displayMode();
   }
 
   /**

--- a/server/app/services/question/types/QuestionDefinitionBuilder.java
+++ b/server/app/services/question/types/QuestionDefinitionBuilder.java
@@ -7,6 +7,7 @@ import java.util.Locale;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.UUID;
+import models.QuestionDisplayMode;
 import services.LocalizedStrings;
 import services.question.PrimaryApplicantInfoTag;
 import services.question.QuestionOption;
@@ -160,6 +161,11 @@ public final class QuestionDefinitionBuilder {
 
   public QuestionDefinitionBuilder setConcurrencyToken(UUID concurrencyToken) {
     builder.setConcurrencyToken(concurrencyToken);
+    return this;
+  }
+
+  public QuestionDefinitionBuilder setDisplayMode(QuestionDisplayMode displayMode) {
+    builder.setDisplayMode(displayMode);
     return this;
   }
 

--- a/server/app/services/question/types/QuestionDefinitionConfig.java
+++ b/server/app/services/question/types/QuestionDefinitionConfig.java
@@ -10,6 +10,7 @@ import java.time.Instant;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.UUID;
+import models.QuestionDisplayMode;
 import services.LocalizedStrings;
 import services.question.PrimaryApplicantInfoTag;
 
@@ -60,6 +61,9 @@ public abstract class QuestionDefinitionConfig {
   @JsonIgnore
   abstract Optional<UUID> concurrencyToken();
 
+  @JsonProperty("displayMode")
+  public abstract QuestionDisplayMode displayMode();
+
   @JsonProperty("universal")
   abstract boolean universal();
 
@@ -74,6 +78,7 @@ public abstract class QuestionDefinitionConfig {
   public static RequiredName builder() {
     return new AutoValue_QuestionDefinitionConfig.Builder()
         .setUniversal(false)
+        .setDisplayMode(QuestionDisplayMode.VISIBLE)
         .setPrimaryApplicantInfoTags(ImmutableSet.of());
   }
 
@@ -117,6 +122,9 @@ public abstract class QuestionDefinitionConfig {
     public abstract Builder setLastModifiedTime(Optional<Instant> lastModifiedTime);
 
     public abstract Builder setConcurrencyToken(UUID concurrencyToken);
+
+    @JsonProperty("displayMode")
+    public abstract Builder setDisplayMode(QuestionDisplayMode displayMode);
 
     @JsonProperty("validationPredicates")
     public abstract Builder setValidationPredicates(

--- a/server/conf/evolutions/default/89.sql
+++ b/server/conf/evolutions/default/89.sql
@@ -1,0 +1,10 @@
+# --- !Ups
+alter table if exists questions
+add column if not exists display_mode varchar(32) not null default 'VISIBLE';
+
+alter table if exists questions
+alter column display_mode DROP DEFAULT;
+
+# --- !Downs
+alter table if exists questions
+drop column if exists display_mode;

--- a/server/test/controllers/admin/AdminImportControllerTest.java
+++ b/server/test/controllers/admin/AdminImportControllerTest.java
@@ -1245,6 +1245,7 @@ public class AdminImportControllerTest extends ResetPostgres {
               },
               "id" : 1,
               "universal" : false,
+              "displayMode" : "VISIBLE",
               "primaryApplicantInfoTags" : [ ]
               }
           } ]
@@ -1420,6 +1421,7 @@ public class AdminImportControllerTest extends ResetPostgres {
                 },
                 "id" : 13,
                 "universal" : true,
+                "displayMode" : "VISIBLE",
                 "primaryApplicantInfoTags" : [ "APPLICANT_NAME" ]
               }
             }, {
@@ -1446,6 +1448,7 @@ public class AdminImportControllerTest extends ResetPostgres {
                 },
                 "id" : 10,
                 "universal" : false,
+                "displayMode" : "VISIBLE",
                 "primaryApplicantInfoTags" : [ ]
               },
               "entityType" : {
@@ -1477,6 +1480,7 @@ public class AdminImportControllerTest extends ResetPostgres {
                 "id" : 94,
                 "enumeratorId" : 10,
                 "universal" : false,
+                "displayMode" : "VISIBLE",
                 "primaryApplicantInfoTags" : [ ]
               },
               "entityType" : {
@@ -1508,6 +1512,7 @@ public class AdminImportControllerTest extends ResetPostgres {
                 "id" : 95,
                 "enumeratorId" : 94,
                 "universal" : false,
+                "displayMode" : "VISIBLE",
                 "primaryApplicantInfoTags" : [ ]
               }
             } ]
@@ -1762,6 +1767,7 @@ public class AdminImportControllerTest extends ResetPostgres {
             },
             "id" : 3,
             "universal" : false,
+            "displayMode" : "VISIBLE",
             "primaryApplicantInfoTags" : [ ]
           }
         }, {
@@ -1786,6 +1792,7 @@ public class AdminImportControllerTest extends ResetPostgres {
             },
             "id" : 4,
             "universal" : false,
+            "displayMode" : "VISIBLE",
             "primaryApplicantInfoTags" : [ ]
           }
         }, {
@@ -1809,6 +1816,7 @@ public class AdminImportControllerTest extends ResetPostgres {
             },
             "id" : 5,
             "universal" : false,
+            "displayMode" : "VISIBLE",
             "primaryApplicantInfoTags" : [ ]
           }
         }, {
@@ -1834,6 +1842,7 @@ public class AdminImportControllerTest extends ResetPostgres {
             },
             "id" : 6,
             "universal" : false,
+            "displayMode" : "VISIBLE",
             "primaryApplicantInfoTags" : [ ]
           }
         } ]
@@ -1946,6 +1955,7 @@ public class AdminImportControllerTest extends ResetPostgres {
               },
               "id" : 3,
               "universal" : true,
+              "displayMode" : "VISIBLE",
               "primaryApplicantInfoTags" : ["APPLICANT_DOB"]
               }
           }, {
@@ -1970,6 +1980,7 @@ public class AdminImportControllerTest extends ResetPostgres {
               },
               "id" : 4,
               "universal" : true,
+              "displayMode" : "VISIBLE",
               "primaryApplicantInfoTags" : ["APPLICANT_NAME"]
               }
           }, {
@@ -1994,6 +2005,7 @@ public class AdminImportControllerTest extends ResetPostgres {
               },
               "id" : 5,
               "universal" : true,
+              "displayMode" : "VISIBLE",
               "primaryApplicantInfoTags" : ["APPLICANT_PHONE"]
               }
           }, {
@@ -2018,6 +2030,7 @@ public class AdminImportControllerTest extends ResetPostgres {
               },
               "id" : 6,
               "universal" : true,
+              "displayMode" : "VISIBLE",
               "primaryApplicantInfoTags" : ["APPLICANT_EMAIL"]
               }
           }]
@@ -2136,6 +2149,7 @@ public class AdminImportControllerTest extends ResetPostgres {
             },
             "id" : 1,
             "universal" : false,
+            "displayMode" : "VISIBLE",
             "primaryApplicantInfoTags" : [ ]
           }
         } ]


### PR DESCRIPTION
### Description

Adds Display Mode to database and `QuestionModel` at related Question objects. Defaults existing data and objects to `VISIBLE`. Not editable by the application at this time.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if the primary reviewer is not an admin and this PR includes functionality changes)
- [ ] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

#### Database evolutions

Read the guidelines [here](https://github.com/civiform/civiform/wiki/Database#writing-database-evolutions)

- [x] Assigned two reviewers
- [x] Guarded against already existing resources using `IF NOT EXISTS` and `IF EXISTS`
- [x] Downs created to undo changes in Ups
- [x] Every comment in script should begin with -- and not # --- unless it denotes Ups or Downs. See [here](https://www.playframework.com/documentation/2.9.x/Evolutions) for details.
- [x] Tested both the Downs and the Ups scripts manually (When testing, include all comments from the evolution in your test script to ensure any syntax errors in the comments are caught.)
- [ ] Data migrations aren't being done (please use a [Durable Job](https://github.com/civiform/civiform/wiki/Database#durable-jobs-for-data-updates) if doing a data migration)
- [ ] Update the model documentation in our [wiki](https://github.com/civiform/civiform/wiki/Database) if necessary


### Issue(s) this completes

Related to #10555