### PR TITLE
 Fix: Prevent submission of removed Yes/No options (#11594)

### DIFF
--- a/server/app/services/applicant/question/MultiSelectQuestion.java
+++ b/server/app/services/applicant/question/MultiSelectQuestion.java
@@ -41,6 +41,22 @@ public final class MultiSelectQuestion extends AbstractQuestion {
     int numberOfSelections = getSelectedOptionValues().map(ImmutableList::size).orElse(0);
     ImmutableSet.Builder<ValidationErrorMessage> errors = ImmutableSet.builder();
 
+    // Validate that all selected option IDs are displayable (not removed/hidden by admin)
+    Optional<ImmutableList<Long>> maybeSelectedIds =
+        applicantQuestion.getApplicantData().readLongList(getSelectionPath());
+    if (maybeSelectedIds.isPresent()) {
+      ImmutableList<Long> selectedIds = maybeSelectedIds.get();
+      ImmutableSet<Long> validOptionIds =
+          definition.getDisplayableOptions().stream()
+              .map(QuestionOption::id)
+              .collect(ImmutableSet.toImmutableSet());
+
+      boolean allSelectionsValid = selectedIds.stream().allMatch(validOptionIds::contains);
+      if (!allSelectionsValid) {
+        errors.add(ValidationErrorMessage.create(MessageKey.INVALID_INPUT));
+      }
+    }
+
     if (definition.getMultiOptionValidationPredicates().minChoicesRequired().isPresent()) {
       int minChoicesRequired =
           definition.getMultiOptionValidationPredicates().minChoicesRequired().getAsInt();

--- a/server/app/services/applicant/question/SingleSelectQuestion.java
+++ b/server/app/services/applicant/question/SingleSelectQuestion.java
@@ -58,9 +58,12 @@ public final class SingleSelectQuestion extends AbstractQuestion {
 
     Long selectedValue = optionalSelectedValue.get();
 
-    // Validate the long is in the set of allowed Question options.
+    // Validate the long is in the set of allowed Question options that are displayable to
+    // applicants.
+    // This prevents submission of options that have been removed/hidden by admins.
     boolean validSelection =
-        getQuestionDefinition().getOptions().stream().anyMatch(o -> selectedValue.equals(o.id()));
+        getQuestionDefinition().getDisplayableOptions().stream()
+            .anyMatch(o -> selectedValue.equals(o.id()));
 
     if (!validSelection) {
       return ImmutableSet.of(ValidationErrorMessage.create(MessageKey.INVALID_INPUT));

--- a/server/app/services/question/types/MultiOptionQuestionDefinition.java
+++ b/server/app/services/question/types/MultiOptionQuestionDefinition.java
@@ -216,6 +216,22 @@ public final class MultiOptionQuestionDefinition extends QuestionDefinition {
   }
 
   /**
+   * Get only the options that should be displayed to applicants in answer forms.
+   *
+   * <p>This filters options based on the {@code displayInAnswerOptions} field. Options without this
+   * field set (legacy options) are included by default for backward compatibility.
+   *
+   * @return a list of options that should be shown to applicants for selection
+   */
+  public ImmutableList<QuestionOption> getDisplayableOptions() {
+    return this.questionOptions.stream()
+        .filter(
+            option ->
+                option.displayInAnswerOptions().isEmpty() || option.displayInAnswerOptions().get())
+        .collect(toImmutableList());
+  }
+
+  /**
    * Get the admin names of the question's options.
    *
    * @return a list of option admin names.


### PR DESCRIPTION
### Description

This PR fixes a data integrity issue where applicants could submit invalid/removed Yes/No options after an admin updates the question configuration.

- Added `getDisplayableOptions()` method to `MultiOptionQuestionDefinition` that filters options based on
`displayInAnswerOptions` field 
- Updated `SingleSelectQuestion` and `MultiSelectQuestion` validation to check against displayable options only
  - Maintains backward compatibility with legacy options (options without `displayInAnswerOptions` field are treated as displayable)
  - Server-side validation provides defense-in-depth protection while client-side filtering maintains good UX

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [X] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [X] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [X] Added an additional reviewer from `civiform/eng-admin` as FYI (if the primary reviewer is not an admin and this PR includes functionality changes)
- [X] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [X] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

#### Database evolutions

Read the guidelines [here](https://github.com/civiform/civiform/wiki/Database#writing-database-evolutions)

- [ ] Assigned two reviewers
- [ ] Guarded against already existing resources using `IF NOT EXISTS` and `IF EXISTS`
- [ ] Downs created to undo changes in Ups
- [ ] Every comment in script should begin with -- and not # --- unless it denotes Ups or Downs. See [here](https://www.playframework.com/documentation/2.9.x/Evolutions) for details.
- [ ] Tested both the Downs and the Ups scripts manually (When testing, include all comments from the evolution in your test script to ensure any syntax errors in the comments are caught.)
- [ ] Data migrations aren't being done (please use a [Durable Job](https://github.com/civiform/civiform/wiki/Database#durable-jobs-for-data-updates) if doing a data migration)
- [ ] Update the model documentation in our [wiki](https://github.com/civiform/civiform/wiki/Database) if necessary

#### Durable jobs

Read the docs [here](https://github.com/civiform/civiform/wiki/Database#durable-jobs-for-data-updates)

- [ ] Assigned two reviewers
- [ ] Included a rollback plan and a job to undo the data changes if appropriate

#### User visible changes

- [ ] Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
  - [ ] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [ ] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Made equivalent changes in Thymeleaf for applicant-facing features and changes (or created an issue in the [Northstar epic](https://github.com/orgs/civiform/projects/1/views/94) to track that it's missing from Thymeleaf)
- [ ] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order
- [ ] Performed manual accessibility tests for any applicant-facing changes or any new admin-facing features. See [manual-accessibility-testing](https://github.com/civiform/civiform/wiki/Accessibility#manual-accessibility-testing)
- [ ] Manually tested with a right-to-left language

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/helper/feature-flags.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://github.com/civiform/civiform/wiki/Feature-Flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Instructions for manual testing

1. **Setup**: Create a Yes/No question with options: Yes, No, Maybe,
  Not sure (all with `displayInAnswerOptions=true`)
  2. **Add to program**: Add the question to a test program
  3. **Start application**: As an applicant, start the application and select "Maybe"
  4. **Simulate admin removing option**: Using database access, update  the "Maybe" option to set `displayInAnswerOptions=false`
  5. **Verify fix**: Return to the applicant view and attempt to submit 
     - **Expected**: "Maybe" option disappears from UI, applicant can select a different valid option
     - **Data integrity**: Invalid option cannot be submitted to database (server-side validation prevents it)

### Issue(s) this completes

Fixes #11594
