### PR TITLE
Temp disabling tests

### DIFF
--- a/server/test/repository/GeoJsonDataRepositoryTest.java
+++ b/server/test/repository/GeoJsonDataRepositoryTest.java
@@ -10,11 +10,13 @@ import java.util.Map;
 import java.util.Optional;
 import models.GeoJsonDataModel;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import services.geojson.Feature;
 import services.geojson.FeatureCollection;
 import services.geojson.Geometry;
 
+@Ignore("Skipping temporarily to unblock everyone else from intermittent test failures.")
 public class GeoJsonDataRepositoryTest extends ResetPostgres {
   private GeoJsonDataRepository geoJsonDataRepository;
   private final String endpoint = "http://example.com/geo.json";


### PR DESCRIPTION
Temporarily disable these tests to unblock everyone while we debug the intermittent failures.
