### PR TITLE
Clarify docs and naming around applicant selection

### DIFF
--- a/server/app/auth/CiviFormProfile.java
+++ b/server/app/auth/CiviFormProfile.java
@@ -49,7 +49,7 @@ public class CiviFormProfile {
     this.accountRepository = Preconditions.checkNotNull(accountRepository);
   }
 
-  /** Get the latest {@link ApplicantModel} associated with the profile. */
+  /** Get the oldest {@link ApplicantModel} associated with the profile. */
   public CompletableFuture<ApplicantModel> getApplicant() {
     if (profileData.containsAttribute(ProfileFactory.APPLICANT_ID_ATTRIBUTE_NAME)) {
       long applicantId =
@@ -75,7 +75,9 @@ public class CiviFormProfile {
   }
 
   private Optional<ApplicantModel> getApplicantForAccount(AccountModel account) {
-    // Accounts (should) correspond to a single applicant.
+    // Accounts (should) correspond to a single applicant, but they don't in particular for guests
+    // merged into logged in accounts.
+    // TODO(#11304#issuecomment-3233634460): Selecting the oldest account is likely incorrect.
     return account.getApplicants().stream().min(comparing(ApplicantModel::getWhenCreated));
   }
 

--- a/server/app/auth/CiviFormProfileMerger.java
+++ b/server/app/auth/CiviFormProfileMerger.java
@@ -70,13 +70,15 @@ public final class CiviFormProfileMerger {
 
   private CiviFormProfile mergeApplicantAndGuestProfile(
       ApplicantModel applicantInDatabase, CiviFormProfile sessionGuestProfile) {
-    // Merge guest applicant data into already existing account in database
+    // Merge guest applicant data with already existing account in database.
+    // TODO(#11304#issuecomment-3233634460): this merges the older account
+    // into the newer which is likely incorrect.
     ApplicantModel guestApplicant = sessionGuestProfile.getApplicant().join();
     AccountModel existingAccount = applicantInDatabase.getAccount();
     ApplicantModel mergedApplicant =
         applicantRepositoryProvider
             .get()
-            .mergeApplicants(guestApplicant, applicantInDatabase, existingAccount)
+            .mergeApplicantsOlderIntoNewer(guestApplicant, applicantInDatabase, existingAccount)
             .toCompletableFuture()
             .join();
     return profileFactory.wrap(mergedApplicant);

--- a/server/app/repository/AccountRepository.java
+++ b/server/app/repository/AccountRepository.java
@@ -241,7 +241,7 @@ public final class AccountRepository {
    *
    * @return The updated newer applicant.
    */
-  public CompletionStage<ApplicantModel> mergeApplicants(
+  public CompletionStage<ApplicantModel> mergeApplicantsOlderIntoNewer(
       ApplicantModel applicant1, ApplicantModel applicant2, AccountModel account) {
     return supplyAsync(
         () ->
@@ -249,7 +249,7 @@ public final class AccountRepository {
                 () -> {
                   applicant1.setAccount(account).save();
                   applicant2.setAccount(account).save();
-                  return mergeApplicants(applicant1, applicant2).saveAndReturn();
+                  return mergeApplicantsOlderIntoNewer(applicant1, applicant2).saveAndReturn();
                 }),
         dbExecutionContext);
   }
@@ -259,7 +259,8 @@ public final class AccountRepository {
    *
    * @return The updated newer applicant.
    */
-  private ApplicantModel mergeApplicants(ApplicantModel applicant1, ApplicantModel applicant2) {
+  private ApplicantModel mergeApplicantsOlderIntoNewer(
+      ApplicantModel applicant1, ApplicantModel applicant2) {
     ApplicantModel older = applicant1;
     ApplicantModel newer = applicant2;
     if (applicant1.getWhenCreated().isAfter(applicant2.getWhenCreated())) {

--- a/server/test/auth/CiviFormProfileMergerTest.java
+++ b/server/test/auth/CiviFormProfileMergerTest.java
@@ -68,7 +68,7 @@ public class CiviFormProfileMergerTest {
     when(civiFormProfile.getProfileData()).thenReturn(civiFormProfileData);
     when(profileFactory.wrap(any(ApplicantModel.class))).thenReturn(civiFormProfile);
     when(civiFormProfile.getApplicant()).thenReturn(completedFuture(applicant));
-    when(repository.mergeApplicants(applicant, applicant, account))
+    when(repository.mergeApplicantsOlderIntoNewer(applicant, applicant, account))
         .thenReturn(completedFuture(applicant));
   }
 
@@ -151,7 +151,7 @@ public class CiviFormProfileMergerTest {
               assertThat(profile).isEqualTo(oidcProfile);
               return userProfile;
             });
-    verify(repository).mergeApplicants(eq(applicant), eq(applicant), eq(account));
+    verify(repository).mergeApplicantsOlderIntoNewer(eq(applicant), eq(applicant), eq(account));
     assertThat(merged).hasValue(userProfile);
   }
 }


### PR DESCRIPTION
### Description

The documentation around getting an `Applicant` from an `Account` are wrong and some of the method names are misleading as such.  This fixes the docs, adds references to an inprogress issue, and makes a method more explicit for clarity.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if the primary reviewer is not an admin and this PR includes functionality changes)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.


Addresses: #11304
