### PR TITLE
Fixing docker compose to run multiple localstack instances

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -32,6 +32,10 @@ services:
     stdin_open: true # docker run -i
     tty: true # docker run -t
 
+  localstack:
+    ports:
+      - 4566:4566
+
   azurite:
     ports:
       - 10000:10000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,6 @@ services:
     profiles: ['aws', 'emulator']
     expose:
       - '4566'
-    ports:
-      - 4566:4566
     environment:
       - SERVICES=s3,ses
     networks:


### PR DESCRIPTION
Moving the definition of ports from the base compose file to the dev compose file to allow for dev and browser tests to run at the same time. This broke when we removed the custom localstack docker image.
