### PR TITLE
Autopopulation Logic for date fields, if the user is applying on APPLICAT_DATE (Issue #11035)

### DIFF
--- a/browser-test/src/applicant/questions/date_autofill.test.ts
+++ b/browser-test/src/applicant/questions/date_autofill.test.ts
@@ -1,0 +1,89 @@
+import {test, expect} from '../../support/civiform_fixtures'
+import {
+  AdminQuestions,
+  AdminPrograms,
+  loginAsAdmin,
+  logout,
+} from '../../support'
+
+test.describe('Date question autofill functionality', {tag: ['@northstar']}, () => {
+  const programName = 'Test program for date autofill'
+
+  test.beforeEach(async ({page, adminQuestions, adminPrograms}) => {
+    await loginAsAdmin(page)
+    
+    await adminQuestions.addDateQuestion({
+      questionName: 'date_autofill_test',
+      questionText: 'What is today\'s date?',
+      minDateType: 'APPLICATION_DATE',
+      maxDateType: 'APPLICATION_DATE',
+    })
+
+    // Create a program with this question
+    await adminPrograms.addProgram(programName)
+    await adminPrograms.editProgramBlock(programName, 'first block', [
+      'date_autofill_test',
+    ])
+    await adminPrograms.publishProgram(programName)
+    await logout(page)
+  })
+
+  test('autofills current date when both min and max date are APPLICATION_DATE', async ({
+    page,
+    applicantQuestions,
+  }) => {
+    await applicantQuestions.applyProgram(programName, /* northStarEnabled= */ true)
+
+    // Get today's date in the format expected by the date input
+    const today = new Date()
+    const todayString = today.toISOString().split('T')[0] // YYYY-MM-DD format
+
+    // Check that the date input is autofilled with today's date
+    const dateInput = page.locator('input[type="date"]')
+    await expect(dateInput).toHaveValue(todayString)
+  })
+
+  test('does not autofill when applicant already has a date value', async ({
+    page,
+    applicantQuestions,
+  }) => {
+    await applicantQuestions.applyProgram(programName, /* northStarEnabled= */ true)
+
+    const customDate = '2023-12-25'
+    await page.fill('input[type="date"]', customDate)
+    await applicantQuestions.clickContinue()
+
+    await applicantQuestions.clickEdit()
+
+    const dateInput = page.locator('input[type="date"]')
+    await expect(dateInput).toHaveValue(customDate)
+  })
+
+  test('does not autofill when only one of min/max date is APPLICATION_DATE', async ({
+    page,
+    adminQuestions,
+    adminPrograms,
+    applicantQuestions,
+  }) => {
+    await loginAsAdmin(page)
+    await adminQuestions.addDateQuestion({
+      questionName: 'date_partial_validation_test',
+      questionText: 'What is your birthday?',
+      minDateType: 'APPLICATION_DATE',
+      maxDateType: 'ANY',
+    })
+
+    const partialProgramName = 'Test program for partial date validation'
+    await adminPrograms.addProgram(partialProgramName)
+    await adminPrograms.editProgramBlock(partialProgramName, 'first block', [
+      'date_partial_validation_test',
+    ])
+    await adminPrograms.publishProgram(partialProgramName)
+    await logout(page)
+
+    await applicantQuestions.applyProgram(partialProgramName, /* northStarEnabled= */ true)
+
+    const dateInput = page.locator('input[type="date"]')
+    await expect(dateInput).toHaveValue('')
+  })
+})

--- a/server/test/views/questiontypes/DateQuestionRendererTest.java
+++ b/server/test/views/questiontypes/DateQuestionRendererTest.java
@@ -6,6 +6,8 @@ import static play.test.Helpers.stubMessagesApi;
 import com.google.common.collect.ImmutableSet;
 import j2html.attributes.Attr;
 import j2html.tags.specialized.DivTag;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.OptionalLong;
@@ -18,6 +20,9 @@ import services.LocalizedStrings;
 import services.applicant.ApplicantData;
 import services.applicant.question.ApplicantQuestion;
 import services.question.types.DateQuestionDefinition;
+import services.question.types.DateQuestionDefinition.DateValidationOption;
+import services.question.types.DateQuestionDefinition.DateValidationOption.DateType;
+import services.question.types.DateQuestionDefinition.DateValidationPredicates;
 import services.question.types.QuestionDefinitionConfig;
 import views.questiontypes.ApplicantQuestionRendererParams.ErrorDisplayMode;
 
@@ -79,5 +84,74 @@ public class DateQuestionRendererTest {
     DivTag result = renderer.render(params);
 
     assertThat(result.render()).doesNotContain(Attr.AUTOFOCUS);
+  }
+
+  @Test
+  public void autofillsCurrentDate_whenBothMinAndMaxDateAreApplicationDate() {
+    // Create a date question with both min and max date set to APPLICATION_DATE
+    DateValidationOption minDate = DateValidationOption.builder()
+        .setDateType(DateType.APPLICATION_DATE)
+        .build();
+    DateValidationOption maxDate = DateValidationOption.builder()
+        .setDateType(DateType.APPLICATION_DATE)
+        .build();
+    
+    DateQuestionDefinition questionWithValidation = new DateQuestionDefinition(
+        QuestionDefinitionConfig.builder()
+            .setName("question name")
+            .setDescription("description")
+            .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
+            .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
+            .setId(OptionalLong.of(1))
+            .setLastModifiedTime(Optional.empty())
+            .setValidationPredicates(
+                DateValidationPredicates.create(Optional.of(minDate), Optional.of(maxDate)))
+            .build());
+    
+    ApplicantQuestion questionWithValidationWrapper = 
+        new ApplicantQuestion(questionWithValidation, new ApplicantModel(), new ApplicantData(), Optional.empty());
+    DateQuestionRenderer rendererWithValidation = new DateQuestionRenderer(questionWithValidationWrapper);
+    
+    DivTag result = rendererWithValidation.render(params);
+    String todayDate = LocalDate.now().format(DateTimeFormatter.ISO_LOCAL_DATE);
+  
+    assertThat(result.render()).contains("value=\"" + todayDate + "\"");
+  }
+
+  @Test
+  public void doesNotAutofill_whenApplicantAlreadyHasDateValue() {
+    DateValidationOption minDate = DateValidationOption.builder()
+        .setDateType(DateType.APPLICATION_DATE)
+        .build();
+    DateValidationOption maxDate = DateValidationOption.builder()
+        .setDateType(DateType.APPLICATION_DATE)
+        .build();
+    
+    DateQuestionDefinition questionWithValidation = new DateQuestionDefinition(
+        QuestionDefinitionConfig.builder()
+            .setName("question name")
+            .setDescription("description")
+            .setQuestionText(LocalizedStrings.of(Locale.US, "question?"))
+            .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
+            .setId(OptionalLong.of(1))
+            .setLastModifiedTime(Optional.empty())
+            .setValidationPredicates(
+                DateValidationPredicates.create(Optional.of(minDate), Optional.of(maxDate)))
+            .build());
+    
+    ApplicantData applicantDataWithDate = new ApplicantData();
+    applicantDataWithDate.putDate(
+        ApplicantData.APPLICANT_PATH.join("question_name").join("date"), 
+        LocalDate.of(2023, 12, 25));
+    
+    ApplicantQuestion questionWithValidationWrapper = 
+        new ApplicantQuestion(questionWithValidation, new ApplicantModel(), applicantDataWithDate, Optional.empty());
+    DateQuestionRenderer rendererWithValidation = new DateQuestionRenderer(questionWithValidationWrapper);
+    
+    DivTag result = rendererWithValidation.render(params);
+    
+    assertThat(result.render()).contains("value=\"2023-12-25\"");
+    String todayDate = LocalDate.now().format(DateTimeFormatter.ISO_LOCAL_DATE);
+    assertThat(result.render()).doesNotContain("value=\"" + todayDate + "\"");
   }
 }


