### PR TITLE
[Maps] Visibility and eligibility predicates for map question

### DIFF
--- a/server/app/assets/javascripts/mapquestion/map_question_selection.ts
+++ b/server/app/assets/javascripts/mapquestion/map_question_selection.ts
@@ -114,10 +114,11 @@ const updateSelectionCountForMap = (
     CF_SELECTED_LOCATION_MESSAGE,
   ) as HTMLElement | null
 
-  if (countText) {
+  const maxLocationSelections = window.app?.data?.maxLocationSelections
+  if (countText && maxLocationSelections) {
     countText.textContent = localizeString(messages.locationsSelectedCount, [
       count.toString(),
-      window.app.data.maxLocationSelections.toString(),
+      maxLocationSelections.toString(),
     ])
   }
 }

--- a/server/app/services/applicant/predicate/JsonPathPredicateGenerator.java
+++ b/server/app/services/applicant/predicate/JsonPathPredicateGenerator.java
@@ -171,7 +171,7 @@ public final class JsonPathPredicateGenerator {
             node.scalar().name().toLowerCase(Locale.ROOT)));
   }
 
-  private Path getPath(LeafExpressionNode node) throws InvalidPredicateException {
+  public Path getPath(LeafExpressionNode node) throws InvalidPredicateException {
     if (!questionsById.containsKey(node.questionId())) {
       // This means a predicate was incorrectly configured - we are depending upon a question that
       // does not appear anywhere in this program.
@@ -225,5 +225,9 @@ public final class JsonPathPredicateGenerator {
     }
 
     return predicateContext;
+  }
+
+  public QuestionDefinition getQuestionDefinition(long questionId) {
+    return questionsById.get(questionId);
   }
 }

--- a/server/app/services/applicant/predicate/PredicateEvaluator.java
+++ b/server/app/services/applicant/predicate/PredicateEvaluator.java
@@ -1,14 +1,22 @@
 package services.applicant.predicate;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import java.util.Collection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import services.Path;
 import services.applicant.ApplicantData;
 import services.applicant.exception.InvalidPredicateException;
+import services.applicant.question.MapSelection;
 import services.program.predicate.AndNode;
 import services.program.predicate.LeafAddressServiceAreaExpressionNode;
 import services.program.predicate.LeafOperationExpressionNode;
 import services.program.predicate.OrNode;
 import services.program.predicate.PredicateExpressionNode;
+import services.question.types.QuestionDefinition;
+import services.question.types.QuestionType;
 
 /** Evaluates complex predicates based on the given {@link ApplicantData}. */
 public final class PredicateEvaluator {
@@ -47,6 +55,14 @@ public final class PredicateEvaluator {
   private boolean evaluateLeafNode(LeafOperationExpressionNode node) {
     try {
       JsonPathPredicate predicate = predicateGenerator.fromLeafNode(node);
+
+      QuestionDefinition questionDefinition =
+          predicateGenerator.getQuestionDefinition(node.questionId());
+      if (questionDefinition != null
+          && questionDefinition.getQuestionType().equals(QuestionType.MAP)) {
+        return evaluateMapQuestionLeafNode(node, applicantData, predicate);
+      }
+
       return applicantData.evalPredicate(predicate);
     } catch (InvalidPredicateException e) {
       logger.error(
@@ -83,5 +99,43 @@ public final class PredicateEvaluator {
   /** Returns true if and only if one or more of the node's children evaluates to true. */
   private boolean evaluateOrNode(OrNode node) {
     return node.children().stream().anyMatch(this::evaluate);
+  }
+
+  /**
+   * Map questions store selections as JSON strings containing both featureId and locationName. This
+   * method extracts just the feature IDs and creates a flattened ApplicantData copy for predicate
+   * evaluation.
+   *
+   * @param node the leaf operation expression node for the map question
+   * @param applicantData the original applicant data containing {@link MapSelection} JSON
+   * @param predicate the predicate to evaluate against the flattened data
+   * @return true if the predicate matches any of the flattened feature IDs
+   * @throws InvalidPredicateException if path generation fails or predicate evaluation fails
+   */
+  private boolean evaluateMapQuestionLeafNode(
+      LeafOperationExpressionNode node, ApplicantData applicantData, JsonPathPredicate predicate)
+      throws InvalidPredicateException {
+    Path questionPath = predicateGenerator.getPath(node);
+    Path selectionsPath = questionPath.join(node.scalar());
+
+    ApplicantData flattenedData = new ApplicantData(applicantData.asJsonString());
+
+    ObjectMapper mapper = new ObjectMapper();
+    ImmutableList<String> featureIds =
+        applicantData.readStringList(selectionsPath).stream()
+            .flatMap(Collection::stream)
+            .map(
+                jsonString -> {
+                  try {
+                    return mapper.readValue(jsonString, MapSelection.class).featureId();
+                  } catch (JsonProcessingException e) {
+                    throw new RuntimeException(e);
+                  }
+                })
+            .collect(ImmutableList.toImmutableList());
+
+    flattenedData.putArray(selectionsPath, featureIds);
+
+    return flattenedData.evalPredicate(predicate);
   }
 }

--- a/server/app/services/applicant/question/MapQuestion.java
+++ b/server/app/services/applicant/question/MapQuestion.java
@@ -1,7 +1,11 @@
 package services.applicant.question;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.guava.GuavaModule;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -131,7 +135,21 @@ public final class MapQuestion extends AbstractQuestion {
 
   private Optional<Map<String, String>> parseLocationJson(String jsonString) {
     try {
-      ObjectMapper mapper = new ObjectMapper();
+      //  Creating an instance of ObjectMapper is a heavy-ish operation so it should be done in the
+      // constructor but that's not possible here, so using the same settings as the global
+      // ObjectMapper for consistency
+      ObjectMapper mapper =
+          new ObjectMapper()
+              // Play defaults
+              .enable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS)
+              .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+              // This adds support for Optional
+              .registerModule(new Jdk8Module())
+              // This adds support for ImmutableList, ImmutableSet, etc.
+              .registerModule(new GuavaModule())
+              // This adds support for Instant, LocalDateTime, java.time classes, etc.
+              .registerModule(new JavaTimeModule());
+
       TypeReference<Map<String, String>> typeRef = new TypeReference<Map<String, String>>() {};
       return Optional.of(mapper.readValue(jsonString, typeRef));
     } catch (Exception e) {

--- a/server/app/services/applicant/question/MapQuestion.java
+++ b/server/app/services/applicant/question/MapQuestion.java
@@ -145,7 +145,13 @@ public final class MapQuestion extends AbstractQuestion {
   }
 
   public String createLocationJson(String featureId, String locationName) {
-    return String.format("{\"featureId\":\"%s\",\"locationName\":\"%s\"}", featureId, locationName);
+    MapSelection selection = MapSelection.create(featureId, locationName);
+    ObjectMapper mapper = new ObjectMapper();
+    try {
+      return mapper.writeValueAsString(selection);
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to serialize MapSelection to JSON", e);
+    }
   }
 
   private ImmutableSet<LocalizedQuestionSetting> getSettings(Locale locale) {

--- a/server/app/services/applicant/question/MapSelection.java
+++ b/server/app/services/applicant/question/MapSelection.java
@@ -1,0 +1,39 @@
+package services.applicant.question;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.auto.value.AutoValue;
+
+/**
+ * Represents a map question selection with a feature ID and location name. Used for both
+ * serializing selections to JSON and parsing them back.
+ */
+@AutoValue
+@JsonDeserialize(builder = AutoValue_MapSelection.Builder.class)
+public abstract class MapSelection {
+
+  @JsonProperty("featureId")
+  public abstract String featureId();
+
+  @JsonProperty("locationName")
+  public abstract String locationName();
+
+  public static MapSelection create(String featureId, String locationName) {
+    return builder().setFeatureId(featureId).setLocationName(locationName).build();
+  }
+
+  public static Builder builder() {
+    return new AutoValue_MapSelection.Builder();
+  }
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+    @JsonProperty("featureId")
+    public abstract Builder setFeatureId(String featureId);
+
+    @JsonProperty("locationName")
+    public abstract Builder setLocationName(String locationName);
+
+    public abstract MapSelection build();
+  }
+}

--- a/server/app/services/program/predicate/PredicateGenerator.java
+++ b/server/app/services/program/predicate/PredicateGenerator.java
@@ -137,7 +137,6 @@ public final class PredicateGenerator {
           singleValueMatcher.find()
               ? singleValueMatcher
               : multiValueMatcher.find() ? multiValueMatcher : null;
-
       if (matcher == null) {
         continue;
       }

--- a/server/app/services/program/predicate/PredicateGenerator.java
+++ b/server/app/services/program/predicate/PredicateGenerator.java
@@ -137,6 +137,7 @@ public final class PredicateGenerator {
           singleValueMatcher.find()
               ? singleValueMatcher
               : multiValueMatcher.find() ? multiValueMatcher : null;
+
       if (matcher == null) {
         continue;
       }

--- a/server/app/views/questiontypes/MapQuestionFragment.html
+++ b/server/app/views/questiontypes/MapQuestionFragment.html
@@ -206,7 +206,7 @@
     window.app = window.app || {}
     window.app.data = window.app.data || {}
     window.app.data.maxLocationSelections =
-      /*[[${mapQuestion.getQuestionDefinition().getMapValidationPredicates().maxLocationSelections().getAsInt()}]]*/ null
+      /*[[${mapQuestion.getQuestionDefinition().getMapValidationPredicates().maxLocationSelections().isPresent() ? mapQuestion.getQuestionDefinition().getMapValidationPredicates().maxLocationSelections().getAsInt() : null}]]*/ null
     window.app.data.messages = {
       locationsCount:
         /*[[#{map.locationsCount}]]*/ 'Displaying {0} of {1} locations',


### PR DESCRIPTION
### Description

The visibility and eligibility predicates for map questions got broken because of a switch to store the name and id of in the applicant data.

This handles that and also allows selecting ids rather than having to input them.

## Release notes

Continued development of map question.

### Instructions for manual testing

1. Set `map_question_enabled=true` in `application.dev.conf`
2. Create a map question (can use one of Seattle's public endpoint to test: `https://earlylearning.powerappsportals.us/provider-list-ccap/`)
3. Make sure to fill out all the question settings.

### Issue(s) this completes

Fixes #11443
