### PR TITLE
feat: Add YES/NO question validation for program import flow

### DIFF
--- a/server/app/services/migration/ProgramMigrationService.java
+++ b/server/app/services/migration/ProgramMigrationService.java
@@ -174,21 +174,12 @@ public final class ProgramMigrationService {
       ImmutableList<QuestionDefinition> questions,
       ImmutableList<String> existingAdminNames) {
 
-    ImmutableSet<CiviFormError> questionErrors =
-        ImmutableSet.<CiviFormError>builder()
-            .addAll(QuestionValidationUtils.validateQuestionOptionAdminNames(questions))
-            .addAll(QuestionValidationUtils.validateAllProgramQuestionsPresent(program, questions))
-            .addAll(QuestionValidationUtils.validateYesNoQuestions(questions))
-            .addAll(
-                QuestionValidationUtils.validateRepeatedQuestions(
-                    program, questions, existingAdminNames))
-            .build();
-
-    if (!questionErrors.isEmpty()) {
-      return questionErrors;
-    }
-
-    return ImmutableSet.of();
+    return ImmutableSet.<CiviFormError>builder()
+    .addAll(QuestionValidationUtils.validateQuestionOptionAdminNames(questions))
+    .addAll(QuestionValidationUtils.validateAllProgramQuestionsPresent(program, questions))
+    .addAll(QuestionValidationUtils.validateYesNoQuestions(questions))
+    .addAll(QuestionValidationUtils.validateRepeatedQuestions(program, questions, existingAdminNames))
+    .build();
   }
 
   /**

--- a/server/app/services/migration/ProgramMigrationService.java
+++ b/server/app/services/migration/ProgramMigrationService.java
@@ -174,16 +174,21 @@ public final class ProgramMigrationService {
       ImmutableList<QuestionDefinition> questions,
       ImmutableList<String> existingAdminNames) {
 
-    ImmutableSet.Builder<CiviFormError> allErrors = ImmutableSet.builder();
+    ImmutableSet<CiviFormError> questionErrors =
+        ImmutableSet.<CiviFormError>builder()
+            .addAll(QuestionValidationUtils.validateQuestionOptionAdminNames(questions))
+            .addAll(QuestionValidationUtils.validateAllProgramQuestionsPresent(program, questions))
+            .addAll(QuestionValidationUtils.validateYesNoQuestions(questions))
+            .addAll(
+                QuestionValidationUtils.validateRepeatedQuestions(
+                    program, questions, existingAdminNames))
+            .build();
 
-    allErrors.addAll(QuestionValidationUtils.validateQuestionOptionAdminNames(questions));
-    allErrors.addAll(
-        QuestionValidationUtils.validateAllProgramQuestionsPresent(program, questions));
-    allErrors.addAll(QuestionValidationUtils.validateYesNoQuestions(questions));
-    allErrors.addAll(
-        QuestionValidationUtils.validateRepeatedQuestions(program, questions, existingAdminNames));
+    if (!questionErrors.isEmpty()) {
+      return questionErrors;
+    }
 
-    return allErrors.build();
+    return ImmutableSet.of();
   }
 
   /**

--- a/server/app/services/migration/ProgramMigrationService.java
+++ b/server/app/services/migration/ProgramMigrationService.java
@@ -175,11 +175,13 @@ public final class ProgramMigrationService {
       ImmutableList<String> existingAdminNames) {
 
     return ImmutableSet.<CiviFormError>builder()
-    .addAll(QuestionValidationUtils.validateQuestionOptionAdminNames(questions))
-    .addAll(QuestionValidationUtils.validateAllProgramQuestionsPresent(program, questions))
-    .addAll(QuestionValidationUtils.validateYesNoQuestions(questions))
-    .addAll(QuestionValidationUtils.validateRepeatedQuestions(program, questions, existingAdminNames))
-    .build();
+        .addAll(QuestionValidationUtils.validateQuestionOptionAdminNames(questions))
+        .addAll(QuestionValidationUtils.validateAllProgramQuestionsPresent(program, questions))
+        .addAll(QuestionValidationUtils.validateYesNoQuestions(questions))
+        .addAll(
+            QuestionValidationUtils.validateRepeatedQuestions(
+                program, questions, existingAdminNames))
+        .build();
   }
 
   /**

--- a/server/app/services/migration/ProgramMigrationService.java
+++ b/server/app/services/migration/ProgramMigrationService.java
@@ -44,14 +44,11 @@ import services.program.BlockDefinition;
 import services.program.ProgramDefinition;
 import services.program.ProgramType;
 import services.question.ActiveAndDraftQuestions;
-import services.question.QuestionOption;
 import services.question.QuestionService;
 import services.question.exceptions.UnsupportedQuestionTypeException;
-import services.question.types.MultiOptionQuestionDefinition;
 import services.question.types.QuestionDefinition;
 import services.question.types.QuestionDefinitionBuilder;
 import services.question.types.QuestionDefinitionConfig;
-import services.question.types.QuestionType;
 import services.question.types.TextQuestionDefinition;
 import services.statuses.StatusDefinitions;
 
@@ -66,9 +63,6 @@ public final class ProgramMigrationService {
   // It will transform to a key formatted like `%s__%s`
   private static final String CONFLICTING_QUESTION_FORMAT = "%s -_- %s";
   private static final Pattern SUFFIX_PATTERN = Pattern.compile(" -_- [a-z]+$");
-
-  private static final ImmutableSet<String> ALLOWED_YES_NO_OPTIONS =
-      ImmutableSet.of("yes", "no", "maybe", "not-sure");
 
   private final ApplicationStatusesRepository applicationStatusesRepository;
   private final ObjectMapper objectMapper;
@@ -188,38 +182,13 @@ public final class ProgramMigrationService {
       return questionErrors;
     }
 
-    try {
-      validateYesNoQuestions(questions);
-    } catch (IllegalStateException e) {
-      return ImmutableSet.of(CiviFormError.of(e.getMessage()));
+    questionErrors = QuestionValidationUtils.validateYesNoQuestions(questions);
+    if (!questionErrors.isEmpty()) {
+      return questionErrors;
     }
 
     return QuestionValidationUtils.validateRepeatedQuestions(
         program, questions, existingAdminNames);
-  }
-
-  /**
-   * Validates that YES_NO questions only contain the allowed options.
-   *
-   * @param questions the list of questions to validate
-   * @throws IllegalStateException if a YES_NO question contains unsupported options
-   */
-  private void validateYesNoQuestions(ImmutableList<QuestionDefinition> questions) {
-    for (QuestionDefinition question : questions) {
-      if (question.getQuestionType() == QuestionType.YES_NO) {
-        MultiOptionQuestionDefinition yesNoQuestion = (MultiOptionQuestionDefinition) question;
-
-        for (QuestionOption option : yesNoQuestion.getOptions()) {
-          if (!ALLOWED_YES_NO_OPTIONS.contains(option.adminName())) {
-            throw new IllegalStateException(
-                String.format(
-                    "Yes/No question '%s' contains unsupported option: '%s'. "
-                        + "Only 'yes', 'no', 'maybe', and 'not-sure' options are allowed.",
-                    question.getName(), option.adminName()));
-          }
-        }
-      }
-    }
   }
 
   /**
@@ -480,11 +449,11 @@ public final class ProgramMigrationService {
       ImmutableList<String> reusedQuestions) {
     ProgramDefinition updatedProgram = programDefinition;
     if (questionDefinitions != null) {
-      // Validate YES_NO questions before saving
-      try {
-        validateYesNoQuestions(questionDefinitions);
-      } catch (IllegalStateException e) {
-        return ErrorAnd.error(ImmutableSet.of(e.getMessage()));
+      ImmutableSet<CiviFormError> yesNoErrors =
+          QuestionValidationUtils.validateYesNoQuestions(questionDefinitions);
+      if (!yesNoErrors.isEmpty()) {
+        String errorMessage = yesNoErrors.iterator().next().message();
+        return ErrorAnd.error(ImmutableSet.of(errorMessage));
       }
 
       if (overwrittenQuestions.size() > 0 && draftIsPopulated()) {

--- a/server/app/services/migration/QuestionValidationUtils.java
+++ b/server/app/services/migration/QuestionValidationUtils.java
@@ -79,16 +79,14 @@ final class QuestionValidationUtils {
             .map(option -> option.adminName())
             .collect(ImmutableSet.toImmutableSet());
 
-    Stream<CiviFormError> invalidOptionErrors =
-        yesNoQuestion.getOptions().stream()
-            .filter(option -> !ALLOWED_YES_NO_OPTIONS.contains(option.adminName()))
-            .map(
-                option ->
-                    CiviFormError.of(
-                        String.format(
-                            "YES_NO question '%s' contains invalid option '%s'. "
-                                + "Only 'yes', 'no', 'maybe', and 'not-sure' options are allowed.",
-                            yesNoQuestion.getName(), option.adminName())));
+    Stream<CiviFormError> invalidOptionErrors = optionAdminNames.stream()
+    .filter(optionName -> !ALLOWED_YES_NO_OPTIONS.contains(optionName))
+    .map(optionName ->
+        CiviFormError.of(
+            String.format(
+                "YES_NO question '%s' contains invalid option '%s'. "
+                    + "Only 'yes', 'no', 'maybe', and 'not-sure' options are allowed.",
+                yesNoQuestion.getName(), optionName)));
 
     Stream<CiviFormError> missingRequiredErrors =
         Stream.of("yes", "no")

--- a/server/app/services/migration/QuestionValidationUtils.java
+++ b/server/app/services/migration/QuestionValidationUtils.java
@@ -79,14 +79,16 @@ final class QuestionValidationUtils {
             .map(option -> option.adminName())
             .collect(ImmutableSet.toImmutableSet());
 
-    Stream<CiviFormError> invalidOptionErrors = optionAdminNames.stream()
-    .filter(optionName -> !ALLOWED_YES_NO_OPTIONS.contains(optionName))
-    .map(optionName ->
-        CiviFormError.of(
-            String.format(
-                "YES_NO question '%s' contains invalid option '%s'. "
-                    + "Only 'yes', 'no', 'maybe', and 'not-sure' options are allowed.",
-                yesNoQuestion.getName(), optionName)));
+    Stream<CiviFormError> invalidOptionErrors =
+        optionAdminNames.stream()
+            .filter(optionName -> !ALLOWED_YES_NO_OPTIONS.contains(optionName))
+            .map(
+                optionName ->
+                    CiviFormError.of(
+                        String.format(
+                            "YES_NO question '%s' contains invalid option '%s'. "
+                                + "Only 'yes', 'no', 'maybe', and 'not-sure' options are allowed.",
+                            yesNoQuestion.getName(), optionName)));
 
     Stream<CiviFormError> missingRequiredErrors =
         Stream.of("yes", "no")

--- a/server/test/services/migration/ProgramMigrationServiceTest.java
+++ b/server/test/services/migration/ProgramMigrationServiceTest.java
@@ -851,9 +851,7 @@ public final class ProgramMigrationServiceTest extends ResetPostgres {
     assertThat(errors).hasSize(1);
     assertThat(errors.iterator().next().message())
         .contains(
-            "Yes/No question '"
-                + INVALID_YES_NO_NAME
-                + "' contains unsupported option: 'absolutely'");
+            "YES_NO question '" + INVALID_YES_NO_NAME + "' contains invalid option 'absolutely'");
     assertThat(errors.iterator().next().message())
         .contains("Only 'yes', 'no', 'maybe', and 'not-sure' options are allowed.");
   }
@@ -876,13 +874,11 @@ public final class ProgramMigrationServiceTest extends ResetPostgres {
     assertThat(errors).hasSize(1);
     assertThat(errors.iterator().next().message())
         .contains(
-            "Yes/No question '"
-                + INVALID_YES_NO_NAME
-                + "' contains unsupported option: 'absolutely'");
+            "YES_NO question '" + INVALID_YES_NO_NAME + "' contains invalid option 'absolutely'");
   }
 
   @Test
-  public void validateQuestions_nonYesNoQuestionsOnly_noErrors() {
+  public void validateQuestions_withoutYesNoQuestions_noErrors() {
     ProgramDefinition programDefinition =
         ProgramBuilder.newActiveProgram("test-program")
             .withBlock("Test Block")
@@ -911,52 +907,6 @@ public final class ProgramMigrationServiceTest extends ResetPostgres {
 
     assertThat(result.isError()).isFalse();
     assertThat(result.hasResult()).isTrue();
-  }
-
-  @Test
-  public void saveImportedProgram_invalidYesNoQuestion_returnsError() {
-    ProgramDefinition programDefinition =
-        ProgramBuilder.newActiveProgram("test-program")
-            .withBlock("Test Block")
-            .withRequiredQuestionDefinition(INVALID_YES_NO_QUESTION)
-            .buildDefinition();
-
-    ErrorAnd<ProgramModel, String> result =
-        service.saveImportedProgram(
-            programDefinition, ImmutableList.of(INVALID_YES_NO_QUESTION), ImmutableMap.of());
-
-    assertThat(result.isError()).isTrue();
-    assertThat(result.getErrors())
-        .contains(
-            "Yes/No question '"
-                + INVALID_YES_NO_NAME
-                + "' contains unsupported option: 'absolutely'. "
-                + "Only 'yes', 'no', 'maybe', and 'not-sure' options are allowed.");
-  }
-
-  @Test
-  public void saveImportedProgram_multipleYesNoQuestionsWithMixedValidity_returnsFirstError() {
-    QuestionDefinition anotherInvalidYesNo =
-        createYesNoQuestion("anotherInvalidYesNo", 10L, ImmutableList.of("yes", "no", "perhaps"));
-
-    ProgramDefinition programDefinition =
-        ProgramBuilder.newActiveProgram("test-program")
-            .withBlock("Test Block")
-            .withRequiredQuestionDefinition(VALID_YES_NO_QUESTION)
-            .withRequiredQuestionDefinition(anotherInvalidYesNo)
-            .buildDefinition();
-
-    ErrorAnd<ProgramModel, String> result =
-        service.saveImportedProgram(
-            programDefinition,
-            ImmutableList.of(VALID_YES_NO_QUESTION, anotherInvalidYesNo),
-            ImmutableMap.of());
-
-    assertThat(result.isError()).isTrue();
-    assertThat(result.getErrors())
-        .contains(
-            "Yes/No question 'anotherInvalidYesNo' contains unsupported option: 'perhaps'. "
-                + "Only 'yes', 'no', 'maybe', and 'not-sure' options are allowed.");
   }
 
   @Test

--- a/server/test/services/migration/ProgramMigrationServiceTest.java
+++ b/server/test/services/migration/ProgramMigrationServiceTest.java
@@ -36,15 +36,20 @@ import repository.QuestionRepository;
 import repository.ResetPostgres;
 import repository.TransactionManager;
 import repository.VersionRepository;
+import services.CiviFormError;
 import services.ErrorAnd;
 import services.LocalizedStrings;
 import services.program.ProgramDefinition;
 import services.program.ProgramQuestionDefinition;
 import services.program.ProgramType;
+import services.question.QuestionOption;
 import services.question.QuestionService;
 import services.question.exceptions.UnsupportedQuestionTypeException;
+import services.question.types.MultiOptionQuestionDefinition;
+import services.question.types.MultiOptionQuestionDefinition.MultiOptionQuestionType;
 import services.question.types.QuestionDefinition;
 import services.question.types.QuestionDefinitionBuilder;
+import services.question.types.QuestionDefinitionConfig;
 import services.question.types.QuestionType;
 import support.ProgramBuilder;
 
@@ -63,6 +68,10 @@ public final class ProgramMigrationServiceTest extends ResetPostgres {
   private static final String QUESTION_2_NAME = "questionTwo";
   private static final String QUESTION_3_NAME = "questionThree";
   private static final String QUESTION_4_NAME = "questionFour";
+  private static final String VALID_YES_NO_NAME = "validYesNoQuestion";
+  private static final String INVALID_YES_NO_NAME = "invalidYesNoQuestion";
+  private static final String DROPDOWN_QUESTION_NAME = "dropdownQuestion";
+
   private static final QuestionDefinition QUESTION_1 = createTextQuestion(QUESTION_1_NAME, 1L);
   private static final QuestionDefinition QUESTION_2 = createTextQuestion(QUESTION_2_NAME, 2L);
   private static final QuestionDefinition QUESTION_3 =
@@ -71,11 +80,22 @@ public final class ProgramMigrationServiceTest extends ResetPostgres {
       createQuestion("enumerator", 4L, QuestionType.ENUMERATOR);
   private static final QuestionDefinition REPEATED =
       createTextQuestionWithEnumerator("repeated", 5L, Optional.of(4L));
+  private static final QuestionDefinition VALID_YES_NO_QUESTION =
+      createYesNoQuestion(
+          VALID_YES_NO_NAME, 6L, ImmutableList.of("yes", "no", "maybe", "not-sure"));
+  private static final QuestionDefinition INVALID_YES_NO_QUESTION =
+      createYesNoQuestion(INVALID_YES_NO_NAME, 7L, ImmutableList.of("yes", "no", "absolutely"));
+  private static final QuestionDefinition MINIMAL_VALID_YES_NO_QUESTION =
+      createYesNoQuestion("minimalValidYesNo", 8L, ImmutableList.of("yes", "no"));
+  private static final QuestionDefinition DROPDOWN_QUESTION =
+      createDropdownQuestion(DROPDOWN_QUESTION_NAME, 9L, ImmutableList.of("option1", "option2"));
+
   private static final ImmutableList<QuestionDefinition> QUESTIONS_1_2 =
       ImmutableList.of(QUESTION_1, QUESTION_2);
   private static final String PROGRAM_NAME_1 = "Program 1";
   private static final String PROGRAM_NAME_2 = "Program 2";
   private static final Long PROGRAM_ID_1 = 1000L;
+
   private final ProgramMigrationService service =
       new ProgramMigrationService(
           instanceOf(ApplicationStatusesRepository.class),
@@ -801,6 +821,160 @@ public final class ProgramMigrationServiceTest extends ResetPostgres {
                 REPEATED.getName(), ENUMERATOR.getName()));
   }
 
+  @Test
+  public void validateQuestions_validYesNoQuestion_noErrors() {
+    ProgramDefinition programDefinition =
+        ProgramBuilder.newActiveProgram("test-program")
+            .withBlock("Test Block")
+            .withRequiredQuestionDefinition(VALID_YES_NO_QUESTION)
+            .buildDefinition();
+
+    ImmutableSet<CiviFormError> errors =
+        service.validateQuestions(
+            programDefinition, ImmutableList.of(VALID_YES_NO_QUESTION), ImmutableList.of());
+
+    assertThat(errors).isEmpty();
+  }
+
+  @Test
+  public void validateQuestions_invalidYesNoQuestion_returnsError() {
+    ProgramDefinition programDefinition =
+        ProgramBuilder.newActiveProgram("test-program")
+            .withBlock("Test Block")
+            .withRequiredQuestionDefinition(INVALID_YES_NO_QUESTION)
+            .buildDefinition();
+
+    ImmutableSet<CiviFormError> errors =
+        service.validateQuestions(
+            programDefinition, ImmutableList.of(INVALID_YES_NO_QUESTION), ImmutableList.of());
+
+    assertThat(errors).hasSize(1);
+    assertThat(errors.iterator().next().message())
+        .contains(
+            "Yes/No question '"
+                + INVALID_YES_NO_NAME
+                + "' contains unsupported option: 'absolutely'");
+    assertThat(errors.iterator().next().message())
+        .contains("Only 'yes', 'no', 'maybe', and 'not-sure' options are allowed.");
+  }
+
+  @Test
+  public void validateQuestions_mixedQuestionsWithInvalidYesNo_returnsYesNoError() {
+    ProgramDefinition programDefinition =
+        ProgramBuilder.newActiveProgram("test-program")
+            .withBlock("Test Block")
+            .withRequiredQuestionDefinition(QUESTION_1)
+            .withRequiredQuestionDefinition(INVALID_YES_NO_QUESTION)
+            .buildDefinition();
+
+    ImmutableSet<CiviFormError> errors =
+        service.validateQuestions(
+            programDefinition,
+            ImmutableList.of(QUESTION_1, INVALID_YES_NO_QUESTION),
+            ImmutableList.of());
+
+    assertThat(errors).hasSize(1);
+    assertThat(errors.iterator().next().message())
+        .contains(
+            "Yes/No question '"
+                + INVALID_YES_NO_NAME
+                + "' contains unsupported option: 'absolutely'");
+  }
+
+  @Test
+  public void validateQuestions_nonYesNoQuestionsOnly_noErrors() {
+    ProgramDefinition programDefinition =
+        ProgramBuilder.newActiveProgram("test-program")
+            .withBlock("Test Block")
+            .withRequiredQuestionDefinition(QUESTION_1)
+            .withRequiredQuestionDefinition(DROPDOWN_QUESTION)
+            .buildDefinition();
+
+    ImmutableSet<CiviFormError> errors =
+        service.validateQuestions(
+            programDefinition, ImmutableList.of(QUESTION_1, DROPDOWN_QUESTION), ImmutableList.of());
+
+    assertThat(errors).isEmpty();
+  }
+
+  @Test
+  public void saveImportedProgram_validYesNoQuestion_succeeds() {
+    ProgramDefinition programDefinition =
+        ProgramBuilder.newActiveProgram("test-program")
+            .withBlock("Test Block")
+            .withRequiredQuestionDefinition(MINIMAL_VALID_YES_NO_QUESTION)
+            .buildDefinition();
+
+    ErrorAnd<ProgramModel, String> result =
+        service.saveImportedProgram(
+            programDefinition, ImmutableList.of(MINIMAL_VALID_YES_NO_QUESTION), ImmutableMap.of());
+
+    assertThat(result.isError()).isFalse();
+    assertThat(result.hasResult()).isTrue();
+  }
+
+  @Test
+  public void saveImportedProgram_invalidYesNoQuestion_returnsError() {
+    ProgramDefinition programDefinition =
+        ProgramBuilder.newActiveProgram("test-program")
+            .withBlock("Test Block")
+            .withRequiredQuestionDefinition(INVALID_YES_NO_QUESTION)
+            .buildDefinition();
+
+    ErrorAnd<ProgramModel, String> result =
+        service.saveImportedProgram(
+            programDefinition, ImmutableList.of(INVALID_YES_NO_QUESTION), ImmutableMap.of());
+
+    assertThat(result.isError()).isTrue();
+    assertThat(result.getErrors())
+        .contains(
+            "Yes/No question '"
+                + INVALID_YES_NO_NAME
+                + "' contains unsupported option: 'absolutely'. "
+                + "Only 'yes', 'no', 'maybe', and 'not-sure' options are allowed.");
+  }
+
+  @Test
+  public void saveImportedProgram_multipleYesNoQuestionsWithMixedValidity_returnsFirstError() {
+    QuestionDefinition anotherInvalidYesNo =
+        createYesNoQuestion("anotherInvalidYesNo", 10L, ImmutableList.of("yes", "no", "perhaps"));
+
+    ProgramDefinition programDefinition =
+        ProgramBuilder.newActiveProgram("test-program")
+            .withBlock("Test Block")
+            .withRequiredQuestionDefinition(VALID_YES_NO_QUESTION)
+            .withRequiredQuestionDefinition(anotherInvalidYesNo)
+            .buildDefinition();
+
+    ErrorAnd<ProgramModel, String> result =
+        service.saveImportedProgram(
+            programDefinition,
+            ImmutableList.of(VALID_YES_NO_QUESTION, anotherInvalidYesNo),
+            ImmutableMap.of());
+
+    assertThat(result.isError()).isTrue();
+    assertThat(result.getErrors())
+        .contains(
+            "Yes/No question 'anotherInvalidYesNo' contains unsupported option: 'perhaps'. "
+                + "Only 'yes', 'no', 'maybe', and 'not-sure' options are allowed.");
+  }
+
+  @Test
+  public void saveImportedProgram_nonYesNoQuestionWithCustomOptions_succeeds() {
+    ProgramDefinition programDefinition =
+        ProgramBuilder.newActiveProgram("test-program")
+            .withBlock("Test Block")
+            .withRequiredQuestionDefinition(DROPDOWN_QUESTION)
+            .buildDefinition();
+
+    ErrorAnd<ProgramModel, String> result =
+        service.saveImportedProgram(
+            programDefinition, ImmutableList.of(DROPDOWN_QUESTION), ImmutableMap.of());
+
+    assertThat(result.isError()).isFalse();
+    assertThat(result.hasResult()).isTrue();
+  }
+
   // Helper methods to create test questions
   private static QuestionDefinition createTextQuestion(String name, Long id) {
     return createTextQuestionWithEnumerator(name, id, Optional.empty());
@@ -834,5 +1008,45 @@ public final class ProgramMigrationServiceTest extends ResetPostgres {
         .setDescription(name)
         .setEnumeratorId(enumeratorId)
         .build();
+  }
+
+  // Helper methods for YES/NO questions
+  private static QuestionDefinition createYesNoQuestion(
+      String name, Long id, ImmutableList<String> optionNames) {
+    return createMultiOptionQuestion(name, id, MultiOptionQuestionType.YES_NO, optionNames);
+  }
+
+  private static QuestionDefinition createDropdownQuestion(
+      String name, Long id, ImmutableList<String> optionNames) {
+    return createMultiOptionQuestion(name, id, MultiOptionQuestionType.DROPDOWN, optionNames);
+  }
+
+  private static QuestionDefinition createMultiOptionQuestion(
+      String name,
+      Long id,
+      MultiOptionQuestionType multiOptionType,
+      ImmutableList<String> optionNames) {
+    ImmutableList.Builder<QuestionOption> optionsBuilder = ImmutableList.builder();
+    for (int i = 0; i < optionNames.size(); i++) {
+      optionsBuilder.add(
+          QuestionOption.create(
+              (long) i, optionNames.get(i), LocalizedStrings.of(Locale.US, optionNames.get(i))));
+    }
+
+    QuestionDefinitionConfig config =
+        QuestionDefinitionConfig.builder()
+            .setName(name)
+            .setDescription("Test " + multiOptionType.name() + " question")
+            .setQuestionText(LocalizedStrings.of(Locale.US, "Select an option"))
+            .build();
+
+    MultiOptionQuestionDefinition question =
+        new MultiOptionQuestionDefinition(config, optionsBuilder.build(), multiOptionType);
+    // Set the ID using the same pattern as existing createQuestionWithEnumerator method
+    try {
+      return new QuestionDefinitionBuilder(question).setId(id).build();
+    } catch (UnsupportedQuestionTypeException e) {
+      throw new RuntimeException(e);
+    }
   }
 }

--- a/server/test/services/migration/QuestionValidationUtilsTest.java
+++ b/server/test/services/migration/QuestionValidationUtilsTest.java
@@ -337,7 +337,6 @@ public final class QuestionValidationUtilsTest extends ResetPostgres {
             "YES_NO question 'case-sensitive-question' is missing required 'no' option.");
   }
 
-
   @Test
   public void validateYesNoQuestions_missingYesOption_returnsError() {
     QuestionDefinition yesNoQuestion =
@@ -384,7 +383,8 @@ public final class QuestionValidationUtilsTest extends ResetPostgres {
   public void validateYesNoQuestions_hasRequiredOptionsAndInvalidOnes_returnsOnlyInvalidErrors() {
     QuestionDefinition yesNoQuestion =
         createYesNoQuestionWithOptions(
-            "valid-required-invalid-extra-question", ImmutableList.of("yes", "no", "invalid-option"));
+            "valid-required-invalid-extra-question",
+            ImmutableList.of("yes", "no", "invalid-option"));
 
     ImmutableSet<CiviFormError> errors =
         QuestionValidationUtils.validateYesNoQuestions(ImmutableList.of(yesNoQuestion));
@@ -392,7 +392,9 @@ public final class QuestionValidationUtilsTest extends ResetPostgres {
     assertThat(errors).hasSize(1);
     assertThat(errors.stream().map(CiviFormError::message))
         .contains(
-            "YES_NO question 'valid-required-invalid-extra-question' contains invalid option 'invalid-option'. Only 'yes', 'no', 'maybe', and 'not-sure' options are allowed.");
+            "YES_NO question 'valid-required-invalid-extra-question' contains invalid option"
+                + " 'invalid-option'. Only 'yes', 'no', 'maybe', and 'not-sure' options are"
+                + " allowed.");
   }
 
   @Test
@@ -407,10 +409,11 @@ public final class QuestionValidationUtilsTest extends ResetPostgres {
     assertThat(errors).hasSize(2);
     assertThat(errors.stream().map(CiviFormError::message))
         .contains(
-            "YES_NO question 'missing-and-invalid-question' contains invalid option 'invalid-option'. Only 'yes', 'no', 'maybe', and 'not-sure' options are allowed.",
+            "YES_NO question 'missing-and-invalid-question' contains invalid option"
+                + " 'invalid-option'. Only 'yes', 'no', 'maybe', and 'not-sure' options are"
+                + " allowed.",
             "YES_NO question 'missing-and-invalid-question' is missing required 'no' option.");
   }
-
 
   // Helper methods for YES/NO question
   private QuestionDefinition createYesNoQuestionWithOptions(

--- a/server/test/services/migration/QuestionValidationUtilsTest.java
+++ b/server/test/services/migration/QuestionValidationUtilsTest.java
@@ -238,12 +238,12 @@ public final class QuestionValidationUtilsTest extends ResetPostgres {
     assertThat(errors).hasSize(1);
     assertThat(errors.iterator().next().message())
         .contains(
-            "Yes/No question 'invalid-yes-no-question' contains unsupported option: 'absolutely'. "
+            "YES_NO question 'invalid-yes-no-question' contains invalid option 'absolutely'. "
                 + "Only 'yes', 'no', 'maybe', and 'not-sure' options are allowed.");
   }
 
   @Test
-  public void validateYesNoQuestions_multipleInvalidOptions_returnsFirstError() {
+  public void validateYesNoQuestions_multipleInvalidOptions_returnsAllErrors() {
     QuestionDefinition yesNoQuestion =
         createYesNoQuestionWithOptions(
             "invalid-yes-no-question", ImmutableList.of("yes", "absolutely", "definitely-not"));
@@ -251,10 +251,12 @@ public final class QuestionValidationUtilsTest extends ResetPostgres {
     ImmutableSet<CiviFormError> errors =
         QuestionValidationUtils.validateYesNoQuestions(ImmutableList.of(yesNoQuestion));
 
-    assertThat(errors).hasSize(1);
-    assertThat(errors.iterator().next().message())
+    assertThat(errors).hasSize(2);
+    assertThat(errors.stream().map(CiviFormError::message))
         .contains(
-            "Yes/No question 'invalid-yes-no-question' contains unsupported option: 'absolutely'. "
+            "YES_NO question 'invalid-yes-no-question' contains invalid option 'absolutely'. "
+                + "Only 'yes', 'no', 'maybe', and 'not-sure' options are allowed.",
+            "YES_NO question 'invalid-yes-no-question' contains invalid option 'definitely-not'. "
                 + "Only 'yes', 'no', 'maybe', and 'not-sure' options are allowed.");
   }
 
@@ -275,7 +277,7 @@ public final class QuestionValidationUtilsTest extends ResetPostgres {
   }
 
   @Test
-  public void validateYesNoQuestions_mixedValidAndInvalidYesNo_returnsFirstInvalidError() {
+  public void validateYesNoQuestions_mixedValidAndInvalidYesNo_returnsInvalidError() {
     QuestionDefinition validYesNoQuestion =
         createYesNoQuestionWithOptions("valid-yes-no-question", ImmutableList.of("yes", "no"));
     QuestionDefinition invalidYesNoQuestion =
@@ -289,7 +291,7 @@ public final class QuestionValidationUtilsTest extends ResetPostgres {
     assertThat(errors).hasSize(1);
     assertThat(errors.iterator().next().message())
         .contains(
-            "Yes/No question 'invalid-yes-no-question' contains unsupported option: 'perhaps'. "
+            "YES_NO question 'invalid-yes-no-question' contains invalid option 'perhaps'. "
                 + "Only 'yes', 'no', 'maybe', and 'not-sure' options are allowed.");
   }
 
@@ -323,10 +325,12 @@ public final class QuestionValidationUtilsTest extends ResetPostgres {
     ImmutableSet<CiviFormError> errors =
         QuestionValidationUtils.validateYesNoQuestions(ImmutableList.of(yesNoQuestion));
 
-    assertThat(errors).hasSize(1);
-    assertThat(errors.iterator().next().message())
+    assertThat(errors).hasSize(2);
+    assertThat(errors.stream().map(CiviFormError::message))
         .contains(
-            "Yes/No question 'case-sensitive-question' contains unsupported option: 'Yes'. "
+            "YES_NO question 'case-sensitive-question' contains invalid option 'Yes'. "
+                + "Only 'yes', 'no', 'maybe', and 'not-sure' options are allowed.",
+            "YES_NO question 'case-sensitive-question' contains invalid option 'No'. "
                 + "Only 'yes', 'no', 'maybe', and 'not-sure' options are allowed.");
   }
 

--- a/server/test/services/migration/QuestionValidationUtilsTest.java
+++ b/server/test/services/migration/QuestionValidationUtilsTest.java
@@ -337,6 +337,81 @@ public final class QuestionValidationUtilsTest extends ResetPostgres {
             "YES_NO question 'case-sensitive-question' is missing required 'no' option.");
   }
 
+
+  @Test
+  public void validateYesNoQuestions_missingYesOption_returnsError() {
+    QuestionDefinition yesNoQuestion =
+        createYesNoQuestionWithOptions("missing-yes-question", ImmutableList.of("no", "maybe"));
+
+    ImmutableSet<CiviFormError> errors =
+        QuestionValidationUtils.validateYesNoQuestions(ImmutableList.of(yesNoQuestion));
+
+    assertThat(errors).hasSize(1);
+    assertThat(errors.stream().map(CiviFormError::message))
+        .contains("YES_NO question 'missing-yes-question' is missing required 'yes' option.");
+  }
+
+  @Test
+  public void validateYesNoQuestions_missingNoOption_returnsError() {
+    QuestionDefinition yesNoQuestion =
+        createYesNoQuestionWithOptions("missing-no-question", ImmutableList.of("yes", "not-sure"));
+
+    ImmutableSet<CiviFormError> errors =
+        QuestionValidationUtils.validateYesNoQuestions(ImmutableList.of(yesNoQuestion));
+
+    assertThat(errors).hasSize(1);
+    assertThat(errors.stream().map(CiviFormError::message))
+        .contains("YES_NO question 'missing-no-question' is missing required 'no' option.");
+  }
+
+  @Test
+  public void validateYesNoQuestions_missingBothRequiredOptions_returnsBothErrors() {
+    QuestionDefinition yesNoQuestion =
+        createYesNoQuestionWithOptions(
+            "missing-both-required-question", ImmutableList.of("maybe", "not-sure"));
+
+    ImmutableSet<CiviFormError> errors =
+        QuestionValidationUtils.validateYesNoQuestions(ImmutableList.of(yesNoQuestion));
+
+    assertThat(errors).hasSize(2);
+    assertThat(errors.stream().map(CiviFormError::message))
+        .contains(
+            "YES_NO question 'missing-both-required-question' is missing required 'yes' option.",
+            "YES_NO question 'missing-both-required-question' is missing required 'no' option.");
+  }
+
+  @Test
+  public void validateYesNoQuestions_hasRequiredOptionsAndInvalidOnes_returnsOnlyInvalidErrors() {
+    QuestionDefinition yesNoQuestion =
+        createYesNoQuestionWithOptions(
+            "valid-required-invalid-extra-question", ImmutableList.of("yes", "no", "invalid-option"));
+
+    ImmutableSet<CiviFormError> errors =
+        QuestionValidationUtils.validateYesNoQuestions(ImmutableList.of(yesNoQuestion));
+
+    assertThat(errors).hasSize(1);
+    assertThat(errors.stream().map(CiviFormError::message))
+        .contains(
+            "YES_NO question 'valid-required-invalid-extra-question' contains invalid option 'invalid-option'. Only 'yes', 'no', 'maybe', and 'not-sure' options are allowed.");
+  }
+
+  @Test
+  public void validateYesNoQuestions_missingRequiredAndHasInvalid_returnsAllErrors() {
+    QuestionDefinition yesNoQuestion =
+        createYesNoQuestionWithOptions(
+            "missing-and-invalid-question", ImmutableList.of("yes", "invalid-option"));
+
+    ImmutableSet<CiviFormError> errors =
+        QuestionValidationUtils.validateYesNoQuestions(ImmutableList.of(yesNoQuestion));
+
+    assertThat(errors).hasSize(2);
+    assertThat(errors.stream().map(CiviFormError::message))
+        .contains(
+            "YES_NO question 'missing-and-invalid-question' contains invalid option 'invalid-option'. Only 'yes', 'no', 'maybe', and 'not-sure' options are allowed.",
+            "YES_NO question 'missing-and-invalid-question' is missing required 'no' option.");
+  }
+
+
   // Helper methods for YES/NO question
   private QuestionDefinition createYesNoQuestionWithOptions(
       String name, ImmutableList<String> optionNames) {

--- a/server/test/services/migration/QuestionValidationUtilsTest.java
+++ b/server/test/services/migration/QuestionValidationUtilsTest.java
@@ -251,13 +251,14 @@ public final class QuestionValidationUtilsTest extends ResetPostgres {
     ImmutableSet<CiviFormError> errors =
         QuestionValidationUtils.validateYesNoQuestions(ImmutableList.of(yesNoQuestion));
 
-    assertThat(errors).hasSize(2);
+    assertThat(errors).hasSize(3);
     assertThat(errors.stream().map(CiviFormError::message))
         .contains(
-            "YES_NO question 'invalid-yes-no-question' contains invalid option 'absolutely'. "
-                + "Only 'yes', 'no', 'maybe', and 'not-sure' options are allowed.",
-            "YES_NO question 'invalid-yes-no-question' contains invalid option 'definitely-not'. "
-                + "Only 'yes', 'no', 'maybe', and 'not-sure' options are allowed.");
+            "YES_NO question 'invalid-yes-no-question' contains invalid option 'absolutely'. Only"
+                + " 'yes', 'no', 'maybe', and 'not-sure' options are allowed.",
+            "YES_NO question 'invalid-yes-no-question' contains invalid option 'definitely-not'."
+                + " Only 'yes', 'no', 'maybe', and 'not-sure' options are allowed.",
+            "YES_NO question 'invalid-yes-no-question' is missing required 'no' option.");
   }
 
   @Test
@@ -325,13 +326,15 @@ public final class QuestionValidationUtilsTest extends ResetPostgres {
     ImmutableSet<CiviFormError> errors =
         QuestionValidationUtils.validateYesNoQuestions(ImmutableList.of(yesNoQuestion));
 
-    assertThat(errors).hasSize(2);
+    assertThat(errors).hasSize(4);
     assertThat(errors.stream().map(CiviFormError::message))
         .contains(
-            "YES_NO question 'case-sensitive-question' contains invalid option 'Yes'. "
-                + "Only 'yes', 'no', 'maybe', and 'not-sure' options are allowed.",
-            "YES_NO question 'case-sensitive-question' contains invalid option 'No'. "
-                + "Only 'yes', 'no', 'maybe', and 'not-sure' options are allowed.");
+            "YES_NO question 'case-sensitive-question' contains invalid option 'Yes'. Only 'yes',"
+                + " 'no', 'maybe', and 'not-sure' options are allowed.",
+            "YES_NO question 'case-sensitive-question' contains invalid option 'No'. Only 'yes',"
+                + " 'no', 'maybe', and 'not-sure' options are allowed.",
+            "YES_NO question 'case-sensitive-question' is missing required 'yes' option.",
+            "YES_NO question 'case-sensitive-question' is missing required 'no' option.");
   }
 
   // Helper methods for YES/NO question

--- a/server/test/services/migration/QuestionValidationUtilsTest.java
+++ b/server/test/services/migration/QuestionValidationUtilsTest.java
@@ -203,6 +203,172 @@ public final class QuestionValidationUtilsTest extends ResetPostgres {
     assertThat(errors.iterator().next().message()).contains(REPEATED_NAME_QUESTION.getName());
   }
 
+  @Test
+  public void validateYesNoQuestions_allValidOptions_noErrors() {
+    QuestionDefinition yesNoQuestion =
+        createYesNoQuestionWithOptions(
+            "valid-yes-no-question", ImmutableList.of("yes", "no", "maybe", "not-sure"));
+
+    ImmutableSet<CiviFormError> errors =
+        QuestionValidationUtils.validateYesNoQuestions(ImmutableList.of(yesNoQuestion));
+
+    assertThat(errors).isEmpty();
+  }
+
+  @Test
+  public void validateYesNoQuestions_minimalValidOptions_noErrors() {
+    QuestionDefinition yesNoQuestion =
+        createYesNoQuestionWithOptions("minimal-yes-no-question", ImmutableList.of("yes", "no"));
+
+    ImmutableSet<CiviFormError> errors =
+        QuestionValidationUtils.validateYesNoQuestions(ImmutableList.of(yesNoQuestion));
+
+    assertThat(errors).isEmpty();
+  }
+
+  @Test
+  public void validateYesNoQuestions_invalidOption_returnsError() {
+    QuestionDefinition yesNoQuestion =
+        createYesNoQuestionWithOptions(
+            "invalid-yes-no-question", ImmutableList.of("yes", "no", "absolutely"));
+
+    ImmutableSet<CiviFormError> errors =
+        QuestionValidationUtils.validateYesNoQuestions(ImmutableList.of(yesNoQuestion));
+
+    assertThat(errors).hasSize(1);
+    assertThat(errors.iterator().next().message())
+        .contains(
+            "Yes/No question 'invalid-yes-no-question' contains unsupported option: 'absolutely'. "
+                + "Only 'yes', 'no', 'maybe', and 'not-sure' options are allowed.");
+  }
+
+  @Test
+  public void validateYesNoQuestions_multipleInvalidOptions_returnsFirstError() {
+    QuestionDefinition yesNoQuestion =
+        createYesNoQuestionWithOptions(
+            "invalid-yes-no-question", ImmutableList.of("yes", "absolutely", "definitely-not"));
+
+    ImmutableSet<CiviFormError> errors =
+        QuestionValidationUtils.validateYesNoQuestions(ImmutableList.of(yesNoQuestion));
+
+    assertThat(errors).hasSize(1);
+    assertThat(errors.iterator().next().message())
+        .contains(
+            "Yes/No question 'invalid-yes-no-question' contains unsupported option: 'absolutely'. "
+                + "Only 'yes', 'no', 'maybe', and 'not-sure' options are allowed.");
+  }
+
+  @Test
+  public void validateYesNoQuestions_mixedQuestionTypes_onlyValidatesYesNo() {
+    QuestionDefinition textQuestion = createQuestion("text-question", 1L);
+    QuestionDefinition dropdownQuestion =
+        createDropdownQuestionWithOptions(
+            "dropdown-question", ImmutableList.of("custom-option-1", "custom-option-2"));
+    QuestionDefinition validYesNoQuestion =
+        createYesNoQuestionWithOptions("valid-yes-no-question", ImmutableList.of("yes", "no"));
+
+    ImmutableSet<CiviFormError> errors =
+        QuestionValidationUtils.validateYesNoQuestions(
+            ImmutableList.of(textQuestion, dropdownQuestion, validYesNoQuestion));
+
+    assertThat(errors).isEmpty();
+  }
+
+  @Test
+  public void validateYesNoQuestions_mixedValidAndInvalidYesNo_returnsFirstInvalidError() {
+    QuestionDefinition validYesNoQuestion =
+        createYesNoQuestionWithOptions("valid-yes-no-question", ImmutableList.of("yes", "no"));
+    QuestionDefinition invalidYesNoQuestion =
+        createYesNoQuestionWithOptions(
+            "invalid-yes-no-question", ImmutableList.of("yes", "no", "perhaps"));
+
+    ImmutableSet<CiviFormError> errors =
+        QuestionValidationUtils.validateYesNoQuestions(
+            ImmutableList.of(validYesNoQuestion, invalidYesNoQuestion));
+
+    assertThat(errors).hasSize(1);
+    assertThat(errors.iterator().next().message())
+        .contains(
+            "Yes/No question 'invalid-yes-no-question' contains unsupported option: 'perhaps'. "
+                + "Only 'yes', 'no', 'maybe', and 'not-sure' options are allowed.");
+  }
+
+  @Test
+  public void validateYesNoQuestions_emptyQuestionList_noErrors() {
+    ImmutableSet<CiviFormError> errors =
+        QuestionValidationUtils.validateYesNoQuestions(ImmutableList.of());
+
+    assertThat(errors).isEmpty();
+  }
+
+  @Test
+  public void validateYesNoQuestions_noYesNoQuestions_noErrors() {
+    QuestionDefinition textQuestion = createQuestion("text-question", 1L);
+    QuestionDefinition dropdownQuestion =
+        createDropdownQuestionWithOptions(
+            "dropdown-question", ImmutableList.of("option-1", "option-2"));
+
+    ImmutableSet<CiviFormError> errors =
+        QuestionValidationUtils.validateYesNoQuestions(
+            ImmutableList.of(textQuestion, dropdownQuestion));
+
+    assertThat(errors).isEmpty();
+  }
+
+  @Test
+  public void validateYesNoQuestions_caseExactMatch_validatesCorrectly() {
+    QuestionDefinition yesNoQuestion =
+        createYesNoQuestionWithOptions("case-sensitive-question", ImmutableList.of("Yes", "No"));
+
+    ImmutableSet<CiviFormError> errors =
+        QuestionValidationUtils.validateYesNoQuestions(ImmutableList.of(yesNoQuestion));
+
+    assertThat(errors).hasSize(1);
+    assertThat(errors.iterator().next().message())
+        .contains(
+            "Yes/No question 'case-sensitive-question' contains unsupported option: 'Yes'. "
+                + "Only 'yes', 'no', 'maybe', and 'not-sure' options are allowed.");
+  }
+
+  // Helper methods for YES/NO question
+  private QuestionDefinition createYesNoQuestionWithOptions(
+      String name, ImmutableList<String> optionNames) {
+    return createMultiOptionQuestionWithOptions(name, QuestionType.YES_NO, optionNames);
+  }
+
+  private QuestionDefinition createDropdownQuestionWithOptions(
+      String name, ImmutableList<String> optionNames) {
+    return createMultiOptionQuestionWithOptions(name, QuestionType.DROPDOWN, optionNames);
+  }
+
+  private QuestionDefinition createMultiOptionQuestionWithOptions(
+      String name, QuestionType type, ImmutableList<String> optionNames) {
+    ImmutableList.Builder<QuestionOption> optionsBuilder = ImmutableList.builder();
+    for (int i = 0; i < optionNames.size(); i++) {
+      optionsBuilder.add(
+          QuestionOption.create(
+              (long) i, optionNames.get(i), LocalizedStrings.of(Locale.US, optionNames.get(i))));
+    }
+
+    MultiOptionQuestionType multiOptionType =
+        switch (type) {
+          case YES_NO -> MultiOptionQuestionType.YES_NO;
+          case DROPDOWN -> MultiOptionQuestionType.DROPDOWN;
+          case RADIO_BUTTON -> MultiOptionQuestionType.RADIO_BUTTON;
+          case CHECKBOX -> MultiOptionQuestionType.CHECKBOX;
+          default -> throw new IllegalArgumentException("Unsupported multi-option type: " + type);
+        };
+
+    QuestionDefinitionConfig config =
+        QuestionDefinitionConfig.builder()
+            .setName(name)
+            .setDescription("Test " + type.name() + " question")
+            .setQuestionText(LocalizedStrings.of(Locale.US, "Select an option"))
+            .build();
+
+    return new MultiOptionQuestionDefinition(config, optionsBuilder.build(), multiOptionType);
+  }
+
   // Helper methods to create test questions
   private static QuestionDefinition createQuestion(String name, Long id) {
     return createQuestionWithEnumerator(name, id, Optional.empty());


### PR DESCRIPTION
Implement validation for YES/NO questions during program import to ensure data integrity.

### Description

- Added `validateYesNoQuestions()` method to `QuestionValidationUtils` to validate that YES/NO questions only contain allowed options: 'yes', 'no', 'maybe', and 'not-sure'
- Integrated validation into both preview flow (`validateQuestions`) and save flow (`saveImportedProgram`) in `ProgramMigrationService`
- Added comprehensive test coverage for both `QuestionValidationUtils` and `ProgramMigrationService`
- Validation uses fast-fail approach, returning clear error messages for the first invalid option found
- Non-YES/NO questions are unaffected and can continue using custom options


## Release notes

Added validation for YES/NO question imports to prevent invalid option configurations. During program import, YES/NO questions are now validated to ensure they only contain the supported options: 'yes', 'no', 'maybe', and 'not-sure'. Invalid configurations will show clear error messages and prevent import until corrected.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [X] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [X] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [X] Added an additional reviewer from `civiform/eng-admin` as FYI (if the primary reviewer is not an admin and this PR includes functionality changes)
- [ ] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [X] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

#### Database evolutions

Read the guidelines [here](https://github.com/civiform/civiform/wiki/Database#writing-database-evolutions)

- [ ] Assigned two reviewers
- [ ] Guarded against already existing resources using `IF NOT EXISTS` and `IF EXISTS`
- [ ] Downs created to undo changes in Ups
- [ ] Every comment in script should begin with -- and not # --- unless it denotes Ups or Downs. See [here](https://www.playframework.com/documentation/2.9.x/Evolutions) for details.
- [ ] Tested both the Downs and the Ups scripts manually (When testing, include all comments from the evolution in your test script to ensure any syntax errors in the comments are caught.)
- [ ] Data migrations aren't being done (please use a [Durable Job](https://github.com/civiform/civiform/wiki/Database#durable-jobs-for-data-updates) if doing a data migration)
- [ ] Update the model documentation in our [wiki](https://github.com/civiform/civiform/wiki/Database) if necessary

#### Durable jobs

Read the docs [here](https://github.com/civiform/civiform/wiki/Database#durable-jobs-for-data-updates)

- [ ] Assigned two reviewers
- [ ] Included a rollback plan and a job to undo the data changes if appropriate

#### User visible changes

- [ ] Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
  - [ ] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [ ] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Made equivalent changes in Thymeleaf for applicant-facing features and changes (or created an issue in the [Northstar epic](https://github.com/orgs/civiform/projects/1/views/94) to track that it's missing from Thymeleaf)
- [ ] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order
- [ ] Manually tested with a screen reader if the feature is applicant-facing. See [screen reader testing](https://github.com/civiform/civiform/wiki/Testing#screen-reader-testing)
- [ ] Manually tested with a right-to-left language

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/helper/feature-flags.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://github.com/civiform/civiform/wiki/Feature-Flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Instructions for manual testing

1. **Test valid YES/NO import:**
   - Use a valid YES/NO question JSON
   - Import should succeed without errors

2. **Test invalid YES/NO import:**
   - Use an invalid YES/NO question JSON with options like "absolutely", "never"
   - Should show error: "Yes/No question 'question-name' contains unsupported option: 'absolutely'. Only 'yes', 'no', 'maybe', and 'not-sure' options are allowed."
   - Import should be blocked

3. **Test mixed question types:**
   - Import program with YES/NO + other question types (dropdown, text)
   - Only YES/NO questions should be validated
   - Other question types should work with custom options

**Screnshots**
**Invalid message:**
<img width="1092" height="625" alt="image" src="https://github.com/user-attachments/assets/50e178ca-9066-4c08-8fa8-2fe5fc2cc249" />

**Valid Message:**
<img width="974" height="634" alt="image" src="https://github.com/user-attachments/assets/0a58a747-ca87-4b1f-8538-0f6cf3f9c14c" />

<img width="958" height="540" alt="image" src="https://github.com/user-attachments/assets/afcec416-6c30-4239-b717-b0e12630a301" />


### Issue(s) this completes

Fixes #10780
