### PR TITLE
Use support email address for server errors

### DIFF
--- a/browser-test/src/error_pages.test.ts
+++ b/browser-test/src/error_pages.test.ts
@@ -58,37 +58,13 @@ test.describe(
         ).toBeAttached()
       })
 
-      await test.step('Updating the support email address updates the error page when IT email is unset', async () => {
+      await test.step('Updating the support email address updates the error page', async () => {
         await loginAsAdmin(page)
         await adminSettings.gotoAdminSettings()
         await adminSettings.setStringSetting(
           'SUPPORT_EMAIL_ADDRESS',
           'support@email.com',
         )
-        await adminSettings.saveChanges()
-        await page.goto('/error?exceptionId=1')
-        await expect(
-          page.getByRole('link', {
-            name: 'support@email.com',
-          }),
-        ).toBeAttached()
-      })
-
-      await test.step('Updating the IT email address updates the error page when both are set', async () => {
-        await adminSettings.gotoAdminSettings()
-        await adminSettings.setStringSetting('IT_EMAIL_ADDRESS', 'it@email.com')
-        await adminSettings.saveChanges()
-        await page.goto('/error?exceptionId=1')
-        await expect(
-          page.getByRole('link', {
-            name: 'it@email.com',
-          }),
-        ).toBeAttached()
-      })
-
-      await test.step('Removing the IT email address updates the error page with fallback to support', async () => {
-        await adminSettings.gotoAdminSettings()
-        await adminSettings.setStringSetting('IT_EMAIL_ADDRESS', '')
         await adminSettings.saveChanges()
         await page.goto('/error?exceptionId=1')
         await expect(

--- a/server/app/views/errors/InternalServerError.java
+++ b/server/app/views/errors/InternalServerError.java
@@ -65,7 +65,8 @@ public final class InternalServerError extends BaseHtmlView {
 
   private UnescapedText buildAdditionalInfo(
       Http.RequestHeader requestHeader, Messages messages, String exceptionId) {
-    String emailAddress = getEmailAddress(requestHeader);
+    // Support email address is required and should never be blank
+    String emailAddress = settingsManifest.getSupportEmailAddress(requestHeader).orElse("");
     String emailLinkHref =
         String.format("mailto:%s?body=[CiviForm Error ID: %s]", emailAddress, exceptionId);
     ATag emailAction =
@@ -81,12 +82,5 @@ public final class InternalServerError extends BaseHtmlView {
     String sanitizedDescription =
         TextFormatter.sanitizeHtml(String.format(descriptionText, emailAction.render()));
     return rawHtml(sanitizedDescription);
-  }
-
-  /** Get either the IT email address or the support email address */
-  private String getEmailAddress(Http.RequestHeader requestHeader) {
-    Optional<String> supportEmail =
-        settingsManifest.getSupportEmailAddress(requestHeader).filter(email -> !email.isBlank());
-    return supportEmail.or(() -> settingsManifest.getItEmailAddress(requestHeader)).orElse("");
   }
 }


### PR DESCRIPTION
### Description

Reverses the order the email address are checked so that IT email address is used as a backup for Support email address.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if the primary reviewer is not an admin and this PR includes functionality changes)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

### Instructions for manual testing

1. Run the app and add different values for Support and IT email addresses
2. Go to `/error?exceptionId=1` to see the error page
3. Confirm that support email address is used on the error page

### Issue(s) this completes

Fixes #11729