### PR TITLE
Enable settings cache

### DIFF
--- a/server/app/controllers/dev/DevToolsController.java
+++ b/server/app/controllers/dev/DevToolsController.java
@@ -56,6 +56,7 @@ public class DevToolsController extends Controller {
   private final AsyncCacheApi programCache;
   private final AsyncCacheApi programDefCache;
   private final AsyncCacheApi versionsByProgramCache;
+  private final AsyncCacheApi settingsCache;
   private final Clock clock;
   private final TransactionManager transactionManager = new TransactionManager();
   private final FormFactory formFactory;
@@ -74,7 +75,8 @@ public class DevToolsController extends Controller {
       @NamedCache("version-programs") AsyncCacheApi programsByVersionCache,
       @NamedCache("program") AsyncCacheApi programCache,
       @NamedCache("full-program-definition") AsyncCacheApi programDefCache,
-      @NamedCache("program-versions") AsyncCacheApi versionsByProgramCache) {
+      @NamedCache("program-versions") AsyncCacheApi versionsByProgramCache,
+      @NamedCache("civiform-settings") AsyncCacheApi settingsCache) {
     this.devDatabaseSeedTask = checkNotNull(devDatabaseSeedTask);
     this.view = checkNotNull(view);
     this.database = DB.getDefault();
@@ -87,6 +89,7 @@ public class DevToolsController extends Controller {
     this.programCache = checkNotNull(programCache);
     this.programDefCache = checkNotNull(programDefCache);
     this.versionsByProgramCache = checkNotNull(versionsByProgramCache);
+    this.settingsCache = checkNotNull(settingsCache);
     this.clock = checkNotNull(clock);
     this.formFactory = checkNotNull(formFactory);
   }
@@ -256,12 +259,18 @@ public class DevToolsController extends Controller {
       programsByVersionCache.removeAll().toCompletableFuture().join();
       questionsByVersionCache.removeAll().toCompletableFuture().join();
     }
+
     if (settingsManifest.getProgramCacheEnabled()) {
       programCache.removeAll().toCompletableFuture().join();
       versionsByProgramCache.removeAll().toCompletableFuture().join();
     }
+
     if (settingsManifest.getQuestionCacheEnabled()) {
       programDefCache.removeAll().toCompletableFuture().join();
+    }
+
+    if (settingsManifest.getSettingsCacheEnabled()) {
+      settingsCache.removeAll().toCompletableFuture().join();
     }
   }
 

--- a/server/conf/application.dev.conf
+++ b/server/conf/application.dev.conf
@@ -70,6 +70,10 @@ api_keys_ban_global_subnet = false
 # Allow dev sessions to last 5 days
 maximum_session_duration_minutes = 7200
 
+# Caching
+settings_cache_enabled = true
+
+# Feature flags
 api_generated_docs_enabled = true
 program_filtering_enabled = true
 name_suffix_dropdown_enabled = true

--- a/server/conf/helper/feature-flags.conf
+++ b/server/conf/helper/feature-flags.conf
@@ -28,6 +28,8 @@ program_cache_enabled = true
 program_cache_enabled = ${?PROGRAM_CACHE_ENABLED}
 question_cache_enabled = true
 question_cache_enabled = ${?QUESTION_CACHE_ENABLED}
+settings_cache_enabled = false
+settings_cache_enabled = ${?SETTINGS_CACHE_ENABLED}
 
 # OIDC logout
 admin_oidc_enhanced_logout_enabled = false
@@ -82,10 +84,6 @@ date_validation_enabled = ${?DATE_VALIDATION_ENABLED}
 # Allow admins to add a map question to their programs
 map_question_enabled = false
 map_question_enabled = ${?MAP_QUESTION_ENABLED}
-
-# Enables reading settings from the cache instead of directly from the database
-settings_cache_enabled = false
-settings_cache_enabled = ${?SETTINGS_CACHE_ENABLED}
 
 # Enables translation management improvement phase one
 translation_management_improvement_enabled = false

--- a/server/test/services/settings/SettingsServiceTest.java
+++ b/server/test/services/settings/SettingsServiceTest.java
@@ -179,6 +179,7 @@ public class SettingsServiceTest extends ResetPostgres {
 
   @Test
   public void updateSettings_newSettingsAreTheSame_doesNotinsertANewSettingsGroup() {
+    createTestSettings();
     var initialSettings = settingsService.loadSettings().toCompletableFuture().join().get();
 
     assertThat(settingsService.updateSettings(initialSettings, testProfile).updated()).isFalse();


### PR DESCRIPTION
- Enables the settings cache in dev/test
- Fixes race condition in the settings unit test
- Adds dev ability to clear settings cache when the other caches are cleared.