### PR TITLE
feat (#11250): Add dynamic show/hide for optional YES/NO question options in preview

### DIFF
--- a/server/app/assets/javascripts/admin_yes_no_question_option.ts
+++ b/server/app/assets/javascripts/admin_yes_no_question_option.ts
@@ -1,0 +1,58 @@
+/**
+ * Enum for YES/NO question option values.
+ * These values match the backend Java YesNoQuestionOption enum
+ * to ensure consistency across the application.
+ */
+export enum YesNoOptionValue {
+  YES = '1',
+  NO = '0',
+  NOT_SURE = '2',
+  MAYBE = '3',
+}
+
+/**
+ * Admin IDs for YES/NO question checkboxes
+ */
+export enum YesNoOptionAdminId {
+  YES = 'yes',
+  NO = 'no',
+  NOT_SURE = 'not-sure',
+  MAYBE = 'maybe',
+}
+
+/**
+ * Display text for YES/NO question options
+ */
+export const YesNoOptionText = {
+  YES: 'Yes',
+  NO: 'No',
+  NOT_SURE: 'Not sure',
+  MAYBE: 'Maybe',
+} as const
+
+/**
+ * Maps option values to their admin IDs
+ */
+export const VALUE_TO_ADMIN_ID: Record<YesNoOptionValue, YesNoOptionAdminId> = {
+  [YesNoOptionValue.YES]: YesNoOptionAdminId.YES,
+  [YesNoOptionValue.NO]: YesNoOptionAdminId.NO,
+  [YesNoOptionValue.NOT_SURE]: YesNoOptionAdminId.NOT_SURE,
+  [YesNoOptionValue.MAYBE]: YesNoOptionAdminId.MAYBE,
+}
+
+/**
+ * Helper to check if an option should always be visible
+ */
+export function isAlwaysVisibleOption(adminId: string): boolean {
+  return adminId === YesNoOptionAdminId.YES || adminId === YesNoOptionAdminId.NO
+}
+
+/**
+ * Helper to check if an option is optional (can be toggled)
+ */
+export function isOptionalOption(adminId: string): boolean {
+  return (
+    adminId === YesNoOptionAdminId.NOT_SURE ||
+    adminId === YesNoOptionAdminId.MAYBE
+  )
+}

--- a/server/app/assets/javascripts/preview.ts
+++ b/server/app/assets/javascripts/preview.ts
@@ -1,4 +1,8 @@
 /** The preview controller is responsible for updating question preview text in the question builder. */
+import {
+  YesNoOptionAdminId,
+  YesNoOptionValue,
+} from './admin_yes_no_question_option'
 import {assertNotNull, formatText, formatTextHtml} from './util'
 import * as DOMPurify from 'dompurify'
 
@@ -111,10 +115,21 @@ export default class PreviewController {
     )
 
     if (questionSettings && questionPreviewContainer) {
-      PreviewController.addOptionObservers({
-        questionSettings,
-        questionPreviewContainer,
-      })
+      const hasYesNoCheckboxes = questionSettings.querySelector(
+        '[name="displayedOptionIds[]"]',
+      )
+      const hasEditableOptions = questionSettings.querySelector(
+        '[name="options[]"]:not(.display-none)',
+      )
+
+      if (hasYesNoCheckboxes) {
+        PreviewController.addYesNoCheckboxListeners()
+      } else if (hasEditableOptions) {
+        PreviewController.addOptionObservers({
+          questionSettings,
+          questionPreviewContainer,
+        })
+      }
     }
   }
 
@@ -181,6 +196,50 @@ export default class PreviewController {
       characterDataOldValue: true,
     })
     syncOptionsToPreview()
