### PR TITLE
fix: PDF and JSON exports to filter displayable options (#11595)

### DIFF
--- a/server/app/services/applicant/question/MultiSelectQuestion.java
+++ b/server/app/services/applicant/question/MultiSelectQuestion.java
@@ -147,6 +147,16 @@ public final class MultiSelectQuestion extends AbstractQuestion {
     return getQuestionDefinition().getOptionsForLocaleOrDefault(locale);
   }
 
+  /** Get displayable options in the applicant's preferred locale. */
+  public ImmutableList<LocalizedQuestionOption> getDisplayableOptions() {
+    return getDisplayableOptions(applicantQuestion.getApplicantData().preferredLocale());
+  }
+
+  /** Get displayable options in the specified locale. */
+  public ImmutableList<LocalizedQuestionOption> getDisplayableOptions(Locale locale) {
+    return getQuestionDefinition().getDisplayableOptionsForLocaleOrDefault(locale);
+  }
+
   @Override
   public String getAnswerString() {
     return getSelectedOptionValues()

--- a/server/app/services/applicant/question/SingleSelectQuestion.java
+++ b/server/app/services/applicant/question/SingleSelectQuestion.java
@@ -136,6 +136,16 @@ public final class SingleSelectQuestion extends AbstractQuestion {
     return getQuestionDefinition().getOptionsForLocaleOrDefault(locale);
   }
 
+  /** Get displayable options in the applicant's preferred locale. */
+  public ImmutableList<LocalizedQuestionOption> getDisplayableOptions() {
+    return getDisplayableOptions(applicantQuestion.getApplicantData().preferredLocale());
+  }
+
+  /** Get displayable options in the specified locale. */
+  public ImmutableList<LocalizedQuestionOption> getDisplayableOptions(Locale locale) {
+    return getQuestionDefinition().getDisplayableOptionsForLocaleOrDefault(locale);
+  }
+
   @Override
   public String getAnswerString() {
     return getSelectedOptionValue()

--- a/server/app/services/export/PdfExporter.java
+++ b/server/app/services/export/PdfExporter.java
@@ -450,7 +450,7 @@ public final class PdfExporter {
       if (question.getQuestionType().isMultiOptionType()) {
         MultiOptionQuestionDefinition multiOption = (MultiOptionQuestionDefinition) question;
         List list = createList(indentationLevel);
-        for (QuestionOption option : multiOption.getOptions()) {
+        for (QuestionOption option : multiOption.getDisplayableOptions()) {
           list.add(new ListItem(option.optionText().getDefault()));
         }
         document.add(list);

--- a/server/app/services/export/QuestionJsonSampler.java
+++ b/server/app/services/export/QuestionJsonSampler.java
@@ -496,7 +496,7 @@ public interface QuestionJsonSampler<Q extends AbstractQuestion> {
         SampleDataContext sampleDataContext, ApplicantQuestion applicantQuestion) {
       ApplicantData applicantData = sampleDataContext.getApplicantData();
       ImmutableList<LocalizedQuestionOption> questionOptions =
-          applicantQuestion.createMultiSelectQuestion().getOptions();
+          applicantQuestion.createMultiSelectQuestion().getDisplayableOptions();
 
       // Add up to two options to the sample data.
       if (questionOptions.size() > 0) {
@@ -659,7 +659,7 @@ public interface QuestionJsonSampler<Q extends AbstractQuestion> {
     public void addSampleData(
         SampleDataContext sampleDataContext, ApplicantQuestion applicantQuestion) {
       ImmutableList<LocalizedQuestionOption> questionOptions =
-          applicantQuestion.createSingleSelectQuestion().getOptions();
+          applicantQuestion.createSingleSelectQuestion().getDisplayableOptions();
 
       if (questionOptions.size() != 0) {
         LocalizedQuestionOption firstOption = questionOptions.get(0);

--- a/server/app/services/question/types/MultiOptionQuestionDefinition.java
+++ b/server/app/services/question/types/MultiOptionQuestionDefinition.java
@@ -232,12 +232,39 @@ public final class MultiOptionQuestionDefinition extends QuestionDefinition {
   }
 
   /**
+   * Get displayable options localized for the given locale, or default locale if not available.
+   *
+   * <p>This is similar to {@link #getOptionsForLocaleOrDefault(Locale)} but only returns options
+   * that should be displayed to applicants (filters by displayInAnswerOptions field).
+   *
+   * @param locale the desired locale for option text
+   * @return localized displayable options
+   */
+  public ImmutableList<LocalizedQuestionOption> getDisplayableOptionsForLocaleOrDefault(
+      Locale locale) {
+    return getDisplayableOptions().stream()
+        .map(option -> option.localizeOrDefault(locale))
+        .collect(toImmutableList());
+  }
+
+  /**
    * Get the admin names of the question's options.
    *
    * @return a list of option admin names.
    */
   public ImmutableList<String> getOptionAdminNames() {
     return this.questionOptions.stream().map(QuestionOption::adminName).collect(toImmutableList());
+  }
+
+  /**
+   * Get admin names of only the options that should be displayed to applicants.
+   *
+   * @return a list of displayable option admin names.
+   */
+  public ImmutableList<String> getDisplayableOptionAdminNames() {
+    return getDisplayableOptions().stream()
+        .map(QuestionOption::adminName)
+        .collect(toImmutableList());
   }
 
   /**

--- a/server/app/views/docs/ApiDocsView.java
+++ b/server/app/views/docs/ApiDocsView.java
@@ -299,7 +299,7 @@ public class ApiDocsView extends BaseHtmlView {
           (MultiOptionQuestionDefinition) questionDefinition;
 
       Stream<DomContent> currentOptionElements =
-          asCommaSeparatedCodeElementStream(multiOptionQD.getOptionAdminNames());
+          asCommaSeparatedCodeElementStream(multiOptionQD.getDisplayableOptionAdminNames());
 
       Stream<DomContent> allPossibleOptionElements =
           asCommaSeparatedCodeElementStream(

--- a/server/test/services/question/types/MultiOptionQuestionDefinitionTest.java
+++ b/server/test/services/question/types/MultiOptionQuestionDefinitionTest.java
@@ -550,6 +550,199 @@ public class MultiOptionQuestionDefinitionTest {
                 .orElse(ImmutableSet.of()));
   }
 
+  @Test
+  public void getDisplayableOptionsForLocaleOrDefault_allOptionsDisplayable_returnsAllOptions()
+      throws Exception {
+    ImmutableList<QuestionOption> options =
+        ImmutableList.of(
+            QuestionOption.create(
+                1L,
+                1L,
+                "opt1",
+                LocalizedStrings.of(Locale.US, "option 1", Locale.GERMAN, "Option 1"),
+                Optional.of(true)),
+            QuestionOption.create(
+                2L,
+                2L,
+                "opt2",
+                LocalizedStrings.of(Locale.US, "option 2", Locale.GERMAN, "Option 2"),
+                Optional.of(true)));
+    QuestionDefinition definition =
+        new QuestionDefinitionBuilder()
+            .setQuestionType(QuestionType.DROPDOWN)
+            .setName("")
+            .setDescription("")
+            .setQuestionText(LocalizedStrings.of())
+            .setQuestionHelpText(LocalizedStrings.empty())
+            .setQuestionOptions(options)
+            .build();
+
+    MultiOptionQuestionDefinition multiOption = (MultiOptionQuestionDefinition) definition;
+
+    assertThat(multiOption.getDisplayableOptionsForLocaleOrDefault(Locale.US))
+        .containsExactly(
+            LocalizedQuestionOption.create(
+                /* id= */ 1L,
+                /* order= */ 1L,
+                /* adminName= */ "opt1",
+                /* optionText= */ "option 1",
+                /* displayInAnswerOptions= */ Optional.of(true),
+                /* locale= */ Locale.US),
+            LocalizedQuestionOption.create(
+                /* id= */ 2L,
+                /* order= */ 2L,
+                /* adminName= */ "opt2",
+                /* optionText= */ "option 2",
+                /* displayInAnswerOptions= */ Optional.of(true),
+                /* locale= */ Locale.US));
+  }
+
+  @Test
+  public void getDisplayableOptionsForLocaleOrDefault_someOptionsHidden_returnsOnlyDisplayable()
+      throws Exception {
+    ImmutableList<QuestionOption> options =
+        ImmutableList.of(
+            QuestionOption.create(
+                1L,
+                1L,
+                "opt1",
+                LocalizedStrings.of(Locale.US, "option 1", Locale.GERMAN, "Option 1"),
+                Optional.of(true)),
+            QuestionOption.create(
+                2L,
+                2L,
+                "opt2",
+                LocalizedStrings.of(Locale.US, "option 2", Locale.GERMAN, "Option 2"),
+                Optional.of(false)),
+            QuestionOption.create(
+                3L,
+                3L,
+                "opt3",
+                LocalizedStrings.of(Locale.US, "option 3", Locale.GERMAN, "Option 3"),
+                Optional.of(true)));
+    QuestionDefinition definition =
+        new QuestionDefinitionBuilder()
+            .setQuestionType(QuestionType.DROPDOWN)
+            .setName("")
+            .setDescription("")
+            .setQuestionText(LocalizedStrings.of())
+            .setQuestionHelpText(LocalizedStrings.empty())
+            .setQuestionOptions(options)
+            .build();
+
+    MultiOptionQuestionDefinition multiOption = (MultiOptionQuestionDefinition) definition;
+
+    assertThat(multiOption.getDisplayableOptionsForLocaleOrDefault(Locale.US))
+        .containsExactly(
+            LocalizedQuestionOption.create(
+                /* id= */ 1L,
+                /* order= */ 1L,
+                /* adminName= */ "opt1",
+                /* optionText= */ "option 1",
+                /* displayInAnswerOptions= */ Optional.of(true),
+                /* locale= */ Locale.US),
+            LocalizedQuestionOption.create(
+                /* id= */ 3L,
+                /* order= */ 3L,
+                /* adminName= */ "opt3",
+                /* optionText= */ "option 3",
+                /* displayInAnswerOptions= */ Optional.of(true),
+                /* locale= */ Locale.US));
+  }
+
+  @Test
+  public void getDisplayableOptionsForLocaleOrDefault_legacyOptions_returnsAllOptions()
+      throws Exception {
+    ImmutableList<QuestionOption> options =
+        ImmutableList.of(
+            QuestionOption.create(
+                1L, "opt1", LocalizedStrings.of(Locale.US, "option 1", Locale.GERMAN, "Option 1")),
+            QuestionOption.create(
+                2L, "opt2", LocalizedStrings.of(Locale.US, "option 2", Locale.GERMAN, "Option 2")));
+    QuestionDefinition definition =
+        new QuestionDefinitionBuilder()
+            .setQuestionType(QuestionType.DROPDOWN)
+            .setName("")
+            .setDescription("")
+            .setQuestionText(LocalizedStrings.of())
+            .setQuestionHelpText(LocalizedStrings.empty())
+            .setQuestionOptions(options)
+            .build();
+
+    MultiOptionQuestionDefinition multiOption = (MultiOptionQuestionDefinition) definition;
+
+    assertThat(multiOption.getDisplayableOptionsForLocaleOrDefault(Locale.US))
+        .containsExactly(
+            LocalizedQuestionOption.create(
+                /* id= */ 1L,
+                /* order= */ 1L,
+                /* adminName= */ "opt1",
+                /* optionText= */ "option 1",
+                /* displayInAnswerOptions= */ Optional.empty(),
+                /* locale= */ Locale.US),
+            LocalizedQuestionOption.create(
+                /* id= */ 2L,
+                /* order= */ 2L,
+                /* adminName= */ "opt2",
+                /* optionText= */ "option 2",
+                /* displayInAnswerOptions= */ Optional.empty(),
+                /* locale= */ Locale.US));
+  }
+
+  @Test
+  public void
+      getDisplayableOptionsForLocaleOrDefault_differentLocale_returnsLocalizedDisplayableOptions()
+          throws Exception {
+    ImmutableList<QuestionOption> options =
+        ImmutableList.of(
+            QuestionOption.create(
+                1L,
+                1L,
+                "opt1",
+                LocalizedStrings.of(Locale.US, "option 1", Locale.GERMAN, "Option 1"),
+                Optional.of(true)),
+            QuestionOption.create(
+                2L,
+                2L,
+                "opt2",
+                LocalizedStrings.of(Locale.US, "option 2", Locale.GERMAN, "Option 2"),
+                Optional.of(false)),
+            QuestionOption.create(
+                3L,
+                3L,
+                "opt3",
+                LocalizedStrings.of(Locale.US, "option 3", Locale.GERMAN, "Option 3"),
+                Optional.of(true)));
+    QuestionDefinition definition =
+        new QuestionDefinitionBuilder()
+            .setQuestionType(QuestionType.DROPDOWN)
+            .setName("")
+            .setDescription("")
+            .setQuestionText(LocalizedStrings.of())
+            .setQuestionHelpText(LocalizedStrings.empty())
+            .setQuestionOptions(options)
+            .build();
+
+    MultiOptionQuestionDefinition multiOption = (MultiOptionQuestionDefinition) definition;
+
+    assertThat(multiOption.getDisplayableOptionsForLocaleOrDefault(Locale.GERMAN))
+        .containsExactly(
+            LocalizedQuestionOption.create(
+                /* id= */ 1L,
+                /* order= */ 1L,
+                /* adminName= */ "opt1",
+                /* optionText= */ "Option 1",
+                /* displayInAnswerOptions= */ Optional.of(true),
+                /* locale= */ Locale.GERMAN),
+            LocalizedQuestionOption.create(
+                /* id= */ 3L,
+                /* order= */ 3L,
+                /* adminName= */ "opt3",
+                /* optionText= */ "Option 3",
+                /* displayInAnswerOptions= */ Optional.of(true),
+                /* locale= */ Locale.GERMAN));
+  }
+
   private QuestionDefinitionConfig.Builder makeConfigBuilder() {
     return QuestionDefinitionConfig.builder()
         .setName("name")


### PR DESCRIPTION
### Description
This PR fixes a data integrity issue where applicants could submit invalid/removed Yes/No options after an admin updates the question configuration.
- Add getDisplayableOptionsForLocaleOrDefault() to MultiOptionQuestionDefinition
- Add getDisplayableOptionAdminNames() to MultiOptionQuestionDefinition
- Add getDisplayableOptions() methods to SingleSelectQuestion and MultiSelectQuestion
- Update PdfExporter to use getDisplayableOptions()
- Update QuestionJsonSampler to use getDisplayableOptions() for sample data
- Update ApiDocsView to use getDisplayableOptionAdminNames() for current options

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [X] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [X] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [X] Added an additional reviewer from `civiform/eng-admin` as FYI (if the primary reviewer is not an admin and this PR includes functionality changes)
- [X] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

#### Database evolutions

Read the guidelines [here](https://github.com/civiform/civiform/wiki/Database#writing-database-evolutions)

- [ ] Assigned two reviewers
- [ ] Guarded against already existing resources using `IF NOT EXISTS` and `IF EXISTS`
- [ ] Downs created to undo changes in Ups
- [ ] Every comment in script should begin with -- and not # --- unless it denotes Ups or Downs. See [here](https://www.playframework.com/documentation/2.9.x/Evolutions) for details.
- [ ] Tested both the Downs and the Ups scripts manually (When testing, include all comments from the evolution in your test script to ensure any syntax errors in the comments are caught.)
- [ ] Data migrations aren't being done (please use a [Durable Job](https://github.com/civiform/civiform/wiki/Database#durable-jobs-for-data-updates) if doing a data migration)
- [ ] Update the model documentation in our [wiki](https://github.com/civiform/civiform/wiki/Database) if necessary

#### Durable jobs

Read the docs [here](https://github.com/civiform/civiform/wiki/Database#durable-jobs-for-data-updates)

- [ ] Assigned two reviewers
- [ ] Included a rollback plan and a job to undo the data changes if appropriate

#### User visible changes

- [ ] Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
  - [ ] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [ ] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Made equivalent changes in Thymeleaf for applicant-facing features and changes (or created an issue in the [Northstar epic](https://github.com/orgs/civiform/projects/1/views/94) to track that it's missing from Thymeleaf)
- [ ] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order
- [ ] Performed manual accessibility tests for any applicant-facing changes or any new admin-facing features. See [manual-accessibility-testing](https://github.com/civiform/civiform/wiki/Accessibility#manual-accessibility-testing)
- [ ] Manually tested with a right-to-left language

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/helper/feature-flags.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://github.com/civiform/civiform/wiki/Feature-Flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Instructions for manual testing

1. Create a Yes/No question with all 4 options enabled (Yes, No, Maybe, Not sure)
2. Add to a program and publish
3. Admin: Disable "Maybe" and "Not sure" options (uncheck displayInAnswerOptions)
4. Generate PDF preview - verify only "Yes" and "No" appear
5. Check API docs - verify "Current options" shows only "Yes" and "No"
6. Check JSON API sample data - verify only uses "Yes" or "No" values

### Issue(s) this completes

Fixes #11595
