### PR TITLE
Fix saving with no categories

### DIFF
--- a/server/app/models/ProgramModel.java
+++ b/server/app/models/ProgramModel.java
@@ -192,7 +192,11 @@ public class ProgramModel extends BaseModel {
     this.programType = definition.programType();
     this.eligibilityIsGating = definition.eligibilityIsGating();
     this.acls = definition.acls();
+
+    // Ebeans needs to manage the collection so add categories instead of
+    // creating a new array instance
     this.categories.addAll(definition.categories());
+
     this.localizedSummaryImageDescription =
         definition.localizedSummaryImageDescription().orElse(null);
     this.summaryImageFileKey = definition.summaryImageFileKey().orElse(null);
@@ -244,7 +248,11 @@ public class ProgramModel extends BaseModel {
     this.programType = programType;
     this.eligibilityIsGating = eligibilityIsGating;
     this.acls = programAcls;
+
+    // Ebeans needs to manage the collection so add categories instead of
+    // creating a new array instance
     this.categories.addAll(categories);
+
     this.applicationSteps = applicationSteps;
     this.bridgeDefinitions = ImmutableMap.of();
   }
@@ -270,11 +278,11 @@ public class ProgramModel extends BaseModel {
         programDefinition.localizedSummaryImageDescription().orElse(null);
     summaryImageFileKey = programDefinition.summaryImageFileKey().orElse(null);
 
-    // Ebean requires that we use its data structure, so clear the existing values then set the new
-    // values.
-    categories.clear();
-    categories.addAll(programDefinition.categories());
-
+    // Ebeans needs to manage the collection. Behavior differs in the @PreUpdate
+    // from the constructors. Here we do create a new list instead of clearing
+    // and adding them so Ebeans can correctly see state changes to the entity.
+    // Yes, it's very confusing and poorly documented.
+    categories = new ArrayList<>(programDefinition.categories());
     applicationSteps = programDefinition.applicationSteps();
     bridgeDefinitions = programDefinition.bridgeDefinitions();
 

--- a/server/test/repository/ProgramRepositoryTest.java
+++ b/server/test/repository/ProgramRepositoryTest.java
@@ -1141,4 +1141,52 @@ public class ProgramRepositoryTest extends ResetPostgres {
     assertThat(existsOne).isTrue();
     assertThat(existsTwo).isFalse();
   }
+
+  @Test
+  public void canAddAndRemoveCategories() {
+    ProgramModel insertedProgramModel = resourceCreator.insertDraftProgram("program-name-1");
+
+    var categories = resourceCreator.insertCategoriesFromParser();
+
+    // save with many categories
+    var updatedProgramModel =
+        repo.updateProgramSync(
+            new ProgramModel(
+                insertedProgramModel.getProgramDefinition().toBuilder()
+                    .setCategories(categories)
+                    .build()));
+
+    assertThat(updatedProgramModel.getCategories().size()).isEqualTo(categories.size());
+
+    // save with fewer categories
+    updatedProgramModel =
+        repo.updateProgramSync(
+            new ProgramModel(
+                insertedProgramModel.getProgramDefinition().toBuilder()
+                    .setCategories(
+                        categories.stream().limit(4).collect(ImmutableList.toImmutableList()))
+                    .build()));
+
+    assertThat(updatedProgramModel.getCategories().size()).isEqualTo(4);
+
+    // save with more categories
+    updatedProgramModel =
+        repo.updateProgramSync(
+            new ProgramModel(
+                insertedProgramModel.getProgramDefinition().toBuilder()
+                    .setCategories(categories)
+                    .build()));
+
+    assertThat(updatedProgramModel.getCategories().size()).isEqualTo(categories.size());
+
+    // Save with no categories
+    updatedProgramModel =
+        repo.updateProgramSync(
+            new ProgramModel(
+                updatedProgramModel.getProgramDefinition().toBuilder()
+                    .setCategories(ImmutableList.of())
+                    .build()));
+
+    assertThat(updatedProgramModel.getCategories().size()).isEqualTo(0);
+  }
 }


### PR DESCRIPTION
### Description

The recent update for ebeans had a fix to deal with changes to the ebeans enhancement. When saving with a category it works fine, but saving with no categories it doesn't persist.

Ebeans update an issue with the ebeans enrichment tool. I fixed it a few days ago based on what little notes on the proper way to do it I could find in PR/Issue comments because the compiler error link gave a two sentence note with little else. The enrichment how doesn't allow you to do new ArrayList in the constructors because it breaks ebeans from managing/tracking state changes, instead you addAll from one collection to the internal variable.

The @PreUpdate step needed to change too based on what I found and all the tests passed. Turns out in the @PreUpdate you do need to do new ArrayList here (not just reassigning or addall). We just didn't have any tests that removed all the categories.



### Issue(s) this completes

Fixes #11724
