### PR TITLE
[Expanded form logic] Add populated value for number-entry question types

### DIFF
--- a/server/app/views/admin/programs/predicates/EditConditionFragment.html
+++ b/server/app/views/admin/programs/predicates/EditConditionFragment.html
@@ -1,15 +1,15 @@
 <th:block
-  th:fragment="editCondition(conditionId, hxEditConditionEndpoint, hxEditSubconditionEndpoint, questionType, operatorNodeTypeList, questionOptions, scalarOptions, operatorOptions, valueOptions)"
+  th:fragment="editCondition(model)"
 >
   <div
     class="usa-card margin-bottom-2 border border-base-lighter radius-md width-mobile-lg"
-    th:data-testid="|condition-${conditionId}|"
+    th:data-testid="|condition-${model.conditionId()}|"
   >
     <div class="usa-card__header">
       <div class="display-flex flex-justify flex-align-center">
         <div
           class="usa-card__heading font-heading-sm"
-          th:text="|Condition ${conditionId}|"
+          th:text="|Condition ${model.conditionId()}|"
         ></div>
         <button
           type="button"
@@ -38,11 +38,11 @@
         Condition is true if
         <select
           class="usa-select width-9 display-inline-block font-body-xs margin-x-1"
-          th:name="|condition-${conditionId}-nodeType|"
+          th:name="|condition-${model.conditionId()}-nodeType|"
           autofocus
         >
           <option
-            th:each="nodeType : ${operatorNodeTypeList}"
+            th:each="nodeType : ${model.operatorNodeTypes()}"
             th:text="${nodeType.toDisplayString()}"
             th:value="${nodeType.name()}"
           ></option>
@@ -50,7 +50,7 @@
         of the following are true:
       </div>
       <div
-        th:replace="~{admin/programs/predicates/EditSubconditionFragment :: editSubcondition(${conditionId}, 1, ${questionType}, ${questionOptions}, ${scalarOptions}, ${operatorOptions}, ${valueOptions}, ${hxEditSubconditionEndpoint}, false)}"
+        th:replace="~{admin/programs/predicates/EditSubconditionFragment :: editSubcondition(${model.emptySubconditionViewModel()})}"
       ></div>
     </div>
 
@@ -60,6 +60,6 @@
     </div>
   </div>
   <div
-    th:replace="~{admin/programs/predicates/AddConditionFragment :: addCondition(${conditionId + 1}, ${hxEditConditionEndpoint})}"
+    th:replace="~{admin/programs/predicates/AddConditionFragment :: addCondition(${model.conditionId() + 1}, ${model.hxEditConditionEndpoint()})}"
   ></div>
 </th:block>

--- a/server/app/views/admin/programs/predicates/EditConditionPartial.html
+++ b/server/app/views/admin/programs/predicates/EditConditionPartial.html
@@ -1,5 +1,5 @@
 <!--/*@thymesVar id="model" type="views.admin.programs.predicates.EditConditionPartialViewModel"*/-->
 
 <div
-  th:replace="~{admin/programs/predicates/EditConditionFragment :: editCondition(${model.conditionId}, ${model.hxEditConditionEndpoint()}, ${model.hxEditSubconditionEndpoint()}, ${model.selectedQuestionType()}, ${model.operatorNodeTypes()}, ${model.questionOptions}, ${model.scalarOptions}, ${model.operatorOptions}, ${model.valueOptions})}"
+  th:replace="~{admin/programs/predicates/EditConditionFragment :: editCondition(${model})}"
 ></div>

--- a/server/app/views/admin/programs/predicates/EditConditionPartialViewModel.java
+++ b/server/app/views/admin/programs/predicates/EditConditionPartialViewModel.java
@@ -16,6 +16,7 @@ public record EditConditionPartialViewModel(
     PredicateUseCase predicateUseCase,
     long conditionId,
     Optional<String> selectedQuestionType,
+    Optional<String> selectedOperator,
     ImmutableList<OptionElement> questionOptions,
     ImmutableList<ScalarOptionElement> scalarOptions,
     ImmutableList<OptionElement> operatorOptions,
@@ -32,5 +33,21 @@ public record EditConditionPartialViewModel(
     return routes.AdminProgramBlockPredicatesController.hxEditSubcondition(
             programId, blockId, predicateUseCase.name())
         .url();
+  }
+
+  public EditSubconditionPartialViewModel emptySubconditionViewModel() {
+    return EditSubconditionPartialViewModel.builder()
+        .programId(programId)
+        .blockId(blockId)
+        .predicateUseCase(predicateUseCase)
+        .conditionId(conditionId)
+        .subconditionId(1L)
+        .selectedQuestionType(Optional.empty())
+        .selectedOperator(Optional.empty())
+        .questionOptions(questionOptions)
+        .scalarOptions(scalarOptions)
+        .operatorOptions(operatorOptions)
+        .valueOptions(valueOptions)
+        .build();
   }
 }

