### PR TITLE
Fix yes/no question in api

### DIFF
--- a/server/app/services/export/CsvColumnFactory.java
+++ b/server/app/services/export/CsvColumnFactory.java
@@ -67,7 +67,7 @@ final class CsvColumnFactory {
           buildColumnsForMultiSelectQuestion(aq.createMultiSelectQuestion(), columnType);
       case CURRENCY -> buildColumnsForCurrencyQuestion(aq.createCurrencyQuestion(), columnType);
       case DATE -> buildColumnsForDateQuestion(aq.createDateQuestion(), columnType);
-      case DROPDOWN, RADIO_BUTTON ->
+      case DROPDOWN, RADIO_BUTTON, YES_NO ->
           buildColumnsForSingleSelectQuestion(aq.createSingleSelectQuestion(), columnType);
       case EMAIL -> buildColumnsForEmailQuestion(aq.createEmailQuestion(), columnType);
         // Enumerator questions themselves are not included in the CSV, but their repeated questions

--- a/server/app/services/export/QuestionJsonPresenter.java
+++ b/server/app/services/export/QuestionJsonPresenter.java
@@ -153,7 +153,7 @@ public interface QuestionJsonPresenter<Q extends AbstractQuestion> {
         case CHECKBOX -> multiSelectJsonPresenter;
         case CURRENCY -> currencyJsonPresenter;
         case DATE -> dateJsonPresenter;
-        case DROPDOWN, RADIO_BUTTON -> singleSelectJsonPresenter;
+        case DROPDOWN, RADIO_BUTTON, YES_NO -> singleSelectJsonPresenter;
         case EMAIL -> emailJsonPresenter;
         case ENUMERATOR -> enumeratorJsonPresenter;
         case FILEUPLOAD -> fileUploadJsonPresenter;

--- a/server/app/services/export/enums/QuestionTypeExternal.java
+++ b/server/app/services/export/enums/QuestionTypeExternal.java
@@ -32,7 +32,7 @@ public enum QuestionTypeExternal {
       case CHECKBOX -> QuestionTypeExternal.MULTI_SELECT;
       case CURRENCY -> QuestionTypeExternal.CURRENCY;
       case DATE -> QuestionTypeExternal.DATE;
-      case DROPDOWN, RADIO_BUTTON -> QuestionTypeExternal.SINGLE_SELECT;
+      case DROPDOWN, RADIO_BUTTON, YES_NO -> QuestionTypeExternal.SINGLE_SELECT;
       case EMAIL -> QuestionTypeExternal.EMAIL;
       case ENUMERATOR -> QuestionTypeExternal.ENUMERATOR;
       case FILEUPLOAD -> QuestionTypeExternal.FILE_UPLOAD;

--- a/server/test/services/export/AbstractExporterTest.java
+++ b/server/test/services/export/AbstractExporterTest.java
@@ -40,6 +40,7 @@ import services.program.predicate.PredicateDefinition;
 import services.program.predicate.PredicateExpressionNode;
 import services.program.predicate.PredicateValue;
 import services.question.QuestionAnswerer;
+import services.question.YesNoQuestionOption;
 import services.question.types.EnumeratorQuestionDefinition;
 import services.question.types.QuestionDefinition;
 import services.question.types.QuestionType;
@@ -1225,6 +1226,25 @@ public abstract class AbstractExporterTest extends ResetPostgres {
               .getQuestionDefinition()
               .getContextualizedPath(nestedRepeatedEntity, ApplicantData.APPLICANT_PATH);
       QuestionAnswerer.answerNumberQuestion(applicant.getApplicantData(), answerPath, answer);
+      applicant.save();
+      return this;
+    }
+
+    FakeApplicationFiller answerYesNoQuestion(
+        QuestionModel question, YesNoQuestionOption optionId) {
+      return answerYesNoQuestion(question, null, optionId);
+    }
+
+    FakeApplicationFiller answerYesNoQuestion(
+        QuestionModel question, String repeatedEntityName, YesNoQuestionOption optionId) {
+      var repeatedEntity =
+          Optional.ofNullable(repeatedEntityName).flatMap(name -> getHouseholdMemberEntity(name));
+      Path answerPath =
+          question
+              .getQuestionDefinition()
+              .getContextualizedPath(repeatedEntity, ApplicantData.APPLICANT_PATH);
+      ApplicantData applicantData = applicant.getApplicantData();
+      QuestionAnswerer.answerSingleSelectQuestion(applicantData, answerPath, optionId.getId());
       applicant.save();
       return this;
     }

--- a/server/test/services/export/JsonExporterServiceTest.java
+++ b/server/test/services/export/JsonExporterServiceTest.java
@@ -31,6 +31,7 @@ import services.program.ProgramNotFoundException;
 import services.program.ProgramService;
 import services.question.QuestionOption;
 import services.question.QuestionService;
+import services.question.YesNoQuestionOption;
 import services.question.exceptions.InvalidUpdateException;
 import services.question.exceptions.UnsupportedQuestionTypeException;
 import services.question.types.MultiOptionQuestionDefinition;
@@ -1651,6 +1652,100 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
 
     resultAsserter.assertJsonAtApplicationPath(
         ".applicant_favorite_season",
+        """
+        {
+          "question_type" : "SINGLE_SELECT",
+          "selection" : null
+        }""");
+  }
+
+  @Test
+  public void export_whenYesNoQuestionIsAnswered_valueIsInResponse() {
+    createFakeQuestions();
+    var fakeProgram =
+        FakeProgramBuilder.newActiveProgram()
+            .withQuestion(testQuestionBank.doesApplicantHaveDogYesNo())
+            .build();
+    FakeApplicationFiller.newFillerFor(fakeProgram)
+        .answerYesNoQuestion(testQuestionBank.doesApplicantHaveDogYesNo(), YesNoQuestionOption.YES)
+        .submit();
+
+    JsonExporterService exporter = instanceOf(JsonExporterService.class);
+
+    String resultJsonString =
+        exporter.export(
+            fakeProgram.getProgramDefinition(),
+            SubmitTimeSequentialAccessPaginationSpec.APPLICATION_MODEL_MAX_PAGE_SIZE_SPEC,
+            SubmittedApplicationFilter.EMPTY);
+    ResultAsserter resultAsserter = new ResultAsserter(resultJsonString);
+
+    resultAsserter.assertJsonAtApplicationPath(
+        ".applicant_has_a_dog",
+        """
+        {
+          "question_type" : "SINGLE_SELECT",
+          "selection" : "yes"
+        }""");
+  }
+
+  @Test
+  public void export_whenYesNoQuestionIsRepeated_answersAreCorrectlyNested() {
+    createFakeQuestions();
+    var fakeProgram =
+        FakeProgramBuilder.newActiveProgram()
+            .withHouseholdMembersEnumeratorQuestion()
+            .withHouseholdMembersRepeatedQuestion(testQuestionBank.doesApplicantHaveDogYesNo())
+            .build();
+    FakeApplicationFiller.newFillerFor(fakeProgram)
+        .answerEnumeratorQuestion(ImmutableList.of("taylor"))
+        .answerYesNoQuestion(
+            testQuestionBank.doesApplicantHaveDogYesNo(), "taylor", YesNoQuestionOption.YES)
+        .submit();
+
+    JsonExporterService exporter = instanceOf(JsonExporterService.class);
+
+    String resultJsonString =
+        exporter.export(
+            fakeProgram.getProgramDefinition(),
+            SubmitTimeSequentialAccessPaginationSpec.APPLICATION_MODEL_MAX_PAGE_SIZE_SPEC,
+            SubmittedApplicationFilter.EMPTY);
+    ResultAsserter resultAsserter = new ResultAsserter(resultJsonString);
+
+    resultAsserter.assertJsonAtApplicationPath(
+        ".applicant_household_members",
+        """
+        {
+          "entities" : [ {
+            "applicant_has_a_dog" : {
+              "question_type" : "SINGLE_SELECT",
+              "selection" : "yes"
+            },
+            "entity_name" : "taylor"
+          } ],
+          "question_type" : "ENUMERATOR"
+        }""");
+  }
+
+  @Test
+  public void export_whenYesNoQuestionIsNotAnswered_valueInResponseIsNull() {
+    createFakeQuestions();
+    var fakeProgram =
+        FakeProgramBuilder.newActiveProgram()
+            .withQuestion(testQuestionBank.doesApplicantHaveDogYesNo())
+            .build();
+    FakeApplicationFiller.newFillerFor(fakeProgram).submit();
+
+    JsonExporterService exporter = instanceOf(JsonExporterService.class);
+
+    String resultJsonString =
+        exporter.export(
+            fakeProgram.getProgramDefinition(),
+            SubmitTimeSequentialAccessPaginationSpec.APPLICATION_MODEL_MAX_PAGE_SIZE_SPEC,
+            SubmittedApplicationFilter.EMPTY);
+    ResultAsserter resultAsserter = new ResultAsserter(resultJsonString);
+
+    resultAsserter.assertJsonAtApplicationPath(
+        ".applicant_has_a_dog",
         """
         {
           "question_type" : "SINGLE_SELECT",


### PR DESCRIPTION
### Description

Adds support for yes/no question in api/json/csv.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if the primary reviewer is not an admin and this PR includes functionality changes)
- [ ] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.


### Issue(s) this completes

Fixes #11596
