### PR TITLE
Start recurring jobs on utc time

### DIFF
--- a/server/app/repository/PersistedDurableJobRepository.java
+++ b/server/app/repository/PersistedDurableJobRepository.java
@@ -1,15 +1,11 @@
 package repository;
 
-import annotations.BindingAnnotations;
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import io.ebean.DB;
 import io.ebean.Database;
 import java.time.Instant;
-import java.time.LocalDateTime;
 import java.util.Optional;
 import javax.inject.Inject;
-import javax.inject.Provider;
 import models.JobType;
 import models.PersistedDurableJobModel;
 
@@ -19,13 +15,10 @@ public final class PersistedDurableJobRepository {
       new QueryProfileLocationBuilder("PersistedDurableJobRepository");
 
   private final Database database;
-  private final Provider<LocalDateTime> nowProvider;
 
   @Inject
-  public PersistedDurableJobRepository(
-      @BindingAnnotations.Now Provider<LocalDateTime> nowProvider) {
+  public PersistedDurableJobRepository() {
     this.database = DB.getDefault();
-    this.nowProvider = Preconditions.checkNotNull(nowProvider);
   }
 
   /**
@@ -78,7 +71,7 @@ public final class PersistedDurableJobRepository {
         .setProfileLocation(queryProfileLocationBuilder.create("getRecurringJobForExecution"))
         .where()
         .eq("job_type", JobType.RECURRING)
-        .le("execution_time", nowProvider.get())
+        .le("execution_time", Instant.now())
         .gt("remaining_attempts", 0)
         .isNull("success_time")
         .setMaxRows(1)


### PR DESCRIPTION
### Description

Change `getRecurringJobForExecution` to check UTC rather than local time to better match against the database. Database timestamps are stored in UTC.

This will change when existing jobs will run because they'll now be run at UTC instead of local time. If I'm correct, they were previously getting run at the wrong time. For example, the REPORTING_DASHBOARD_MONTHLY_REFRESH was getting stored in the DB with the execution time 9am UTC, and probably getting run at 9am PDT for Seattle. I will verify this with Swathi.