### PR TITLE
[Expanded logic] Update predicate header display text

### DIFF
--- a/server/app/controllers/admin/AdminProgramPreviewController.java
+++ b/server/app/controllers/admin/AdminProgramPreviewController.java
@@ -19,6 +19,7 @@ import services.program.ProgramDefinition;
 import services.program.ProgramNotFoundException;
 import services.program.ProgramService;
 import services.question.QuestionService;
+import services.settings.SettingsManifest;
 
 /** Controller for admins previewing a program as an applicant. */
 public final class AdminProgramPreviewController extends CiviFormController {
@@ -26,6 +27,7 @@ public final class AdminProgramPreviewController extends CiviFormController {
   private final ProgramService programService;
   private final QuestionService questionService;
   private final ProgramSlugHandler programSlugHandler;
+  private final SettingsManifest settingsManifest;
 
   @Inject
   public AdminProgramPreviewController(
@@ -34,12 +36,14 @@ public final class AdminProgramPreviewController extends CiviFormController {
       ProgramService programService,
       QuestionService questionService,
       VersionRepository versionRepository,
-      ProgramSlugHandler programSlugHandler) {
+      ProgramSlugHandler programSlugHandler,
+      SettingsManifest settingsManifest) {
     super(profileUtils, versionRepository);
     this.pdfExporterService = checkNotNull(pdfExporterService);
     this.programService = checkNotNull(programService);
     this.questionService = checkNotNull(questionService);
     this.programSlugHandler = checkNotNull(programSlugHandler);
+    this.settingsManifest = checkNotNull(settingsManifest);
   }
 
   /**
@@ -65,7 +69,9 @@ public final class AdminProgramPreviewController extends CiviFormController {
             roQuestionService -> {
               PdfExporter.InMemoryPdf pdf =
                   pdfExporterService.generateProgramPreviewPdf(
-                      program, roQuestionService.getAllQuestions());
+                      program,
+                      roQuestionService.getAllQuestions(),
+                      settingsManifest.getExpandedFormLogicEnabled(request));
               return ok(pdf.getByteArray())
                   .as("application/pdf")
                   .withHeader(

--- a/server/app/controllers/admin/PredicateUtils.java
+++ b/server/app/controllers/admin/PredicateUtils.java
@@ -16,7 +16,10 @@ public final class PredicateUtils {
   public static ReadablePredicate getReadablePredicateDescription(
       String blockName,
       PredicateDefinition predicate,
-      ImmutableList<QuestionDefinition> questionDefinitions) {
+      ImmutableList<QuestionDefinition> questionDefinitions,
+      boolean expandedFormLogicEnabled) {
+    String headingSuffix =
+        expandedFormLogicEnabled ? "conditions are true:" : "of the following is true:";
     return switch (predicate.predicateFormat()) {
       case SINGLE_QUESTION ->
           ReadablePredicate.create(
@@ -52,9 +55,10 @@ public final class PredicateUtils {
               /* conditionList= */ Optional.empty(),
               /* formattedHtmlConditionList= */ Optional.empty());
         }
-        String heading = headingPrefix + " any of the following is true:";
+        String rootNodeTypeDisplay = predicate.rootNode().getType().toDisplayString();
+        String heading = headingPrefix + " " + rootNodeTypeDisplay + " " + headingSuffix;
         UnescapedText formattedHtmlHeading =
-            join(formattedHtmlHeadingPrefix, strong("any"), "of the following is true:");
+            join(formattedHtmlHeadingPrefix, strong(rootNodeTypeDisplay), headingSuffix);
         ImmutableList<String> conditionList =
             andNodes.stream()
                 .map(andNode -> andNode.getAndNode().toDisplayString(questionDefinitions))

--- a/server/app/services/applications/PdfExporterService.java
+++ b/server/app/services/applications/PdfExporterService.java
@@ -45,10 +45,12 @@ public final class PdfExporterService {
    * <p>Used for admins to see their current program setup.
    */
   public PdfExporter.InMemoryPdf generateProgramPreviewPdf(
-      ProgramDefinition programDefinition, ImmutableList<QuestionDefinition> allQuestions) {
+      ProgramDefinition programDefinition,
+      ImmutableList<QuestionDefinition> allQuestions,
+      boolean expandedFormLogicEnabled) {
     PdfExporter.InMemoryPdf pdf;
     try {
-      pdf = pdfExporter.exportProgram(programDefinition, allQuestions);
+      pdf = pdfExporter.exportProgram(programDefinition, allQuestions, expandedFormLogicEnabled);
     } catch (DocumentException | IOException | TranslationNotFoundException e) {
       throw new RuntimeException(e);
     }

--- a/server/app/services/export/PdfExporter.java
+++ b/server/app/services/export/PdfExporter.java
@@ -286,18 +286,22 @@ public final class PdfExporter {
    *     predicates correctly.
    */
   public InMemoryPdf exportProgram(
-      ProgramDefinition programDefinition, ImmutableList<QuestionDefinition> allQuestions)
+      ProgramDefinition programDefinition,
+      ImmutableList<QuestionDefinition> allQuestions,
+      boolean expandedFormLogicEnabled)
       throws DocumentException, IOException, TranslationNotFoundException {
     LocalDateTime timeCreated = nowProvider.get();
     String filename = String.format("%s-%s.pdf", programDefinition.adminName(), timeCreated);
-    byte[] bytes = buildProgramPdf(programDefinition, allQuestions, timeCreated);
+    byte[] bytes =
+        buildProgramPdf(programDefinition, allQuestions, timeCreated, expandedFormLogicEnabled);
     return new InMemoryPdf(bytes, filename);
   }
 
   private byte[] buildProgramPdf(
       ProgramDefinition programDefinition,
       ImmutableList<QuestionDefinition> allQuestions,
-      LocalDateTime timeCreated)
+      LocalDateTime timeCreated,
+      boolean expandedFormLogicEnabled)
       throws DocumentException, IOException {
     ByteArrayOutputStream byteArrayOutputStream = null;
     PdfWriter writer = null;
@@ -351,7 +355,12 @@ public final class PdfExporter {
 
       for (BlockDefinition block : programDefinition.getNonRepeatedBlockDefinitions()) {
         renderProgramBlock(
-            document, programDefinition, block, allQuestions, /* indentationLevel= */ 0);
+            document,
+            programDefinition,
+            block,
+            allQuestions,
+            /* indentationLevel= */ 0,
+            expandedFormLogicEnabled);
       }
     } finally {
       if (document != null) {
@@ -379,7 +388,8 @@ public final class PdfExporter {
       ProgramDefinition program,
       BlockDefinition block,
       ImmutableList<QuestionDefinition> allQuestions,
-      int indentationLevel)
+      int indentationLevel,
+      boolean expandedFormLogicEnabled)
       throws DocumentException {
     document.add(Chunk.NEWLINE);
     LineSeparator ls = new LineSeparator();
@@ -399,7 +409,12 @@ public final class PdfExporter {
     // Visibility & eligibility information
     if (block.visibilityPredicate().isPresent()) {
       renderPredicate(
-          document, block.visibilityPredicate().get(), block, allQuestions, indentationLevel);
+          document,
+          block.visibilityPredicate().get(),
+          block,
+          allQuestions,
+          indentationLevel,
+          expandedFormLogicEnabled);
     }
     if (block.eligibilityDefinition().isPresent()) {
       renderPredicate(
@@ -407,7 +422,8 @@ public final class PdfExporter {
           block.eligibilityDefinition().get().predicate(),
           block,
           allQuestions,
-          indentationLevel);
+          indentationLevel,
+          expandedFormLogicEnabled);
     }
 
     for (int i = 0; i < block.getQuestionCount(); i++) {
@@ -467,7 +483,13 @@ public final class PdfExporter {
     if (block.isEnumerator()) {
       for (BlockDefinition subBlock : program.getBlockDefinitionsForEnumerator(block.id())) {
         // Indent the blocks related to the enumerator so it's clear they're related
-        renderProgramBlock(document, program, subBlock, allQuestions, indentationLevel + 1);
+        renderProgramBlock(
+            document,
+            program,
+            subBlock,
+            allQuestions,
+            indentationLevel + 1,
+            expandedFormLogicEnabled);
       }
     }
   }
@@ -477,10 +499,12 @@ public final class PdfExporter {
       PredicateDefinition predicate,
       BlockDefinition block,
       ImmutableList<QuestionDefinition> allQuestions,
-      int indentationLevel)
+      int indentationLevel,
+      boolean expandedFormLogicEnabled)
       throws DocumentException {
     ReadablePredicate readablePredicate =
-        PredicateUtils.getReadablePredicateDescription(block.name(), predicate, allQuestions);
+        PredicateUtils.getReadablePredicateDescription(
+            block.name(), predicate, allQuestions, expandedFormLogicEnabled);
 
     document.add(text(readablePredicate.heading(), PREDICATE_FONT, indentationLevel));
     if (readablePredicate.conditionList().isPresent()) {

--- a/server/app/views/admin/programs/ProgramBaseView.java
+++ b/server/app/views/admin/programs/ProgramBaseView.java
@@ -170,7 +170,8 @@ abstract class ProgramBaseView extends BaseHtmlView {
       ImmutableList<QuestionDefinition> questionDefinitions,
       PredicateUseCase predicateUseCase,
       boolean includeEditFooter,
-      boolean expanded) {
+      boolean expanded,
+      boolean expandedFormLogicEnabled) {
     DivTag header =
         div()
             .with(
@@ -206,7 +207,7 @@ abstract class ProgramBaseView extends BaseHtmlView {
 
     ReadablePredicate readablePredicate =
         PredicateUtils.getReadablePredicateDescription(
-            blockName, predicateDefinition, questionDefinitions);
+            blockName, predicateDefinition, questionDefinitions, expandedFormLogicEnabled);
     DivTag content =
         div()
             .withId(predicateUseCase.name().toLowerCase(Locale.ROOT) + "-content")

--- a/server/app/views/admin/programs/ProgramBlocksView.java
+++ b/server/app/views/admin/programs/ProgramBlocksView.java
@@ -510,7 +510,8 @@ public final class ProgramBlocksView extends ProgramBaseView {
             blockDefinition.id(),
             blockDefinition.visibilityPredicate(),
             blockDefinition.name(),
-            allQuestions);
+            allQuestions,
+            settingsManifest.getExpandedFormLogicEnabled(request));
 
     Optional<DivTag> maybeEligibilityPredicateDisplay = Optional.empty();
     if (!program.programType().equals(ProgramType.COMMON_INTAKE_FORM)) {
@@ -521,7 +522,8 @@ public final class ProgramBlocksView extends ProgramBaseView {
                   blockDefinition.id(),
                   blockDefinition.eligibilityDefinition(),
                   blockDefinition.name(),
-                  allQuestions));
+                  allQuestions,
+                  settingsManifest.getExpandedFormLogicEnabled(request)));
     }
 
     // Precompute a map of questions to block ids that use the question in visibility conditions.
@@ -659,7 +661,8 @@ public final class ProgramBlocksView extends ProgramBaseView {
       long blockId,
       Optional<PredicateDefinition> predicate,
       String blockName,
-      ImmutableList<QuestionDefinition> questions) {
+      ImmutableList<QuestionDefinition> questions,
+      boolean expandedFormLogicEnabled) {
     DivTag div =
         div()
             .withId("visibility-predicate")
@@ -682,7 +685,8 @@ public final class ProgramBlocksView extends ProgramBaseView {
               questions,
               PredicateUseCase.VISIBILITY,
               /* includeEditFooter= */ viewAllowsEditingProgram(),
-              /* expanded= */ false));
+              /* expanded= */ false,
+              expandedFormLogicEnabled));
     }
   }
 
