### PR TITLE
[Maps] Hide filters if no filters configured

### DIFF
--- a/server/app/views/questiontypes/MapQuestionFragment.html
+++ b/server/app/views/questiontypes/MapQuestionFragment.html
@@ -24,51 +24,53 @@
   ></div>
 
   <!-- Filters -->
-  <fieldset class="grid-row grid-gap">
-    <legend
-      class="usa-legend text-bold"
-      th:text="#{map.filterLegendText}"
-    ></legend>
-    <div
-      th:each="filter, i : ${mapQuestion.getFilters()}"
-      class="grid-col flex-align-self-end"
-    >
-      <label
-        class="usa-label"
-        th:for="'filter' + ${i.index + 1} + '-' + ${mapId}"
-        th:utext="${filter.formattedSettingDisplayName(ariaLabelForNewTabs)}"
-      ></label>
-      <select
-        class="usa-select"
-        th:data-filter-key="${filter.settingValue()}"
-        th:id="'filter' + ${i.index + 1} + '-' + ${mapId}"
-        th:data-map-id="${mapId}"
+  <div th:if="${mapQuestion.getFilters().size() > 0}">
+    <fieldset class="grid-row grid-gap">
+      <legend
+        class="usa-legend text-bold"
+        th:text="#{map.filterLegendText}"
+      ></legend>
+      <div
+        th:each="filter, i : ${mapQuestion.getFilters()}"
+        class="grid-col flex-align-self-end"
       >
-        <option value th:text="#{map.selectOptionPlaceholderText}"></option>
-        <option
-          th:if="${questionRendererParams.geoJson().isPresent()}"
-          th:each="option : ${questionRendererParams.geoJson().get().getPossibleValuesForKey(filter.settingValue())}"
-          th:value="${option}"
-          th:text="${option == 'true' ? 'Yes' : (option == 'false' ? 'No' : option)}"
-        ></option>
-      </select>
-    </div>
-  </fieldset>
+        <label
+          class="usa-label"
+          th:for="'filter' + ${i.index + 1} + '-' + ${mapId}"
+          th:utext="${filter.formattedSettingDisplayName(ariaLabelForNewTabs)}"
+        ></label>
+        <select
+          class="usa-select"
+          th:data-filter-key="${filter.settingValue()}"
+          th:id="'filter' + ${i.index + 1} + '-' + ${mapId}"
+          th:data-map-id="${mapId}"
+        >
+          <option value th:text="#{map.selectOptionPlaceholderText}"></option>
+          <option
+            th:if="${questionRendererParams.geoJson().isPresent()}"
+            th:each="option : ${questionRendererParams.geoJson().get().getPossibleValuesForKey(filter.settingValue())}"
+            th:value="${option}"
+            th:text="${option == 'true' ? 'Yes' : (option == 'false' ? 'No' : option)}"
+          ></option>
+        </select>
+      </div>
+    </fieldset>
 
-  <!-- Apply filters buttons -->
-  <div class="margin-bottom-2">
-    <button
-      type="button"
-      class="usa-button cf-apply-filters-button"
-      th:data-map-id="${mapId}"
-      th:text="#{map.applyFiltersButtonText}"
-    ></button>
-    <button
-      type="button"
-      class="usa-button usa-button--outline cf-reset-filters-button"
-      th:data-map-id="${mapId}"
-      th:text="#{map.resetFiltersButtonText}"
-    ></button>
+    <!-- Apply filters buttons -->
+    <div class="margin-bottom-2">
+      <button
+        type="button"
+        class="usa-button cf-apply-filters-button"
+        th:data-map-id="${mapId}"
+        th:text="#{map.applyFiltersButtonText}"
+      ></button>
+      <button
+        type="button"
+        class="usa-button usa-button--outline cf-reset-filters-button"
+        th:data-map-id="${mapId}"
+        th:text="#{map.resetFiltersButtonText}"
+      ></button>
+    </div>
   </div>
 
   <div class="grid-row grid-gap padding-1">


### PR DESCRIPTION
### Description

Filter buttons were still showing up even if there were no filters. Now, they only show up if there are filters configured.

## Release notes

Continued development of map question.

### Instructions for manual testing

1. Set map_question_enabled=true in application.dev.conf
1. Create a map question (can use one of Seattle's public endpoint to test: https://earlylearning.powerappsportals.us/provider-list-ccap/)
2. Make sure to fill out all the question settings (but no filters).
3. Ensure the filter buttons aren't there.

### Issue(s) this completes

Fixes #11529
