### PR TITLE
Deprecate North Star - PR 4 of 5 

### DIFF
--- a/server/app/controllers/admin/NorthStarProgramCardPreviewController.java
+++ b/server/app/controllers/admin/NorthStarProgramCardPreviewController.java
@@ -48,7 +48,7 @@ public final class NorthStarProgramCardPreviewController extends CiviFormControl
   @Secure(authorizers = Authorizers.Labels.CIVIFORM_ADMIN)
   public String cardPreview(Http.Request request, long programId)
       throws InterruptedException, ExecutionException {
-    if (!settingsManifest.getNorthStarApplicantUi(request)) {
+    if (!settingsManifest.getNorthStarApplicantUi()) {
       return "";
     }
 

--- a/server/app/controllers/admin/NorthStarQuestionPreviewController.java
+++ b/server/app/controllers/admin/NorthStarQuestionPreviewController.java
@@ -43,7 +43,7 @@ public final class NorthStarQuestionPreviewController extends CiviFormController
 
   @Secure
   public Result sampleQuestion(Request request, String questionType) {
-    if (!settingsManifest.getNorthStarApplicantUi(request)) {
+    if (!settingsManifest.getNorthStarApplicantUi()) {
       return notFound();
     }
 

--- a/server/app/controllers/applicant/ApplicantProgramBlocksController.java
+++ b/server/app/controllers/applicant/ApplicantProgramBlocksController.java
@@ -564,7 +564,7 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
                                 applicantRoutes,
                                 profile);
 
-                        if (settingsManifest.getNorthStarApplicantUi(request)) {
+                        if (settingsManifest.getNorthStarApplicantUi()) {
                           final String programSlug;
                           try {
                             programSlug = programService.getSlug(programId);
@@ -704,7 +704,7 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
                         .setBannerToastMessage(flashSuccessBanner)
                         .setBannerMessage(successBannerMessage)
                         .build();
-                if (settingsManifest.getNorthStarApplicantUi(request)) {
+                if (settingsManifest.getNorthStarApplicantUi()) {
                   final String programSlug;
                   try {
                     programSlug = programService.getSlug(programId);
@@ -1620,7 +1620,7 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
                     errorDisplayMode,
                     applicantRoutes,
                     submittingProfile);
-            if (settingsManifest.getNorthStarApplicantUi(request)) {
+            if (settingsManifest.getNorthStarApplicantUi()) {
               final String programSlug;
               try {
                 programSlug = programService.getSlug(programId);
@@ -1710,7 +1710,7 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
     } catch (ProgramBlockDefinitionNotFoundException e) {
       throw new RuntimeException(e);
     }
-    if (settingsManifest.getNorthStarApplicantUi(request)) {
+    if (settingsManifest.getNorthStarApplicantUi()) {
       return supplyAsync(
           () -> {
             NorthStarApplicantIneligibleView.Params params =
@@ -1844,7 +1844,7 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
               ApplicantQuestionRendererParams.ErrorDisplayMode.DISPLAY_ERRORS,
               applicantRoutes,
               profile);
-      if (settingsManifest.getNorthStarApplicantUi(request)) {
+      if (settingsManifest.getNorthStarApplicantUi()) {
         return CompletableFuture.completedFuture(
             ok(northStarAddressCorrectionBlockView.render(
                     request,
@@ -1900,7 +1900,7 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
     AlertSettings eligibilityAlertSettings = AlertSettings.empty();
 
     if (roApplicantProgramService.shouldDisplayEligibilityMessage()) {
-      if (settingsManifest.getNorthStarApplicantUi(request)) {
+      if (settingsManifest.getNorthStarApplicantUi()) {
         eligibilityAlertSettings =
             getNorthStarEligibilityAlertSettings(
                 roApplicantProgramService, request, programId, blockId);
@@ -1910,7 +1910,7 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
                 request,
                 profileUtils.currentUserProfile(request).isTrustedIntermediary(),
                 !roApplicantProgramService.isApplicationNotEligible(),
-                settingsManifest.getNorthStarApplicantUi(request),
+                settingsManifest.getNorthStarApplicantUi(),
                 false,
                 programId,
                 roApplicantProgramService.getIneligibleQuestions());
@@ -2030,7 +2030,7 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
             request,
             profileUtils.currentUserProfile(request).isTrustedIntermediary(),
             !roApplicantProgramService.isApplicationNotEligible(),
-            settingsManifest.getNorthStarApplicantUi(request),
+            settingsManifest.getNorthStarApplicantUi(),
             false,
             programId,
             roApplicantProgramService.getIneligibleQuestions());

--- a/server/app/controllers/applicant/ApplicantProgramReviewController.java
+++ b/server/app/controllers/applicant/ApplicantProgramReviewController.java
@@ -169,7 +169,7 @@ public class ApplicantProgramReviewController extends CiviFormController {
                                   request,
                                   profileUtils.currentUserProfile(request).isTrustedIntermediary(),
                                   !roApplicantProgramService.isApplicationNotEligible(),
-                                  settingsManifest.getNorthStarApplicantUi(request),
+                                  settingsManifest.getNorthStarApplicantUi(),
                                   false,
                                   programId,
                                   roApplicantProgramService.getIneligibleQuestions());
@@ -217,7 +217,7 @@ public class ApplicantProgramReviewController extends CiviFormController {
                           params.setLoginPromptModal(loginPromptModal);
                         }
 
-                        if (settingsManifest.getNorthStarApplicantUi(request)) {
+                        if (settingsManifest.getNorthStarApplicantUi()) {
                           int totalBlockCount =
                               roApplicantProgramService.getAllActiveBlocks().size();
                           int completedBlockCount =
@@ -467,7 +467,7 @@ public class ApplicantProgramReviewController extends CiviFormController {
       ApplicantPersonalInfo personalInfo,
       ReadOnlyApplicantProgramService roApplicantProgramService,
       ProgramDefinition programDefinition) {
-    if (settingsManifest.getNorthStarApplicantUi(request)) {
+    if (settingsManifest.getNorthStarApplicantUi()) {
       NorthStarApplicantIneligibleView.Params params =
           NorthStarApplicantIneligibleView.Params.builder()
               .setRequest(request)
@@ -499,7 +499,7 @@ public class ApplicantProgramReviewController extends CiviFormController {
       long applicantId,
       ReadOnlyApplicantProgramService roApplicantProgramService,
       long programId) {
-    if (settingsManifest.getNorthStarApplicantUi(request)) {
+    if (settingsManifest.getNorthStarApplicantUi()) {
       Call reviewPage = applicantRoutes.review(profile, applicantId, programId);
       return found(reviewPage).flashing(FlashKey.DUPLICATE_SUBMISSION, "true");
     } else {

--- a/server/app/controllers/applicant/ApplicantProgramsController.java
+++ b/server/app/controllers/applicant/ApplicantProgramsController.java
@@ -110,7 +110,7 @@ public final class ApplicantProgramsController extends CiviFormController {
         .thenApplyAsync(
             applicationPrograms -> {
               Result result;
-              if (settingsManifest.getNorthStarApplicantUi(request)) {
+              if (settingsManifest.getNorthStarApplicantUi()) {
                 result =
                     ok(northStarProgramIndexView.render(
                             messagesApi.preferred(request),
@@ -163,7 +163,7 @@ public final class ApplicantProgramsController extends CiviFormController {
 
     return programsFuture.thenApplyAsync(
         programs -> {
-          return settingsManifest.getNorthStarApplicantUi(request)
+          return settingsManifest.getNorthStarApplicantUi()
               ? ok(northStarProgramIndexView.render(
                       messagesApi.preferred(request),
                       request,

--- a/server/app/controllers/applicant/ProgramSlugHandler.java
+++ b/server/app/controllers/applicant/ProgramSlugHandler.java
@@ -257,7 +257,7 @@ public final class ProgramSlugHandler {
               .findFirst();
     }
 
-    return settingsManifest.getNorthStarApplicantUi(request)
+    return settingsManifest.getNorthStarApplicantUi()
             && activeProgramDefinition.displayMode()
                 != DisplayMode.DISABLED // If the program is disabled,
         // redirect to review page because that will trigger the ProgramDisabledAction.

--- a/server/app/controllers/applicant/UpsellController.java
+++ b/server/app/controllers/applicant/UpsellController.java
@@ -153,7 +153,7 @@ public final class UpsellController extends CiviFormController {
               Optional<ToastMessage> toastMessage =
                   toastMessageValue.map(m -> ToastMessage.alert(m));
 
-              if (settingsManifest.getNorthStarApplicantUi(request)) {
+              if (settingsManifest.getNorthStarApplicantUi()) {
                 Instant instant = Instant.parse(submitTime);
                 Date submitDate = Date.from(instant);
                 DateFormat dateFormat =

--- a/server/app/services/applicant/ApplicantService.java
+++ b/server/app/services/applicant/ApplicantService.java
@@ -1320,7 +1320,7 @@ public final class ApplicantService {
           } else if (programType.equals(ProgramType.DEFAULT)
               || (programType.equals(ProgramType.EXTERNAL)
                   && settingsManifest.getExternalProgramCardsEnabled(request)
-                  && settingsManifest.getNorthStarApplicantUi(request))) {
+                  && settingsManifest.getNorthStarApplicantUi())) {
             unappliedPrograms.add(applicantProgramDataBuilder.build());
           }
         });

--- a/server/app/services/settings/SettingsManifest.java
+++ b/server/app/services/settings/SettingsManifest.java
@@ -1047,8 +1047,8 @@ public final class SettingsManifest extends AbstractSettingsManifest {
   }
 
   /** Enables showing new UI with an updated user experience in Applicant flows */
-  public boolean getNorthStarApplicantUi(RequestHeader request) {
-    return getBool("NORTH_STAR_APPLICANT_UI", request);
+  public boolean getNorthStarApplicantUi() {
+    return getBool("NORTH_STAR_APPLICANT_UI");
   }
 
   /** Enable using custom theme colors on North Star applicant UI. */
@@ -2302,7 +2302,7 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                               + " flows",
                           /* isRequired= */ false,
                           SettingType.BOOLEAN,
-                          SettingMode.ADMIN_WRITEABLE),
+                          SettingMode.ADMIN_READABLE),
                       SettingDescription.create(
                           "CUSTOM_THEME_COLORS_ENABLED",
                           "Enable using custom theme colors on North Star applicant UI.",

--- a/server/app/views/admin/programs/ProgramFormBuilder.java
+++ b/server/app/views/admin/programs/ProgramFormBuilder.java
@@ -157,7 +157,7 @@ abstract class ProgramFormBuilder extends BaseHtmlView {
     boolean isExternalProgram = programType.equals(ProgramType.EXTERNAL);
     boolean isExternalProgramCardsEnabled =
         settingsManifest.getExternalProgramCardsEnabled(request);
-    boolean isNorthStarEnabled = settingsManifest.getNorthStarApplicantUi(request);
+    boolean isNorthStarEnabled = settingsManifest.getNorthStarApplicantUi();
 
     boolean disableProgramEligibility = isCommonIntakeForm || isExternalProgram;
     boolean disableLongDescription =
@@ -298,7 +298,7 @@ abstract class ProgramFormBuilder extends BaseHtmlView {
             .setReadOnly(disableExternalLink)
             .setAttribute(
                 "data-northstar-enabled",
-                String.valueOf(settingsManifest.getNorthStarApplicantUi(request)))
+                String.valueOf(settingsManifest.getNorthStarApplicantUi()))
             .getInputTag()
             .withClass(SPACE_BETWEEN_FORM_ELEMENTS),
         // Email notifications

--- a/server/app/views/admin/programs/ProgramImageView.java
+++ b/server/app/views/admin/programs/ProgramImageView.java
@@ -149,7 +149,7 @@ public final class ProgramImageView extends BaseHtmlView {
         div().withClasses("grid", "grid-cols-2", "gap-10", "w-full");
     formsAndCurrentCardContainer.with(formsContainer);
 
-    if (settingsManifest.getNorthStarApplicantUi(request)) {
+    if (settingsManifest.getNorthStarApplicantUi()) {
       DivTag cardPreview;
       try {
         String content =

--- a/server/app/views/admin/programs/ProgramTranslationView.java
+++ b/server/app/views/admin/programs/ProgramTranslationView.java
@@ -67,7 +67,7 @@ public final class ProgramTranslationView extends TranslationFormView {
             request,
             locale,
             formAction,
-            formFields(request, program, translationForm, activeStatusDefinitions));
+            formFields(program, translationForm, activeStatusDefinitions));
     form.withId("program-translation-form");
 
     String title =
@@ -96,7 +96,6 @@ public final class ProgramTranslationView extends TranslationFormView {
   }
 
   private ImmutableList<DomContent> formFields(
-      Http.Request request,
       ProgramDefinition program,
       ProgramTranslationForm translationForm,
       StatusDefinitions currentStatusDefinitions) {
@@ -120,7 +119,7 @@ public final class ProgramTranslationView extends TranslationFormView {
                                 .setHref(programDetailsLink)
                                 .setStyles("ml-2")
                                 .asAnchorText()),
-                    getApplicantVisibleProgramDetailFields(program, updateData, request)));
+                    getApplicantVisibleProgramDetailFields(program, updateData)));
 
     // Add Status Tracking messages.
     String programStatusesLink =
@@ -226,7 +225,7 @@ public final class ProgramTranslationView extends TranslationFormView {
   }
 
   private ImmutableList<DomContent> getApplicantVisibleProgramDetailFields(
-      ProgramDefinition program, LocalizationUpdate updateData, Http.Request request) {
+      ProgramDefinition program, LocalizationUpdate updateData) {
     ImmutableList.Builder<DomContent> applicantVisibleDetails =
         ImmutableList.<DomContent>builder()
             .add(
@@ -241,7 +240,7 @@ public final class ProgramTranslationView extends TranslationFormView {
 
     // On north star, only default programs have a long description. Whereas when north star is off,
     // both default programs and common intake forms have long description.
-    boolean northStarEnabled = settingsManifest.getNorthStarApplicantUi(request);
+    boolean northStarEnabled = settingsManifest.getNorthStarApplicantUi();
     ProgramType programType = program.programType();
     boolean showLongDescription = northStarEnabled && programType.equals(ProgramType.DEFAULT);
     boolean showLongDescriptionNS =

--- a/server/app/views/admin/questions/QuestionEditView.java
+++ b/server/app/views/admin/questions/QuestionEditView.java
@@ -244,7 +244,7 @@ public final class QuestionEditView extends BaseHtmlView {
       Request request, DivTag formContent, QuestionType type, String title, Optional<Modal> modal) {
     DivTag previewContent;
 
-    if (settingsManifest.getNorthStarApplicantUi(request)) {
+    if (settingsManifest.getNorthStarApplicantUi()) {
       // TODO(#7266): If the admin UI uses Thymeleaf, we can directly embed North Star Thymeleaf
       // fragments without using HTMX
       previewContent =

--- a/server/app/views/components/ProgramCardFactory.java
+++ b/server/app/views/components/ProgramCardFactory.java
@@ -44,7 +44,7 @@ public final class ProgramCardFactory {
 
   public DivTag renderCard(ProgramCardData cardData, Http.Request request) {
     ProgramDefinition displayProgram = getDisplayProgram(cardData);
-    boolean northStarEnabled = settingsManifest.getNorthStarApplicantUi(request);
+    boolean northStarEnabled = settingsManifest.getNorthStarApplicantUi();
 
     String programTitleText = displayProgram.localizedName().getDefault();
 

--- a/server/conf/env-var-docs.json
+++ b/server/conf/env-var-docs.json
@@ -907,7 +907,7 @@
         "type": "bool"
       },
       "NORTH_STAR_APPLICANT_UI": {
-        "mode": "ADMIN_WRITEABLE",
+        "mode": "ADMIN_READABLE",
         "description": "Enables showing new UI with an updated user experience in Applicant flows",
         "type": "bool"
       },

--- a/server/conf/helper/feature-flags.conf
+++ b/server/conf/helper/feature-flags.conf
@@ -40,7 +40,7 @@ suggest_programs_on_application_confirmation_page = false
 suggest_programs_on_application_confirmation_page = ${?SUGGEST_PROGRAMS_ON_APPLICATION_CONFIRMATION_PAGE}
 
 # North Star Applicant UI
-north_star_applicant_ui = false
+north_star_applicant_ui = true
 north_star_applicant_ui = ${?NORTH_STAR_APPLICANT_UI}
 
 # Enable to show a banner that tells users this is not a production site

--- a/server/test/controllers/admin/AdminProgramControllerTest.java
+++ b/server/test/controllers/admin/AdminProgramControllerTest.java
@@ -109,44 +109,6 @@ public class AdminProgramControllerTest extends ResetPostgres {
     assertThat(contentAsString(result)).contains(CSRF.getToken(request.asScala()).value());
   }
 
-  /**
-   * @deprecated todo: Remove the test after NORTH_STAR_APPLICANT_UI is fully enabled
-   */
-  @Deprecated
-  @Test
-  public void create_showsNewProgramInList() {
-    RequestBuilder requestBuilder =
-        fakeRequestBuilder()
-            .bodyForm(
-                ImmutableMap.of(
-                    "adminName",
-                    "internal-program-name",
-                    "adminDescription",
-                    "Internal program description",
-                    "localizedDisplayName",
-                    "External program name",
-                    "localizedDisplayDescription",
-                    "External program description",
-                    "localizedShortDescription",
-                    "External short program description",
-                    "externalLink",
-                    "https://external.program.link",
-                    "displayMode",
-                    DisplayMode.PUBLIC.getValue(),
-                    "applicationSteps[0][title]",
-                    "step one title",
-                    "applicationSteps[0][description]",
-                    "step one description"));
-
-    controller.create(requestBuilder.build());
-
-    Request request =
-        fakeRequestBuilder().addCiviFormSetting("NORTH_STAR_APPLICANT_UI", "false").build();
-    Result programDashboardResult = controller.index(request);
-    assertThat(contentAsString(programDashboardResult)).contains("External program name");
-    assertThat(contentAsString(programDashboardResult)).contains("External program description");
-  }
-
   @Test
   public void create_northStar_showsNewProgramInListWithShortDescription() {
     RequestBuilder requestBuilder =
@@ -220,56 +182,6 @@ public class AdminProgramControllerTest extends ResetPostgres {
         .hasValue(
             routes.AdminProgramImageController.index(programId, ProgramEditStatus.CREATION.name())
                 .url());
-  }
-
-  /**
-   * @deprecated todo: Remove the test after NORTH_STAR_APPLICANT_UI is fully enabled
-   */
-  @Deprecated
-  @Test
-  public void create_returnsNewProgramWithAcls() {
-    RequestBuilder requestBuilder =
-        fakeRequestBuilder()
-            .bodyForm(
-                ImmutableMap.of(
-                    "adminName",
-                    "internal-program-with-acls",
-                    "adminDescription",
-                    "Internal program description with acls",
-                    "localizedDisplayName",
-                    "External program name with acls",
-                    "localizedDisplayDescription",
-                    "External program description with acls",
-                    "localizedShortDescription",
-                    "External short program description with acls",
-                    "externalLink",
-                    "https://external.program.link",
-                    "displayMode",
-                    DisplayMode.SELECT_TI.getValue(),
-                    "tiGroups[]",
-                    "1",
-                    "applicationSteps[0][title]",
-                    "step one title",
-                    "applicationSteps[0][description]",
-                    "step one description"));
-
-    Result result = controller.create(requestBuilder.build());
-
-    assertThat(result.status()).isEqualTo(SEE_OTHER);
-
-    Optional<ProgramModel> newProgram =
-        versionRepository.getProgramByNameForVersion(
-            "internal-program-with-acls", versionRepository.getDraftVersionOrCreate());
-    assertThat(newProgram).isPresent();
-    assertThat(newProgram.get().getProgramDefinition().acls().getTiProgramViewAcls())
-        .containsExactly(1L);
-
-    Request request =
-        fakeRequestBuilder().addCiviFormSetting("NORTH_STAR_APPLICANT_UI", "false").build();
-    Result programDashboard = controller.index(request);
-    assertThat(contentAsString(programDashboard)).contains("External program name with acls");
-    assertThat(contentAsString(programDashboard))
-        .contains("External program description with acls");
   }
 
   @Test
@@ -399,59 +311,6 @@ public class AdminProgramControllerTest extends ResetPostgres {
     assertThat(updatedDraft.getProgramDefinition().eligibilityIsGating()).isTrue();
   }
 
-  /**
-   * @deprecated todo: Remove the test after NORTH_STAR_APPLICANT_UI is fully enabled
-   */
-  @Deprecated
-  @Test
-  public void create_includesNewAndExistingProgramsInList() {
-    ProgramBuilder.newActiveProgram("Existing One").build();
-    RequestBuilder requestBuilder =
-        fakeRequestBuilder()
-            .bodyForm(
-                ImmutableMap.of(
-                    "adminName",
-                    "internal-program-name",
-                    "adminDescription",
-                    "Internal program description",
-                    "localizedDisplayName",
-                    "External program name",
-                    "localizedDisplayDescription",
-                    "External program description",
-                    "localizedShortDescription",
-                    "External short program description",
-                    "externalLink",
-                    "https://external.program.link",
-                    "displayMode",
-                    DisplayMode.PUBLIC.getValue(),
-                    "applicationSteps[0][title]",
-                    "step one title",
-                    "applicationSteps[0][description]",
-                    "step one description"));
-
-    Result result = controller.create(requestBuilder.build());
-
-    assertThat(result.status()).isEqualTo(SEE_OTHER);
-    long programId =
-        versionRepository
-            .getDraftVersionOrCreate()
-            .getPrograms()
-            .get(0)
-            .getProgramDefinition()
-            .id();
-    assertThat(result.redirectLocation())
-        .hasValue(
-            routes.AdminProgramImageController.index(programId, ProgramEditStatus.CREATION.name())
-                .url());
-
-    Request request =
-        fakeRequestBuilder().addCiviFormSetting("NORTH_STAR_APPLICANT_UI", "false").build();
-    Result programDashboard = controller.index(request);
-    assertThat(contentAsString(programDashboard)).contains("Existing One");
-    assertThat(contentAsString(programDashboard)).contains("External program name");
-    assertThat(contentAsString(programDashboard)).contains("External program description");
-  }
-
   @Test
   public void create_northStar_includesNewAndExistingProgramsInList() {
     ProgramBuilder.newActiveProgram("Existing One").build();
@@ -567,59 +426,6 @@ public class AdminProgramControllerTest extends ResetPostgres {
 
     assertThat(result.status()).isEqualTo(OK);
     assertThat(contentAsString(result)).contains("confirm-common-intake-change");
-  }
-
-  /**
-   * @deprecated todo: Remove the test after NORTH_STAR_APPLICANT_UI is fully enabled
-   */
-  @Deprecated
-  @Test
-  public void create_doesNotPromptUserToConfirmCommonIntakeChangeIfNoneExists() {
-    RequestBuilder requestBuilder =
-        fakeRequestBuilder()
-            .bodyForm(
-                ImmutableMap.of(
-                    "adminName",
-                    "internal-program-name",
-                    "adminDescription",
-                    "Internal program description",
-                    "localizedDisplayName",
-                    "External program name",
-                    "localizedDisplayDescription",
-                    "External program description",
-                    "localizedShortDescription",
-                    "External short program description",
-                    "displayMode",
-                    DisplayMode.PUBLIC.getValue(),
-                    "programTypeValue",
-                    ProgramType.COMMON_INTAKE_FORM.getValue(),
-                    "confirmedChangeCommonIntakeForm",
-                    "false",
-                    "applicationSteps[0][title]",
-                    "step one title",
-                    "applicationSteps[0][description]",
-                    "step one description"));
-
-    Result result = controller.create(requestBuilder.build());
-
-    assertThat(result.status()).isEqualTo(SEE_OTHER);
-    long programId =
-        versionRepository
-            .getDraftVersionOrCreate()
-            .getPrograms()
-            .get(0)
-            .getProgramDefinition()
-            .id();
-    assertThat(result.redirectLocation())
-        .hasValue(
-            routes.AdminProgramImageController.index(programId, ProgramEditStatus.CREATION.name())
-                .url());
-
-    Request request =
-        fakeRequestBuilder().addCiviFormSetting("NORTH_STAR_APPLICANT_UI", "false").build();
-    Result programDashboard = controller.index(request);
-    assertThat(contentAsString(programDashboard)).contains("External program name");
-    assertThat(contentAsString(programDashboard)).contains("External program description");
   }
 
   @Test
@@ -831,48 +637,6 @@ public class AdminProgramControllerTest extends ResetPostgres {
     assertThat(result.status()).isEqualTo(OK);
     assertThat(contentAsString(result)).contains("Edit program");
     assertThat(contentAsString(result)).contains(CSRF.getToken(request.asScala()).value());
-  }
-
-  /**
-   * @deprecated todo: Remove the test after NORTH_STAR_APPLICANT_UI is fully enabled
-   */
-  @Deprecated
-  @Test
-  public void update_overwritesExistingProgram() throws Exception {
-    ProgramModel program =
-        ProgramBuilder.newDraftProgram("Existing One", "old description").build();
-    RequestBuilder requestBuilder =
-        fakeRequestBuilder()
-            .bodyForm(
-                ImmutableMap.of(
-                    "adminDescription",
-                    "New program slug",
-                    "localizedDisplayName",
-                    "New program name",
-                    "localizedDisplayDescription",
-                    "New program description",
-                    "localizedShortDescription",
-                    "New external short program description",
-                    "externalLink",
-                    "https://external.program.link",
-                    "displayMode",
-                    DisplayMode.PUBLIC.getValue(),
-                    "programTypeValue",
-                    ProgramType.COMMON_INTAKE_FORM.getValue(),
-                    "tiGroups[]",
-                    "1",
-                    "applicationSteps[0][title]",
-                    "step one title",
-                    "applicationSteps[0][description]",
-                    "step one description"));
-    controller.update(requestBuilder.build(), program.id, ProgramEditStatus.EDIT.name());
-
-    Request request =
-        fakeRequestBuilder().addCiviFormSetting("NORTH_STAR_APPLICANT_UI", "false").build();
-    Result indexResult = controller.index(request);
-    assertThat(contentAsString(indexResult))
-        .contains("Create new program", "New program name", "New program description");
-    assertThat(contentAsString(indexResult)).doesNotContain("Existing one", "short description");
   }
 
   @Test
@@ -1150,61 +914,6 @@ public class AdminProgramControllerTest extends ResetPostgres {
 
     Result redirectResult = controller.index(fakeRequest());
     assertThat(contentAsString(redirectResult)).contains("New program name");
-  }
-
-  /**
-   * @deprecated todo: Remove the test after NORTH_STAR_APPLICANT_UI is fully enabled
-   */
-  @Deprecated
-  @Test
-  public void update_allowsChangingCommonIntakeAfterConfirming() throws Exception {
-    ProgramModel program =
-        ProgramBuilder.newDraftProgram("Existing One", "old description").build();
-    ProgramBuilder.newActiveCommonIntakeForm("Old common intake").build();
-
-    String newProgramName = "External program name";
-    String newProgramDescription = "New program description";
-    RequestBuilder requestBuilder =
-        fakeRequestBuilder()
-            .bodyForm(
-                ImmutableMap.of(
-                    "adminDescription",
-                    "New program slug",
-                    "localizedDisplayName",
-                    newProgramName,
-                    "localizedDisplayDescription",
-                    "New program description",
-                    "localizedShortDescription",
-                    "External program short description",
-                    "externalLink",
-                    "https://external.program.link",
-                    "displayMode",
-                    DisplayMode.PUBLIC.getValue(),
-                    "programTypeValue",
-                    ProgramType.COMMON_INTAKE_FORM.getValue(),
-                    "confirmedChangeCommonIntakeForm",
-                    "true",
-                    "applicationSteps[0][title]",
-                    "step one title",
-                    "applicationSteps[0][description]",
-                    "step one description"));
-
-    Result result =
-        controller.update(requestBuilder.build(), program.id, ProgramEditStatus.EDIT.name());
-
-    assertThat(result.status()).isEqualTo(SEE_OTHER);
-    Optional<ProgramModel> newProgram =
-        versionRepository.getProgramByNameForVersion(
-            "Existing One", versionRepository.getDraftVersionOrCreate());
-    assertThat(newProgram).isPresent();
-    assertThat(result.redirectLocation())
-        .hasValue(routes.AdminProgramBlocksController.index(newProgram.get().id).url());
-
-    Request request =
-        fakeRequestBuilder().addCiviFormSetting("NORTH_STAR_APPLICANT_UI", "false").build();
-    Result redirectResult = controller.index(request);
-    assertThat(contentAsString(redirectResult)).contains(newProgramName);
-    assertThat(contentAsString(redirectResult)).contains(newProgramDescription);
   }
 
   @Test

--- a/server/test/controllers/admin/AdminProgramPreviewControllerTest.java
+++ b/server/test/controllers/admin/AdminProgramPreviewControllerTest.java
@@ -8,7 +8,6 @@ import static support.FakeRequestBuilder.fakeRequest;
 import static support.FakeRequestBuilder.fakeRequestBuilder;
 
 import controllers.WithMockedProfiles;
-import models.AccountModel;
 import models.ProgramModel;
 import org.junit.Before;
 import org.junit.Test;
@@ -24,25 +23,6 @@ public class AdminProgramPreviewControllerTest extends WithMockedProfiles {
   public void setup() {
     resetDatabase();
     controller = instanceOf(AdminProgramPreviewController.class);
-  }
-
-  @Test
-  public void preview_redirectsToProgramReviewPage() {
-    ProgramModel program = resourceCreator().insertActiveProgram("test-slug");
-    AccountModel adminAccount = createGlobalAdminWithMockedProfile();
-
-    String programSlug = "test-slug";
-    Request request =
-        fakeRequestBuilder().addCiviFormSetting("NORTH_STAR_APPLICANT_UI", "false").build();
-    Result result = controller.preview(request, programSlug).toCompletableFuture().join();
-    assertThat(result.status()).isEqualTo(SEE_OTHER);
-    assertThat(result.redirectLocation())
-        .hasValue(
-            controllers.applicant.routes.ApplicantProgramReviewController.reviewWithApplicantId(
-                    adminAccount.ownedApplicantIds().get(0),
-                    Long.toString(program.id),
-                    /* isFromUrlCall= */ false)
-                .url());
   }
 
   @Test

--- a/server/test/controllers/admin/AdminQuestionControllerTest.java
+++ b/server/test/controllers/admin/AdminQuestionControllerTest.java
@@ -208,21 +208,6 @@ public class AdminQuestionControllerTest extends ResetPostgres {
   }
 
   @Test
-  public void edit_returnsPopulatedForm() {
-    QuestionModel question = testQuestionBank.nameApplicantName();
-    Request request =
-        fakeRequestBuilder()
-            .addCiviFormSetting("NORTH_STAR_APPLICANT_UI", "false")
-            .addCSRFToken()
-            .build();
-    Result result = controller.edit(request, question.id).toCompletableFuture().join();
-    assertThat(result.status()).isEqualTo(OK);
-    assertThat(contentAsString(result)).contains("Edit name question");
-    assertThat(contentAsString(result)).contains(CSRF.getToken(request.asScala()).value());
-    assertThat(contentAsString(result)).contains("Sample question of type:");
-  }
-
-  @Test
   public void northStar_edit_returnsPopulatedForm() {
     QuestionModel question = testQuestionBank.nameApplicantName();
     Request request = fakeRequestBuilder().addCSRFToken().build();
@@ -231,22 +216,6 @@ public class AdminQuestionControllerTest extends ResetPostgres {
     assertThat(contentAsString(result)).contains("Edit name question");
     assertThat(contentAsString(result)).contains(CSRF.getToken(request.asScala()).value());
     assertThat(contentAsString(result)).contains("what is your name?");
-  }
-
-  @Test
-  public void edit_repeatedQuestion_hasEnumeratorName() {
-    QuestionModel repeatedQuestion = testQuestionBank.nameRepeatedApplicantHouseholdMemberName();
-    Request request =
-        fakeRequestBuilder()
-            .addCiviFormSetting("NORTH_STAR_APPLICANT_UI", "false")
-            .addCSRFToken()
-            .build();
-    Result result = controller.edit(request, repeatedQuestion.id).toCompletableFuture().join();
-    assertThat(result.status()).isEqualTo(OK);
-    assertThat(contentAsString(result)).contains("Edit name question");
-    assertThat(contentAsString(result)).contains("applicant household members");
-    assertThat(contentAsString(result)).contains(CSRF.getToken(request.asScala()).value());
-    assertThat(contentAsString(result)).contains("Sample question of type:");
   }
 
   @Test
@@ -317,22 +286,6 @@ public class AdminQuestionControllerTest extends ResetPostgres {
     assertThat(result.contentType()).hasValue("text/html");
     assertThat(result.charset()).hasValue("utf-8");
     assertThat(contentAsString(result)).contains("has message");
-  }
-
-  @Test
-  public void newOne_returnsExpectedForm() {
-    Request request =
-        fakeRequestBuilder()
-            .addCiviFormSetting("NORTH_STAR_APPLICANT_UI", "false")
-            .addCSRFToken()
-            .build();
-    Result result = controller.newOne(request, "text", "/some/redirect/url");
-
-    assertThat(result.status()).isEqualTo(OK);
-    assertThat(contentAsString(result)).contains("New text question");
-    assertThat(contentAsString(result)).contains(CSRF.getToken(request.asScala()).value());
-    assertThat(contentAsString(result)).contains("Sample question of type:");
-    assertThat(contentAsString(result)).contains("/some/redirect/url");
   }
 
   @Test

--- a/server/test/controllers/applicant/ApplicantProgramBlocksControllerTest.java
+++ b/server/test/controllers/applicant/ApplicantProgramBlocksControllerTest.java
@@ -427,7 +427,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     String programId = Long.toString(program.id);
     Request request =
         fakeRequestBuilder().langCookie(Locale.forLanguageTag("es-US"), stubMessagesApi()).build();
-    when(settingsManifest.getNorthStarApplicantUi(request)).thenReturn(false);
+    when(settingsManifest.getNorthStarApplicantUi()).thenReturn(false);
 
     Result result =
         subject
@@ -451,7 +451,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
 
     Request request =
         fakeRequestBuilder().langCookie(Locale.forLanguageTag("es-US"), stubMessagesApi()).build();
-    when(settingsManifest.getNorthStarApplicantUi(request)).thenReturn(true);
+    when(settingsManifest.getNorthStarApplicantUi()).thenReturn(true);
 
     Result result =
         subject
@@ -1140,7 +1140,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
                     ""))
             .build();
 
-    when(settingsManifest.getNorthStarApplicantUi(request)).thenReturn(false);
+    when(settingsManifest.getNorthStarApplicantUi()).thenReturn(false);
 
     Result result =
         subject
@@ -1180,7 +1180,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
                     ""))
             .build();
 
-    when(settingsManifest.getNorthStarApplicantUi(request)).thenReturn(true);
+    when(settingsManifest.getNorthStarApplicantUi()).thenReturn(true);
 
     Result result =
         subject
@@ -1346,7 +1346,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
                     "InitialLastName"))
             .build();
 
-    when(settingsManifest.getNorthStarApplicantUi(requestWithAnswer)).thenReturn(false);
+    when(settingsManifest.getNorthStarApplicantUi()).thenReturn(false);
 
     subject
         .updateWithApplicantId(
@@ -1370,7 +1370,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
                     ""))
             .build();
 
-    when(settingsManifest.getNorthStarApplicantUi(requestWithoutAnswer)).thenReturn(false);
+    when(settingsManifest.getNorthStarApplicantUi()).thenReturn(false);
 
     Result result =
         subject
@@ -1413,7 +1413,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
                     "InitialLastName"))
             .build();
 
-    when(settingsManifest.getNorthStarApplicantUi(requestWithAnswer)).thenReturn(true);
+    when(settingsManifest.getNorthStarApplicantUi()).thenReturn(true);
 
     subject
         .updateWithApplicantId(
@@ -1437,7 +1437,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
                     ""))
             .build();
 
-    when(settingsManifest.getNorthStarApplicantUi(requestWithoutAnswer)).thenReturn(true);
+    when(settingsManifest.getNorthStarApplicantUi()).thenReturn(true);
 
     Result result =
         subject

--- a/server/test/controllers/applicant/ApplicantProgramReviewControllerTest.java
+++ b/server/test/controllers/applicant/ApplicantProgramReviewControllerTest.java
@@ -526,7 +526,7 @@ public class ApplicantProgramReviewControllerTest extends WithMockedProfiles {
                     applicantId, programId))
             .header(skipUserProfile, "false")
             .build();
-    when(settingsManifest.getNorthStarApplicantUi(request)).thenReturn(false);
+    when(settingsManifest.getNorthStarApplicantUi()).thenReturn(false);
     return subject
         .submitWithApplicantId(request, applicantId, programId)
         .toCompletableFuture()
@@ -541,7 +541,7 @@ public class ApplicantProgramReviewControllerTest extends WithMockedProfiles {
                     applicantId, programId))
             .header(skipUserProfile, "false")
             .build();
-    when(settingsManifest.getNorthStarApplicantUi(request)).thenReturn(true);
+    when(settingsManifest.getNorthStarApplicantUi()).thenReturn(true);
     return subject
         .submitWithApplicantId(request, applicantId, programId)
         .toCompletableFuture()

--- a/server/test/controllers/applicant/ApplicantProgramsControllerTest.java
+++ b/server/test/controllers/applicant/ApplicantProgramsControllerTest.java
@@ -365,30 +365,6 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
   }
 
   @Test
-  // Tests the behavior of the `show()` method when the parameter contains an alphanumeric value,
-  // representing a program slug.
-  public void show_withStringProgramParam_showsByProgramSlug() {
-    ProgramModel program = resourceCreator().insertActiveProgram("program");
-
-    // Set preferred locale so that browser doesn't get redirected to set it. This way we get a
-    // meaningful redirect location.
-    currentApplicant.getApplicantData().setPreferredLocale(Locale.US);
-    currentApplicant.save();
-
-    String alphaNumProgramParam = program.getSlug();
-    Request request =
-        fakeRequestBuilder().addCiviFormSetting("NORTH_STAR_APPLICANT_UI", "false").build();
-    Result result = controller.show(request, alphaNumProgramParam).toCompletableFuture().join();
-
-    assertThat(result.status()).isEqualTo(SEE_OTHER);
-    assertThat(result.redirectLocation())
-        .contains(
-            routes.ApplicantProgramReviewController.review(
-                    Long.toString(program.id), /* isFromUrlCall= */ false)
-                .url());
-  }
-
-  @Test
   public void northStar_show_withStringProgramParam_showsProgramOverview() {
     ProgramModel program = resourceCreator().insertActiveProgram("program");
 
@@ -418,32 +394,6 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
         controller.showWithApplicantId(fakeRequest(), 1, "123").toCompletableFuture().join();
     assertThat(result.status()).isEqualTo(SEE_OTHER);
     assertThat(result.redirectLocation()).hasValue("/");
-  }
-
-  @Test
-  public void showWithApplicantId_withStringProgramParam_redirectsToReview() {
-    ProgramModel program = resourceCreator().insertActiveProgram("program");
-
-    // Set preferred locale so that browser doesn't get redirected to set it. This way we get a
-    // meaningful redirect location.
-    currentApplicant.getApplicantData().setPreferredLocale(Locale.US);
-    currentApplicant.save();
-
-    String alphaNumProgramParam = program.getSlug();
-    Request request =
-        fakeRequestBuilder().addCiviFormSetting("NORTH_STAR_APPLICANT_UI", "false").build();
-    Result result =
-        controller
-            .showWithApplicantId(request, currentApplicant.id, alphaNumProgramParam)
-            .toCompletableFuture()
-            .join();
-
-    assertThat(result.status()).isEqualTo(SEE_OTHER);
-    assertThat(result.redirectLocation())
-        .contains(
-            routes.ApplicantProgramReviewController.review(
-                    Long.toString(program.id), /* isFromUrlCall= */ false)
-                .url());
   }
 
   @Test

--- a/server/test/controllers/applicant/ProgramSlugHandlerTest.java
+++ b/server/test/controllers/applicant/ProgramSlugHandlerTest.java
@@ -3,7 +3,6 @@ package controllers.applicant;
 import static controllers.CallbackController.REDIRECT_TO_SESSION_KEY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static play.mvc.Http.Status.OK;
@@ -30,7 +29,6 @@ import play.i18n.Lang;
 import play.i18n.Langs;
 import play.i18n.MessagesApi;
 import play.libs.concurrent.ClassLoaderExecutionContext;
-import play.mvc.Http.Request;
 import play.mvc.Result;
 import repository.AccountRepository;
 import repository.VersionRepository;
@@ -48,41 +46,6 @@ public class ProgramSlugHandlerTest extends WithMockedProfiles {
   @Before
   public void setUp() {
     resetDatabase();
-  }
-
-  @Test
-  public void programBySlug_redirectsToActiveProgramVersionForExistingApplications() {
-    ProgramDefinition programDefinition =
-        ProgramBuilder.newActiveProgram("test program", "desc").buildDefinition();
-    VersionRepository versionRepository = instanceOf(VersionRepository.class);
-
-    ApplicantModel applicant = createApplicantWithMockedProfile();
-    applicant.getApplicantData().setPreferredLocale(Locale.ENGLISH);
-    applicant.save();
-
-    ApplicationModel app =
-        new ApplicationModel(applicant, programDefinition.toProgram(), LifecycleStage.DRAFT);
-    app.save();
-
-    ProgramModel programModelV2 =
-        resourceCreator().insertDraftProgram(programDefinition.adminName());
-    versionRepository.publishNewSynchronizedVersion();
-
-    CiviFormController controller = instanceOf(CiviFormController.class);
-
-    Request request =
-        fakeRequestBuilder().addCiviFormSetting("NORTH_STAR_APPLICANT_UI", "false").build();
-    Result result =
-        instanceOf(ProgramSlugHandler.class)
-            .showProgram(controller, request, programDefinition.slug())
-            .toCompletableFuture()
-            .join();
-
-    assertThat(result.redirectLocation())
-        .contains(
-            controllers.applicant.routes.ApplicantProgramReviewController.review(
-                    Long.toString(programModelV2.id), /* isFromUrlCall= */ false)
-                .url());
   }
 
   @Test
@@ -277,7 +240,7 @@ public class ProgramSlugHandlerTest extends WithMockedProfiles {
     when(mockLangs.availables()).thenReturn(ImmutableList.of(Lang.forCode("en-US")));
 
     SettingsManifest mockSettingsManifest = mock(SettingsManifest.class);
-    when(mockSettingsManifest.getNorthStarApplicantUi(any())).thenReturn(true);
+    when(mockSettingsManifest.getNorthStarApplicantUi()).thenReturn(true);
 
     ApplicationModel app =
         new ApplicationModel(applicant, programDefinition.toProgram(), LifecycleStage.DRAFT);
@@ -325,7 +288,7 @@ public class ProgramSlugHandlerTest extends WithMockedProfiles {
     when(mockLangs.availables()).thenReturn(ImmutableList.of(Lang.forCode("en-US")));
 
     SettingsManifest mockSettingsManifest = mock(SettingsManifest.class);
-    when(mockSettingsManifest.getNorthStarApplicantUi(any())).thenReturn(true);
+    when(mockSettingsManifest.getNorthStarApplicantUi()).thenReturn(true);
 
     LanguageUtils languageUtils =
         new LanguageUtils(
@@ -370,7 +333,7 @@ public class ProgramSlugHandlerTest extends WithMockedProfiles {
     when(mockLangs.availables()).thenReturn(ImmutableList.of(Lang.forCode("en-US")));
 
     SettingsManifest mockSettingsManifest = mock(SettingsManifest.class);
-    when(mockSettingsManifest.getNorthStarApplicantUi(any())).thenReturn(true);
+    when(mockSettingsManifest.getNorthStarApplicantUi()).thenReturn(true);
 
     ApplicationModel app =
         new ApplicationModel(applicant, programDefinition.toProgram(), LifecycleStage.ACTIVE);
@@ -419,7 +382,7 @@ public class ProgramSlugHandlerTest extends WithMockedProfiles {
     when(mockLangs.availables()).thenReturn(ImmutableList.of(Lang.forCode("en-US")));
 
     SettingsManifest mockSettingsManifest = mock(SettingsManifest.class);
-    when(mockSettingsManifest.getNorthStarApplicantUi(any())).thenReturn(true);
+    when(mockSettingsManifest.getNorthStarApplicantUi()).thenReturn(true);
 
     ApplicationModel app =
         new ApplicationModel(applicant, programDefinition.toProgram(), LifecycleStage.ACTIVE);

--- a/server/test/controllers/applicant/UpsellControllerTest.java
+++ b/server/test/controllers/applicant/UpsellControllerTest.java
@@ -13,24 +13,12 @@ import controllers.WithMockedProfiles;
 import java.time.Instant;
 import models.ApplicantModel;
 import models.ApplicationModel;
-import models.QuestionModel;
 import org.junit.Before;
 import org.junit.Test;
 import play.mvc.Http.Request;
 import play.mvc.Result;
-import services.Path;
-import services.applicant.ApplicantData;
-import services.applicant.question.Scalar;
-import services.program.EligibilityDefinition;
 import services.program.ProgramDefinition;
 import services.program.ProgramNotFoundException;
-import services.program.predicate.LeafOperationExpressionNode;
-import services.program.predicate.Operator;
-import services.program.predicate.PredicateAction;
-import services.program.predicate.PredicateDefinition;
-import services.program.predicate.PredicateExpressionNode;
-import services.program.predicate.PredicateValue;
-import services.question.QuestionAnswerer;
 import support.ProgramBuilder;
 
 public class UpsellControllerTest extends WithMockedProfiles {
@@ -40,34 +28,6 @@ public class UpsellControllerTest extends WithMockedProfiles {
   @Before
   public void setUp() {
     resetDatabase();
-  }
-
-  @Test
-  public void considerRegister_redirectsToUpsellViewForDefaultProgramType() {
-    ProgramDefinition programDefinition =
-        ProgramBuilder.newActiveProgram("test program", "desc").buildDefinition();
-    ApplicantModel applicant = createApplicantWithMockedProfile();
-    ApplicationModel application =
-        resourceCreator.insertActiveApplication(applicant, programDefinition.toProgram());
-    application.setSubmitTimeForTest(FAKE_SUBMIT_TIME);
-    String redirectLocation = "someUrl";
-
-    Request request =
-        fakeRequestBuilder().addCiviFormSetting("NORTH_STAR_APPLICANT_UI", "false").build();
-    Result result =
-        instanceOf(UpsellController.class)
-            .considerRegister(
-                request,
-                applicant.id,
-                programDefinition.id(),
-                application.id,
-                redirectLocation,
-                application.getSubmitTime().toString())
-            .toCompletableFuture()
-            .join();
-    assertThat(result.status()).isEqualTo(OK);
-    assertThat(contentAsString(result)).contains("Application confirmation");
-    assertThat(contentAsString(result)).contains("Create account");
   }
 
   @Test
@@ -96,127 +56,6 @@ public class UpsellControllerTest extends WithMockedProfiles {
     assertThat(result.status()).isEqualTo(OK);
     assertThat(contentAsString(result)).contains("Application confirmation");
     assertThat(contentAsString(result)).contains("Create an account");
-  }
-
-  @Test
-  public void
-      considerRegister_redirectsToUpsellViewForCommonIntakeWithNoRecommendedProgramsFound() {
-    QuestionModel predicateQuestion = testQuestionBank().textApplicantFavoriteColor();
-    EligibilityDefinition eligibility =
-        EligibilityDefinition.builder()
-            .setPredicate(
-                PredicateDefinition.create(
-                    PredicateExpressionNode.create(
-                        LeafOperationExpressionNode.create(
-                            predicateQuestion.id,
-                            Scalar.TEXT,
-                            Operator.EQUAL_TO,
-                            PredicateValue.of("yellow"))),
-                    PredicateAction.ELIGIBLE_BLOCK))
-            .build();
-    ProgramDefinition programDefinition =
-        ProgramBuilder.newActiveProgram("color-program")
-            .withBlock()
-            .withRequiredQuestion(predicateQuestion)
-            .withEligibilityDefinition(eligibility)
-            .buildDefinition();
-
-    ApplicantModel applicant = createApplicantWithMockedProfile();
-
-    // Answer the color question with an ineligible response
-    Path colorPath = ApplicantData.APPLICANT_PATH.join("applicant_favorite_color");
-    QuestionAnswerer.answerTextQuestion(applicant.getApplicantData(), colorPath, "green");
-    QuestionAnswerer.addMetadata(applicant.getApplicantData(), colorPath, 456L, 12345L);
-    applicant.save();
-
-    ProgramDefinition commonIntakeForm =
-        ProgramBuilder.newActiveCommonIntakeForm("commonintake")
-            .withBlock()
-            .withRequiredQuestion(predicateQuestion)
-            .buildDefinition();
-    ApplicationModel application =
-        resourceCreator.insertActiveApplication(applicant, commonIntakeForm.toProgram());
-    application.setSubmitTimeForTest(FAKE_SUBMIT_TIME);
-    String redirectLocation = "someUrl";
-
-    Request request =
-        fakeRequestBuilder().addCiviFormSetting("NORTH_STAR_APPLICANT_UI", "false").build();
-    Result result =
-        instanceOf(UpsellController.class)
-            .considerRegister(
-                request,
-                applicant.id,
-                commonIntakeForm.id(),
-                application.id,
-                redirectLocation,
-                application.getSubmitTime().toString())
-            .toCompletableFuture()
-            .join();
-    assertThat(result.status()).isEqualTo(OK);
-    assertThat(contentAsString(result)).contains("Programs");
-    assertThat(contentAsString(result)).contains("could not find");
-    assertThat(contentAsString(result))
-        .doesNotContain(programDefinition.localizedName().getDefault());
-    assertThat(contentAsString(result)).contains("Create account");
-  }
-
-  @Test
-  public void considerRegister_redirectsToUpsellViewForCommonIntakeWithRecommendedPrograms() {
-    QuestionModel predicateQuestion = testQuestionBank().textApplicantFavoriteColor();
-    EligibilityDefinition eligibility =
-        EligibilityDefinition.builder()
-            .setPredicate(
-                PredicateDefinition.create(
-                    PredicateExpressionNode.create(
-                        LeafOperationExpressionNode.create(
-                            predicateQuestion.id,
-                            Scalar.TEXT,
-                            Operator.EQUAL_TO,
-                            PredicateValue.of("yellow"))),
-                    PredicateAction.ELIGIBLE_BLOCK))
-            .build();
-    ProgramDefinition programDefinition =
-        ProgramBuilder.newActiveProgram("color-program")
-            .withBlock()
-            .withRequiredQuestion(predicateQuestion)
-            .withEligibilityDefinition(eligibility)
-            .buildDefinition();
-
-    ApplicantModel applicant = createApplicantWithMockedProfile();
-
-    // Answer the color question with an eligible response
-    Path colorPath = ApplicantData.APPLICANT_PATH.join("applicant_favorite_color");
-    QuestionAnswerer.answerTextQuestion(applicant.getApplicantData(), colorPath, "yellow");
-    QuestionAnswerer.addMetadata(applicant.getApplicantData(), colorPath, 456L, 12345L);
-    applicant.save();
-
-    ProgramDefinition commonIntakeForm =
-        ProgramBuilder.newActiveCommonIntakeForm("commonintake")
-            .withBlock()
-            .withRequiredQuestion(predicateQuestion)
-            .buildDefinition();
-    ApplicationModel application =
-        resourceCreator.insertActiveApplication(applicant, commonIntakeForm.toProgram());
-    application.setSubmitTimeForTest(FAKE_SUBMIT_TIME);
-    String redirectLocation = "someUrl";
-
-    Request request =
-        fakeRequestBuilder().addCiviFormSetting("NORTH_STAR_APPLICANT_UI", "false").build();
-    Result result =
-        instanceOf(UpsellController.class)
-            .considerRegister(
-                request,
-                applicant.id,
-                commonIntakeForm.id(),
-                application.id,
-                redirectLocation,
-                application.getSubmitTime().toString())
-            .toCompletableFuture()
-            .join();
-    assertThat(result.status()).isEqualTo(OK);
-    assertThat(contentAsString(result)).contains("Programs");
-    assertThat(contentAsString(result)).contains(programDefinition.localizedName().getDefault());
-    assertThat(contentAsString(result)).contains("Create account");
   }
 
   @Test

--- a/server/test/services/applicant/ApplicantServiceTest.java
+++ b/server/test/services/applicant/ApplicantServiceTest.java
@@ -2527,30 +2527,6 @@ public class ApplicantServiceTest extends ResetPostgres {
   }
 
   @Test
-  public void relevantProgramsForApplicant_externalProgram() {
-    ApplicantModel applicant = createTestApplicant();
-    ProgramBuilder.newActiveProgram(
-            "External Program", "External Program", "", DisplayMode.PUBLIC, ProgramType.EXTERNAL)
-        .build();
-
-    // External program is not included in 'unapplied' list when North Star is disabled, regardless
-    // of external program card feature being enabled
-    Request request =
-        fakeRequestBuilder()
-            .addCiviFormSetting("NORTH_STAR_APPLICANT_UI", "false")
-            .addCiviFormSetting("EXTERNAL_PROGRAM_CARDS_ENABLED", "true")
-            .build();
-    ApplicantService.ApplicationPrograms result =
-        subject
-            .relevantProgramsForApplicant(applicant.id, trustedIntermediaryProfile, request)
-            .toCompletableFuture()
-            .join();
-    // programDefinition is created during test set up.
-    assertThat(result.unapplied().stream().map(p -> p.program().id()))
-        .containsExactly(programDefinition.id());
-  }
-
-  @Test
   public void unappliedAndPotentiallyEligible_returnsProgramsTheApplicantCanApplyTo() {
     ApplicantModel applicant = createTestApplicant();
     EligibilityDefinition eligibilityDef = createEligibilityDefinition(questionDefinition);


### PR DESCRIPTION
### Description

This PR takes care of the following steps in deprecating the North Star:

1. Removes the RequestHeader parameter from SettingsManifest#getNorthStarApplicantUi method and all its usages. 
2. In env-var-docs.json, changes the mode for the feature flag from ADMIN_WRITEABLE to ADMIN_READABLE. This removes the ability to change the value on the admin settings page within CiviForm. 
3. In `feature-flags.conf`, changes the default value of the flag from false to true. This determines the default value if a CE has not overridden it in their deployment config.
4. Removes any unit tests that required the flag to be set to `false`.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [ ] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if the primary reviewer is not an admin and this PR includes functionality changes)
- [ ] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.


### Issue(s) this is part of:

Part of https://github.com/civiform/civiform/issues/9318
