### PR TITLE
fix: improve readability of multi-line import validation errors

### DIFF
--- a/server/app/controllers/admin/AdminImportController.java
+++ b/server/app/controllers/admin/AdminImportController.java
@@ -212,7 +212,8 @@ public class AdminImportController extends CiviFormController {
       if (!questionErrors.isEmpty()) {
         return ok(
             adminImportViewPartial
-                .renderError("One or more question errors occured:", joinErrors(questionErrors))
+                .renderErrorWithLineBreaks(
+                    "One or more question errors occured:", joinErrors(questionErrors))
                 .render());
       }
 

--- a/server/app/views/admin/migration/AdminImportViewPartial.java
+++ b/server/app/views/admin/migration/AdminImportViewPartial.java
@@ -13,6 +13,7 @@ import static j2html.TagCreator.p;
 import static j2html.TagCreator.span;
 import static j2html.TagCreator.text;
 
+import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import controllers.admin.routes;
@@ -57,6 +58,32 @@ public final class AdminImportViewPartial extends BaseHtmlView {
                 /* text= */ errorMessage,
                 /* title= */ Optional.of(title),
                 /* hidden= */ false),
+            asRedirectElement(button("Try again"), routes.AdminImportController.index().url())
+                .withClasses("my-5", "usa-button", "usa-button--outline"));
+  }
+
+  /** Renders an error with properly formatted line breaks for multiple validation errors. */
+  public DomContent renderErrorWithLineBreaks(String title, String errorMessage) {
+    Iterable<String> errorLines = Splitter.on(". ").split(errorMessage);
+
+    DivTag errorDiv = div().withClasses("usa-alert", "usa-alert--error", "usa-alert--no-icon");
+
+    DivTag bodyDiv = div().withClass("usa-alert__body");
+    if (title != null) {
+      bodyDiv.with(h3(title).withClass("usa-alert__heading"));
+    }
+
+    // Add each error line as a separate paragraph
+    for (String line : errorLines) {
+      if (!line.trim().isEmpty()) {
+        bodyDiv.with(p("• " + line.trim()).withClass("usa-alert__text"));
+      }
+    }
+
+    return div()
+        .withId(PROGRAM_DATA_ID)
+        .with(
+            errorDiv.with(bodyDiv),
             asRedirectElement(button("Try again"), routes.AdminImportController.index().url())
                 .withClasses("my-5", "usa-button", "usa-button--outline"));
   }


### PR DESCRIPTION
### Description

Improved Yes/No import error display formatting.
- Added renderErrorWithLineBreaks() method to display multiple validation errors as readable bulleted list instead of concatenated text

## Release notes

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [X] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [X] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [X] Added an additional reviewer from `civiform/eng-admin` as FYI (if the primary reviewer is not an admin and this PR includes functionality changes)
- [X] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [X] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

#### Database evolutions

Read the guidelines [here](https://github.com/civiform/civiform/wiki/Database#writing-database-evolutions)

- [ ] Assigned two reviewers
- [ ] Guarded against already existing resources using `IF NOT EXISTS` and `IF EXISTS`
- [ ] Downs created to undo changes in Ups
- [ ] Every comment in script should begin with -- and not # --- unless it denotes Ups or Downs. See [here](https://www.playframework.com/documentation/2.9.x/Evolutions) for details.
- [ ] Tested both the Downs and the Ups scripts manually (When testing, include all comments from the evolution in your test script to ensure any syntax errors in the comments are caught.)
- [ ] Data migrations aren't being done (please use a [Durable Job](https://github.com/civiform/civiform/wiki/Database#durable-jobs-for-data-updates) if doing a data migration)
- [ ] Update the model documentation in our [wiki](https://github.com/civiform/civiform/wiki/Database) if necessary

#### Durable jobs

Read the docs [here](https://github.com/civiform/civiform/wiki/Database#durable-jobs-for-data-updates)

- [ ] Assigned two reviewers
- [ ] Included a rollback plan and a job to undo the data changes if appropriate

#### User visible changes

- [ ] Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
  - [ ] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [ ] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Made equivalent changes in Thymeleaf for applicant-facing features and changes (or created an issue in the [Northstar epic](https://github.com/orgs/civiform/projects/1/views/94) to track that it's missing from Thymeleaf)
- [X] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [X] Manually tested at 200% size
- [ ] Manually evaluated tab order
- [ ] Manually tested with a screen reader if the feature is applicant-facing. See [screen reader testing](https://github.com/civiform/civiform/wiki/Testing#screen-reader-testing)
- [ ] Manually tested with a right-to-left language

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/helper/feature-flags.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://github.com/civiform/civiform/wiki/Feature-Flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Instructions for manual testing
1. Import a program JSON with multiple YES/NO validation errors
    - Test for multiple errors 
    - Verify error messages appear as bulleted list with each error on separate line


### Issue(s) this completes

Fixes #11330