--- a/server/app/views/admin/programs/predicates/EditSubconditionFragment.html
+++ b/server/app/views/admin/programs/predicates/EditSubconditionFragment.html
@@ -1,5 +1,5 @@
 <th:block
-  th:fragment="editSubcondition(conditionId, subconditionId, questionType, questionOptions, scalarOptions, operatorOptions, valueOptions, hxEditSubconditionEndpoint, hasSelectedQuestion)"
+  th:fragment="editSubcondition(model)"
 >
   <div class="subcondition-container">
     <!-- Define input ids in the expected format: 
@@ -10,7 +10,7 @@
     -->
     <div
       class="border-left-05 border-base-lighter padding-left-3"
-      th:with="questionDropdownId=${'condition-' + conditionId + '-subcondition-' + subconditionId + '-question'}, scalarDropDownId=${'condition-' + conditionId + '-subcondition-' + subconditionId + '-scalar'},operatorDropdownId=${'condition-' + conditionId + '-subcondition-' + subconditionId + '-operator'},valueInputId=${'condition-' + conditionId + '-subcondition-' + subconditionId + '-value'}"
+      th:with="questionDropdownId=${'condition-' + model.conditionId + '-subcondition-' + model.subconditionId + '-question'}, scalarDropDownId=${'condition-' + model.conditionId + '-subcondition-' + model.subconditionId + '-scalar'},operatorDropdownId=${'condition-' + model.conditionId + '-subcondition-' + model.subconditionId + '-operator'},valueInputId=${'condition-' + model.conditionId + '-subcondition-' + model.subconditionId + '-value'}"
     >
       <div class="usa-form-group margin-top-2">
         <label class="usa-label" th:for="${questionDropdownId}"
@@ -22,13 +22,13 @@
           th:name="${questionDropdownId}"
           th:data-scalar-target-id="${scalarDropDownId}"
           hx-swap="outerHTML"
-          th:hx-post="${hxEditSubconditionEndpoint}"
-          th:hx-vals='|{"conditionId": "${conditionId}", "subconditionId": "${subconditionId}" }|'
+          th:hx-post="${model.hxEditSubconditionEndpoint()}"
+          th:hx-vals='|{"conditionId": "${model.conditionId}", "subconditionId": "${model.subconditionId}" }|'
           th:hx-target="${'closest div[class*=subcondition-container]'}"
         >
-          <option th:selected="${!hasSelectedQuestion}">-Select-</option>
+          <option th:selected="${!model.hasSelectedQuestion}">-Select-</option>
           <option
-            th:each="question : ${questionOptions}"
+            th:each="question : ${model.questionOptions}"
             th:value="${question.value()}"
             th:text="${question.displayText()}"
             th:selected="${question.selected()}"
@@ -44,16 +44,16 @@
           th:id="${scalarDropDownId}"
           th:name="${scalarDropDownId}"
           th:data-operator-target-id="${operatorDropdownId}"
-          th:disabled="${!hasSelectedQuestion}"
+          th:disabled="${!model.hasSelectedQuestion}"
         >
           <option
-            th:selected="${!hasSelectedQuestion}"
-            th:hidden="${hasSelectedQuestion}"
+            th:selected="${!model.hasSelectedQuestion}"
+            th:hidden="${model.hasSelectedQuestion}"
           >
             -Select-
           </option>
           <option
-            th:each="scalar : ${scalarOptions}"
+            th:each="scalar : ${model.scalarOptions}"
             th:value="${scalar.value()}"
             th:text="${scalar.displayText()}"
             th:data-type="${scalar.scalarType()}"
@@ -69,16 +69,19 @@
           class="usa-select"
           th:id="${operatorDropdownId}"
           th:name="${operatorDropdownId}"
-          th:disabled="${!hasSelectedQuestion}"
+          th:disabled="${!model.hasSelectedQuestion}"
+          th:hx-post="${model.hxEditSubconditionEndpoint()}"
+          th:hx-vals='|{"conditionId": "${model.conditionId}", "subconditionId": "${model.subconditionId}" }|'
+          th:hx-target="${'closest div[class*=subcondition-container]'}"
         >
           <option
-            th:selected="${!hasSelectedQuestion}"
-            th:hidden="${hasSelectedQuestion}"
+            th:selected="${!model.hasSelectedQuestion}"
+            th:hidden="${model.hasSelectedQuestion}"
           >
             -Select-
           </option>
           <option
-            th:each="operator : ${operatorOptions}"
+            th:each="operator : ${model.operatorOptions}"
             th:value="${operator.value()}"
             th:text="${operator.displayText()}"
             th:selected="${operator.selected()}"
