### PR TITLE
Northstar migration for admin_bulk_update_statuses

### DIFF
--- a/browser-test/src/admin/northstar_admin_bulk_update_statuses.test.ts
+++ b/browser-test/src/admin/northstar_admin_bulk_update_statuses.test.ts
@@ -1,0 +1,220 @@
+import {test, expect} from '../support/civiform_fixtures'
+import {Page} from 'playwright'
+import {
+  loginAsAdmin,
+  loginAsProgramAdmin,
+  loginAsTestUser,
+  logout,
+  waitForPageJsLoad,
+  testUserDisplayName,
+  supportsEmailInspection,
+  extractEmailsForRecipient,
+  AdminPrograms,
+  ApplicantQuestions,
+  AdminProgramStatuses,
+  disableFeatureFlag,
+} from '../support'
+
+test.describe('with program statuses', () => {
+  const programName = 'Applicant with statuses program'
+  const approvedStatusName = 'Approved'
+  const rejectedStatusName = 'Rejected'
+  const reapplyStatusName = 'Reapply'
+
+  test.beforeEach(
+    async ({page, adminPrograms, adminProgramStatuses, applicantQuestions}) => {
+      await disableFeatureFlag(page, 'north_star_applicant_ui')
+      await loginAsAdmin(page)
+
+      await adminPrograms.addProgram(programName)
+      await adminPrograms.gotoDraftProgramManageStatusesPage(programName)
+      await adminProgramStatuses.createStatus(approvedStatusName)
+      await adminProgramStatuses.createStatus(rejectedStatusName)
+      await adminProgramStatuses.createStatus(reapplyStatusName)
+      await adminPrograms.publishProgram(programName)
+      await adminPrograms.expectActiveProgram(programName)
+      await logout(page)
+
+      // Submit an application as a test user so that we can navigate back to the applications page.
+      await loginAsTestUser(page)
+      await applicantQuestions.clickApplyProgramButton(programName)
+      await applicantQuestions.submitFromReviewPage()
+      await logout(page)
+      await loginAsProgramAdmin(page)
+      await adminPrograms.viewApplications(programName)
+    },
+  )
+
+  test('single application updated with bulk status select', async ({
+    page,
+    adminPrograms,
+  }) => {
+    // Default page shows all applications.
+    await adminPrograms.expectApplicationCount(1)
+    await adminPrograms.expectApplicationHasStatusString(
+      testUserDisplayName(),
+      'None',
+    )
+    await page.locator('#selectAll').check()
+    await page.locator('#bulk-status-selector').selectOption('Approved')
+    await page.getByRole('button', {name: 'Status change'}).click()
+    await waitForPageJsLoad(page)
+    await adminPrograms.expectApplicationHasStatusString(
+      testUserDisplayName(),
+      approvedStatusName,
+    )
+  })
+  test('if more than 100 applications, only the first page of applications undergo status update', async ({
+    page,
+    adminPrograms,
+    applicantQuestions,
+    adminProgramMigration,
+  }) => {
+    test.slow()
+    // There is already 1 application from the beforeEach, so apply 105 more times.
+    for (let i = 0; i < 105; i++) {
+      await logout(page)
+
+      // Submit an application as a guest.
+      await applicantQuestions.clickApplyProgramButton(programName)
+      await applicantQuestions.submitFromReviewPage()
+    }
+    const id = await adminPrograms.getApplicationId()
+
+    await logout(page)
+    await loginAsProgramAdmin(page)
+    // Navigate to the applications list
+    await adminPrograms.viewApplications(programName)
+    await page.locator('#selectAll').check()
+    await page.locator('#bulk-status-selector').selectOption('Approved')
+    await page.getByRole('button', {name: 'Status change'}).click()
+    await waitForPageJsLoad(page)
+
+    await adminProgramMigration.expectAlert(
+      'Status update success',
+      'usa-alert--info',
+    )
+
+    for (let i = 0; i < 100; i++) {
+      await adminPrograms.expectApplicationHasStatusString(
+        `Guest (${id - i})`,
+        approvedStatusName,
+      )
+    }
+    await page.locator('.usa-pagination__button:has-text("2")').click()
+    // last applicant
+    await adminPrograms.expectApplicationHasStatusString(
+      testUserDisplayName(),
+      'None',
+    )
+  })
+})
+test.describe('when email is configured for the status and applicant, a checkbox is shown to notify the applicant', () => {
+  const programWithStatusesName = 'Test program with email statuses'
+  const emailStatusName = 'Email status'
+  const emailBody = 'Some email content'
+  const noEmailStatusName = 'No email status'
+  test.beforeEach(
+    async ({page, adminPrograms, applicantQuestions, adminProgramStatuses}) => {
+      await disableFeatureFlag(page, 'north_star_applicant_ui')
+      await setupProgramsWithStatuses(
+        page,
+        adminPrograms,
+        applicantQuestions,
+        adminProgramStatuses,
+      )
+      await loginAsProgramAdmin(page)
+      await adminPrograms.viewApplications(programWithStatusesName)
+    },
+  )
+  test('choosing not to notify applicants changes status and does not send email', async ({
+    page,
+    adminPrograms,
+  }) => {
+    const emailsBefore = supportsEmailInspection()
+      ? await extractEmailsForRecipient(page, testUserDisplayName())
+      : []
+    await page.locator('#selectAll').check()
+    await page.locator('#bulk-status-selector').selectOption(emailStatusName)
+    // the notification checkbox is unchecked
+    await page.locator('#bulk-status-notification').uncheck()
+    await page.getByRole('button', {name: 'Status change'}).click()
+    await waitForPageJsLoad(page)
+
+    await adminPrograms.expectApplicationHasStatusString(
+      testUserDisplayName(),
+      emailStatusName,
+    )
+
+    if (supportsEmailInspection()) {
+      const emailsAfter = await extractEmailsForRecipient(
+        page,
+        testUserDisplayName(),
+      )
+      expect(emailsAfter.length).toEqual(emailsBefore.length)
+    }
+  })
+
+  test('choosing to notify applicant changes status and does send email', async ({
+    page,
+    adminPrograms,
+  }) => {
+    const emailsBefore = supportsEmailInspection()
+      ? await extractEmailsForRecipient(page, testUserDisplayName())
+      : []
+
+    await page.locator('#selectAll').check()
+    await page.locator('#bulk-status-selector').selectOption(emailStatusName)
+    await page.locator('#bulk-status-notification').check()
+    await page.getByRole('button', {name: 'Status change'}).click()
+    await waitForPageJsLoad(page)
+
+    await adminPrograms.expectApplicationHasStatusString(
+      testUserDisplayName(),
+      emailStatusName,
+    )
+
+    if (supportsEmailInspection()) {
+      await adminPrograms.expectEmailSent(
+        emailsBefore.length,
+        testUserDisplayName(),
+        emailBody,
+        programWithStatusesName,
+      )
+    }
+  })
+  const setupProgramsWithStatuses = async (
+    page: Page,
+    adminPrograms: AdminPrograms,
+    applicantQuestions: ApplicantQuestions,
+    adminProgramStatuses: AdminProgramStatuses,
+  ) => {
+    await test.step('login as admin and create program with statuses', async () => {
+      await loginAsAdmin(page)
+      await adminPrograms.addProgram(programWithStatusesName)
+      await adminPrograms.gotoDraftProgramManageStatusesPage(
+        programWithStatusesName,
+      )
+      await adminProgramStatuses.createStatus(noEmailStatusName)
+      await adminProgramStatuses.createStatus(emailStatusName, {
+        emailBody: emailBody,
+      })
+      await adminPrograms.publishProgram(programWithStatusesName)
+      await adminPrograms.expectActiveProgram(programWithStatusesName)
+      await logout(page)
+    })
+
+    await test.step('submit an application as a guest', async () => {
+      await applicantQuestions.clickApplyProgramButton(programWithStatusesName)
+      await applicantQuestions.submitFromReviewPage()
+      await logout(page)
+    })
+
+    await test.step('submit an application as a logged in user', async () => {
+      await loginAsTestUser(page)
+      await applicantQuestions.clickApplyProgramButton(programWithStatusesName)
+      await applicantQuestions.submitFromReviewPage()
+      await logout(page)
+    })
+  }
+})

