### PR TITLE
[Maps] Make `View More Details` links more descriptive

### DIFF
--- a/server/app/assets/javascripts/mapquestion/map.ts
+++ b/server/app/assets/javascripts/mapquestion/map.ts
@@ -167,6 +167,9 @@ const createPopupContent = (
         .namedItem(CF_POPUP_CONTENT_LOCATION_LINK)
         ?.cloneNode(true) as HTMLAnchorElement
       linkElement.href = detailsUrl
+      linkElement.ariaLabel = localizeString(getMessages().locationLinkTextSr, [
+        name,
+      ])
       popupContent.appendChild(linkElement)
     } catch {
       console.warn('Invalid URL format, skipping link:', detailsUrl)

--- a/server/app/assets/javascripts/mapquestion/map_util.ts
+++ b/server/app/assets/javascripts/mapquestion/map_util.ts
@@ -11,6 +11,7 @@ export interface MapSettings {
 
 export interface MapMessages {
   readonly locationsCount: string
+  readonly locationLinkTextSr: string
   readonly locationsSelectedCount: string
   readonly mapRegionAltText: string
   readonly goToPage: string

--- a/server/app/services/MessageKey.java
+++ b/server/app/services/MessageKey.java
@@ -332,6 +332,7 @@ public enum MessageKey {
   MAP_LOCATION_DETAILS_URL_HELP_TEXT("map.locationDetailsUrlHelpText"), // North Star only
   MAP_LOCATION_DETAILS_URL_LABEL("map.locationDetailsUrlLabel"), // North Star only
   MAP_LOCATION_LINK_TEXT("map.locationLinkText"), // North Star only
+  MAP_LOCATION_LINK_TEXT_SR("map.locationLinkTextSr"), // North Star only
   MAP_LOCATION_NAME_HELP_TEXT("map.locationNameHelpText"), // North Star only
   MAP_LOCATION_NAME_LABEL("map.locationNameLabel"), // North Star only
   MAP_LOCATIONS_COUNT("map.locationsCount"), // North Star only

--- a/server/app/views/questiontypes/MapQuestionFragment.html
+++ b/server/app/views/questiontypes/MapQuestionFragment.html
@@ -147,6 +147,7 @@
               th:href="${locationUrl}"
               class="usa-link usa-link--external cf-location-checkbox-link"
               target="_blank"
+              th:aria-label="#{map.locationLinkTextSr(${locationName})}"
               th:text="#{map.locationLinkText}"
             ></a>
             <div th:if="${mapQuestion.hasTagSetting()}">
@@ -362,6 +363,8 @@
       mapSelectedButtonText: /*[[#{map.mapSelectedButtonText}]]*/ 'Selected',
       mapSelectLocationButtonText:
         /*[[#{map.selectLocationButtonText}]]*/ 'Select location',
+      locationLinkTextSr:
+        /*[[#{map.locationLinkTextSr}]]*/ 'View more details for {0}',
     }
     window.app.data.iconUrls = {
       locationIcon: /*[[${locationIcon}]]*/ '',

--- a/server/conf/i18n/messages
+++ b/server/conf/i18n/messages
@@ -937,6 +937,8 @@ map.filterLegendText=Filters
 map.goToPage=Go to page {0} of map locations
 # Link text for location details URLs
 map.locationLinkText=View more details
+# The screen reader text on a link to view more details for a location. The variable represents the location name.
+map.locationLinkTextSr=View more details for {0}
 # Text showing the count of displayed locations, with placeholders for current count and total count
 map.locationsCount=Displaying {0} of {1} locations
 # Text showing the count of selected locations, with placeholders for current count and maximum allowed selections


### PR DESCRIPTION
### Description

Make the `View more details` links more descriptive to make them more accessible.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from `civiform/eng-admin` as FYI (if the primary reviewer is not an admin and this PR includes functionality changes)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [x] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [x] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [x] Noted in the PR description which, if any, code in this PR was generated by AI.

#### User visible changes

- [x] Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
  - [x] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [x] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [x] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [x] Made equivalent changes in Thymeleaf for applicant-facing features and changes (or created an issue in the [Northstar epic](https://github.com/orgs/civiform/projects/1/views/94) to track that it's missing from Thymeleaf)
- [x] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [x] Manually tested at 200% size
- [x] Manually evaluated tab order
- [x] Performed manual accessibility tests for any applicant-facing changes or any new admin-facing features. See [manual-accessibility-testing](https://github.com/civiform/civiform/wiki/Accessibility#manual-accessibility-testing)
- [x] Manually tested with a right-to-left language

### Instructions for manual testing

1. Set map_question_enabled=true in application.dev.conf
2. Create a map question (https://earlylearning.powerappsportals.us/provider-list-ccap/)
4. Add the map question to a program
5. Use voiceover to confirm that the links now read out "View more details for..."

### Issue(s) this completes

Fixes #11628; 
