### PR TITLE
Fix missing northstar favicon; update Admin so both default to application.conf for favicon url

### DIFF
--- a/browser-test/src/northstar_link_tags.test.ts
+++ b/browser-test/src/northstar_link_tags.test.ts
@@ -1,0 +1,17 @@
+import {test, expect} from './support/civiform_fixtures'
+import {enableFeatureFlag} from './support'
+
+test.describe('navigating to a deep link', {tag: ['@northstar']}, () => {
+  test.beforeEach(async ({page}) => {
+    await enableFeatureFlag(page, 'north_star_applicant_ui')
+  })
+
+  test('has favicon link', async ({page, applicantQuestions}) => {
+    await applicantQuestions.gotoApplicantHomePage()
+
+    const linkTagLocator = page.locator('link[rel="icon"]')
+
+    await expect(linkTagLocator).toHaveAttribute('href')
+    expect(await linkTagLocator.getAttribute('href')).not.toBeNull()
+  })
+})

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -23,6 +23,8 @@ services:
       - 9000:9000
       - 8457:8457
       - 50000:50000
+    environment:
+      FAVICON_URL: "https://img.icons8.com/?size=100&id=80349&format=png&color=000000"
 
   civiform-shell:
     image: civiform-dev
@@ -83,7 +85,7 @@ services:
       - ./monitoring/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
       - prometheus-data:/prometheus
 
-  grafana:  
+  grafana:
     profiles: ['monitoring']
     image: grafana/grafana@sha256:1bf0ac005f1bf15bb5840c94cea715516526fb98dc28d0c630db24d02cd2ef17
     depends_on:

