### PR TITLE
show error for missing geojson on applicant side

### DIFF
--- a/server/app/views/applicant/NorthStarApplicantProgramBlockEditView.java
+++ b/server/app/views/applicant/NorthStarApplicantProgramBlockEditView.java
@@ -280,7 +280,10 @@ public final class NorthStarApplicantProgramBlockEditView extends NorthStarBaseV
                                   params.block().hasErrors(),
                                   ordinalErrorCount.get()));
                   if (question.getType().equals(QuestionType.MAP)) {
-                    paramsBuilder.setGeoJson(getQuestionGeoJsonData(question));
+                    Optional<FeatureCollection> geoJsonData = getQuestionGeoJsonData(question);
+                    if (!geoJsonData.isEmpty()) {
+                      paramsBuilder.setGeoJson(geoJsonData.get());
+                    }
                   }
 
                   if (params.block().isFileUpload()) {
@@ -295,7 +298,7 @@ public final class NorthStarApplicantProgramBlockEditView extends NorthStarBaseV
                 }));
   }
 
-  private FeatureCollection getQuestionGeoJsonData(ApplicantQuestion question) {
+  private Optional<FeatureCollection> getQuestionGeoJsonData(ApplicantQuestion question) {
     String geoJsonEndpoint =
         ((MapValidationPredicates) question.getQuestionDefinition().getValidationPredicates())
             .geoJsonEndpoint();
@@ -307,11 +310,7 @@ public final class NorthStarApplicantProgramBlockEditView extends NorthStarBaseV
             .join();
 
     if (maybeExistingGeoJsonDataRow.isEmpty()) {
-      // TODO(#11078): Failure state for missing GeoJSON data
-      throw new IllegalStateException(
-          String.format(
-              "No GeoJSON data found for %s question.",
-              question.getQuestionDefinition().getName()));
+      return Optional.empty();
     }
 
     FeatureCollection geoJson = maybeExistingGeoJsonDataRow.get().getGeoJson();
@@ -332,7 +331,7 @@ public final class NorthStarApplicantProgramBlockEditView extends NorthStarBaseV
                 })
             .collect(Collectors.toList());
 
