### PR TITLE
fix: Filter eligibility/visibility options by admin configuration (#11592)

### DIFF
--- a/server/app/services/question/types/MultiOptionQuestionDefinition.java
+++ b/server/app/services/question/types/MultiOptionQuestionDefinition.java
@@ -216,6 +216,22 @@ public final class MultiOptionQuestionDefinition extends QuestionDefinition {
   }
 
   /**
+   * Get only the options that should be displayed to applicants in answer forms.
+   *
+   * <p>This filters options based on the {@code displayInAnswerOptions} field. Options without this
+   * field set (legacy options) are included by default for backward compatibility.
+   *
+   * @return a list of options that should be shown to applicants for selection
+   */
+  public ImmutableList<QuestionOption> getDisplayableOptions() {
+    return this.questionOptions.stream()
+        .filter(
+            option ->
+                option.displayInAnswerOptions().isEmpty() || option.displayInAnswerOptions().get())
+        .collect(toImmutableList());
+  }
+
+  /**
    * Get the admin names of the question's options.
    *
    * @return a list of option admin names.

--- a/server/app/views/admin/programs/ProgramPredicateConfigureView.java
+++ b/server/app/views/admin/programs/ProgramPredicateConfigureView.java
@@ -698,8 +698,10 @@ public final class ProgramPredicateConfigureView extends ProgramBaseView {
       // choose from instead of a freeform text field. Not only is it a better UX, but we store the
       // ID of the options rather than the display strings since the option display strings are
       // localized.
+      // Only show options that are displayable to applicants (displayInAnswerOptions=true).
+      // This ensures eligibility/visibility conditions only use options that admins have enabled.
       ImmutableList<QuestionOption> options =
-          ((MultiOptionQuestionDefinition) questionDefinition).getOptions();
+          ((MultiOptionQuestionDefinition) questionDefinition).getDisplayableOptions();
 
       ImmutableSet<String> currentlyCheckedValues =
           assertLeafOperationNode(maybeLeafNode)


### PR DESCRIPTION
### Description

This PR fixes a bug where eligibility/visibility condition configuration UI displayed all Yes/No options (Yes, No, Not sure, Maybe) regardless of which options the admin enabled in the question configuration.

**Related to**: This PR uses the same `getDisplayableOptions()` method as #11594. If #11594 merges first, there will be a minor merge conflict in `MultiOptionQuestionDefinition.java` (easily resolved - both versions are identical).

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [X] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [X] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [X] Added an additional reviewer from `civiform/eng-admin` as FYI (if the primary reviewer is not an admin and this PR includes functionality changes)
- [X] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [X] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

#### Database evolutions

Read the guidelines [here](https://github.com/civiform/civiform/wiki/Database#writing-database-evolutions)

- [ ] Assigned two reviewers
- [ ] Guarded against already existing resources using `IF NOT EXISTS` and `IF EXISTS`
- [ ] Downs created to undo changes in Ups
- [ ] Every comment in script should begin with -- and not # --- unless it denotes Ups or Downs. See [here](https://www.playframework.com/documentation/2.9.x/Evolutions) for details.
- [ ] Tested both the Downs and the Ups scripts manually (When testing, include all comments from the evolution in your test script to ensure any syntax errors in the comments are caught.)
- [ ] Data migrations aren't being done (please use a [Durable Job](https://github.com/civiform/civiform/wiki/Database#durable-jobs-for-data-updates) if doing a data migration)
- [ ] Update the model documentation in our [wiki](https://github.com/civiform/civiform/wiki/Database) if necessary

#### Durable jobs

Read the docs [here](https://github.com/civiform/civiform/wiki/Database#durable-jobs-for-data-updates)

- [ ] Assigned two reviewers
- [ ] Included a rollback plan and a job to undo the data changes if appropriate

#### User visible changes

- [ ] Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
  - [ ] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [ ] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Made equivalent changes in Thymeleaf for applicant-facing features and changes (or created an issue in the [Northstar epic](https://github.com/orgs/civiform/projects/1/views/94) to track that it's missing from Thymeleaf)
- [ ] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order
- [ ] Performed manual accessibility tests for any applicant-facing changes or any new admin-facing features. See [manual-accessibility-testing](https://github.com/civiform/civiform/wiki/Accessibility#manual-accessibility-testing)
- [ ] Manually tested with a right-to-left language

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/helper/feature-flags.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://github.com/civiform/civiform/wiki/Feature-Flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Instructions for manual testing

  1. **Create Yes/No question** with only Yes and No options enabled:
     - Go to Admin → Questions → Create Question
     - Select "Yes/No" question type
     - Check only "Yes" and "No" options
     - Uncheck "Not sure" and "Maybe"
     - Save question

  2. **Add to program**: Add the question to a test program screen

  3. **Configure eligibility condition**:
     - Go to program screen eligibility conditions
     - Add condition using the Yes/No question
     - **Expected**: Only "Yes" and "No" checkboxes appear
     - **Before fix**: All 4 options appeared

  4. **Verify**: Confirm only admin-enabled options are shown

*Repaet steps 3-4 to test for visibility behavior

### Screenshots
[
<img width="386" height="435" alt="image" src="https://github.com/user-attachments/assets/371bc619-317c-4d5e-8e6e-57a3107a8403" />
](url)

[
<img width="529" height="391" alt="image" src="https://github.com/user-attachments/assets/82dfd8ed-21a5-4b26-ba61-f144f500e23c" />
](url)

[
<img width="359" height="427" alt="image" src="https://github.com/user-attachments/assets/62abbe66-2f6c-4c60-8651-23de6117a84c" />
](url)

[
<img width="389" height="396" alt="image" src="https://github.com/user-attachments/assets/0a5ab9cf-c128-434d-96fc-bdfba658e7c4" />
](url)

[
<img width="416" height="428" alt="image" src="https://github.com/user-attachments/assets/47177936-3ae0-413b-ad1e-e6e279ee27fc" />
](url)

[
<img width="389" height="419" alt="image" src="https://github.com/user-attachments/assets/9d60e4ca-8b6b-43bc-bddd-04eafa01683e" />
](url)

### Issue(s) this completes

Fixes #11592.
