### PR TITLE
Skip urlchecker test on cloud

### DIFF
--- a/browser-test/src/admin/tools/url_checker.test.ts
+++ b/browser-test/src/admin/tools/url_checker.test.ts
@@ -1,9 +1,14 @@
 import {test, expect} from '../../support/civiform_fixtures'
-import {loginAsAdmin} from '../../support'
+import {isLocalDevEnvironment, loginAsAdmin} from '../../support'
 import {UrlCheckerPage} from '../../page/admin/tools/url_checker_page'
 
 test.describe('admin url checker page', () => {
   test('checks', async ({page}) => {
+    // Skip on cloud. Trying to find url options that
+    // work locally and in the different clouds has proved
+    // difficult.
+    test.skip(!isLocalDevEnvironment(), 'Skip on cloud')
+
     const urlCheckerPage = new UrlCheckerPage(page)
 
     await loginAsAdmin(page)


### PR DESCRIPTION
Skip the url checker tests on the cloud. There isn't a common url that I could find to test with that worked between localhost/azure/aws.