### PR TITLE
Improve handling of container shutdown signals

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,6 +65,7 @@ services:
     expose:
       - '9000'
       - '8457'
+    stop_signal: SIGKILL
     environment:
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-test}
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-test}

--- a/localstack/localstack.Dockerfile
+++ b/localstack/localstack.Dockerfile
@@ -16,5 +16,6 @@ RUN apt-get install nginx --assume-yes
 
 COPY localstack.nginx.conf /etc/nginx/conf.d/
 ADD localstack-docker-entrypoint.sh /usr/local/bin/
+ADD stop-nginx.sh /etc/localstack/init/shutdown.d/
 
 ENTRYPOINT ["localstack-docker-entrypoint.sh"]

--- a/localstack/stop-nginx.sh
+++ b/localstack/stop-nginx.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+nginx -s stop
+exit 0

--- a/test-support/test_oidc_provider.js
+++ b/test-support/test_oidc_provider.js
@@ -161,9 +161,13 @@ oidc.Client.Schema.prototype.invalidate = function invalidate(message, code) {
   orig.call(this, message)
 }
 
-process.on('SIGINT', () => {
-  console.info('Interrupted')
-  process.exit(0)
+// Docker sends a SIGTERM, but handle them all just in case
+const signals = ['SIGTERM', 'SIGINT', 'SIGQUIT', 'SIGHUP']
+signals.forEach(signal => {
+  process.on(signal, () => {
+    console.info(`${signal} received. Shutting down.`)
+    process.exit(0)
+  })
 })
 
 // This will print any server errors out. Otherwise there's no visibility into what's going on.


### PR DESCRIPTION
Currently, it takes a while for the stack to shutdown because some of the containers don't handle the SIGTERM that happens when Docker tries shutting things down. When these containers don't respond within a certain timeout, Docker then SIGKILLs them. This PR improves how containers are shut down to make it much faster.

- In the Localstack container, while Localstack itself shuts down quickly, it is waiting for nginx to shut down too, but nginx is never getting the SIGTERM signal. This adds a shutdown hook to Localstack's handler to have it shut down nginx when Localstack is correctly handling the SIGTERM signal.
- In the dev-oidc container, we were only handling SIGINT. This modifies it to handle SIGTERM (as well as other shutdown type signals) to exit the process cleanly.
- The CiviForm container is a lot trickier, since it involves sbt. We could probably be smarter about handling SIGTERM in the app itself, but we'd still have issues trying to kill things during startup. So in this case, we just tell Docker to send a SIGKILL to shut it down. This isn't very clean, but it shouldn't really matter. I've tested this killing it at various points in the process and it doesn't seem to leave any bad artifacts around that causes problems.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if the primary reviewer is not an admin and this PR includes functionality changes)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [x] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [x] Noted in the PR description which, if any, code in this PR was generated by AI.

### Instructions for manual testing

Start/stop/delete containers at various points and make sure everything still works.
