### PR TITLE
Change check condition for recurring jobs

### DIFF
--- a/server/app/durablejobs/AbstractJobScheduler.java
+++ b/server/app/durablejobs/AbstractJobScheduler.java
@@ -95,7 +95,7 @@ public abstract class AbstractJobScheduler {
       // Re-fetch upon each attempt so the transaction prevents duplicates.
 
       if (!persistedDurableJobRepository
-          .findScheduledJob(newJob.getJobName(), newJob.getExecutionTime())
+          .findScheduledRecurringJob(newJob.getJobName())
           .isPresent()) {
         newJob.save(transaction);
         transaction.commit();

--- a/server/app/durablejobs/RecurringJobScheduler.java
+++ b/server/app/durablejobs/RecurringJobScheduler.java
@@ -5,7 +5,6 @@ import static org.checkerframework.errorprone.com.google.common.base.Preconditio
 import annotations.BindingAnnotations.RecurringJobsProviderName;
 import com.google.common.collect.ImmutableList;
 import java.time.Clock;
-import java.time.Instant;
 import java.util.Optional;
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -21,7 +20,6 @@ import repository.PersistedDurableJobRepository;
  */
 @Singleton
 public final class RecurringJobScheduler extends AbstractJobScheduler {
-  private final Clock clock;
   private final PersistedDurableJobRepository persistedDurableJobRepository;
 
   @Inject
@@ -30,7 +28,6 @@ public final class RecurringJobScheduler extends AbstractJobScheduler {
       @RecurringJobsProviderName DurableJobRegistry durableJobRegistry,
       PersistedDurableJobRepository persistedDurableJobRepository) {
     super(clock, durableJobRegistry, persistedDurableJobRepository);
-    this.clock = checkNotNull(clock);
     this.persistedDurableJobRepository = checkNotNull(persistedDurableJobRepository);
   }
 
@@ -46,10 +43,8 @@ public final class RecurringJobScheduler extends AbstractJobScheduler {
   @Override
   protected synchronized Optional<PersistedDurableJobModel> findScheduledJob(
       DurableJobRegistry.RegisteredJob registeredJob) {
-    Instant executionTime =
-        registeredJob.getRecurringJobExecutionTimeResolver().get().resolveExecutionTime(clock);
 
-    return persistedDurableJobRepository.findScheduledJob(
-        registeredJob.getJobName().getJobNameString(), executionTime);
+    return persistedDurableJobRepository.findScheduledRecurringJob(
+        registeredJob.getJobName().getJobNameString());
   }
 }

--- a/server/app/repository/PersistedDurableJobRepository.java
+++ b/server/app/repository/PersistedDurableJobRepository.java
@@ -5,7 +5,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import io.ebean.DB;
 import io.ebean.Database;
-import java.time.Instant;
+
 import java.time.LocalDateTime;
 import java.util.Optional;
 import javax.inject.Inject;
@@ -32,15 +32,16 @@ public final class PersistedDurableJobRepository {
    * Find the first scheduled job matching the job name and execution time, or an empty Optional if
    * none exists
    */
-  public Optional<PersistedDurableJobModel> findScheduledJob(
-      String jobName, Instant executionTime) {
+  public Optional<PersistedDurableJobModel> findScheduledRecurringJob(
+      String jobName) {
     return database
         .find(PersistedDurableJobModel.class)
         .setLabel("PersistedDurableJobModel.findById")
         .setProfileLocation(queryProfileLocationBuilder.create("findScheduledJob"))
         .where()
         .eq("job_name", jobName)
-        .eq("execution_time", executionTime)
+        .isNull("success_time")
+        .gt("remaining_attempts", 0)
         .setMaxRows(1)
         .findOneOrEmpty();
   }

--- a/server/test/repository/PersistedDurableJobRepositoryTest.java
+++ b/server/test/repository/PersistedDurableJobRepositoryTest.java
@@ -30,9 +30,9 @@ public class PersistedDurableJobRepositoryTest extends ResetPostgres {
     Instant tomorrow = Instant.now().plus(1, ChronoUnit.DAYS);
     var job = new PersistedDurableJobModel("fake-name", JobType.RECURRING, tomorrow);
 
-    assertThat(repo.findScheduledJob("fake-name", tomorrow)).isEmpty();
+    assertThat(repo.findScheduledRecurringJob("fake-name")).isEmpty();
     job.save();
-    assertThat(repo.findScheduledJob("fake-name", tomorrow)).contains(job);
+    assertThat(repo.findScheduledRecurringJob("fake-name")).contains(job);
   }
 
   @Test


### PR DESCRIPTION
### Description

Change the recurring job scheduler to check if a job already exists with the same name that hasn't succeeded yet and has more retries left. This should prevent scheduling multiple of the same jobs at the same time.

This changes the behavior slightly for recurring jobs. My gut check is that it won't practically affect any real behavior because none of the jobs that exist as of yet are scheduled that close together.