### PR TITLE
Centralize object mapper configuration

### DIFF
--- a/server/app/models/EbeanServerConfigStartup.java
+++ b/server/app/models/EbeanServerConfigStartup.java
@@ -1,11 +1,9 @@
 package models;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.guava.GuavaModule;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import io.ebean.DatabaseBuilder;
 import io.ebean.event.ServerConfigStartup;
+import services.ObjectMapperSingleton;
 
 /**
  * Provides a Jackson {@link ObjectMapper} that understands how to (de)serialize Guava types and
@@ -15,9 +13,8 @@ import io.ebean.event.ServerConfigStartup;
 public class EbeanServerConfigStartup implements ServerConfigStartup {
   @Override
   public void onStart(DatabaseBuilder config) {
-    ObjectMapper mapper =
-        new ObjectMapper().registerModule(new GuavaModule()).registerModule(new Jdk8Module());
-    mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
+    // Use legacy serialization settings. (De)serialization errors may occur if changed.
+    ObjectMapper mapper = ObjectMapperSingleton.createLegacyCopy();
     config.objectMapper(mapper);
   }
 }

--- a/server/app/services/ObjectMapperProvider.java
+++ b/server/app/services/ObjectMapperProvider.java
@@ -1,10 +1,6 @@
 package services;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.guava.GuavaModule;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.google.inject.Provider;
 import play.libs.Json;
 
@@ -17,17 +13,7 @@ public class ObjectMapperProvider implements Provider<ObjectMapper> {
 
   @Override
   public ObjectMapper get() {
-    ObjectMapper mapper =
-        new ObjectMapper()
-            // Play defaults
-            .enable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS)
-            .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
-            // This adds support for Optional
-            .registerModule(new Jdk8Module())
-            // This adds support for ImmutableList, ImmutableSet, etc.
-            .registerModule(new GuavaModule())
-            // This adds support for Instant, LocalDateTime, java.time classes, etc.
-            .registerModule(new JavaTimeModule());
+    ObjectMapper mapper = ObjectMapperSingleton.instance();
 
     // Needs to set to Json helper
     Json.setObjectMapper(mapper);

--- a/server/app/services/ObjectMapperSingleton.java
+++ b/server/app/services/ObjectMapperSingleton.java
@@ -1,0 +1,78 @@
+package services;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.datatype.guava.GuavaModule;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+/**
+ * Singleton to provide access to {@link ObjectMapper} with application-wide settings applied.
+ *
+ * <p>Prefer getting the instance with {@code @Inject} on the class constructor. Primary use cases
+ * for calling this are places in old code that can't be retrofitted easily.
+ */
+public final class ObjectMapperSingleton {
+  private static final ObjectMapper INSTANCE = createObjectMapper();
+
+  private ObjectMapperSingleton() {
+    // Prevent instantiation
+  }
+
+  /** Creates and configures the ObjectMapper instance. */
+  private static ObjectMapper createObjectMapper() {
+    return JsonMapper.builder()
+        .enable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS)
+        .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+        // This adds support for Optional
+        .addModule(new Jdk8Module())
+        // This adds support for ImmutableList, ImmutableSet, etc.
+        .addModule(new GuavaModule())
+        // This adds support for Instant, LocalDateTime, java.time classes, etc.
+        .addModule(new JavaTimeModule())
+        .build();
+  }
+
+  /**
+   * Get the instance of {@link ObjectMapper}.
+   *
+   * <p>Prefer getting the instance with {@code @Inject} on the class constructor. Primary use cases
+   * for calling this are places in old code that can't be retrofitted easily.
+   *
+   * <p>Callers must NOT make changes directly to the {@link ObjectMapper} configuration with this
+   * instance as it will change settings for the entire application.
+   *
+   * <p>To make targeted configuration customizations call {@link #createCopy()} instead.
+   */
+  public static ObjectMapper instance() {
+    return INSTANCE;
+  }
+
+  /**
+   * Create a copy of the {@link ObjectMapper} instance.
+   *
+   * <p>Use this if you need to apply additional configuration specific to certain use cases without
+   * affecting the global object.
+   */
+  public static ObjectMapper createCopy() {
+    return INSTANCE.copy();
+  }
+
+  /**
+   * Create a copy of {@link ObjectMapper} instance.
+   *
+   * <p>This is NOT to be used by new code and is here for backwards compatibility with old code. If
+   * customizing the {@link ObjectMapper} is needed use {@link #createCopy()} for new code.
+   */
+  public static ObjectMapper createLegacyCopy() {
+    return INSTANCE
+        .copy()
+        // Reset new settings back to default
+        .disable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS)
+        .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+        // Old settings
+        .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
+  }
+}