--- a/browser-test/src/admin/northstar_admin_bulk_update_statuses.test.ts
+++ b/browser-test/src/admin/northstar_admin_bulk_update_statuses.test.ts
@@ -12,10 +12,10 @@ import {
   AdminPrograms,
   ApplicantQuestions,
   AdminProgramStatuses,
-  disableFeatureFlag,
+  enableFeatureFlag,
 } from '../support'
 
-test.describe('with program statuses', () => {
+test.describe('with program statuses', {tag: ['@northstar']}, () => {
   const programName = 'Applicant with statuses program'
   const approvedStatusName = 'Approved'
   const rejectedStatusName = 'Rejected'
@@ -23,7 +23,7 @@ test.describe('with program statuses', () => {
 
   test.beforeEach(
     async ({page, adminPrograms, adminProgramStatuses, applicantQuestions}) => {
-      await disableFeatureFlag(page, 'north_star_applicant_ui')
+      await enableFeatureFlag(page, 'north_star_applicant_ui')
       await loginAsAdmin(page)
 
       await adminPrograms.addProgram(programName)
@@ -37,8 +37,8 @@ test.describe('with program statuses', () => {
 
       // Submit an application as a test user so that we can navigate back to the applications page.
       await loginAsTestUser(page)
-      await applicantQuestions.clickApplyProgramButton(programName)
-      await applicantQuestions.submitFromReviewPage()
+      await applicantQuestions.applyProgram(programName, true)
+      await applicantQuestions.submitFromReviewPage(true)
       await logout(page)
       await loginAsProgramAdmin(page)
       await adminPrograms.viewApplications(programName)
@@ -76,8 +76,8 @@ test.describe('with program statuses', () => {
       await logout(page)
 
       // Submit an application as a guest.
-      await applicantQuestions.clickApplyProgramButton(programName)
-      await applicantQuestions.submitFromReviewPage()
+      await applicantQuestions.applyProgram(programName, true)
+      await applicantQuestions.submitFromReviewPage(true)
     }
     const id = await adminPrograms.getApplicationId()
 
@@ -116,7 +116,7 @@ test.describe('when email is configured for the status and applicant, a checkbox
   const noEmailStatusName = 'No email status'
   test.beforeEach(
     async ({page, adminPrograms, applicantQuestions, adminProgramStatuses}) => {
-      await disableFeatureFlag(page, 'north_star_applicant_ui')
+      await enableFeatureFlag(page, 'north_star_applicant_ui')
       await setupProgramsWithStatuses(
         page,
         adminPrograms,
@@ -205,15 +205,15 @@ test.describe('when email is configured for the status and applicant, a checkbox
     })
 
     await test.step('submit an application as a guest', async () => {
-      await applicantQuestions.clickApplyProgramButton(programWithStatusesName)
-      await applicantQuestions.submitFromReviewPage()
+      await applicantQuestions.applyProgram(programWithStatusesName, true)
+      await applicantQuestions.submitFromReviewPage(true)
       await logout(page)
     })
 
     await test.step('submit an application as a logged in user', async () => {
       await loginAsTestUser(page)
-      await applicantQuestions.clickApplyProgramButton(programWithStatusesName)
-      await applicantQuestions.submitFromReviewPage()
+      await applicantQuestions.applyProgram(programWithStatusesName, true)
+      await applicantQuestions.submitFromReviewPage(true)
       await logout(page)
     })
   }


### PR DESCRIPTION
### Description

Please explain the changes you made here.

## Release notes

Remove this section if the title of the pull request can be used as the default release notes description. If more detail is needed to communicate to partners the scope of the PR's changes, use this release notes section (and remove this placeholder text).

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [ ] Added the correct label: < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from outside your organization as FYI (if the primary reviewer is in the same organization as you)
- [ ] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

#### Database evolutions

Read the guidelines [here](https://github.com/civiform/civiform/wiki/Database#writing-database-evolutions)

- [ ] Assigned two reviewers
- [ ] Guarded against already existing resources using `IF NOT EXISTS` and `IF EXISTS`
- [ ] Downs created to undo changes in Ups
- [ ] Every comment in script should begin with -- and not # --- unless it denotes Ups or Downs. See [here](https://www.playframework.com/documentation/2.9.x/Evolutions) for details.
- [ ] Tested both the Downs and the Ups scripts manually (When testing, include all comments from the evolution in your test script to ensure any syntax errors in the comments are caught.)
- [ ] Data migrations aren't being done (please use a [Durable Job](https://github.com/civiform/civiform/wiki/Database#durable-jobs-for-data-updates) if doing a data migration)
- [ ] Update the model documentation in our [wiki](https://github.com/civiform/civiform/wiki/Database) if necessary

#### Durable jobs

Read the docs [here](https://github.com/civiform/civiform/wiki/Database#durable-jobs-for-data-updates)

- [ ] Assigned two reviewers
- [ ] Included a rollback plan and a job to undo the data changes if appropriate

#### User visible changes

- [ ] Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
  - [ ] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [ ] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Made equivalent changes in Thymeleaf for applicant-facing features and changes (or created an issue in the [Northstar epic](https://github.com/orgs/civiform/projects/1/views/94) to track that it's missing from Thymeleaf)
- [ ] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order
- [ ] Manually tested with a screen reader if the feature is applicant-facing. See [screen reader testing](https://github.com/civiform/civiform/wiki/Testing#screen-reader-testing)

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/helper/feature-flags.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://github.com/civiform/civiform/wiki/Feature-Flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Instructions for manual testing

If instructions are needed for manual testing by reviewers, include them here.

### Issue(s) this completes

Fixes #<issue_number>; Fixes #<issue_number>...
