### PR TITLE
DO NOT SUBMIT: hack for accessing bin/run-dev civiform on mobile chrome

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -9,6 +9,11 @@ x-sbt-volumes:
     - ./server:/usr/src/server
 
 services:
+  mobile-proxy:
+    image: ubuntu/squid
+    ports:
+      - 8081:3128
+
   dev-oidc:
     ports:
       - 3390:3390
@@ -23,6 +28,8 @@ services:
       - 9000:9000
       - 8457:8457
       - 50000:50000
+    environment:
+      BASE_URL=http://civiform:9000
 
   civiform-shell:
     image: civiform-dev


### PR DESCRIPTION
DO NOT SUBMIT

Discovered issues:
- this works on podman but not docker desktop: https://github.com/civiform/civiform/pull/11621#issuecomment-3378949391

This is an exploration into how to access a `bin/run-dev` civiform instance using a mobile phone.  My setup is an apple silicon macbook running chrome and a pixel 7 android phone running chrome, I'm not sure if this works on an iphone because I don't have one.

This approach runs a HTTP proxy inside the civiform docker network and exposes it to my phone via https://developer.chrome.com/docs/devtools/remote-debugging/local-server#usb-port-forwarding.  In my phone wifi settings, I made it use the proxy.

So, all traffic from my phone goes through the proxy.  Because the proxy is running inside the docker network, it knows how to resolve `civiform` and `dev-oicd` hostnames.  Setting `BASE_URL=http://civiform:9000` in the civiform server env vars is required otherwise it will redirect to `localhost`, which android does not send over the http proxy.

Steps:
1. run `bin/run-dev` with these changes.
2. Follow https://developer.chrome.com/docs/devtools/remote-debugging/local-server#usb-port-forwarding up to step 4. Forward port 8081 to 127.0.0.1:8081.
3. Follow https://developer.chrome.com/docs/devtools/remote-debugging/local-server#configure_proxy_settings_on_your_device.  Use proxy hostname = 127.0.0.1 and proxy port = 8081.
4. Open up http://civiform:9000 on your phone. Everything should work including login.
5. Optional: if you want to also access the civiform instance from your laptop browser, add the following to your /etc/hosts file on your laptop: `127.0.0.1 civiform` (like in https://github.com/civiform/civiform/wiki/Getting-started#setting-up-routing-for-local-testing)