### PR TITLE
Make csrf token always visible to htmx

### DIFF
--- a/server/app/views/admin/AdminLayout.html
+++ b/server/app/views/admin/AdminLayout.html
@@ -41,7 +41,12 @@
       type="text/javascript"
     ></script>
   </head>
-  <body class="display-flex minh-viewport body-background-gradient">
+
+  <!--/* Body sets HTMX header so the CSRF token is always there */-->
+  <body
+    class="display-flex minh-viewport body-background-gradient"
+    th:hx-headers='|{"CSRF-TOKEN":"${templateGlobals.csrfToken()}"}|'
+  >
     <!--/* Header navigation */-->
     <th:block th:insert="~{admin/shared/AdminCommonHeader}"></th:block>
 


### PR DESCRIPTION
### Description

Making CSRF token always visible to HTMX. This removes the need to include it as a hidden element on a form for an HTMX. This is for the admin thymeleaf pages.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if the primary reviewer is not an admin and this PR includes functionality changes)
- [ ] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

