### PR TITLE
test(11591): Add comprehensive unit test to verify the fix for bug #11591

### DIFF
--- a/server/test/services/question/types/QuestionOptionTest.java
+++ b/server/test/services/question/types/QuestionOptionTest.java
@@ -59,4 +59,59 @@ public class QuestionOptionTest {
                 /* displayInAnswerOptions= */ Optional.empty(),
                 /* locale= */ LocalizedStrings.DEFAULT_LOCALE));
   }
+
+  @Test
+  public void create_withDisplayOrder_preservesDisplayOrderWhenLocalized() {
+    // This test verifies that Yes/No question options display in the same order
+    // after create, edit and in UI
+    QuestionOption yesOption =
+        QuestionOption.create(
+            /* id= */ 1L, // YES = 1 (true)
+            /* displayOrder= */ 0L, // Shows first
+            /* adminName= */ "yes",
+            /* optionText= */ LocalizedStrings.of(Locale.US, "Yes"),
+            /* displayInAnswerOptions= */ Optional.of(true));
+
+    QuestionOption noOption =
+        QuestionOption.create(
+            /* id= */ 0L, // NO = 0 (false)
+            /* displayOrder= */ 1L, // Shows second
+            /* adminName= */ "no",
+            /* optionText= */ LocalizedStrings.of(Locale.US, "No"),
+            /* displayInAnswerOptions= */ Optional.of(true));
+
+    QuestionOption notSureOption =
+        QuestionOption.create(
+            /* id= */ 2L, // NOT_SURE = 2
+            /* displayOrder= */ 2L, // Shows third
+            /* adminName= */ "not-sure",
+            /* optionText= */ LocalizedStrings.of(Locale.US, "Not sure"),
+            /* displayInAnswerOptions= */ Optional.of(true));
+
+    QuestionOption maybeOption =
+        QuestionOption.create(
+            /* id= */ 3L, // MAYBE = 3
+            /* displayOrder= */ 3L, // Shows fourth
+            /* adminName= */ "maybe",
+            /* optionText= */ LocalizedStrings.of(Locale.US, "Maybe"),
+            /* displayInAnswerOptions= */ Optional.of(true));
+
+    // Verify that displayOrder is preserved (not replaced with empty)
+    assertThat(yesOption.displayOrder()).isEqualTo(OptionalLong.of(0L));
+    assertThat(noOption.displayOrder()).isEqualTo(OptionalLong.of(1L));
+    assertThat(notSureOption.displayOrder()).isEqualTo(OptionalLong.of(2L));
+    assertThat(maybeOption.displayOrder()).isEqualTo(OptionalLong.of(3L));
+
+    // Verify that when localized, the displayOrder is used (not the id)
+    LocalizedQuestionOption localizedYes = yesOption.localize(Locale.US);
+    LocalizedQuestionOption localizedNo = noOption.localize(Locale.US);
+    LocalizedQuestionOption localizedNotSure = notSureOption.localize(Locale.US);
+    LocalizedQuestionOption localizedMaybe = maybeOption.localize(Locale.US);
+
+    // Critical assertion: displayOrder should be used for order, not id
+    assertThat(localizedYes.order()).isEqualTo(0L); // displayOrder=0, not id=1
+    assertThat(localizedNo.order()).isEqualTo(1L); // displayOrder=1, not id=0
+    assertThat(localizedNotSure.order()).isEqualTo(2L); // displayOrder=2, same as id=2
+    assertThat(localizedMaybe.order()).isEqualTo(3L); // displayOrder=3, same as id=3
+  }
 }


### PR DESCRIPTION

### Description

The test validates the fix for bug https://github.com/civiform/civiform/issues/11591

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [X] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [X] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if the primary reviewer is not an admin and this PR includes functionality changes)
- [X] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

#### Database evolutions

Read the guidelines [here](https://github.com/civiform/civiform/wiki/Database#writing-database-evolutions)

- [ ] Assigned two reviewers
- [ ] Guarded against already existing resources using `IF NOT EXISTS` and `IF EXISTS`
- [ ] Downs created to undo changes in Ups
- [ ] Every comment in script should begin with -- and not # --- unless it denotes Ups or Downs. See [here](https://www.playframework.com/documentation/2.9.x/Evolutions) for details.
- [ ] Tested both the Downs and the Ups scripts manually (When testing, include all comments from the evolution in your test script to ensure any syntax errors in the comments are caught.)
- [ ] Data migrations aren't being done (please use a [Durable Job](https://github.com/civiform/civiform/wiki/Database#durable-jobs-for-data-updates) if doing a data migration)
- [ ] Update the model documentation in our [wiki](https://github.com/civiform/civiform/wiki/Database) if necessary

#### Durable jobs

Read the docs [here](https://github.com/civiform/civiform/wiki/Database#durable-jobs-for-data-updates)

- [ ] Assigned two reviewers
- [ ] Included a rollback plan and a job to undo the data changes if appropriate

#### User visible changes

- [ ] Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
  - [ ] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [ ] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Made equivalent changes in Thymeleaf for applicant-facing features and changes (or created an issue in the [Northstar epic](https://github.com/orgs/civiform/projects/1/views/94) to track that it's missing from Thymeleaf)
- [ ] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order
- [ ] Performed manual accessibility tests for any applicant-facing changes or any new admin-facing features. See [manual-accessibility-testing](https://github.com/civiform/civiform/wiki/Accessibility#manual-accessibility-testing)
- [ ] Manually tested with a right-to-left language

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/helper/feature-flags.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://github.com/civiform/civiform/wiki/Feature-Flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.


### Issue(s) this completes

Fixes #11591
