### PR TITLE
Add release notes link in awssdk renovate PRs

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -29,7 +29,7 @@
     {
       groupName: "awssdk",
       matchPackageNames: ["software.amazon.awssdk:{/,}**"],
-      prHeader: "Release Notes: https://github.com/aws/aws-sdk-java-v2/compare/{{displayFrom}}...{{displayTo}}"
+      prHeader: "Release Notes: https://github.com/aws/aws-sdk-java-v2/compare/{{currentValue}}...{{newValue}}"
     },
     {
       matchPackageNames: ["github/codeql-action"],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -29,7 +29,7 @@
     {
       groupName: "awssdk",
       matchPackageNames: ["software.amazon.awssdk:{/,}**"],
-      prHeader: "(link in testing, message avritt.rohwer@exygy if it doesn't work correctly) Release Notes: https://github.com/aws/aws-sdk-java-v2/compare/{{currentVersion}}...{{newVersion}}"
+      prHeader: "(link in testing, see https://github.com/civiform/civiform/issues/11338#issuecomment-3221792359 for notes) Release Notes: https://github.com/aws/aws-sdk-java-v2/compare/{{currentVersion}}...{{newVersion}}"
     },
     {
       matchPackageNames: ["github/codeql-action"],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -27,6 +27,11 @@
       matchPackageNames: ["com.google.auto.value:{/,}**"],
     },
     {
+      groupName: "awssdk",
+      matchPackageNames: ["software.amazon.awssdk:{/,}**"],
+      prHeader: "Release Notes: https://github.com/aws/aws-sdk-java-v2/compare/{{currentValue}}...{{newValue}}"
+    },
+    {
       matchPackageNames: ["github/codeql-action"],
       prHeader: "Release Notes: https://github.com/github/codeql-action/blob/main/CHANGELOG.md",
     },

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -29,7 +29,7 @@
     {
       groupName: "awssdk",
       matchPackageNames: ["software.amazon.awssdk:{/,}**"],
-      prHeader: "Release Notes: https://github.com/aws/aws-sdk-java-v2/compare/{{currentValue}}...{{newValue}}"
+      prHeader: "Release Notes: https://github.com/aws/aws-sdk-java-v2/compare/{{displayFrom}}...{{displayTo}}"
     },
     {
       matchPackageNames: ["github/codeql-action"],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -29,7 +29,7 @@
     {
       groupName: "awssdk",
       matchPackageNames: ["software.amazon.awssdk:{/,}**"],
-      prHeader: "(link in testing, message avritt.rohwer@exygy if it doesn't work correctly) Release Notes: https://github.com/aws/aws-sdk-java-v2/compare/{{currentValue}}...{{newValue}}"
+      prHeader: "(link in testing, message avritt.rohwer@exygy if it doesn't work correctly) Release Notes: https://github.com/aws/aws-sdk-java-v2/compare/{{currentVersion}}...{{newVersion}}"
     },
     {
       matchPackageNames: ["github/codeql-action"],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -29,7 +29,7 @@
     {
       groupName: "awssdk",
       matchPackageNames: ["software.amazon.awssdk:{/,}**"],
-      prHeader: "Release Notes: https://github.com/aws/aws-sdk-java-v2/compare/{{currentValue}}...{{newValue}}"
+      prHeader: "(link in testing, message avritt.rohwer@exygy if it doesn't work correctly) Release Notes: https://github.com/aws/aws-sdk-java-v2/compare/{{currentValue}}...{{newValue}}"
     },
     {
       matchPackageNames: ["github/codeql-action"],


### PR DESCRIPTION
### Description

Add release notes link for awssdk renovate PRs. For example, for https://github.com/civiform/civiform/pull/11345 it should link https://github.com/aws/aws-sdk-java-v2/compare/2.32.24...2.32.29.  I used the template parameter names found from https://docs.renovatebot.com/configuration-options/#prbodydefinitions

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from `civiform/eng-admin` as FYI (if the primary reviewer is not an admin and this PR includes functionality changes)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [x] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [x] Noted in the PR description which, if any, code in this PR was generated by AI.

### Instructions for manual testing

I'm not really sure how to test this