@@ -694,7 +698,8 @@ public final class ProgramBlocksView extends ProgramBaseView {
       long blockId,
       Optional<EligibilityDefinition> predicate,
       String blockName,
-      ImmutableList<QuestionDefinition> questions) {
+      ImmutableList<QuestionDefinition> questions,
+      boolean expandedFormLogicEnabled) {
     DivTag div =
         div()
             .withId("eligibility-predicate")
@@ -718,7 +723,8 @@ public final class ProgramBlocksView extends ProgramBaseView {
               questions,
               PredicateUseCase.ELIGIBILITY,
               /* includeEditFooter= */ viewAllowsEditingProgram(),
-              /* expanded= */ false));
+              /* expanded= */ false,
+              /* expandedFormLogicEnabled= */ expandedFormLogicEnabled));
     }
   }
 

--- a/server/app/views/admin/programs/ProgramPredicatesEditView.java
+++ b/server/app/views/admin/programs/ProgramPredicatesEditView.java
@@ -127,7 +127,8 @@ public final class ProgramPredicatesEditView extends ProgramBaseView {
                                     predicateQuestions,
                                     predicateUseCase,
                                     /* includeEditFooter= */ false,
-                                    /* expanded= */ true)))
+                                    /* expanded= */ true,
+                                    settingsManifest.getExpandedFormLogicEnabled(request))))
                 .orElse(
                     div()
                         .with(
@@ -173,7 +174,8 @@ public final class ProgramPredicatesEditView extends ProgramBaseView {
                                     predicateQuestions,
                                     predicateUseCase,
                                     /* includeEditFooter= */ false,
-                                    /* expanded= */ true)))
+                                    /* expanded= */ true,
+                                    settingsManifest.getExpandedFormLogicEnabled(request))))
                 .orElse(
                     div()
                         .with(

--- a/server/test/controllers/admin/PredicateUtilsTest.java
+++ b/server/test/controllers/admin/PredicateUtilsTest.java
@@ -5,7 +5,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import j2html.tags.UnescapedText;
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import services.applicant.question.Scalar;
 import services.program.predicate.AndNode;
 import services.program.predicate.LeafOperationExpressionNode;
@@ -16,9 +19,12 @@ import services.program.predicate.PredicateDefinition;
 import services.program.predicate.PredicateExpressionNode;
 import services.program.predicate.PredicateValue;
 
+@RunWith(JUnitParamsRunner.class)
 public class PredicateUtilsTest {
   @Test
-  public void getReadablePredicateDescription_singleQuestion_headingOnly() {
+  @Parameters({"true", "false"})
+  public void getReadablePredicateDescription_singleQuestion_headingOnly(
+      boolean expandedFormLogicEnabled) {
     PredicateDefinition predicate =
         PredicateDefinition.create(
             PredicateExpressionNode.create(
@@ -31,7 +37,7 @@ public class PredicateUtilsTest {
 
     ReadablePredicate readablePredicate =
         PredicateUtils.getReadablePredicateDescription(
-            "My Test Block", predicate, ImmutableList.of());
+            "My Test Block", predicate, ImmutableList.of(), expandedFormLogicEnabled);
 
     assertThat(readablePredicate.heading())
         .isEqualTo("My Test Block is shown if number is greater than or equal to 1000");
@@ -45,7 +51,9 @@ public class PredicateUtilsTest {
   }
 
   @Test
-  public void getReadablePredicateDescription_singleAnd_headingOnly() {
+  @Parameters({"true", "false"})
+  public void getReadablePredicateDescription_singleAnd_headingOnly(
+      boolean expandedFormLogicEnabled) {
     ImmutableList<PredicateExpressionNode> andStatements =
         ImmutableList.of(
             PredicateExpressionNode.create(
@@ -76,7 +84,7 @@ public class PredicateUtilsTest {
 
     ReadablePredicate readablePredicate =
         PredicateUtils.getReadablePredicateDescription(
-            "My Test Block", predicate, ImmutableList.of());
+            "My Test Block", predicate, ImmutableList.of(), expandedFormLogicEnabled);
 
     assertThat(readablePredicate.heading())
         .isEqualTo(
@@ -94,7 +102,9 @@ public class PredicateUtilsTest {
   }
 
   @Test
-  public void getReadablePredicateDescription_multipleAnds_headingAndConditionList() {
+  @Parameters({"true", "false"})
+  public void getReadablePredicateDescription_multipleAnds_headingAndConditionList(
+      boolean expandedFormLogicEnabled) {
     // number == 4 && text == "four"
     ImmutableList<PredicateExpressionNode> andStatements1 =
         ImmutableList.of(
@@ -136,15 +146,24 @@ public class PredicateUtilsTest {
 
     ReadablePredicate readablePredicate =
         PredicateUtils.getReadablePredicateDescription(
-            "My Test Block", predicate, ImmutableList.of());
+            "My Test Block", predicate, ImmutableList.of(), expandedFormLogicEnabled);
 
-    assertThat(readablePredicate.heading())
-        .isEqualTo("Applicant is eligible if any of the following is true:");
-    assertThat(readablePredicate.formattedHtmlHeading().toString())
-        .isEqualTo(
-            """
-            Applicant is <strong>eligible</strong> if <strong>any</strong> of the following is \
-            true:""");
+    if (expandedFormLogicEnabled) {
+      assertThat(readablePredicate.heading())
+          .isEqualTo("Applicant is eligible if any conditions are true:");
+      assertThat(readablePredicate.formattedHtmlHeading().toString())
+          .isEqualTo(
+              """
+Applicant is <strong>eligible</strong> if <strong>any</strong> conditions are true:""");
+    } else {
+      assertThat(readablePredicate.heading())
+          .isEqualTo("Applicant is eligible if any of the following is true:");
+      assertThat(readablePredicate.formattedHtmlHeading().toString())
+          .isEqualTo(
+              """
+              Applicant is <strong>eligible</strong> if <strong>any</strong> of the \
+              following is true:""");
+    }
     assertThat(readablePredicate.conditionList()).isPresent();
     assertThat(readablePredicate.conditionList().get().size()).isEqualTo(2);
     assertThat(readablePredicate.conditionList().get().get(0))

--- a/server/test/services/applications/PdfExporterServiceTest.java
+++ b/server/test/services/applications/PdfExporterServiceTest.java
@@ -76,7 +76,9 @@ public class PdfExporterServiceTest extends AbstractExporterTest {
 
     PdfExporter.InMemoryPdf result =
         service.generateProgramPreviewPdf(
-            fakeProgram.getProgramDefinition(), getFakeQuestionDefinitions());
+            fakeProgram.getProgramDefinition(),
+            getFakeQuestionDefinitions(),
+            /* expandedFormLogicEnabled= */ true);
 
     List<String> linesFromPdf = getPdfLines(result);
     assertThat(linesFromPdf).isNotEmpty();

--- a/server/test/services/export/PdfExporterTest.java
+++ b/server/test/services/export/PdfExporterTest.java
@@ -15,9 +15,12 @@ import com.itextpdf.text.pdf.parser.PdfTextExtractor;
 import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
 import models.QuestionModel;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import services.Path;
 import services.applicant.ApplicantData;
 import services.applications.PdfExporterService;
@@ -26,6 +29,7 @@ import services.program.ProgramDefinition;
 import services.question.QuestionAnswerer;
 import services.question.types.QuestionDefinition;
 
+@RunWith(JUnitParamsRunner.class)
 public class PdfExporterTest extends AbstractExporterTest {
 
   @Before
@@ -386,7 +390,8 @@ public class PdfExporterTest extends AbstractExporterTest {
     PdfExporterService service = instanceOf(PdfExporterService.class);
     ProgramDefinition programDef = fakeProgram.getProgramDefinition();
     PdfExporter.InMemoryPdf result =
-        service.generateProgramPreviewPdf(programDef, getFakeQuestionDefinitions());
+        service.generateProgramPreviewPdf(
+            programDef, getFakeQuestionDefinitions(), /* expandedFormLogicEnabled= */ true);
 
     List<String> linesFromPdf = getPdfLines(result);
     assertThat(linesFromPdf).isNotEmpty();
@@ -425,7 +430,8 @@ public class PdfExporterTest extends AbstractExporterTest {
     ProgramDefinition programDef = fakeProgram.getProgramDefinition();
 
     PdfExporter.InMemoryPdf result =
-        service.generateProgramPreviewPdf(programDef, getFakeQuestionDefinitions());
+        service.generateProgramPreviewPdf(
+            programDef, getFakeQuestionDefinitions(), /* expandedFormLogicEnabled= */ true);
 
     String pdfText = getPdfText(result);
     // For every block (which is every question, since our fake program creates one block per
@@ -482,7 +488,8 @@ public class PdfExporterTest extends AbstractExporterTest {
     ProgramDefinition programDef = fakeProgram.getProgramDefinition();
 
     PdfExporter.InMemoryPdf result =
-        service.generateProgramPreviewPdf(programDef, getFakeQuestionDefinitions());
+        service.generateProgramPreviewPdf(
+            programDef, getFakeQuestionDefinitions(), /* expandedFormLogicEnabled= */ true);
 
     String pdfText = getPdfText(result);
 
@@ -505,14 +512,17 @@ public class PdfExporterTest extends AbstractExporterTest {
   }
 
   @Test
-  public void exportProgram_hasEligibilityPredicate() throws IOException {
+  @Parameters({"true", "false"})
+  public void exportProgram_hasEligibilityPredicate(boolean expandedFormLogicEnabled)
+      throws IOException {
     createFakeProgramWithEligibilityPredicateAndThreeApplications();
 
     PdfExporterService service = instanceOf(PdfExporterService.class);
     ProgramDefinition programDef = fakeProgramWithEligibility.getProgramDefinition();
 
     PdfExporter.InMemoryPdf result =
-        service.generateProgramPreviewPdf(programDef, getFakeQuestionDefinitions());
+        service.generateProgramPreviewPdf(
+            programDef, getFakeQuestionDefinitions(), expandedFormLogicEnabled);
 
     String pdfText = getPdfText(result);
     assertThat(pdfText)
@@ -521,14 +531,17 @@ public class PdfExporterTest extends AbstractExporterTest {
   }
 
   @Test
-  public void exportProgram_hasVisibilityPredicate() throws IOException {
+  @Parameters({"true", "false"})
+  public void exportProgram_hasVisibilityPredicate(boolean expandedFormLogicEnabled)
+      throws IOException {
     createFakeProgramWithVisibilityPredicate();
 
     PdfExporterService service = instanceOf(PdfExporterService.class);
     ProgramDefinition programDef = fakeProgramWithVisibility.getProgramDefinition();
 
     PdfExporter.InMemoryPdf result =
-        service.generateProgramPreviewPdf(programDef, getFakeQuestionDefinitions());
+        service.generateProgramPreviewPdf(
+            programDef, getFakeQuestionDefinitions(), expandedFormLogicEnabled);
 
     String pdfText = getPdfText(result);
     assertThat(pdfText)
@@ -543,7 +556,8 @@ public class PdfExporterTest extends AbstractExporterTest {
     ProgramDefinition programDef = fakeProgramWithEnumerator.getProgramDefinition();
 
     PdfExporter.InMemoryPdf result =
-        service.generateProgramPreviewPdf(programDef, getFakeQuestionDefinitions());
+        service.generateProgramPreviewPdf(
+            programDef, getFakeQuestionDefinitions(), /* expandedFormLogicEnabled= */ true);
 
     String pdfText = getPdfText(result);
     assertThat(pdfText).contains("What is the $this's name?");

--- a/server/test/views/admin/programs/ProgramBaseViewTest.java
+++ b/server/test/views/admin/programs/ProgramBaseViewTest.java
@@ -6,6 +6,7 @@ import static views.ViewUtils.ProgramDisplayType.DRAFT;
 import com.google.common.collect.ImmutableList;
 import j2html.tags.specialized.DivTag;
 import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
@@ -39,7 +40,8 @@ public class ProgramBaseViewTest {
           testQuestionBank.emailApplicantEmail().getQuestionDefinition());
 
   @Test
-  public void renderExistingPredicate_singleQuestion() {
+  @Parameters({"true", "false"})
+  public void renderExistingPredicate_singleQuestion(boolean expandedFormLogicEnabled) {
     var predicateDefinition =
         PredicateDefinition.create(
             PredicateExpressionNode.create(
@@ -61,7 +63,8 @@ public class ProgramBaseViewTest {
                 questionDefinitions,
                 PredicateUseCase.VISIBILITY,
                 /* includeEditFooter= */ false,
-                /* expanded= */ false);
+                /* expanded= */ false,
+                expandedFormLogicEnabled);
 
     assertThat(result.render())
         .contains(
@@ -71,7 +74,8 @@ public class ProgramBaseViewTest {
   }
 
   @Test
-  public void renderExistingPredicate_includeEditFooter() {
+  @Parameters({"true", "false"})
+  public void renderExistingPredicate_includeEditFooter(boolean expandedFormLogicEnabled) {
     var predicateDefinition =
         PredicateDefinition.create(
             PredicateExpressionNode.create(
@@ -93,13 +97,16 @@ public class ProgramBaseViewTest {
                 questionDefinitions,
                 PredicateUseCase.VISIBILITY,
                 /* includeEditFooter= */ true,
-                /* expanded= */ false);
+                /* expanded= */ false,
+                expandedFormLogicEnabled);
 
     assertThat(result.render()).contains("Edit visibility conditions");
   }
 
   @Test
-  public void renderExistingPredicate_orOfSingleLayerAnds_withSingleAnd() {
+  @Parameters({"true", "false"})
+  public void renderExistingPredicate_orOfSingleLayerAnds_withSingleAnd(
+      boolean expandedFormLogicEnabled) {
     var predicateDefinition =
         PredicateDefinition.create(
             PredicateExpressionNode.create(
@@ -137,7 +144,8 @@ public class ProgramBaseViewTest {
                 questionDefinitions,
                 PredicateUseCase.VISIBILITY,
                 /* includeEditFooter= */ false,
-                /* expanded= */ false);
+                /* expanded= */ false,
+                expandedFormLogicEnabled);
 
     assertThat(result.render())
         .contains(
@@ -149,7 +157,9 @@ public class ProgramBaseViewTest {
   }
 
   @Test
-  public void renderExistingPredicate_orOfSingleLayerAnds_withMultipleAnd() {
+  @Parameters({"true", "false"})
+  public void renderExistingPredicate_orOfSingleLayerAnds_withMultipleAnd(
+      boolean expandedFormLogicEnabled) {
     var predicateDefinition =
         PredicateDefinition.create(
             PredicateExpressionNode.create(
@@ -208,24 +218,34 @@ public class ProgramBaseViewTest {
                 questionDefinitions,
                 PredicateUseCase.VISIBILITY,
                 /* includeEditFooter= */ false,
-                /* expanded= */ false);
+                /* expanded= */ false,
+                expandedFormLogicEnabled);
 
-    assertThat(result.render())
-        .contains(
-            """
-            Block_name is <strong>hidden</strong> if <strong>any</strong> of the following is \
-            true:</p>""");
-    assertThat(result.render())
-        .contains(
-            """
-            Block_name is <strong>hidden</strong> if <strong>any</strong> of the following is \
-            true:</p><ol class="list-decimal ml-4 pt-4"><li><strong>&quot;applicant birth \
-            date&quot;</strong> date is equal to <strong>2023-01-01</strong> AND \
-            <strong>&quot;applicant email address&quot;</strong> email is equal to \
-            <strong>&quot;test@example.com&quot;</strong></li><li><strong>&quot;applicant birth \
-            date&quot;</strong> date is equal to <strong>2023-03-03</strong> AND \
-            <strong>&quot;applicant email address&quot;</strong> email is equal to \
-            <strong>&quot;other@example.com&quot;</strong></li>""");
+    if (expandedFormLogicEnabled) {
+      assertThat(result.render())
+          .contains(
+              """
+              Block_name is <strong>hidden</strong> if <strong>any</strong> conditions are \
+              true:</p><ol class="list-decimal ml-4 pt-4"><li><strong>&quot;applicant birth \
+              date&quot;</strong> date is equal to <strong>2023-01-01</strong> AND \
+              <strong>&quot;applicant email address&quot;</strong> email is equal to \
+              <strong>&quot;test@example.com&quot;</strong></li><li><strong>&quot;applicant birth \
+              date&quot;</strong> date is equal to <strong>2023-03-03</strong> AND \
+              <strong>&quot;applicant email address&quot;</strong> email is equal to \
+              <strong>&quot;other@example.com&quot;</strong></li>""");
+    } else {
+      assertThat(result.render())
+          .contains(
+              """
+              Block_name is <strong>hidden</strong> if <strong>any</strong> of the following is \
+              true:</p><ol class="list-decimal ml-4 pt-4"><li><strong>&quot;applicant birth \
+              date&quot;</strong> date is equal to <strong>2023-01-01</strong> AND \
+              <strong>&quot;applicant email address&quot;</strong> email is equal to \
+              <strong>&quot;test@example.com&quot;</strong></li><li><strong>&quot;applicant birth \
+              date&quot;</strong> date is equal to <strong>2023-03-03</strong> AND \
+              <strong>&quot;applicant email address&quot;</strong> email is equal to \
+              <strong>&quot;other@example.com&quot;</strong></li>""");
+    }
   }
 
   private static final class ProgramBlockBaseViewTestChild extends ProgramBaseView {


### PR DESCRIPTION
### Description

Predicates with multiple conditions currently show a header with text `"if any of the following is true"` since all top-level conditions are always combined with an `OR` operator. With expanded logic, this text is updated to `'if any/all conditions are true"`. This better reflects the expanded ability to use either and/or operator, and references conditions. 

See [figma mock](https://www.figma.com/design/cZLnuohNOVyOSYTtQlLSXA/Admin---Complex-Form-Logic?node-id=3121-17644&t=GPtbCvgoP8NEcRZB-0) and [thread](https://www.figma.com/design/cZLnuohNOVyOSYTtQlLSXA?node-id=3121-17644#1484110916) for decision.

This change updates the predicate header text behind the expanded form logic feature flag, since the term "conditions" are specific to the new feature editing UI. Since the header display text is built in `PredicateUtils`, this requires piping the flag value through some layers from the controllers.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if the primary reviewer is not an admin and this PR includes functionality changes)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.


#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/helper/feature-flags.conf`
- [x] Conditioned new functionality on a [FeatureFlag](https://github.com/civiform/civiform/wiki/Feature-Flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Issue(s) this completes

Part of #11780 