-    return new FeatureCollection(geoJson.type(), geoJsonWithUpdatedProperties);
+    return Optional.of(new FeatureCollection(geoJson.type(), geoJsonWithUpdatedProperties));
   }
 
   private String getGoBackToAdminUrl(ApplicationBaseViewParams params) {

--- a/server/app/views/questiontypes/MapQuestionFragment.html
+++ b/server/app/views/questiontypes/MapQuestionFragment.html
@@ -13,22 +13,10 @@
   th:classappend="${hasGroupErrors ? 'cf-question-field-with-error' : ''}"
   data-testid="questionRoot"
 >
-  <!--/* Title and Help Text */-->
-  <div
-    th:replace="~{questiontypes/QuestionBaseFragment :: titleAndHelpTextMultipleInput(${question}, ${questionId})}"
-  ></div>
-
-  <!--/* Display errors */-->
-  <div
-    th:replace="~{questiontypes/QuestionBaseFragment :: validationErrors(${mapQuestion.getValidationErrors().get(question.getContextualizedPath())}, ${questionRendererParams}, ${questionId})}"
-  ></div>
-
-  <div class="padding-bottom-2">
-    <h3 class="font-family-serif" th:text="#{map.availableLocations}"></h3>
+  <div th:if="${questionRendererParams.geoJson().isPresent()}">
+    <!--/* Title and Help Text */-->
     <div
-      th:if="${mapQuestion.getQuestionDefinition().getMapValidationPredicates().maxLocationSelections().isPresent()}"
-      class="text-gray-50"
-      th:text="#{map.selectLocations(${mapQuestion.getQuestionDefinition().getMapValidationPredicates().maxLocationSelections().getAsInt()})}"
+      th:replace="~{questiontypes/QuestionBaseFragment :: titleAndHelpTextMultipleInput(${question}, ${questionId})}"
     ></div>
   </div>
   <!-- Filters -->
@@ -66,32 +54,17 @@
       </div>
     </fieldset>
 
-    <!-- Apply filters buttons -->
-    <div class="margin-bottom-2">
-      <button
-        type="button"
-        class="usa-button margin-top-1 cf-apply-filters-button"
-        th:data-map-id="${mapId}"
-        th:text="#{map.applyFiltersButtonText}"
-      ></button>
-      <button
-        type="button"
-        class="usa-button usa-button--outline cf-reset-filters-button"
-        th:data-map-id="${mapId}"
-        th:text="#{map.resetFiltersButtonText}"
-      ></button>
-    </div>
-  </div>
-
-  <div class="grid-row grid-gap padding-1">
+    <!--/* Display errors */-->
     <div
-      class="grid-col-12 desktop:grid-col-6 margin-bottom-3 desktop:margin-bottom-0"
-    >
+      th:replace="~{questiontypes/QuestionBaseFragment :: validationErrors(${mapQuestion.getValidationErrors().get(question.getContextualizedPath())}, ${questionRendererParams}, ${questionId})}"
+    ></div>
+
+    <div class="padding-bottom-2">
+      <h3 class="font-family-serif" th:text="#{map.availableLocations}"></h3>
       <div
-        th:with="totalLocations=${questionRendererParams.geoJson().isPresent() ? questionRendererParams.geoJson().get().features().size() : 0}"
-        class="text-ink margin-bottom-1 cf-location-count"
-        th:data-map-id="${mapId}"
-        th:text="#{map.locationsCount(${totalLocations}, ${totalLocations})}"
+        th:if="${mapQuestion.getQuestionDefinition().getMapValidationPredicates().maxLocationSelections().isPresent()}"
+        class="text-gray-50"
+        th:text="#{map.selectLocations(${mapQuestion.getQuestionDefinition().getMapValidationPredicates().maxLocationSelections().getAsInt()})}"
       ></div>
       <!--/* Hidden input that we have checked to allow clearing data from a map question */-->
       <input
@@ -254,38 +227,7 @@
         </li>
       </template>
     </div>
-
-    <!-- Map container -->
-    <div class="grid-col-12 desktop:grid-col-6">
-      <!-- TODO(#11150): Add map question preview functionality -->
-      <div
-        th:id="${mapId}"
-        class="cf-map-container width-full height-full maxh-viewport bg-base-lighter"
-        data-testid="map-container"
-      >
-        <div th:if="${isPreview}" class="square-mobile"></div>
-      </div>
-    </div>
-  </div>
-  <!-- Selected locations section -->
-  <div class="margin-top-3">
-    <h3
-      class="font-family-serif"
-      th:text="#{map.selectedLocationsHeading}"
-    ></h3>
-    <p
-      th:if="${mapQuestion.getQuestionDefinition().getMapValidationPredicates().maxLocationSelections().isPresent()}"
-      th:with="totalLocationsSelected=0,
-            maxLocationSelectionsAllowed=${mapQuestion.getQuestionDefinition().getMapValidationPredicates().maxLocationSelections().getAsInt()}"
-      th:text="#{map.locationsSelectedCount(${totalLocationsSelected}, ${maxLocationSelectionsAllowed})}"
-      class="cf-selected-locations-message"
-      th:data-map-id="${mapId}"
-    ></p>
-    <p
-      th:if="${isPreview}"
-      th:text="#{map.noSelectionsMessage}"
-      class="cf-selected-locations-message"
-    ></p>
+    <!-- Filters -->
     <div
       th:if="${mapQuestion.hasTagSetting()}"
       class="usa-alert usa-alert--warning cf-map-question-tag-alert cf-map-question-tag-alert-hidden"
@@ -301,7 +243,341 @@
       data-testid="selected-locations-list"
       th:data-map-id="${mapId}"
     >
-      <!-- Selected locations will be dynamically populated here -->
+      <fieldset class="grid-row grid-gap cf-map-question-filter-fieldset">
+        <legend
+          class="usa-legend text-bold"
+          th:text="#{map.filterLegendText}"
+        ></legend>
+        <div
+          th:each="filter, i : ${mapQuestion.getFilters()}"
+          class="grid-col flex-align-self-end cf-map-question-filter"
+        >
+          <label
+            class="usa-label margin-top-1"
+            th:for="'filter' + ${i.index + 1} + '-' + ${mapId}"
+            th:utext="${filter.formattedSettingDisplayName(ariaLabelForNewTabs)}"
+          ></label>
+          <select
+            class="usa-select"
+            th:data-filter-key="${filter.settingValue()}"
+            th:id="'filter' + ${i.index + 1} + '-' + ${mapId}"
+            th:data-map-id="${mapId}"
+          >
+            <option value th:text="#{map.selectOptionPlaceholderText}"></option>
+            <option
+              th:each="option : ${questionRendererParams.geoJson().isPresent() ? questionRendererParams.geoJson().get().getPossibleValuesForKey(filter.settingValue()) : {}}"
+              th:value="${option}"
+              th:text="${option == 'true' ? 'Yes' : (option == 'false' ? 'No' : option)}"
+            ></option>
+          </select>
+        </div>
+      </fieldset>
+
+      <!-- Apply filters buttons -->
+      <div class="margin-bottom-2">
+        <button
+          type="button"
+          class="usa-button margin-top-1 cf-apply-filters-button"
+          th:data-map-id="${mapId}"
+          th:text="#{map.applyFiltersButtonText}"
+        ></button>
+        <button
+          type="button"
+          class="usa-button usa-button--outline cf-reset-filters-button"
+          th:data-map-id="${mapId}"
+          th:text="#{map.resetFiltersButtonText}"
+        ></button>
+      </div>
+    </div>
+
+    <div class="grid-row grid-gap padding-1">
+      <div
+        class="grid-col-12 desktop:grid-col-6 margin-bottom-3 desktop:margin-bottom-0"
+      >
+        <div
+          th:with="totalLocations=${questionRendererParams.geoJson().isPresent() ? questionRendererParams.geoJson().get().features().size() : 0}"
+          class="text-ink margin-bottom-1 cf-location-count"
+          th:data-map-id="${mapId}"
+          th:text="#{map.locationsCount(${totalLocations}, ${totalLocations})}"
+        ></div>
+        <!--/* Hidden input that we have checked to allow clearing data from a map question */-->
+        <input
+          type="checkbox"
+          class="hidden"
+          value=""
+          th:name="${mapQuestion.getSelectionPathAsArray()}"
+          checked
+        />
+        <div
+          th:if="${questionRendererParams.geoJson().isPresent()}"
+          class="cf-locations-list"
+          th:data-map-id="${mapId}"
+          role="group"
+          aria-label="Location selection"
+        >
+          <div
+            th:each="feature, iterator : ${questionRendererParams.geoJson().get().features()}"
+            th:with="locationId='location-' + ${iterator.index},
+                        locationName=${feature.properties().get(mapQuestion.getNameValue())},
+                        locationAddress=${feature.properties().get(mapQuestion.getAddressValue())},
+                        locationUrl=${feature.properties().get(mapQuestion.getDetailsUrlValue())},
+                        featureId=${feature.id}"
+            th:data-feature-id="${featureId}"
+            class="usa-checkbox cf-location-checkbox border-2px border-gray-30 radius-md margin-y-1 padding-x-1 padding-bottom-1"
+          >
+            <input
+              class="usa-checkbox__input cf-location-checkbox-input"
+              th:id="${locationId}"
+              th:value="${mapQuestion.createLocationJson(featureId, locationName)}"
+              th:name="${mapQuestion.getSelectionPathAsArray()}"
+              th:checked="${mapQuestion.locationIsSelected(featureId)}"
+              th:data-map-id="${mapId}"
+              th:data-feature-id="${featureId}"
+              type="checkbox"
+            />
+            <label
+              class="usa-checkbox__label cf-location-checkbox-label"
+              th:for="${locationId}"
+            >
+              <div
+                class="text-bold cf-location-checkbox-name"
+                th:text="${locationName}"
+              ></div>
+              <div
+                class="cf-location-checkbox-address"
+                th:if="${locationAddress}"
+                th:text="${locationAddress}"
+              ></div>
+              <a
+                th:if="${locationUrl && locationUrl != ''}"
+                th:href="${locationUrl}"
+                class="usa-link usa-link--external cf-location-checkbox-link"
+                target="_blank"
+                th:text="#{map.locationLinkText}"
+              ></a>
+            </label>
+          </div>
+          <div
+            th:if="${!questionRendererParams.geoJson().isPresent()}"
+            class="square-mobile"
+          ></div>
+        </div>
+        <nav
+          th:if="${questionRendererParams.geoJson().isPresent()}"
+          tabindex="-1"
+          th:aria-label="#{map.ariaLabelPaginationList}"
+          class="usa-pagination flex-justify-end cf-pagination"
+          th:data-map-id="${mapId}"
+        >
+          <div
+            aria-live="polite"
+            aria-atomic="true"
+            class="sr-only cf-pagination-status"
+            th:data-map-id="${mapId}"
+          ></div>
+          <ul class="usa-pagination__list cf-pagination-list">
+            <li
+              class="usa-pagination__item usa-pagination__arrow cf-map-question-pagination-previous-button"
+            >
+              <button
+                type="button"
+                class="usa-button--unstyled usa-pagination__link usa-pagination__previous-page"
+                name="cf-map-question-pagination-previous-button"
+                th:aria-label="#{map.ariaLabelPreviousPage}"
+                th:data-map-id="${mapId}"
+              >
+                <cf:icon
+                  type="icon-navigate_before"
+                  class="usa-icon"
+                  name="cf-map-question-pagination-previous-button"
+                  th:data-map-id="${mapId}"
+                />
+                <span
+                  class="usa-pagination__link-text"
+                  name="cf-map-question-pagination-previous-button"
+                  th:data-map-id="${mapId}"
+                  th:text="#{button.previousScreen}"
+                ></span>
+              </button>
+            </li>
+            <!--/* Page buttons will be dynamically populated here from templates below */-->
+            <li
+              class="usa-pagination__item usa-pagination__arrow cf-map-question-pagination-next-button"
+            >
+              <button
+                type="button"
+                class="usa-button--unstyled usa-pagination__link usa-pagination__next-page"
+                name="cf-map-question-pagination-next-button"
+                th:aria-label="#{map.ariaLabelNextPage}"
+                th:data-map-id="${mapId}"
+              >
+                <span
+                  class="usa-pagination__link-text"
+                  name="cf-map-question-pagination-next-button"
+                  th:data-map-id="${mapId}"
+                  th:text="#{button.nextPage}"
+                ></span>
+                <cf:icon
+                  type="icon-navigate_next"
+                  class="usa-icon"
+                  name="cf-map-question-pagination-next-button"
+                  th:data-map-id="${mapId}"
+                />
+              </button>
+            </li>
+          </ul>
+        </nav>
+
+        <!--/* Templates for pagination button elements */-->
+        <template
+          class="cf-pagination-button-template"
+          th:data-map-id="${mapId}"
+        >
+          <li
+            class="usa-pagination__item usa-pagination__page-no cf-pagination-item"
+          >
+            <button
+              type="button"
+              class="usa-button--unstyled usa-pagination__button cf-map-question-pagination-button"
+              name="cf-map-question-pagination-button"
+            ></button>
+          </li>
+        </template>
+        <template
+          class="cf-pagination-overflow-template"
+          th:data-map-id="${mapId}"
+        >
+          <li
+            class="usa-pagination__item usa-pagination__overflow cf-pagination-item"
+            aria-label="ellipsis indicating non-visible pages"
+          >
+            <span>…</span>
+          </li>
+        </template>
+      </div>
+
+      <!-- Map container -->
+      <div class="grid-col-12 desktop:grid-col-6">
+        <!-- TODO(#11150): Add map question preview functionality -->
+        <div
+          th:id="${mapId}"
+          class="cf-map-container width-full height-full maxh-viewport bg-base-lighter"
+          data-testid="map-container"
+        >
+          <div th:if="${isPreview}" class="square-mobile"></div>
+        </div>
+      </div>
+    </div>
+    <!-- Selected locations section -->
+    <div class="margin-top-3">
+      <h3
+        class="font-family-serif"
+        th:text="#{map.selectedLocationsHeading}"
+      ></h3>
+      <p
+        th:if="${mapQuestion.getQuestionDefinition().getMapValidationPredicates().maxLocationSelections().isPresent()}"
+        th:with="totalLocationsSelected=0,
+              maxLocationSelectionsAllowed=${mapQuestion.getQuestionDefinition().getMapValidationPredicates().maxLocationSelections().getAsInt()}"
+        th:text="#{map.locationsSelectedCount(${totalLocationsSelected}, ${maxLocationSelectionsAllowed})}"
+        class="cf-selected-locations-message"
+        th:data-map-id="${mapId}"
+      ></p>
+      <p
+        th:if="${isPreview}"
+        th:text="#{map.noSelectionsMessage}"
+        class="cf-selected-locations-message"
+      ></p>
+      <div
+        class="cf-selected-locations-container"
+        data-testid="selected-locations-list"
+        th:data-map-id="${mapId}"
+      >
+        <!-- Selected locations will be dynamically populated here -->
+      </div>
+    </div>
+    <!-- Template for when there are no selections -->
+    <template
+      class="text-base-dark cf-no-selections-message"
+      th:data-map-id="${mapId}"
+      th:text="#{map.noSelectionsMessage}"
+    ></template>
+    <!-- Hidden template for popups -->
+    <template class="cf-popup-content-template" th:data-map-id="${mapId}">
+      <div
+        id="cf-popup-content-location-name"
+        class="text-bold font-serif-sm padding-bottom-2"
+      ></div>
+      <div id="cf-popup-content-location-address" class="font-sans-sm"></div>
+      <a
+        id="cf-popup-content-location-link"
+        class="font-sans-sm usa-link usa-link--external"
+        target="_blank"
+        th:text="#{map.locationLinkText}"
+      ></a>
+      <button
+        type="button"
+        name="cf-select-location-button"
+        class="usa-button usa-button--secondary margin-top-1"
+        th:data-feature-id="${featureId}"
+        th:text="#{map.selectLocationButtonText}"
+      ></button>
+    </template>
+
+    <script
+      th:if="${questionRendererParams.geoJson().isPresent()}"
+      th:inline="javascript"
+      th:nonce="${cspNonce}"
+    >
+      window.app = window.app || {}
+      window.app.data = window.app.data || {}
+      window.app.data.maxLocationSelections =
+        /*[[${mapQuestion.getQuestionDefinition().getMapValidationPredicates().maxLocationSelections().isPresent() ? mapQuestion.getQuestionDefinition().getMapValidationPredicates().maxLocationSelections().getAsInt() : null}]]*/ null
+      window.app.data.messages = {
+        locationsCount:
+          /*[[#{map.locationsCount}]]*/ 'Displaying {0} of {1} locations',
+        locationsSelectedCount:
+          /*[[#{map.locationsSelectedCount}]]*/ 'You have selected {0} of {1} locations',
+        mapRegionAltText:
+          /*[[#{map.mapRegionAltText}]]*/ 'Interactive map displaying locations',
+        goToPage: /*[[#{map.goToPage}]]*/ 'Go to page {0}',
+        paginationStatus: /*[[#{map.paginationStatus}]]*/ 'Page has changed.',
+        mapSelectedButtonText: /*[[#{map.mapSelectedButtonText}]]*/ 'Selected',
+        mapSelectLocationButtonText:
+          /*[[#{map.selectLocationButtonText}]]*/ 'Select location',
+      }
+      window.app.data.iconUrls = {
+        locationIcon: /*[[${locationIcon}]]*/ '',
+        selectedLocationIcon: /*[[${selectedLocationIcon}]]*/ '',
+      }
+
+      window.app.data.maps = window.app.data.maps || {}
+
+      id = /*[[${mapId}]]*/ 'id'
+      window.app.data.maps[id] = {
+        geoJson: /*[[${questionRendererParams.geoJson().get()}]]*/ {},
+        settings: {
+          nameGeoJsonKey: /*[[${mapQuestion.getNameValue()}]]*/ '',
+          addressGeoJsonKey: /*[[${mapQuestion.getAddressValue()}]]*/ '',
+          detailsUrlGeoJsonKey: /*[[${mapQuestion.getDetailsUrlValue()}]]*/ '',
+        },
+      }
+    </script>
+  </div>
+  <div th:unless="${questionRendererParams.geoJson().isPresent()}">
+    <div class="usa-alert usa-alert--warning">
+      <div class="usa-alert__body">
+        <h4 class="usa-alert__heading"></h4>
+        <p class="usa-alert__text">
+          We're sorry we are unable to display this question at this time.
+          Please try returning to this application at a later time.
+        </p>
+        <p>
+          In the meantime, return to the
+          <a class="usa-link" href="javascript:void(0);">homepage</a>
+          or <a class="usa-link" href="javascript:void(0);">contact us</a>
+          and we'll point you in the right direction.
+        </p>
+      </div>
     </div>
   </div>
   <!-- Template for when there are no selections -->


### PR DESCRIPTION
### Description

Shows an error and hides the map when there is an error getting the geojson on the applicant side.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [ ] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if the primary reviewer is not an admin and this PR includes functionality changes)
- [ ] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

#### Database evolutions

Read the guidelines [here](https://github.com/civiform/civiform/wiki/Database#writing-database-evolutions)

- [ ] Assigned two reviewers
- [ ] Guarded against already existing resources using `IF NOT EXISTS` and `IF EXISTS`
- [ ] Downs created to undo changes in Ups
- [ ] Every comment in script should begin with -- and not # --- unless it denotes Ups or Downs. See [here](https://www.playframework.com/documentation/2.9.x/Evolutions) for details.
- [ ] Tested both the Downs and the Ups scripts manually (When testing, include all comments from the evolution in your test script to ensure any syntax errors in the comments are caught.)
- [ ] Data migrations aren't being done (please use a [Durable Job](https://github.com/civiform/civiform/wiki/Database#durable-jobs-for-data-updates) if doing a data migration)
- [ ] Update the model documentation in our [wiki](https://github.com/civiform/civiform/wiki/Database) if necessary

#### Durable jobs

Read the docs [here](https://github.com/civiform/civiform/wiki/Database#durable-jobs-for-data-updates)

- [ ] Assigned two reviewers
- [ ] Included a rollback plan and a job to undo the data changes if appropriate

#### User visible changes

- [ ] Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
  - [ ] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [ ] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Made equivalent changes in Thymeleaf for applicant-facing features and changes (or created an issue in the [Northstar epic](https://github.com/orgs/civiform/projects/1/views/94) to track that it's missing from Thymeleaf)
- [ ] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order
- [ ] Performed manual accessibility tests for any applicant-facing changes or any new admin-facing features. See [manual-accessibility-testing](https://github.com/civiform/civiform/wiki/Accessibility#manual-accessibility-testing)
- [ ] Manually tested with a right-to-left language

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/helper/feature-flags.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://github.com/civiform/civiform/wiki/Feature-Flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Instructions for manual testing

If instructions are needed for manual testing by reviewers, include them here.

### Issue(s) this completes

Fixes #<issue_number>; Fixes #<issue_number>...
