### PR TITLE
Add null check on ID Tokens for OidcLogoutAction

### DIFF
--- a/server/app/auth/oidc/CiviformOidcLogoutActionBuilder.java
+++ b/server/app/auth/oidc/CiviformOidcLogoutActionBuilder.java
@@ -102,6 +102,9 @@ public final class CiviformOidcLogoutActionBuilder extends OidcLogoutActionBuild
     }
 
     IdTokens idTokens = account.get().getIdTokens();
+    if (idTokens == null) {
+      return Optional.empty();
+    }
 
     // When we build the logout action, we do not remove the id token. We leave it in place in case
     // of transient logout failures. Expired tokens are purged at login time instead.

--- a/server/test/auth/oidc/CiviformOidcLogoutActionBuilderTest.java
+++ b/server/test/auth/oidc/CiviformOidcLogoutActionBuilderTest.java
@@ -199,4 +199,124 @@ public class CiviformOidcLogoutActionBuilderTest extends ResetPostgres {
     assertThat(queryParamValue(locationUri, "custom_target_url_parameter_name"))
         .hasValue(targetUrl);
   }
+
+  @Test
+  public void testBuilderLogsOutIfIdTokensIsNull() throws URISyntaxException {
+    // Enable enhanced logout for admins.
+    Config civiformConfig =
+        ConfigFactory.parseMap(ImmutableMap.of("admin_oidc_enhanced_logout_enabled", "true"));
+
+    // Set up an admin account
+    AccountModel account = new AccountModel();
+    account.setGlobalAdmin(true);
+    // Explicitly set tokens Null to test behavior.
+    IdTokens idTokens = null;
+    account.setIdTokens(idTokens);
+    when(accountRepository.lookupAccount(accountId)).thenReturn(Optional.of(account));
+    Provider<AccountRepository> accountRepositoryProvider = () -> accountRepository;
+
+    OidcClientProviderParams params =
+        OidcClientProviderParams.create(civiformConfig, profileFactory, accountRepositoryProvider);
+    CiviformOidcLogoutActionBuilder builder =
+        new CiviformOidcLogoutActionBuilder(
+            oidcConfig, clientId, params, IdentityProviderType.ADMIN_IDENTITY_PROVIDER);
+
+    Optional<RedirectionAction> logoutAction =
+        builder.getLogoutAction(
+            new CallContext(getWebContext(), sessionStore), civiFormProfileData, targetUrl);
+
+    assertThat(logoutAction).isNotEmpty();
+    assertThat(logoutAction.get().getCode()).isEqualTo(302);
+
+    String location = ((FoundAction) logoutAction.get()).getLocation();
+    assertThat(location).isNotEmpty();
+    URI locationUri = new URI(location);
+    assertThat(locationUri.getHost()).isEqualTo(oidcHost);
+    assertThat(locationUri.getPort()).isEqualTo(oidcPort);
+    assertThat(locationUri.getPath()).isEqualTo("/session/end");
+
+    assertThat(queryParamValue(locationUri, "client_id")).hasValue(clientId);
+    assertThat(queryParamValue(locationUri, "post_logout_redirect_uri")).hasValue(targetUrl);
+
+    // No Serialized Tokens since token is null
+    Optional<String> serializedToken = queryParamValue(locationUri, "id_token_hint");
+    assertThat(serializedToken).isEmpty();
+  }
+
+  @Test
+  public void testBuilderLogsOutIfIdTokenNotFoundForAccount() throws URISyntaxException {
+    // Enable enhanced logout for admins.
+    Config civiformConfig =
+        ConfigFactory.parseMap(ImmutableMap.of("admin_oidc_enhanced_logout_enabled", "true"));
+
+    // Set up an admin account
+    AccountModel account = new AccountModel();
+    account.setGlobalAdmin(true);
+    // Assign token to session different from session being logged out to force an empty lookup.
+    IdTokens idTokens = new IdTokens(ImmutableMap.of("some_session_id", idToken));
+    account.setIdTokens(idTokens);
+    when(accountRepository.lookupAccount(accountId)).thenReturn(Optional.of(account));
+    Provider<AccountRepository> accountRepositoryProvider = () -> accountRepository;
+
+    OidcClientProviderParams params =
+        OidcClientProviderParams.create(civiformConfig, profileFactory, accountRepositoryProvider);
+    CiviformOidcLogoutActionBuilder builder =
+        new CiviformOidcLogoutActionBuilder(
+            oidcConfig, clientId, params, IdentityProviderType.ADMIN_IDENTITY_PROVIDER);
+
+    Optional<RedirectionAction> logoutAction =
+        builder.getLogoutAction(
+            new CallContext(getWebContext(), sessionStore), civiFormProfileData, targetUrl);
+
+    assertThat(logoutAction).isNotEmpty();
+    assertThat(logoutAction.get().getCode()).isEqualTo(302);
+
+    String location = ((FoundAction) logoutAction.get()).getLocation();
+    assertThat(location).isNotEmpty();
+    URI locationUri = new URI(location);
+    assertThat(locationUri.getHost()).isEqualTo(oidcHost);
+    assertThat(locationUri.getPort()).isEqualTo(oidcPort);
+    assertThat(locationUri.getPath()).isEqualTo("/session/end");
+
+    assertThat(queryParamValue(locationUri, "client_id")).hasValue(clientId);
+    assertThat(queryParamValue(locationUri, "post_logout_redirect_uri")).hasValue(targetUrl);
+
+    // No Serialized Tokens since token not found for account.
+    Optional<String> serializedToken = queryParamValue(locationUri, "id_token_hint");
+    assertThat(serializedToken).isEmpty();
+  }
+
+  @Test
+  public void testBuilderLogsOutIfAccountIsNotFound() throws URISyntaxException {
+    // Enable enhanced logout for admins.
+    Config civiformConfig =
+        ConfigFactory.parseMap(ImmutableMap.of("admin_oidc_enhanced_logout_enabled", "true"));
+
+    // Return empty account on lookup.
+    when(accountRepository.lookupAccount(accountId)).thenReturn(Optional.empty());
+    Provider<AccountRepository> accountRepositoryProvider = () -> accountRepository;
+
+    OidcClientProviderParams params =
+        OidcClientProviderParams.create(civiformConfig, profileFactory, accountRepositoryProvider);
+    CiviformOidcLogoutActionBuilder builder =
+        new CiviformOidcLogoutActionBuilder(
+            oidcConfig, clientId, params, IdentityProviderType.ADMIN_IDENTITY_PROVIDER);
+
+    Optional<RedirectionAction> logoutAction =
+        builder.getLogoutAction(
+            new CallContext(getWebContext(), sessionStore), civiFormProfileData, targetUrl);
+
+    assertThat(logoutAction).isNotEmpty();
+    assertThat(logoutAction.get().getCode()).isEqualTo(302);
+
+    String location = ((FoundAction) logoutAction.get()).getLocation();
+    assertThat(location).isNotEmpty();
+    URI locationUri = new URI(location);
+    assertThat(locationUri.getHost()).isEqualTo(oidcHost);
+    assertThat(locationUri.getPort()).isEqualTo(oidcPort);
+    assertThat(locationUri.getPath()).isEqualTo("/session/end");
+
+    assertThat(queryParamValue(locationUri, "client_id")).hasValue(clientId);
+    assertThat(queryParamValue(locationUri, "post_logout_redirect_uri")).hasValue(targetUrl);
+  }
 }


### PR DESCRIPTION
Add null check on ID Tokens for OidcLogoutAction

### Description

To prevent error on logout, add a check if the tokens returned from account.get().getIdTokens() are null  and return Optional.empty if so

Added additional test coverage for other cases that return Optional.empty

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from `civiform/eng-admin` as FYI (if the primary reviewer is not an admin and this PR includes functionality changes)

### Issue(s) this completes

Fixes #10310