--- a/server/app/views/HtmlBundle.java
+++ b/server/app/views/HtmlBundle.java
@@ -245,15 +245,15 @@ public final class HtmlBundle {
   private HeadTag renderHead() {
     // TODO: Throw exception if page title is not set.
     return head()
-      .with(title(pageTitle))
-      .condWith(
-        faviconURL.isPresent(),
-        link().withRel("icon").withHref(faviconURL.get()),
-        link().withRel("apple-touch-icon").withHref("/apple-touch-icon.png"),
-        link().withRel("apple-touch-icon-precomposed.png").withHref("/apple-touch-icon.png"))
-      .with(metadata)
-      .with(CspUtil.applyCsp(request, headScripts))
-      .with(CspUtil.applyCspToStyles(request, stylesheets));
+        .with(title(pageTitle))
+        .condWith(
+            faviconURL.isPresent(),
+            link().withRel("icon").withHref(faviconURL.get()),
+            link().withRel("apple-touch-icon").withHref("/apple-touch-icon.png"),
+            link().withRel("apple-touch-icon-precomposed.png").withHref("/apple-touch-icon.png"))
+        .with(metadata)
+        .with(CspUtil.applyCsp(request, headScripts))
+        .with(CspUtil.applyCspToStyles(request, stylesheets));
   }
 
   private HeaderTag renderHeader() {

--- a/server/app/views/HtmlBundle.java
+++ b/server/app/views/HtmlBundle.java
@@ -39,11 +39,6 @@ import views.style.BaseStyles;
 
 /** The HtmlBundle class stores all of the data necessary for rendering a page. */
 public final class HtmlBundle {
-  // This is the fallback favicon to use if one is not provided.
-  // This image is just white background with "CF" in blue text
-  private static final String FALLBACK_FAVICON_DATA_URI =
-      "data:image/x-icon;base64,AAABAAEAEBAAAAEAIACcAQAAFgAAAIlQTkcNChoKAAAADUlIRFIAAAAQAAAAEAgGAAAAH/P/YQAAAWNJREFUOE9j/A8EDBQAxsFjwKuPPxgK5h1n2HnhCdhDDtqSDJNSrBikhbgYDIrWMVx78gHFo7vrPRnsgWrgXvBp28lw5s4bhuZIYwY+LjaGltXnGXg4WRmOt/uBDZAT5WEo9tOFG6KvIMwgwM0GMeDui88MmnmrGWZn2TLEO6iCFd169pHh/P23DCGWigzGJesZzNXEGGZm2GAEN9gAkLN923YxXOoPZtCQ5sdQBHKBiYoowxSgl2CAnZWZgZGRAeKC3RefMni37mS40BfEoCUjgNUA9DC4NSWMQUGMB2LAozdfGVSyVjJMT7dmSHZWBxtw+dF7hjXH7jGUB+ozWFVuYlCS4GMoD9CDG26gKMwAdgUsHUT07WPYf+UZQ1OECYMQDztD06pzDGwsTAynuwIYjAiFAcjYD19/MRTNP8Gw+cwjhj///oGjcTLQzzLC3OBYwBuIFKRkhBfINWQQ5QVyvQAAuEmo0TDmRP4AAAAASUVORK5CYII=";
-
   private static final Logger logger = LoggerFactory.getLogger(HtmlBundle.class);
 
   private static final String USWDS_FILEPATH = "dist/uswds.bundle";
@@ -250,22 +245,15 @@ public final class HtmlBundle {
   private HeadTag renderHead() {
     // TODO: Throw exception if page title is not set.
     return head()
-        .with(title(pageTitle))
-        // The "orElse" value is never used, but it must be included because the
-        // "withHref" evaluates even if the "condWith" is false.
-        .condWith(
-            faviconURL.isPresent(),
-            link().withRel("icon").withHref(faviconURL.orElse("")),
-            link().withRel("apple-touch-icon").withHref("/apple-touch-icon.png"),
-            link().withRel("apple-touch-icon-precomposed.png").withHref("/apple-touch-icon.png"))
-        .condWith(
-            faviconURL.isEmpty(),
-            link().withRel("icon").withHref(FALLBACK_FAVICON_DATA_URI),
-            link().withRel("apple-touch-icon").withHref(FALLBACK_FAVICON_DATA_URI),
-            link().withRel("apple-touch-icon-precomposed.png").withHref(FALLBACK_FAVICON_DATA_URI))
-        .with(metadata)
-        .with(CspUtil.applyCsp(request, headScripts))
-        .with(CspUtil.applyCspToStyles(request, stylesheets));
+      .with(title(pageTitle))
+      .condWith(
+        faviconURL.isPresent(),
+        link().withRel("icon").withHref(faviconURL.get()),
+        link().withRel("apple-touch-icon").withHref("/apple-touch-icon.png"),
+        link().withRel("apple-touch-icon-precomposed.png").withHref("/apple-touch-icon.png"))
+      .with(metadata)
+      .with(CspUtil.applyCsp(request, headScripts))
+      .with(CspUtil.applyCspToStyles(request, stylesheets));
   }
 
   private HeaderTag renderHeader() {

--- a/server/app/views/NorthStarBaseView.java
+++ b/server/app/views/NorthStarBaseView.java
@@ -65,6 +65,7 @@ public abstract class NorthStarBaseView {
     ThymeleafModule.PlayThymeleafContext context = playThymeleafContextFactory.create(request);
     context.setVariable("civiformImageTag", settingsManifest.getCiviformImageTag().get());
     context.setVariable("addNoIndexMetaTag", settingsManifest.getStagingAddNoindexMetaTag());
+    context.setVariable("favicon", settingsManifest.getFaviconUrl().get());
     context.setVariable("tailwindStylesheet", assetsFinder.path("stylesheets/tailwind.css"));
     context.setVariable("northStarStylesheet", assetsFinder.path("dist/uswds_northstar.min.css"));
     context.setVariable("mapQuestionEnabled", settingsManifest.getMapQuestionEnabled());

--- a/server/app/views/applicant/ApplicantBaseFragment.html
+++ b/server/app/views/applicant/ApplicantBaseFragment.html
@@ -4,6 +4,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="civiform-build-tag" th:content="${civiformImageTag}" />
   <meta th:if="${addNoIndexMetaTag}" name="robots" content="noindex" />
+  <link th:if="${favicon}" rel="icon" th:href="${favicon}" />
   <meta name="htmx-config" th:content='|{"inlineStyleNonce":"${cspNonce}"}|' />
   <!--/* Best practice: add ❤️ every time you touch this file :) */-->
   <meta

--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -627,3 +627,7 @@ session_inactivity_warning_threshold_minutes = ${?SESSION_INACTIVITY_WARNING_THR
 
 session_duration_warning_threshold_minutes = 10 # Warn the user 10 mins before the max session duration timeout
 session_duration_warning_threshold_minutes = ${?SESSION_DURATION_WARNING_THRESHOLD_MINUTES}
+
+# The URL of a 32x32 or 16x16 pixel [favicon](https://developer.mozilla.org/en-US/docs/Glossary/Favicon)
+favicon_url= "data:image/x-icon;base64,AAABAAEAEBAAAAEAIACcAQAAFgAAAIlQTkcNChoKAAAADUlIRFIAAAAQAAAAEAgGAAAAH/P/YQAAAWNJREFUOE9j/A8EDBQAxsFjwKuPPxgK5h1n2HnhCdhDDtqSDJNSrBikhbgYDIrWMVx78gHFo7vrPRnsgWrgXvBp28lw5s4bhuZIYwY+LjaGltXnGXg4WRmOt/uBDZAT5WEo9tOFG6KvIMwgwM0GMeDui88MmnmrGWZn2TLEO6iCFd169pHh/P23DCGWigzGJesZzNXEGGZm2GAEN9gAkLN923YxXOoPZtCQ5sdQBHKBiYoowxSgl2CAnZWZgZGRAeKC3RefMni37mS40BfEoCUjgNUA9DC4NSWMQUGMB2LAozdfGVSyVjJMT7dmSHZWBxtw+dF7hjXH7jGUB+ozWFVuYlCS4GMoD9CDG26gKMwAdgUsHUT07WPYf+UZQ1OECYMQDztD06pzDGwsTAynuwIYjAiFAcjYD19/MRTNP8Gw+cwjhj///oGjcTLQzzLC3OBYwBuIFKRkhBfINWQQ5QVyvQAAuEmo0TDmRP4AAAAASUVORK5CYII="
+favicon_url=${?FAVICON_URL}

--- a/server/conf/application.dev.conf
+++ b/server/conf/application.dev.conf
@@ -35,9 +35,6 @@ play.filters {
   }
 }
 
-# Set this to empty so that dev environments just get the builtin favicon
-favicon_url = ""
-
 ## Keycloak
 ### Keycloak OIDC for applicants
 keycloak.applicant.client_id = "applicant-client"
@@ -77,6 +74,7 @@ program_filtering_enabled = true
 name_suffix_dropdown_enabled = true
 session_timeout_enabled = false
 custom_theme_colors_enabled = true
+import_duplicate_handling_options_enabled = true
 north_star_applicant_ui = true
 external_program_cards_enabled = true
 date_validation_enabled = true

--- a/server/conf/helper/whitelabel.conf
+++ b/server/conf/helper/whitelabel.conf
@@ -17,15 +17,6 @@ whitelabel_civic_entity_short_name = ${?WHITELABEL_CIVIC_ENTITY_SHORT_NAME}
 whitelabel_civic_entity_full_name = "City of TestCity"
 whitelabel_civic_entity_full_name = ${?WHITELABEL_CIVIC_ENTITY_FULL_NAME}
 
-# The URL of a 32x32 or 16x16 pixel [favicon](https://developer.mozilla.org/en-US/docs/Glossary/Favicon)
-# image, in GIF, PNG, or ICO format.
-# The civiform.us favicon doesn't exist anymore. If no favicon is set we will
-# default to a hard-coded data-uri with a simple CF icon. Because not all
-# governments have a custom favicon set I'm leaving this default to a 404
-# so that they don't get an unexpected new icon they may not want.
-favicon_url = "https://civiform.us/favicon.png"
-favicon_url = ${?FAVICON_URL}
-
 # The URL to the civic entity's production CiviForm site
 civic_entity_production_url = ""
 civic_entity_production_url = ${?CIVIC_ENTITY_PRODUCTION_URL}


### PR DESCRIPTION
### Description

This PR fixes the missing favicon in Northstar. [Related issues](https://github.com/civiform/civiform/issues/10975). This will update any jurisdictions that don't have a favicon_url set in their environment - but got the [ay ok from product](https://civiform.slack.com/archives/C01R8SJA2HE/p1755026806648479). I didn't add a snapshot since it looked like favicon's don't show up in the snapshots.

- Remove favicon_url in whitelabel.conf and application.dev.conf
- Add favicon_url in application.conf
- Remove FALLBACK_FAVICON_DATA_URI and related logic in HtmlBundle.java
- Add logic in northstar to fetch favicon in application.conf or environment (highest precedence)

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from `civiform/eng-admin` as FYI (if the primary reviewer is not an admin and this PR includes functionality changes)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

#### Database evolutions

Read the guidelines [here](https://github.com/civiform/civiform/wiki/Database#writing-database-evolutions)

- [ ] Assigned two reviewers
- [ ] Guarded against already existing resources using `IF NOT EXISTS` and `IF EXISTS`
- [ ] Downs created to undo changes in Ups
- [ ] Every comment in script should begin with -- and not # --- unless it denotes Ups or Downs. See [here](https://www.playframework.com/documentation/2.9.x/Evolutions) for details.
- [ ] Tested both the Downs and the Ups scripts manually (When testing, include all comments from the evolution in your test script to ensure any syntax errors in the comments are caught.)
- [ ] Data migrations aren't being done (please use a [Durable Job](https://github.com/civiform/civiform/wiki/Database#durable-jobs-for-data-updates) if doing a data migration)
- [ ] Update the model documentation in our [wiki](https://github.com/civiform/civiform/wiki/Database) if necessary

#### Durable jobs

Read the docs [here](https://github.com/civiform/civiform/wiki/Database#durable-jobs-for-data-updates)

- [ ] Assigned two reviewers
- [ ] Included a rollback plan and a job to undo the data changes if appropriate

#### User visible changes

- [ ] Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
  - [ ] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [ ] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Made equivalent changes in Thymeleaf for applicant-facing features and changes (or created an issue in the [Northstar epic](https://github.com/orgs/civiform/projects/1/views/94) to track that it's missing from Thymeleaf)
- [ ] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order
- [ ] Manually tested with a screen reader if the feature is applicant-facing. See [screen reader testing](https://github.com/civiform/civiform/wiki/Testing#screen-reader-testing)
- [ ] Manually tested with a right-to-left language

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/helper/feature-flags.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://github.com/civiform/civiform/wiki/Feature-Flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Instructions for manual testing


### Issue(s) this completes

Fixes #10975