### PR DESCRIPTION
**Description**

In this pull request, I attempted to implement autofill functionality for date questions, when both min and max date validation are set to APPLICATION_DATE (used to be APPLICANT_DATE, added references to APPLICATION_DATE). When an admin configures a date question to require exactly the current date (both minDate and maxDate set to APPLICATION_DATE), the date input will now be automatically filled with today's date for applicants. 

The original issue mentions using APPLICANT_DATE as the constant, however I used APPLICATION_DATE and added the references needed for it as mentioned above. 

**Changes made:**

- Added autofill logic to `DateQuestionRenderer.java` that checks if both minDate and maxDate have dateType == APPLICATION_DATE
- Only autofills when there's no existing applicant date value (preserves user input)
- Added comprehensive unit tests in `DateQuestionRendererTest.java`
- Added browser tests in `date_autofill.test.ts` to verify end-to-end functionality

**Checklist**

- [x] Added the correct label: enhancement
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if the primary reviewer is not an admin and this PR includes functionality changes)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [x] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [x] Noted in the PR description which, if any, code in this PR was generated by AI.

**Frontend changes**

- [x] Made equivalent changes in Thymeleaf for applicant-facing features and changes (or created an issue in the [Northstar epic](https://github.com/orgs/civiform/projects/1/views/94) to track that it's missing from Thymeleaf)
- [ ] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order
- [ ] Manually tested with a screen reader if the feature is applicant-facing. See [screen reader testing](https://github.com/civiform/civiform/wiki/Testing#screen-reader-testing)
- [ ] Manually tested with a right-to-left language

**Instructions for individual manual testing**

1. Create a date question with both min and max date set to "Application Date"
2. Add the question to a program and publish it
3. Apply to the program as an applicant
4. Verify the date input is automatically filled with today's date
5. Verify that if you edit and return to the page, your custom date is preserved
6. Test with different date validation settings to ensure autofill only occurs when both min/max are APPLICATION_DATE

**Issue(s) this completes**

Fixes #11035 