### PR TITLE
Fix: Add check for confirmation message preview element before adding listeners

### DIFF
--- a/server/app/assets/javascripts/admin_application_view.ts
+++ b/server/app/assets/javascripts/admin_application_view.ts
@@ -154,6 +154,16 @@ class AdminApplicationView {
   }
 
   private registerConfirmationMessageInputListeners() {
+    // Check for presence of the confirmation message preview element before adding listeners
+    if (
+      !document.getElementById(
+        AdminApplicationView.CONFIRMATION_MESSAGE_PREVIEW_ID,
+      )
+    ) {
+      // If the confirmation message preview isn't present, there's nothing to do.
+      return
+    }
+
     // Render confirmation message text on load
     window.addEventListener(
       'pageshow',


### PR DESCRIPTION
### Description

Currently, the `admin_application_view.registerConfirmationMessageInputListeners()` method doesn't check for the (non)presence of the confirmation message preview element before registering listeners. Add that check, and return from the method if that element isn't present.

TESTED=manually
No Gen AI code.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if the primary reviewer is not an admin and this PR includes functionality changes)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [x] Noted in the PR description which, if any, code in this PR was generated by AI.

### Instructions for manual testing

1. Comment out the lines added in this PR (`admin_application_view.ts:158-165`)
2. Run `bin/run-dev`
3. Go to any admin page, and observe the `Uncaught TypeError: can't access property "querySelector"` errors in the JavaScript console from within your browser's dev tools.
4. Uncomment `admin_application_view.ts:158-165`, recompile the dev instance, and reload.
5. The `Uncaught TypeError` failures should be gone.

### Issue(s) this completes

Fixes #11650
