### PR TITLE
GeoJsonDataRepository query on confirm time rather than create time

### DIFF
--- a/server/app/repository/GeoJsonDataRepository.java
+++ b/server/app/repository/GeoJsonDataRepository.java
@@ -36,7 +36,7 @@ public final class GeoJsonDataRepository {
                 .setProfileLocation(queryProfileLocationBuilder.create("getGeoJsonData"))
                 .where()
                 .eq("endpoint", endpoint)
-                .orderBy("createTime desc")
+                .orderBy("confirmTime desc")
                 .setMaxRows(1)
                 .findOneOrEmpty(),
         dbExecutionContext);


### PR DESCRIPTION
This should fix a flaky mismatch in expectations of the test.

The two records are created by the tests and so their create times order isn't always the same. We set the confirm time with the intention of checking that the most recent confirm time is queried, so we should actually query on confirm time. (In real life, the record with the most recent confirm time and create time should be the same unless for some reason records get created really close together)