### PR TITLE
Update dependency htmx.org to v2.0.6 

### DIFF
--- a/server/app/views/admin/programs/ProgramBlocksView.java
+++ b/server/app/views/admin/programs/ProgramBlocksView.java
@@ -912,7 +912,7 @@ public final class ProgramBlocksView extends ProgramBaseView {
                 "bg-transparent",
                 "rounded-full",
                 StyleUtils.hover("bg-gray-400", "text-gray-300"))
-            .withType("submit")
+            .withType("button")
             .attr("hx-post", toggleOptionalAction)
             .attr("hx-select-oob", String.format("#%s", toggleOptionalFormId))
             .with(p("optional").withClasses("hover-group:text-white"))
@@ -1019,7 +1019,7 @@ public final class ProgramBlocksView extends ProgramBaseView {
                 "bg-transparent",
                 "rounded-full",
                 StyleUtils.hover("bg-gray-400", "text-gray-300"))
-            .withType("submit")
+            .withType("button")
             .attr("hx-post", toggleAddressCorrectionAction)
             // Replace entire Questions section so that the tooltips for all address
             // questions get updated.

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -33,7 +33,7 @@
         "eslint-config-prettier": "10.1.8",
         "eslint-plugin-no-unsanitized": "^4.0.2",
         "globals": "16.3.0",
-        "htmx.org": "2.0.4",
+        "htmx.org": "2.0.6",
         "jest": "30.0.5",
         "jest-environment-jsdom": "30.0.5",
         "mini-css-extract-plugin": "^2.7.6",
@@ -5250,9 +5250,9 @@
       "license": "MIT"
     },
     "node_modules/htmx.org": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/htmx.org/-/htmx.org-2.0.4.tgz",
-      "integrity": "sha512-HLxMCdfXDOJirs3vBZl/ZLoY+c7PfM4Ahr2Ad4YXh6d22T5ltbTXFFkpx9Tgb2vvmWFMbIc3LqN2ToNkZJvyYQ==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/htmx.org/-/htmx.org-2.0.6.tgz",
+      "integrity": "sha512-7ythjYneGSk3yCHgtCnQeaoF+D+o7U2LF37WU3O0JYv3gTZSicdEFiI/Ai/NJyC5ZpYJWMpUb11OC5Lr6AfAqA==",
       "dev": true,
       "license": "0BSD"
     },

--- a/server/package.json
+++ b/server/package.json
@@ -25,7 +25,7 @@
     "eslint-config-prettier": "10.1.8",
     "eslint-plugin-no-unsanitized": "^4.0.2",
     "globals": "16.3.0",
-    "htmx.org": "2.0.4",
+    "htmx.org": "2.0.6",
     "jest": "30.0.5",
     "jest-environment-jsdom": "30.0.5",
     "mini-css-extract-plugin": "^2.7.6",


### PR DESCRIPTION
### Description

https://github.com/civiform/civiform/pull/10851 has been failing and it seems to be because of the type when we're using hx-post. This idea came from gemini. I can also just make the change here and then re-run https://github.com/civiform/civiform/pull/10851

Related to: https://github.com/civiform/civiform/pull/10851

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if the primary reviewer is not an admin and this PR includes functionality changes)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.



### Issue(s) this completes

Fixes #<issue_number>; Fixes #<issue_number>...
