### PR TITLE
Add more release note links in renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -29,7 +29,7 @@
     {
       groupName: "awssdk",
       matchPackageNames: ["software.amazon.awssdk:{/,}**"],
-      prHeader: "(link in testing, see https://github.com/civiform/civiform/issues/11338#issuecomment-3221792359 for notes) Release Notes: https://github.com/aws/aws-sdk-java-v2/compare/{{currentVersion}}...{{newVersion}}"
+      prHeader: "Release Notes: https://github.com/aws/aws-sdk-java-v2/blob/master/CHANGELOG.md"
     },
     {
       matchPackageNames: ["github/codeql-action"],
@@ -62,6 +62,11 @@
       matchPackageNames: ["org.junit.jupiter:{/,}**"],
     },
     {
+      groupName: "microsoft graph",
+      matchPackageNames: ["com.microsoft.graph:{/,}**"],
+      prHeader: "Release Notes: https://github.com/microsoftgraph/msgraph-sdk-java/blob/main/CHANGELOG.md"
+    },
+    {
       groupName: "pac4j",
       matchPackageNames: ["org.pac4j:pac4j{/,}**"],
     },
@@ -72,6 +77,11 @@
         "@playwright/test{/,}**",
         "mcr.microsoft.com/playwright{/,}**",
       ],
+    },
+    {
+      groupName: "sass-embedded",
+      matchPackageNames: ["sass-emdedded"],
+      prHeader: "Release Notes: https://github.com/sass/embedded-host-node/blob/main/CHANGELOG.md"
     },
     {
       matchPackageNames: ["docker/setup-buildx-action"],


### PR DESCRIPTION
### Description

Adds release note link for microsoft graph and sass-embedded. Also updates the aws link to just go to CHANGELOG.md.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from `civiform/eng-admin` as FYI (if the primary reviewer is not an admin and this PR includes functionality changes)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [x] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [x] Noted in the PR description which, if any, code in this PR was generated by AI.