### PR TITLE
Hacks to get bin/run-dev to work with podman

### DIFF
--- a/bin/docker-reset
+++ b/bin/docker-reset
@@ -14,15 +14,15 @@ fi
 
 if [[ $(docker ps --all --quiet --filter=name="${PROJECT}" | wc -c) -ne 0 ]]; then
   echo "Removing containers and associated volumes for ${PROJECT}"
-  docker remove --force --volumes $(docker ps --all --quiet --filter=name="${PROJECT}") >/dev/null
+  docker rm --force --volumes $(docker ps --all --quiet --filter=name="${PROJECT}") >/dev/null
 fi
 
 if [[ $(docker volume list --quiet --filter=name="${PROJECT}" | wc -c) -ne 0 ]]; then
   echo "Removing all volumes for ${PROJECT}"
-  docker volume remove --force $(docker volume list --quiet --filter=name="${PROJECT}") >/dev/null
+  docker volume rm --force $(docker volume list --quiet --filter=name="${PROJECT}") >/dev/null
 fi
 
 if [[ $(docker network list --quiet --filter=name="${PROJECT}" | wc -c) -ne 0 ]]; then
   echo "Removing all networks for ${PROJECT}"
-  docker network remove --force $(docker network list --quiet --filter=name="${PROJECT}") >/dev/null
+  docker network rm --force $(docker network list --quiet --filter=name="${PROJECT}") >/dev/null
 fi

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -31,6 +31,8 @@ services:
     volumes: *sbt-volumes
     stdin_open: true # docker run -i
     tty: true # docker run -t
+    networks:
+    - default
 
   localstack:
     # Overrides the localstack image used to work around
@@ -74,6 +76,8 @@ services:
       PGADMIN_CONFIG_SERVER_MODE: 'False'
       PGADMIN_CONFIG_MASTER_PASSWORD_REQUIRED: 'False'
       PGADMIN_CONFIG_WTF_CSRF_ENABLED: 'False'
+    networks:
+    - default
 
   prometheus:
     profiles: ['monitoring']
@@ -82,6 +86,8 @@ services:
     volumes:
       - ./monitoring/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
       - prometheus-data:/prometheus
+    networks:
+    - default
 
   grafana:  
     profiles: ['monitoring']
@@ -98,8 +104,8 @@ services:
       - ./monitoring/grafana/provisioning/datasources:/etc/grafana/provisioning/datasources
       - ./monitoring/grafana/dashboards:/var/lib/grafana/dashboards
       - grafana-data:/var/lib/grafana
-    links:
-      - prometheus
+    networks:
+    - default
 
 volumes:
   db-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,7 @@
+networks:
+  default:
+    driver: bridge
+
 # Use postgres/example user/password credentials
 services:
   localstack:
@@ -7,12 +11,6 @@ services:
       - '4566'
     environment:
       - SERVICES=s3,ses
-    links:
-      # Once a file is uploaded to localstack, localstack redirects back to CiviForm.
-      # It does this by mapping any 'localhost' domain to the 'civiform' domain (see
-      # localstack/localstack.nginx.conf). So, we need the localstack service to be
-      # aware of the civiform service to do that redirect correctly.
-      - 'civiform:civiform-service'
     networks:
       default:
         aliases:
@@ -29,6 +27,8 @@ services:
     profiles: ['azure', 'emulator']
     expose:
       - '10000'
+    networks:
+    - default
 
   # The dev oidc server needs to be visible to the Civiform server and web browsers
   # on the same host:port. Developers need to add a localhost IP alias for this
@@ -42,9 +42,13 @@ services:
     environment:
       # Use an explicit port to not conflict with other test instances.
       - OIDC_PORT=3390
+    networks:
+    - default
 
   mock-web-services:
     image: civiform-mock-web-services
+    networks:
+    - default
 
   db:
     image: postgres:16.10@sha256:66a5efb5677ffac1037774a0e141fd3a4c035c9c0c0e624c9cc980dfa10f45e5
@@ -55,13 +59,11 @@ services:
       POSTGRES_PASSWORD: example
     volumes:
       - ./init_postgres.sql:/docker-entrypoint-initdb.d/init_postgres.sql
+    networks:
+    - default
 
   civiform:
     image: civiform-dev
-    links:
-      - 'db:database'
-      - 'dev-oidc'
-      - 'mock-web-services'
     expose:
       - '9000'
       - '8457'
@@ -129,3 +131,5 @@ services:
       - FAVICON_URL
       - DISABLE_ERRORPRONE=${DISABLE_ERRORPRONE:-false}
     entrypoint: /bin/bash
+    networks:
+    - default

--- a/localstack/localstack.nginx.conf
+++ b/localstack/localstack.nginx.conf
@@ -3,6 +3,6 @@ server {
   server_name localhost;
 
   location / {
-    proxy_pass http://civiform-service:9000/;
+    proxy_pass http://civiforms:9000/;
   }
 }

--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -538,7 +538,7 @@ db {
 
   # https://www.playframework.com/documentation/latest/Developing-with-the-H2-Database
   default.driver = org.postgresql.Driver
-  default.url = "jdbc:postgresql://database:5432/postgres"
+  default.url = "jdbc:postgresql://db:5432/postgres"
   default.username = postgres
   default.password = "example"
 


### PR DESCRIPTION
DO NOT SUBMIT

Steps to reproduce (I am on macos apple silicon)

1. Install podman CLI for macos: https://podman.io/
2. Init a podman machine with enough memory to build civiform: `podman machine init --memory 6144`
3. Start the machine: `podman machine start`
4. Config podman to use docker.io for unqualified container names: `podman machine ssh "echo 'unqualified-search-registries = [\"docker.io\"]' > ~/.config/containers/registries.conf"`
5. Install docker-compose: https://formulae.brew.sh/formula/docker-compose
6. Symbolically link docker to podman: `ln -s $(which podman) <SOME_DIRECTORY_IN_YOUR_PATH>/docker`
7. Pull images: `USE_LOCAL_CIVIFORM=0 bin/pull-image`
8. Run dev: `bin/run-dev`
9. Clean up docker containers: `bin/docker-reset`