### PR TITLE
Fix and expand ApplicantData test

### DIFF
--- a/server/app/services/CfJsonDocumentContext.java
+++ b/server/app/services/CfJsonDocumentContext.java
@@ -656,7 +656,8 @@ public class CfJsonDocumentContext {
           }
         } else {
           try {
-            if (!this.read(path, Object.class).equals(entry.getValue())) {
+            Optional<Object> value = this.read(path, Object.class);
+            if (value.isEmpty() || !value.get().equals(entry.getValue())) {
               pathsRemoved.add(path);
             }
           } catch (JsonPathTypeMismatchException e) {

--- a/server/test/models/ApplicantModelTest.java
+++ b/server/test/models/ApplicantModelTest.java
@@ -101,7 +101,7 @@ public class ApplicantModelTest extends ResetPostgres {
     data2.putString(subObjectFoo, "also_foo");
     // New value in new key, will be copied.
     data2.putString(subObjectBar, "bar");
-    // Values will be added to the existing ones, even duplicates.
+    // List values will be added to the existing ones, even duplicates.
     data2.putArray(listColor, Lists.newArrayList("red", "green"));
 
     List<Path> removedPaths = data1.mergeFrom(data2);
@@ -110,6 +110,7 @@ public class ApplicantModelTest extends ResetPostgres {
     assertThat(removedPaths).contains(foo);
     // The new value was the same so it's not considered removed/dropped
     assertThat(removedPaths).doesNotContain(subObjectFoo);
+    // Assert the expected values are present.
     assertThat(data1.readString(foo)).hasValue("foo");
     assertThat(data1.readString(subObjectBar)).hasValue("bar");
     assertThat(data1.readStringList(listColor).orElse(ImmutableList.of()))

--- a/server/test/models/ApplicantModelTest.java
+++ b/server/test/models/ApplicantModelTest.java
@@ -2,6 +2,8 @@ package models;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.List;
@@ -78,22 +80,40 @@ public class ApplicantModelTest extends ResetPostgres {
 
   @Test
   public void mergeApplicantData() {
-    ApplicantData data1 = new ApplicantModel().getApplicantData();
     Path foo = Path.create("$.applicant.foo");
-    Path subMapFoo = Path.create("$.applicant.subObject.foo");
-    Path subMapBar = Path.create("$.applicant.subObject.bar");
+    // Children in the 'subObject' json map.
+    Path subObjectFoo = Path.create("$.applicant.subObject.foo");
+    Path subObjectBar = Path.create("$.applicant.subObject.bar");
+    // A list of selections.
+    Path listColor = Path.create("$.applicant.colors");
+
+    // The main data.
+    ApplicantData data1 = new ApplicantModel().getApplicantData();
     data1.putString(foo, "foo");
-    data1.putString(subMapFoo, "also_foo");
+    data1.putString(subObjectFoo, "also_foo");
+    data1.putArray(listColor, Lists.newArrayList("red"));
+
+    // The 'new' data that will be merged from.
     ApplicantData data2 = new ApplicantModel().getApplicantData();
+    // Different value for existing key, won't be copied.
     data2.putString(foo, "bar");
-    data2.putString(subMapBar, "bar");
-    data1.putString(subMapFoo, "also_foo");
+    // Same value as existing value in existing map, will be ignored.
+    data2.putString(subObjectFoo, "also_foo");
+    // New value in new key, will be copied.
+    data2.putString(subObjectBar, "bar");
+    // Values will be added to the existing ones, even duplicates.
+    data2.putArray(listColor, Lists.newArrayList("red", "green"));
 
     List<Path> removedPaths = data1.mergeFrom(data2);
 
+    // The new value was different so it was dropped.
     assertThat(removedPaths).contains(foo);
-    assertThat(removedPaths).doesNotContain(subMapFoo);
-    assertThat(data1.readString(subMapBar)).isNotEmpty();
+    // The new value was the same so it's not considered removed/dropped
+    assertThat(removedPaths).doesNotContain(subObjectFoo);
+    assertThat(data1.readString(foo)).hasValue("foo");
+    assertThat(data1.readString(subObjectBar)).hasValue("bar");
+    assertThat(data1.readStringList(listColor).orElse(ImmutableList.of()))
+        .containsExactly("red", "red", "green");
   }
 
   @Test


### PR DESCRIPTION
### Description

* Fixed a test-only impacting bug in the code. `this.read(path, Object.class).equals(...)` compares an Optional to not an optional which is always false.
* Fixed the related existing test setup
* Expanded the testing to include a list.


### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if the primary reviewer is not an admin and this PR includes functionality changes)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

