### PR TITLE
Silent NPX

### DIFF
--- a/formatter/fmt
+++ b/formatter/fmt
@@ -138,7 +138,8 @@ else
   # The prettier_file_list array should not be surrounded by quotes, in this case
   # we want word splitting to occur so prettier will operate in each file. If
   # quoted it gets treated as a single path.
-  npx prettier \
+  npx --silent \
+    prettier \
     --write \
     --config ../.prettierrc.js \
     --ignore-path ../.prettierignore \
@@ -170,7 +171,7 @@ else
     # The eslint_app_file_list array should not be surrounded by quotes, in this case
     # we want word splitting to occur so eslint will operate in each file. If
     # quoted it gets treated as a single path.
-    npx eslint --fix ${eslint_app_file_list[@]}
+    npx --silent eslint --fix ${eslint_app_file_list[@]}
 
     cd ..
   fi
@@ -185,7 +186,7 @@ else
     # The eslint_browsertest_file_list array should not be surrounded by quotes, in this case
     # we want word splitting to occur so eslint will operate in each file. If
     # quoted it gets treated as a single path.
-    npx eslint --fix ${eslint_browsertest_file_list[@]}
+    npx --silent eslint --fix ${eslint_browsertest_file_list[@]}
 
     cd ..
   fi


### PR DESCRIPTION
Adding `--silent` to `npx` calls in the formatter.

I'm tired of seeing excess noise when formatting. This will make `npx` proper stop outputting extra text, but leave the tool it is running (ex. prettier) to output as normal.
