### PR TITLE
Fix apple-touch-icon error

### DIFF
--- a/server/app/views/HtmlBundle.java
+++ b/server/app/views/HtmlBundle.java
@@ -251,8 +251,8 @@ public final class HtmlBundle {
         .condWith(
             faviconURL.isPresent(),
             link().withRel("icon").withHref(faviconURL.orElse("")),
-            link().withRel("apple-touch-icon").withHref("/apple-touch-icon.png"),
-            link().withRel("apple-touch-icon-precomposed.png").withHref("/apple-touch-icon.png"))
+            link().withRel("apple-touch-icon").withHref(faviconURL.orElse("")),
+            link().withRel("apple-touch-icon-precomposed.png").withHref(faviconURL.orElse("")))
         .with(metadata)
         .with(CspUtil.applyCsp(request, headScripts))
         .with(CspUtil.applyCspToStyles(request, stylesheets));

--- a/server/conf/routes
+++ b/server/conf/routes
@@ -8,8 +8,6 @@ GET     /*path/                                                                 
 # Redirect automatic requests from the browser to the specified favicon.
 GET     /favicon.ico                                                                                    controllers.HomeController.favicon()
 GET     /favicon.png                                                                                    controllers.HomeController.favicon()
-GET     /apple-touch-icon.png                                                                           controllers.HomeController.favicon()
-GET     /apple-touch-icon-precomposed.png                                                               controllers.HomeController.favicon()
 
 # The landing page
 GET     /                                                                                               controllers.HomeController.index(request: Request)


### PR DESCRIPTION
A recent release of Firefox has started calling the `apple-touch-icon` image because of the new PWA support. It doesn't load on dev because we're using a `data-image` and because of that it is printing a lot of excessive noise to the console. This will just directly set the URL instead of the roundabout excessive routes that I've been meaning to remove anyway.
