### PR TITLE
Pause syncing from civiform to civiform-message

### DIFF
--- a/.github/workflows/sync_messages_repo.yaml
+++ b/.github/workflows/sync_messages_repo.yaml
@@ -9,6 +9,7 @@ on:
     branches: [main]
     paths:
       - 'server/conf/i18n/**'
+  # Temporarily disable due to merge conflicts
   # schedule:
     # Run daily at 2 AM UTC
     # - cron: '0 2 * * *'


### PR DESCRIPTION
### Description

Temporarily disabling the job to sync civiform to civiform-message. Civiform-message hasn't been able to create a PR and sync to civiform due to this job that runs everyday to update civiform-message into civiform. Pausing it for a day or two to resolve the conflicts.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [ ] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from `civiform/eng-admin` as FYI (if the primary reviewer is not an admin and this PR includes functionality changes)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [x] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

#### Durable jobs

Read the docs [here](https://github.com/civiform/civiform/wiki/Database#durable-jobs-for-data-updates)

- [x] Assigned two reviewers
- [ ] Included a rollback plan and a job to undo the data changes if appropriate

### Instructions for manual testing

If instructions are needed for manual testing by reviewers, include them here.

### Issue(s) this completes

Fixes #<issue_number>; Fixes #<issue_number>...
