### PR TITLE
Skip map tests for probers

### DIFF
--- a/browser-test/src/northstar_question_lifecycle.test.ts
+++ b/browser-test/src/northstar_question_lifecycle.test.ts
@@ -41,7 +41,8 @@ test.describe('normal question lifecycle', {tag: ['@northstar']}, () => {
       adminQuestions,
       adminPrograms,
     }) => {
-      if (type === QuestionType.MAP && isLocalDevEnvironment()) {
+      // Map questions rely on mock web services in tests, so they can only be run in local dev environemnts
+      if (type === QuestionType.MAP && !isLocalDevEnvironment()) {
         test.skip()
       }
       await loginAsAdmin(page)

--- a/browser-test/src/northstar_question_lifecycle.test.ts
+++ b/browser-test/src/northstar_question_lifecycle.test.ts
@@ -3,6 +3,7 @@ import {
   AdminQuestions,
   disableFeatureFlag,
   enableFeatureFlag,
+  isLocalDevEnvironment,
   loginAsAdmin,
   validateScreenshot,
   waitForPageJsLoad,
@@ -40,6 +41,9 @@ test.describe('normal question lifecycle', {tag: ['@northstar']}, () => {
       adminQuestions,
       adminPrograms,
     }) => {
+      if (type === QuestionType.MAP && isLocalDevEnvironment()) {
+        test.skip()
+      }
       await loginAsAdmin(page)
 
       const questionName = `qlc-${type}`


### PR DESCRIPTION
### Description

Map tests will only work in the dev environment because they rely on mock web services. They're currently failing in probers:  https://github.com/civiform/civiform-staging-deploy/actions/runs/17006670032