+  }
+
+  private static addYesNoCheckboxListeners() {
+    const notSureCheckbox = document.getElementById(
+      YesNoOptionAdminId.NOT_SURE,
+    ) as HTMLInputElement
+    const maybeCheckbox = document.getElementById(
+      YesNoOptionAdminId.MAYBE,
+    ) as HTMLInputElement
+
+    if (!notSureCheckbox || !maybeCheckbox) {
+      return
+    }
+
+    const toggleVisibility = () => {
+      const previewContainer = document.getElementById('sample-question')
+      if (!previewContainer) return
+
+      const options = previewContainer.querySelectorAll(
+        '.cf-multi-option-question-option',
+      )
+
+      options.forEach((option) => {
+        const radioInput = option.querySelector(
+          'input[type="radio"]',
+        ) as HTMLInputElement
+        if (!radioInput) return
+
+        if (radioInput.value === YesNoOptionValue.NOT_SURE) {
+          ;(option as HTMLElement).style.display = notSureCheckbox.checked
+            ? ''
+            : 'none'
+        } else if (radioInput.value === YesNoOptionValue.MAYBE) {
+          ;(option as HTMLElement).style.display = maybeCheckbox.checked
+            ? ''
+            : 'none'
+        }
+      })
+    }
+
+    notSureCheckbox.addEventListener('change', toggleVisibility)
+    maybeCheckbox.addEventListener('change', toggleVisibility)
+
+    toggleVisibility()
   }
 
   private static updateOptionsList({

--- a/server/app/views/admin/questions/NorthStarQuestionPreview.java
+++ b/server/app/views/admin/questions/NorthStarQuestionPreview.java
@@ -79,6 +79,8 @@ public class NorthStarQuestionPreview extends NorthStarBaseView {
     context.setVariable("stateAbbreviations", AddressQuestion.STATE_ABBREVIATIONS);
     context.setVariable("enumMaxEntityCount", EnumeratorQuestionForm.MAX_ENUM_ENTITIES_ALLOWED);
 
+    context.setVariable("isYesNoQuestionEnabled", settingsManifest.getYesNoQuestionEnabled());
+
     return templateEngine.process("admin/questions/QuestionPreviewFragment", context);
   }
 

--- a/server/app/views/questiontypes/ApplicantQuestionRendererFactory.java
+++ b/server/app/views/questiontypes/ApplicantQuestionRendererFactory.java
@@ -5,6 +5,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.google.common.collect.ImmutableList;
 import java.util.Locale;
 import java.util.Optional;
+import java.util.OptionalLong;
 import models.ApplicantModel;
 import play.i18n.Messages;
 import services.LocalizedStrings;
@@ -12,6 +13,7 @@ import services.applicant.ApplicantData;
 import services.applicant.question.ApplicantQuestion;
 import services.program.ProgramQuestionDefinition;
 import services.question.QuestionOption;
+import services.question.YesNoQuestionOption;
 import services.question.exceptions.UnsupportedQuestionTypeException;
 import services.question.types.QuestionDefinition;
 import services.question.types.QuestionDefinitionBuilder;
@@ -86,13 +88,47 @@ public final class ApplicantQuestionRendererFactory {
             .setQuestionType(questionType);
 
     if (questionType.isMultiOptionType()) {
-      builder.setQuestionOptions(
-          ImmutableList.of(
-              QuestionOption.create(
-                  1L,
-                  1L,
-                  "sample option admin name",
-                  LocalizedStrings.of(Locale.US, "Sample question option"))));
+      if (questionType == QuestionType.YES_NO) {
+        ImmutableList<QuestionOption> yesNoOptions =
+            ImmutableList.of(
+                QuestionOption.builder()
+                    .setId(YesNoQuestionOption.YES.getId())
+                    .setAdminName(YesNoQuestionOption.YES.getAdminName())
+                    .setOptionText(LocalizedStrings.of(Locale.US, "Yes"))
+                    .setDisplayOrder(OptionalLong.of(0L))
+                    .setDisplayInAnswerOptions(Optional.of(true))
+                    .build(),
+                QuestionOption.builder()
+                    .setId(YesNoQuestionOption.NO.getId())
+                    .setAdminName(YesNoQuestionOption.NO.getAdminName())
+                    .setOptionText(LocalizedStrings.of(Locale.US, "No"))
+                    .setDisplayOrder(OptionalLong.of(1L))
+                    .setDisplayInAnswerOptions(Optional.of(true))
+                    .build(),
+                QuestionOption.builder()
+                    .setId(YesNoQuestionOption.NOT_SURE.getId())
+                    .setAdminName(YesNoQuestionOption.NOT_SURE.getAdminName())
+                    .setOptionText(LocalizedStrings.of(Locale.US, "Not sure"))
+                    .setDisplayOrder(OptionalLong.of(2L))
+                    .setDisplayInAnswerOptions(Optional.of(true))
+                    .build(),
+                QuestionOption.builder()
+                    .setId(YesNoQuestionOption.MAYBE.getId())
+                    .setAdminName(YesNoQuestionOption.MAYBE.getAdminName())
+                    .setOptionText(LocalizedStrings.of(Locale.US, "Maybe"))
+                    .setDisplayOrder(OptionalLong.of(3L))
+                    .setDisplayInAnswerOptions(Optional.of(true))
+                    .build());
+        builder.setQuestionOptions(yesNoOptions);
+      } else {
+        builder.setQuestionOptions(
+            ImmutableList.of(
+                QuestionOption.create(
+                    1L,
+                    1L,
+                    "sample option admin name",
+                    LocalizedStrings.of(Locale.US, "Sample question option"))));
+      }
     }
 
     if (questionType.equals(QuestionType.ENUMERATOR)) {


### PR DESCRIPTION
### Description

This PR adds dynamic show/hide functionality for optional YES/NO question options ("Not sure" and "Maybe") in the admin question preview. Admin users can now toggle checkboxes to control which options appear in the preview, while "Yes" and "No" remain always visible as required options.

**Key changes:**

- Created TypeScript enum YesNoQuestionOption to centralize YES/NO option constants and match backend Java enum values
- Added checkbox listeners in preview controller to dynamically toggle option visibility
- Fixed condition logic to properly detect YES/NO question types when hidden inputs are present
- Refactored Java code to use the YesNoQuestionOption enum instead of hardcoded values

## Release notes

Admin users can now control which YES/NO question options are displayed to applicants by toggling checkboxes for the optional "Not sure" and "Maybe" responses in the question builder preview.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [X] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [X] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [X] Added an additional reviewer from `civiform/eng-admin` as FYI (if the primary reviewer is not an admin and this PR includes functionality changes)
- [ ] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [X] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

#### Database evolutions

Read the guidelines [here](https://github.com/civiform/civiform/wiki/Database#writing-database-evolutions)

- [ ] Assigned two reviewers
- [ ] Guarded against already existing resources using `IF NOT EXISTS` and `IF EXISTS`
- [ ] Downs created to undo changes in Ups
- [ ] Every comment in script should begin with -- and not # --- unless it denotes Ups or Downs. See [here](https://www.playframework.com/documentation/2.9.x/Evolutions) for details.
- [ ] Tested both the Downs and the Ups scripts manually (When testing, include all comments from the evolution in your test script to ensure any syntax errors in the comments are caught.)
- [ ] Data migrations aren't being done (please use a [Durable Job](https://github.com/civiform/civiform/wiki/Database#durable-jobs-for-data-updates) if doing a data migration)
- [ ] Update the model documentation in our [wiki](https://github.com/civiform/civiform/wiki/Database) if necessary

#### Durable jobs

Read the docs [here](https://github.com/civiform/civiform/wiki/Database#durable-jobs-for-data-updates)

- [ ] Assigned two reviewers
- [ ] Included a rollback plan and a job to undo the data changes if appropriate

#### User visible changes

- [ ] Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
  - [ ] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [ ] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Made equivalent changes in Thymeleaf for applicant-facing features and changes (or created an issue in the [Northstar epic](https://github.com/orgs/civiform/projects/1/views/94) to track that it's missing from Thymeleaf)
- [ ] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order
- [ ] Manually tested with a screen reader if the feature is applicant-facing. See [screen reader testing](https://github.com/civiform/civiform/wiki/Testing#screen-reader-testing)
- [ ] Manually tested with a right-to-left language

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/helper/feature-flags.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://github.com/civiform/civiform/wiki/Feature-Flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Instructions for manual testing

Navigate to the admin question builder

1. Create or edit a YES/NO question type
2. In the Question Settings panel, observe the checkboxes for each option with their Admin IDs
3. Check/uncheck the "not-sure" and "maybe" option checkboxes
4. Verify that the Sample Question preview on the right updates immediately to show/hide these options
5. Verify that "Yes" and "No" options always remain visible

### Issue(s) this completes

Fixes #11250 