@@ -86,7 +89,7 @@
         </select>
       </div>
       <div
-        th:replace="~{admin/programs/predicates/PredicateValuesInputFragment :: predicateValues(${questionType}, ${valueOptions}, ${valueInputId}, ${hasSelectedQuestion})}"
+        th:replace="~{admin/programs/predicates/PredicateValuesInputFragment :: predicateValues(${model.selectedQuestionType}, ${model.valueOptions}, ${valueInputId}, ${model.hasSelectedQuestion})}"
       ></div>
       <div class="width-full display-inline-block">
         <a

--- a/server/app/views/admin/programs/predicates/EditSubconditionPartial.html
+++ b/server/app/views/admin/programs/predicates/EditSubconditionPartial.html
@@ -1,5 +1,5 @@
 <!--/*@thymesVar id="model" type="views.admin.programs.predicates.EditSubconditionPartialViewModel"*/-->
 
 <div
-  th:replace="~{admin/programs/predicates/EditSubconditionFragment :: editSubcondition(${model.conditionId}, ${model.subconditionId}, ${model.selectedQuestionType}, ${model.questionOptions()}, ${model.scalarOptions()}, ${model.operatorOptions()}, ${model.valueOptions()}, ${model.hxEditSubconditionEndpoint()}, ${model.hasSelectedQuestion()})}"
+  th:replace="~{admin/programs/predicates/EditSubconditionFragment :: editSubcondition(${model})}"
 ></div>

--- a/server/app/views/admin/programs/predicates/EditSubconditionPartialViewModel.java
+++ b/server/app/views/admin/programs/predicates/EditSubconditionPartialViewModel.java
@@ -7,6 +7,7 @@ import controllers.admin.routes;
 import java.util.Optional;
 import lombok.Builder;
 import services.program.predicate.PredicateUseCase;
+import services.program.predicate.Operator;
 import views.admin.BaseViewModel;
 
 /**
@@ -21,6 +22,7 @@ public record EditSubconditionPartialViewModel(
     long conditionId,
     long subconditionId,
     Optional<String> selectedQuestionType,
+    Optional<String> selectedOperator,
     ImmutableList<OptionElement> questionOptions,
     ImmutableList<ScalarOptionElement> scalarOptions,
     ImmutableList<OptionElement> operatorOptions,


### PR DESCRIPTION
### Description

Please explain the changes you made here.

## Release notes

Remove this section if the feature is still under development or if title of the pull request can be used as the default release notes description. If more detail is needed to communicate to partners the scope of the PR's changes, use this release notes section (and remove this placeholder text).

When the Release engineer creates Release Notes, they will not look for this section for Under Development tagged PRs, and will use it if present for all other PRs included in the Release Notes.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [ ] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if the primary reviewer is not an admin and this PR includes functionality changes)
- [ ] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

#### Database evolutions

Read the guidelines [here](https://github.com/civiform/civiform/wiki/Database#writing-database-evolutions)

- [ ] Assigned two reviewers
- [ ] Guarded against already existing resources using `IF NOT EXISTS` and `IF EXISTS`
- [ ] Downs created to undo changes in Ups
- [ ] Every comment in script should begin with -- and not # --- unless it denotes Ups or Downs. See [here](https://www.playframework.com/documentation/2.9.x/Evolutions) for details.
- [ ] Tested both the Downs and the Ups scripts manually (When testing, include all comments from the evolution in your test script to ensure any syntax errors in the comments are caught.)
- [ ] Data migrations aren't being done (please use a [Durable Job](https://github.com/civiform/civiform/wiki/Database#durable-jobs-for-data-updates) if doing a data migration)
- [ ] Update the model documentation in our [wiki](https://github.com/civiform/civiform/wiki/Database) if necessary

#### Durable jobs

Read the docs [here](https://github.com/civiform/civiform/wiki/Database#durable-jobs-for-data-updates)

- [ ] Assigned two reviewers
- [ ] Included a rollback plan and a job to undo the data changes if appropriate

#### User visible changes

- [ ] Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
  - [ ] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [ ] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Made equivalent changes in Thymeleaf for applicant-facing features and changes (or created an issue in the [Northstar epic](https://github.com/orgs/civiform/projects/1/views/94) to track that it's missing from Thymeleaf)
- [ ] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order
- [ ] Performed manual accessibility tests for any applicant-facing changes or any new admin-facing features. See [manual-accessibility-testing](https://github.com/civiform/civiform/wiki/Accessibility#manual-accessibility-testing)
- [ ] Manually tested with a right-to-left language

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/helper/feature-flags.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://github.com/civiform/civiform/wiki/Feature-Flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Instructions for manual testing

If instructions are needed for manual testing by reviewers, include them here.

### Issue(s) this completes

Fixes #<issue_number>; Fixes #<issue_number>...
