### PR TITLE
[Maps] Handle map question api implementation (until it is actually implemented)

### DIFF
--- a/server/app/services/export/QuestionJsonSampler.java
+++ b/server/app/services/export/QuestionJsonSampler.java
@@ -206,8 +206,11 @@ public interface QuestionJsonSampler<Q extends AbstractQuestion> {
         case PHONE -> phoneJsonSampler;
           // Static content questions are not included in API responses because they
           // do not include an answer from the user.
-        case STATIC, MAP -> emptyJsonSampler;
+        case MAP, // Fallthrough intended until map question is implemented for the API.
+                STATIC ->
+            emptyJsonSampler;
         case TEXT -> textJsonSampler;
+        case YES_NO -> singleSelectJsonSampler;
 
         default ->
             throw new RuntimeException(String.format("Unrecognized questionType %s", questionType));

--- a/server/app/services/export/QuestionJsonSampler.java
+++ b/server/app/services/export/QuestionJsonSampler.java
@@ -206,7 +206,7 @@ public interface QuestionJsonSampler<Q extends AbstractQuestion> {
         case PHONE -> phoneJsonSampler;
           // Static content questions are not included in API responses because they
           // do not include an answer from the user.
-        case STATIC -> emptyJsonSampler;
+        case STATIC, MAP -> emptyJsonSampler;
         case TEXT -> textJsonSampler;
 
         default ->

--- a/server/test/services/export/QuestionJsonSamplerTest.java
+++ b/server/test/services/export/QuestionJsonSamplerTest.java
@@ -8,6 +8,7 @@ import static controllers.dev.seeding.SampleQuestionDefinitions.EMAIL_QUESTION_D
 import static controllers.dev.seeding.SampleQuestionDefinitions.ENUMERATOR_QUESTION_DEFINITION;
 import static controllers.dev.seeding.SampleQuestionDefinitions.FILE_UPLOAD_QUESTION_DEFINITION;
 import static controllers.dev.seeding.SampleQuestionDefinitions.ID_QUESTION_DEFINITION;
+import static controllers.dev.seeding.SampleQuestionDefinitions.MAP_QUESTION_DEFINITION;
 import static controllers.dev.seeding.SampleQuestionDefinitions.NAME_QUESTION_DEFINITION;
 import static controllers.dev.seeding.SampleQuestionDefinitions.NUMBER_QUESTION_DEFINITION;
 import static controllers.dev.seeding.SampleQuestionDefinitions.PHONE_QUESTION_DEFINITION;
@@ -290,6 +291,17 @@ public class QuestionJsonSamplerTest extends ResetPostgres {
   }
 
   @Test
+  public void mapQuestions_returnEmpty() {
+    @SuppressWarnings("unchecked")
+    ImmutableMap<Path, Optional<?>> entries =
+        questionJsonSamplerFactory
+            .create(QuestionType.MAP)
+            .getSampleJsonEntries(MAP_QUESTION_DEFINITION.withPopulatedTestId());
+
+    assertThat(entries).isEmpty();
+  }
+
+  @Test
   public void sampleEnumeratorQuestions_nestedEnumerator() {
     SampleDataContext sampleDataContext = new SampleDataContext();
     questionJsonSamplerFactory
@@ -394,5 +406,24 @@ public class QuestionJsonSamplerTest extends ResetPostgres {
                 Path.create(
                     "applicant.sample_enumerator_question.entities[1].sample_enumerated_date_question.date"),
                 Optional.of("2023-01-02")));
+  }
+
+  @Test
+  public void allQuestionTypesAreImplemented() {
+    for (QuestionType questionType : QuestionType.values()) {
+      if (questionType == QuestionType.NULL_QUESTION) {
+        continue;
+      }
+
+      try {
+        questionJsonSamplerFactory.create(questionType);
+      } catch (RuntimeException e) {
+        throw new AssertionError(
+            String.format(
+                "QuestionType %s is not implemented in QuestionJsonSampler: %s",
+                questionType, e.getMessage()),
+            e);
+      }
+    }
   }
 }


### PR DESCRIPTION
### Description

Map questions are causing a bug with API documentation. Map questions will be implemented for the API later, but they will need a little tweaking to make it up to spec (API needs to send ids, but user review needs to display names). For now, just use an empty sample.