### PR TITLE
Update tests and utilities to remove timing issues

### DIFF
--- a/browser-test/src/admin/northstar_admin_application_statuses.test.ts
+++ b/browser-test/src/admin/northstar_admin_application_statuses.test.ts
@@ -131,7 +131,7 @@ test.describe('view program statuses', {tag: ['@northstar']}, () => {
     })
 
     test('shows placeholder option', async ({adminPrograms}) => {
-      expect(await adminPrograms.getStatusOption()).toBe('Choose an option:')
+      await adminPrograms.expectStatusSelection('Choose an option:')
     })
 
     test('renders', async ({page}) => {
@@ -158,7 +158,7 @@ test.describe('view program statuses', {tag: ['@northstar']}, () => {
       }) => {
         await adminPrograms.setStatusOptionAndAwaitModal(noEmailStatusName)
         await dismissModal(page)
-        expect(await adminPrograms.getStatusOption()).toBe('Choose an option:')
+        await adminPrograms.expectStatusSelection('Choose an option:')
       })
 
       test('when confirmed, the page is shown a success toast', async ({
@@ -170,7 +170,7 @@ test.describe('view program statuses', {tag: ['@northstar']}, () => {
           `Status Change: Unset -> ${noEmailStatusName}`,
         )
         await adminPrograms.confirmStatusUpdateModal(modal)
-        expect(await adminPrograms.getStatusOption()).toBe(noEmailStatusName)
+        await adminPrograms.expectStatusSelection(noEmailStatusName)
         await adminPrograms.expectUpdateStatusToast()
       })
 
@@ -206,7 +206,7 @@ test.describe('view program statuses', {tag: ['@northstar']}, () => {
           const modal =
             await adminPrograms.setStatusOptionAndAwaitModal(noEmailStatusName)
           await adminPrograms.confirmStatusUpdateModal(modal)
-          expect(await adminPrograms.getStatusOption()).toBe(noEmailStatusName)
+          await adminPrograms.expectStatusSelection(noEmailStatusName)
         })
 
         const modal =
@@ -225,7 +225,7 @@ test.describe('view program statuses', {tag: ['@northstar']}, () => {
           const modal =
             await adminPrograms.setStatusOptionAndAwaitModal(noEmailStatusName)
           await adminPrograms.confirmStatusUpdateModal(modal)
-          expect(await adminPrograms.getStatusOption()).toBe(noEmailStatusName)
+          await adminPrograms.expectStatusSelection(noEmailStatusName)
         })
 
         await page.getByRole('link', {name: 'Back'}).click()
@@ -266,7 +266,7 @@ test.describe('view program statuses', {tag: ['@northstar']}, () => {
           await expect(notifyCheckbox).not.toBeChecked()
 
           await adminPrograms.confirmStatusUpdateModal(modal)
-          expect(await adminPrograms.getStatusOption()).toBe(emailStatusName)
+          await adminPrograms.expectStatusSelection(emailStatusName)
           await adminPrograms.expectUpdateStatusToast()
 
           if (supportsEmailInspection()) {
@@ -294,7 +294,7 @@ test.describe('view program statuses', {tag: ['@northstar']}, () => {
 
           expect(await modal.innerText()).toContain(' of this change at ')
           await adminPrograms.confirmStatusUpdateModal(modal)
-          expect(await adminPrograms.getStatusOption()).toBe(emailStatusName)
+          await adminPrograms.expectStatusSelection(emailStatusName)
           await adminPrograms.expectUpdateStatusToast()
 
           if (supportsEmailInspection()) {
@@ -473,7 +473,7 @@ test.describe('view program statuses', {tag: ['@northstar']}, () => {
         `Status Change: ${waitingStatus} -> ${approvedStatus}`,
       )
       await adminPrograms.confirmStatusUpdateModal(modal)
-      expect(await adminPrograms.getStatusOption()).toBe(approvedStatus)
+      await adminPrograms.expectStatusSelection(approvedStatus)
       await adminPrograms.expectUpdateStatusToast()
 
       await page.getByRole('link', {name: 'Back'}).click()
@@ -849,7 +849,7 @@ test.describe('view program statuses', {tag: ['@northstar']}, () => {
           ' of this change at ' + guestEmail,
         )
         await adminPrograms.confirmStatusUpdateModal(modal)
-        expect(await adminPrograms.getStatusOption()).toBe(emailStatusName)
+        await adminPrograms.expectStatusSelection(emailStatusName)
         await adminPrograms.expectUpdateStatusToast()
       })
       await test.step('verify status update email was sent to applicant', async () => {

--- a/browser-test/src/support/admin_programs.ts
+++ b/browser-test/src/support/admin_programs.ts
@@ -1627,6 +1627,10 @@ export class AdminPrograms {
     return this.page.locator(this.statusSelector()).inputValue()
   }
 
+  async expectStatusSelection(status: string) {
+    await expect(this.page.locator(this.statusSelector())).toHaveValue(status)
+  }
+
   /**
    * Selects the provided status option and then awaits the confirmation dialog.
    */
@@ -1695,8 +1699,9 @@ export class AdminPrograms {
   }
 
   async expectNoteUpdatedToast() {
-    const toastMessages = await this.page.innerText('#toast-container')
-    expect(toastMessages).toContain('Application note updated')
+    await expect(this.page.locator('#toast-container')).toContainText(
+      'Application note updated',
+    )
   }
 
   async getJson(applyFilters: boolean): Promise<DownloadedApplication[]> {


### PR DESCRIPTION
### Description

Addressed timing issues in the new northstar_admin_application_statuses by using newer playwright syntax. 


### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if the primary reviewer is not an admin and this PR includes functionality changes)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.
