### PR TITLE
[North Star] Update ApplicantProgramReviewControllerTest.java

### DIFF
--- a/server/test/controllers/applicant/ApplicantProgramReviewControllerTest.java
+++ b/server/test/controllers/applicant/ApplicantProgramReviewControllerTest.java
@@ -469,6 +469,40 @@ public class ApplicantProgramReviewControllerTest extends WithMockedProfiles {
     assertThat(applications.asList().get(0).getProgram().id).isEqualTo(activeProgram.id);
   }
 
+  @Test
+  public void northstar_submit_duplicate_handlesErrorAndDoesNotSaveDuplicateApplication() {
+    ProgramModel activeProgram =
+        ProgramBuilder.newActiveProgram()
+            .withBlock()
+            .withRequiredQuestion(testQuestionBank().nameApplicantName())
+            .withBlock()
+            .withRequiredQuestion(testQuestionBank().staticContent())
+            .build();
+    answer(activeProgram.id);
+    this.northstarSubmit(applicant.id, activeProgram.id);
+
+    // Submit the application again without editing
+    Result noEditsResult = this.northstarSubmit(applicant.id, activeProgram.id);
+    // Error is handled and applicant is shown duplicates page
+    assertThat(noEditsResult.status()).isEqualTo(FOUND);
+
+    // Edit the application but re-enter the same values
+    answer(activeProgram.id);
+    Result sameValuesResult = this.northstarSubmit(applicant.id, activeProgram.id);
+    // Error is handled and applicant is shown duplicates page
+    assertThat(sameValuesResult.status()).isEqualTo(FOUND);
+
+    // There is only one application saved in the db
+    ApplicationRepository applicationRepository = instanceOf(ApplicationRepository.class);
+    ImmutableSet<ApplicationModel> applications =
+        applicationRepository
+            .getApplicationsForApplicant(applicant.id, ImmutableSet.of(LifecycleStage.ACTIVE))
+            .toCompletableFuture()
+            .join();
+    assertThat(applications).hasSize(1);
+    assertThat(applications.asList().get(0).getProgram().id).isEqualTo(activeProgram.id);
+  }
+
   public Result reviewWithApplicantId(long applicantId, long programId) {
     String programIdStr = String.valueOf(programId);
     Request request =
@@ -487,12 +521,27 @@ public class ApplicantProgramReviewControllerTest extends WithMockedProfiles {
   public Result submit(long applicantId, long programId) {
     Request request =
         fakeRequestBuilder()
-            .addCiviFormSetting("NORTH_STAR_APPLICANT_UI", "false")
             .call(
                 routes.ApplicantProgramReviewController.submitWithApplicantId(
                     applicantId, programId))
             .header(skipUserProfile, "false")
             .build();
+    when(settingsManifest.getNorthStarApplicantUi(request)).thenReturn(false);
+    return subject
+        .submitWithApplicantId(request, applicantId, programId)
+        .toCompletableFuture()
+        .join();
+  }
+
+  public Result northstarSubmit(long applicantId, long programId) {
+    Request request =
+        fakeRequestBuilder()
+            .call(
+                routes.ApplicantProgramReviewController.submitWithApplicantId(
+                    applicantId, programId))
+            .header(skipUserProfile, "false")
+            .build();
+    when(settingsManifest.getNorthStarApplicantUi(request)).thenReturn(true);
     return subject
         .submitWithApplicantId(request, applicantId, programId)
         .toCompletableFuture()


### PR DESCRIPTION
### Description

Update tests in ApplicantProgramReviewControllerTest.java to account for northstar flag being on.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [ ] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if the primary reviewer is not an admin and this PR includes functionality changes)
- [ ] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.


### Issue(s) this completes

Fixes #10971