### PR TITLE
docker-compose.dev.yml: add SELinux shared mount option

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -6,7 +6,7 @@
 # Volumes to un-shadow build directories under server are created in the dockerfile.
 x-sbt-volumes:
   volumes: &sbt-volumes
-    - ./server:/usr/src/server
+    - ./server:/usr/src/server:z
 
 services:
   dev-oidc:


### PR DESCRIPTION
### Description

Marks that the server source code volume is shared: https://docs.docker.com/engine/storage/bind-mounts/#configure-the-selinux-label.  Without this, `bin/run-dev` fails on linux hosts that have SELinux enabled.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from `civiform/eng-admin` as FYI (if the primary reviewer is not an admin and this PR includes functionality changes)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [x] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [x] Noted in the PR description which, if any, code in this PR was generated by AI.

### Instructions for manual testing

I ran `bin/dev` and to make sure it worked on:

1. My apple silicon macbook using podman
2. My x86 linux host running Fedora with SELinux (apparently) enabled

### Issue(s) this completes