--- a/server/app/services/applicant/JsonPathProvider.java
+++ b/server/app/services/applicant/JsonPathProvider.java
@@ -1,9 +1,6 @@
 package services.applicant;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.guava.GuavaModule;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.Option;
@@ -12,6 +9,7 @@ import com.jayway.jsonpath.spi.json.JacksonJsonProvider;
 import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
 import java.util.EnumSet;
 import javax.inject.Singleton;
+import services.ObjectMapperSingleton;
 
 /** Custom JsonPathProvider used to parse applicant data in JSON format. */
 @Singleton
@@ -33,9 +31,8 @@ public final class JsonPathProvider {
   }
 
   private static Configuration generateConfiguration() {
-    ObjectMapper mapper =
-        new ObjectMapper().registerModule(new GuavaModule()).registerModule(new Jdk8Module());
-    mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
+    // Use legacy serialization settings. (De)serialization errors may occur if changed.
+    ObjectMapper mapper = ObjectMapperSingleton.createLegacyCopy();
 
     return Configuration.builder()
         .jsonProvider(new JacksonJsonProvider(mapper))

--- a/server/app/services/applicant/predicate/PredicateEvaluator.java
+++ b/server/app/services/applicant/predicate/PredicateEvaluator.java
@@ -1,11 +1,11 @@
 package services.applicant.predicate;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import java.util.Collection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import services.ObjectMapperSingleton;
 import services.Path;
 import services.applicant.ApplicantData;
 import services.applicant.exception.InvalidPredicateException;
@@ -120,14 +120,15 @@ public final class PredicateEvaluator {
 
     ApplicantData flattenedData = new ApplicantData(applicantData.asJsonString());
 
-    ObjectMapper mapper = new ObjectMapper();
     ImmutableList<String> featureIds =
         applicantData.readStringList(selectionsPath).stream()
             .flatMap(Collection::stream)
             .map(
                 jsonString -> {
                   try {
-                    return mapper.readValue(jsonString, MapSelection.class).featureId();
+                    return ObjectMapperSingleton.instance()
+                        .readValue(jsonString, MapSelection.class)
+                        .featureId();
                   } catch (JsonProcessingException e) {
                     throw new RuntimeException(e);
                   }

--- a/server/app/services/applicant/question/MapQuestion.java
+++ b/server/app/services/applicant/question/MapQuestion.java
@@ -1,11 +1,6 @@
 package services.applicant.question;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.guava.GuavaModule;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -13,6 +8,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import services.MessageKey;
+import services.ObjectMapperSingleton;
 import services.Path;
 import services.applicant.ValidationErrorMessage;
 import services.question.LocalizedQuestionSetting;
@@ -138,20 +134,8 @@ public final class MapQuestion extends AbstractQuestion {
       //  Creating an instance of ObjectMapper is a heavy-ish operation so it should be done in the
       // constructor but that's not possible here, so using the same settings as the global
       // ObjectMapper for consistency
-      ObjectMapper mapper =
-          new ObjectMapper()
-              // Play defaults
-              .enable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS)
-              .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
-              // This adds support for Optional
-              .registerModule(new Jdk8Module())
-              // This adds support for ImmutableList, ImmutableSet, etc.
-              .registerModule(new GuavaModule())
-              // This adds support for Instant, LocalDateTime, java.time classes, etc.
-              .registerModule(new JavaTimeModule());
-
       TypeReference<Map<String, String>> typeRef = new TypeReference<Map<String, String>>() {};
-      return Optional.of(mapper.readValue(jsonString, typeRef));
+      return Optional.of(ObjectMapperSingleton.instance().readValue(jsonString, typeRef));
     } catch (Exception e) {
       return Optional.empty();
     }
@@ -164,9 +148,8 @@ public final class MapQuestion extends AbstractQuestion {
 
   public String createLocationJson(String featureId, String locationName) {
     MapSelection selection = MapSelection.create(featureId, locationName);
-    ObjectMapper mapper = new ObjectMapper();
     try {
-      return mapper.writeValueAsString(selection);
+      return ObjectMapperSingleton.instance().writeValueAsString(selection);
     } catch (Exception e) {
       throw new RuntimeException("Failed to serialize MapSelection to JSON", e);
     }

--- a/server/app/services/cloud/aws/SignedS3UploadRequest.java
+++ b/server/app/services/cloud/aws/SignedS3UploadRequest.java
@@ -5,9 +5,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.guava.GuavaModule;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
 import java.nio.charset.StandardCharsets;
@@ -20,6 +17,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.Optional;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
+import services.ObjectMapperSingleton;
 import services.cloud.StorageServiceName;
 import services.cloud.StorageUploadRequest;
 import software.amazon.awssdk.utils.BinaryUtils;
@@ -329,12 +327,8 @@ public abstract class SignedS3UploadRequest implements StorageUploadRequest {
 
   @AutoValue
   abstract static class UploadPolicy {
-    private static final ObjectMapper mapper =
-        new ObjectMapper().registerModule(new GuavaModule()).registerModule(new Jdk8Module());
-
-    static {
-      mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
-    }
+    // Use legacy serialization settings. (De)serialization errors may occur if changed.
+    private static final ObjectMapper mapper = ObjectMapperSingleton.createLegacyCopy();
 
     static Builder builder() {
       return new AutoValue_SignedS3UploadRequest_UploadPolicy.Builder();

--- a/server/app/services/export/JsonPrettifier.java
+++ b/server/app/services/export/JsonPrettifier.java
@@ -3,11 +3,12 @@ package services.export;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import services.ObjectMapperSingleton;
 
 /** Provides methods related to "prettifying" (formatting) JSON strings. */
 public final class JsonPrettifier {
   private static final ObjectMapper OBJECT_MAPPER =
-      new ObjectMapper()
+      ObjectMapperSingleton.createCopy()
           .enable(SerializationFeature.INDENT_OUTPUT)
           .enable(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS);
 

--- a/server/app/services/question/types/QuestionDefinition.java
+++ b/server/app/services/question/types/QuestionDefinition.java
@@ -6,10 +6,6 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.guava.GuavaModule;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
@@ -24,6 +20,7 @@ import java.util.UUID;
 import models.QuestionDisplayMode;
 import services.CiviFormError;
 import services.LocalizedStrings;
+import services.ObjectMapperSingleton;
 import services.Path;
 import services.applicant.RepeatedEntity;
 import services.applicant.question.Scalar;
@@ -130,15 +127,8 @@ public abstract class QuestionDefinition {
         name = "text"),
   })
   public abstract static class ValidationPredicates {
-    protected static final ObjectMapper mapper =
-        new ObjectMapper()
-            .registerModule(new GuavaModule())
-            .registerModule(new Jdk8Module())
-            .registerModule(new JavaTimeModule());
-
-    static {
-      mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
-    }
+    // Use legacy serialization settings. (De)serialization errors may occur if changed.
+    protected static final ObjectMapper mapper = ObjectMapperSingleton.createLegacyCopy();
 
     public String serializeAsString() {
       try {

--- a/server/test/services/apibridge/RequestPayloadMapperTest.java
+++ b/server/test/services/apibridge/RequestPayloadMapperTest.java
@@ -3,21 +3,22 @@ package services.apibridge;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import models.ApiBridgeConfigurationModel.ApiBridgeDefinitionItem;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import repository.ResetPostgres;
 import services.Path;
 import services.applicant.ApplicantData;
 import services.applicant.question.Scalar;
 import services.question.YesNoQuestionOption;
 
 @RunWith(JUnitParamsRunner.class)
-public class RequestPayloadMapperTest {
+public class RequestPayloadMapperTest extends ResetPostgres {
   private static final String schema =
       """
       {
@@ -67,8 +68,12 @@ public class RequestPayloadMapperTest {
       }
       """;
 
-  private final RequestPayloadMapper requestPayloadMapper =
-      new RequestPayloadMapper(new ObjectMapper());
+  private RequestPayloadMapper requestPayloadMapper;
+
+  @Before
+  public void setup() {
+    requestPayloadMapper = instanceOf(RequestPayloadMapper.class);
+  }
 
   private Object[] validStringValues() {
     return new Object[] {

--- a/server/test/services/apibridge/ResponsePayloadMapperTest.java
+++ b/server/test/services/apibridge/ResponsePayloadMapperTest.java
@@ -3,15 +3,16 @@ package services.apibridge;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.time.LocalDate;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import models.ApiBridgeConfigurationModel.ApiBridgeDefinitionItem;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import repository.ResetPostgres;
 import services.Path;
 import services.applicant.ApplicantData;
 import services.applicant.Currency;
@@ -19,7 +20,7 @@ import services.applicant.question.Scalar;
 import services.question.YesNoQuestionOption;
 
 @RunWith(JUnitParamsRunner.class)
-public class ResponsePayloadMapperTest {
+public class ResponsePayloadMapperTest extends ResetPostgres {
   private static final String schema =
       """
       {
@@ -69,8 +70,12 @@ public class ResponsePayloadMapperTest {
       }
       """;
 
-  private final ResponsePayloadMapper responsePayloadMapper =
-      new ResponsePayloadMapper(new ObjectMapper());
+  private ResponsePayloadMapper responsePayloadMapper;
+
+  @Before
+  public void setup() {
+    responsePayloadMapper = instanceOf(ResponsePayloadMapper.class);
+  }
 
   private Object[] validStringValues() {
     return new Object[] {

--- a/server/test/services/geojson/GeoJsonClientTest.java
+++ b/server/test/services/geojson/GeoJsonClientTest.java
@@ -31,7 +31,7 @@ public class GeoJsonClientTest extends WithApplication {
   public void setUp() throws Exception {
     WSClient wsClient = mock(WSClient.class);
     GeoJsonDataRepository geoJsonDataRepository = mock(GeoJsonDataRepository.class);
-    ObjectMapper objectMapper = new ObjectMapper();
+    ObjectMapper objectMapper = instanceOf(ObjectMapper.class);
 
     geoJsonClient = new GeoJsonClient(wsClient, geoJsonDataRepository, objectMapper);
 

--- a/server/test/support/ResourceCreator.java
+++ b/server/test/support/ResourceCreator.java
@@ -30,6 +30,7 @@ import play.Mode;
 import play.inject.Injector;
 import repository.DatabaseExecutionContext;
 import services.LocalizedStrings;
+import services.ObjectMapperSingleton;
 import services.apikey.ApiKeyService;
 import services.geojson.FeatureCollection;
 import services.program.ProgramType;
@@ -208,7 +209,7 @@ public class ResourceCreator {
 
   public GeoJsonDataModel insertGeoJsonData(DatabaseExecutionContext dbExecutionContext)
       throws IOException {
-    ObjectMapper objectMapper = new ObjectMapper();
+    ObjectMapper objectMapper = ObjectMapperSingleton.instance();
     FeatureCollection sampleData =
         objectMapper.readValue(
             getClass().getResourceAsStream("/geojson/sample_locations.json"),


### PR DESCRIPTION
Centralizing `ObjectMapper` creation.

Creating a new instance of Jackson `ObjectMapper` is a heavy-ish operation. Additionally we should be using the same settings application-wide so that (de)serialization are consistently. PR #10805 created a `Provider` so that our custom settings are used by `@Inject`. This creates a singleton class and migrates the last few spots creating their own `ObjectMapper` to use the singleton. These are spots in the code where it is not possible to use `@Inject`.

The legacy code settings are maintained to prevent possible errors with existing stored json. No new code should use the legacy settings.


Related to #10805