### PR TITLE
Restrict email fallback to TI accounts

### DIFF
--- a/server/app/auth/oidc/CiviformOidcProfileCreator.java
+++ b/server/app/auth/oidc/CiviformOidcProfileCreator.java
@@ -93,7 +93,7 @@ public abstract class CiviformOidcProfileCreator extends OidcProfileCreator {
       return Optional.empty();
     }
     // This string format can never change. It is the unique ID for OIDC based
-    // account.
+    // accounts.
     return Optional.of(String.format("iss: %s sub: %s", issuer, subject));
   }
 
@@ -205,36 +205,46 @@ public abstract class CiviformOidcProfileCreator extends OidcProfileCreator {
 
   @VisibleForTesting
   public final Optional<ApplicantModel> getExistingApplicant(OidcProfile profile) {
-    // User keying changed in March 2022 and is reflected and managed here.
-    // Originally users were keyed on their email address, however this is not
-    // guaranteed to be a unique stable ID. In March 2022 the code base changed to
-    // using authority_id which is unique and stable per authentication provider.
-
     String authorityId =
         getAuthorityId(profile)
             .orElseThrow(
                 () -> new InvalidOidcProfileException("Unable to get authority ID from profile."));
 
-    Optional<ApplicantModel> applicantOpt =
+    Optional<ApplicantModel> idApplicantOpt =
         accountRepositoryProvider
             .get()
             .lookupApplicantByAuthorityId(authorityId)
             .toCompletableFuture()
             .join();
-    if (applicantOpt.isPresent()) {
+    if (idApplicantOpt.isPresent()) {
       logger.debug("Found user using authority ID: {}", authorityId);
-      return applicantOpt;
+      return idApplicantOpt;
     }
 
-    // For pre-existing deployments before April 2022, users will exist without an
-    // authority ID and will be keyed on their email.
+    // Do an email fallback match for TI Clients.
+    // When a TI makes a Client they can optionally specify that person's
+    // email, and if someone with that email newly logs in we connect them
+    // with the account.
     String userEmail = profile.getAttribute(emailAttributeName(), String.class);
-    logger.debug("Looking up user using email {}", userEmail);
-    return accountRepositoryProvider
-        .get()
-        .lookupApplicantByEmail(userEmail)
-        .toCompletableFuture()
-        .join();
+    // TODO(#11410): Use case insensitive search and match if there's a single hit.
+    Optional<ApplicantModel> emailApplicantOpt =
+        accountRepositoryProvider
+            .get()
+            .lookupApplicantByEmail(userEmail)
+            .toCompletableFuture()
+            .join();
+    if (emailApplicantOpt.isEmpty()) {
+      logger.debug("Did not find user by authority id {} or email {}", authorityId, userEmail);
+      return Optional.empty();
+    }
+    // Ensure they are a TI Client.
+    if (emailApplicantOpt.get().getAccount().getManagedByGroup().isPresent()) {
+      logger.debug("Found TI Client by email {}", userEmail);
+      return emailApplicantOpt;
+    }
+
+    logger.debug("Found user by email but they are not a TI Client {}", userEmail);
+    return Optional.empty();
   }
 
   protected final boolean isTrustedIntermediary(CiviFormProfile profile) {


### PR DESCRIPTION
### Description

When we lookup a logged in users account and there isn't an `authority_id` match, we fallback to email.

This is a big errorprone and was originally included to support Seattle accounts that are now 3.5 years ago.

This PR cleans that up so that the email fallback is only used to connect a TI Client with an account a TI created for them.

[TDD: Remove broad email matching in account lookup - Google Docs](https://docs.google.com/document/d/1tNm4Zw3xoYURhJBFvNecYuMaW8fA0QjehoWBczePSf0/edit?tab=t.0)

## Release notes

Update account lookup to no longer use email as a fallback unless the user is a TI Client.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [ ] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if the primary reviewer is not an admin and this PR includes functionality changes)
- [ ] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

### Instructions for manual testing

**TI Client**

1. Create a TI Client specifying an email
2. Apply for a program for them as the TI
3. Logout
4. Login as the Client
5. Notice: you can see the Client's application.

**Non matching on email**
1. Login as a user
1. Apply for a program
1. log out.
1. In the local database remove that Account's authority_id
1. Login as the same user
1. Notice: You do not see the previous application
1. Notice: In the database 

 
### Issue(s) this completes

Fixes #<issue_number>; Fixes #<issue_number>...
