### PR TITLE
Allow tests to select the extra buttons for active programs when draft and active are present

### DIFF
--- a/browser-test/src/support/admin_programs.ts
+++ b/browser-test/src/support/admin_programs.ts
@@ -1894,7 +1894,11 @@ export class AdminPrograms {
     return this.page
       .locator('div.cf-admin-program-card')
       .filter({has: this.page.getByText(programName, {exact: true})})
-      .filter({has: this.page.getByText(lifecycle)})
+      .filter({
+        has: this.page.locator(
+          `[data-lifecycle-stage=${lifecycle.toLowerCase()}]`,
+        ),
+      })
   }
 
   getProgramAction(
@@ -1913,7 +1917,9 @@ export class AdminPrograms {
     lifecycle: ProgramLifecycle,
   ): Locator {
     const programCard = this.getProgramCard(programName, lifecycle)
-    return programCard.locator('.cf-with-dropdown')
+    return programCard
+      .locator(`[data-lifecycle-stage=${lifecycle.toLowerCase()}]`)
+      .locator('.cf-with-dropdown')
   }
 
   getProgramExtraAction(

--- a/server/app/views/components/ProgramCardFactory.java
+++ b/server/app/views/components/ProgramCardFactory.java
@@ -169,6 +169,11 @@ public final class ProgramCardFactory {
             StyleUtils.responsiveXLarge("ml-8"));
 
     return div()
+        // This is used to provide the uniqueness needed for Playwright to locate
+        // the correct element for testing. In the future this should be accounted
+        // for in a way that allows for web first assertions ideally via accessibility
+        // name, but that is a larger change than can be accommodated.
+        .withData("lifecycle-stage", isActive ? "active" : "draft")
         .withClasses(
             "py-7",
             "flex",


### PR DESCRIPTION
### Description

Currently the browser tests only allow selecting the extra actions button for draft mode or active mode when no draft exists. Tests will fail if you have a draft and try to get the active mode action buttons because Playwright is matching two elements. There isn't a great way to get the correct locator as is because looking for the text "active/draft" would need to find an ancestor element. Playwright isn't great at walking up the tree to a specific element.

This adds a data- attribute to inject the active/draft state on the correct parent element and has it filtering for that instead of the text of the inner child span.

I've tested this with Anna's sample test which passes.

Big note: This isn't ideal. In the future we should have a better way where we can find these using web first assertions with accessibility names to mimic how those tools would find elements. But that would require a big lift to accomplish on this old page.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if the primary reviewer is not an admin and this PR includes functionality changes)
- [ ] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

