### PR TITLE
Docker compose: remove the usage of links

### DIFF
--- a/browser-test/browser-test-compose.yml
+++ b/browser-test/browser-test-compose.yml
@@ -18,9 +18,6 @@ services:
   civiform:
     image: civiform-dev
     restart: always
-    links:
-      - 'db:database'
-      - 'dev-oidc'
     ports:
       - 9999:9000
     environment:
@@ -30,7 +27,7 @@ services:
       - IDCS_DISCOVERY_URI=http://dev-oidc:3390/.well-known/openid-configuration
       - APPLICANT_REGISTER_URI=http://dev-oidc:3390/
       - CIVIFORM_ADMIN_IDP=adfs
-      - DB_JDBC_STRING=jdbc:postgresql://database:5432/postgres
+      - DB_JDBC_STRING=jdbc:postgresql://db:5432/postgres
       - BASE_URL=${BASE_URL:-http://civiform:9000}
       - LOCALSTACK_URL=http://localhost.localstack.cloud:4566
       - CIVIFORM_TIME_ZONE_ID

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -79,7 +79,7 @@ services:
       - ./monitoring/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
       - prometheus-data:/prometheus
 
-  grafana:  
+  grafana:
     profiles: ['monitoring']
     image: grafana/grafana@sha256:a1701c2180249361737a99a01bc770db39381640e4d631825d38ff4535efa47d
     depends_on:
@@ -94,8 +94,6 @@ services:
       - ./monitoring/grafana/provisioning/datasources:/etc/grafana/provisioning/datasources
       - ./monitoring/grafana/dashboards:/var/lib/grafana/dashboards
       - grafana-data:/var/lib/grafana
-    links:
-      - prometheus
 
 volumes:
   db-data:

--- a/docker-compose.keycloak.yml
+++ b/docker-compose.keycloak.yml
@@ -32,10 +32,6 @@ services:
 
   civiform:
     image: civiform-dev
-    links:
-      - 'db:database'
-      - 'mock-web-services'
-      - 'dev-oidc'
     depends_on:
       - dev-oidc
     expose:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,10 +52,6 @@ services:
 
   civiform:
     image: civiform-dev
-    links:
-      - 'db:database'
-      - 'dev-oidc'
-      - 'mock-web-services'
     expose:
       - '9000'
       - '8457'

--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -538,7 +538,7 @@ db {
 
   # https://www.playframework.com/documentation/latest/Developing-with-the-H2-Database
   default.driver = org.postgresql.Driver
-  default.url = "jdbc:postgresql://database:5432/postgres"
+  default.url = "jdbc:postgresql://db:5432/postgres"
   default.username = postgres
   default.password = "example"
 

--- a/test-support/prod-simulator-compose.yml
+++ b/test-support/prod-simulator-compose.yml
@@ -12,8 +12,6 @@ services:
     image: civiform:prod
     restart: always
     container_name: civiform_prod
-    links:
-      - 'db:database'
     ports:
       - 8888:9000
     environment:

--- a/test-support/unit-test-docker-compose.yml
+++ b/test-support/unit-test-docker-compose.yml
@@ -24,10 +24,6 @@ services:
   civiform:
     image: civiform-dev
     restart: always
-    links:
-      - 'db:database'
-      - 'dev-oidc'
-      - 'mock-web-services'
     volumes:
       - ../server/code-coverage:/usr/src/server/code-coverage
     entrypoint: /bin/bash
@@ -44,6 +40,6 @@ services:
       - IDCS_CLIENT_ID=idcs-fake-oidc-client
       - IDCS_SECRET=idcs-fake-oidc-secret
       - IDCS_DISCOVERY_URI=http://dev-oidc:3390/.well-known/openid-configuration
-      - DB_JDBC_STRING=jdbc:postgresql://database:5432/postgres
+      - DB_JDBC_STRING=jdbc:postgresql://db:5432/postgres
       - BASE_URL=http://localhost:9000
       - CIVIFORM_TIME_ZONE_ID


### PR DESCRIPTION
### Description

Remove links usage in docker compose files. Links are not supported by podman.

From https://docs.docker.com/reference/compose-file/services/#links:

> Links are not required to enable services to communicate. When no specific network configuration is set, any service is able to reach any other service at that service's name on the `default` network.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from `civiform/eng-admin` as FYI (if the primary reviewer is not an admin and this PR includes functionality changes)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [x] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [x] Noted in the PR description which, if any, code in this PR was generated by AI.

#### Database evolutions

Read the guidelines [here](https://github.com/civiform/civiform/wiki/Database#writing-database-evolutions)

- [ ] Assigned two reviewers
- [ ] Guarded against already existing resources using `IF NOT EXISTS` and `IF EXISTS`
- [ ] Downs created to undo changes in Ups
- [ ] Every comment in script should begin with -- and not # --- unless it denotes Ups or Downs. See [here](https://www.playframework.com/documentation/2.9.x/Evolutions) for details.
- [ ] Tested both the Downs and the Ups scripts manually (When testing, include all comments from the evolution in your test script to ensure any syntax errors in the comments are caught.)
- [ ] Data migrations aren't being done (please use a [Durable Job](https://github.com/civiform/civiform/wiki/Database#durable-jobs-for-data-updates) if doing a data migration)
- [ ] Update the model documentation in our [wiki](https://github.com/civiform/civiform/wiki/Database) if necessary

#### Durable jobs

Read the docs [here](https://github.com/civiform/civiform/wiki/Database#durable-jobs-for-data-updates)

- [ ] Assigned two reviewers
- [ ] Included a rollback plan and a job to undo the data changes if appropriate

#### User visible changes

- [ ] Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
  - [ ] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [ ] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Made equivalent changes in Thymeleaf for applicant-facing features and changes (or created an issue in the [Northstar epic](https://github.com/orgs/civiform/projects/1/views/94) to track that it's missing from Thymeleaf)
- [ ] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order
- [ ] Manually tested with a screen reader if the feature is applicant-facing. See [screen reader testing](https://github.com/civiform/civiform/wiki/Testing#screen-reader-testing)
- [ ] Manually tested with a right-to-left language

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/helper/feature-flags.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://github.com/civiform/civiform/wiki/Feature-Flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Instructions for manual testing

1. Ran `bin/dev` and made sure site worked
2. Ran `bin/run-test` and made sure all tests passed

### Issue(s) this completes

