### PR TITLE
Fix download flag browser test

### DIFF
--- a/browser-test/src/admin/admin_application_download.test.ts
+++ b/browser-test/src/admin/admin_application_download.test.ts
@@ -19,10 +19,6 @@ test.describe(
     const downloadFlag = 'remove_download_for_program_admins_enabled'
     const adminFlag = 'allow_civiform_admin_access_programs'
 
-    test.beforeEach(async ({page}) => {
-      await enableFeatureFlag(page, 'north_star_applicant_ui')
-    })
-
     test(
       downloadFlag,
       async ({page, adminPrograms, seeding, applicantQuestions}) => {


### PR DESCRIPTION
We can't set the NS flag in tests anymore, and no longer need to.