### PR TITLE
[Maps] check for tag text before displaying tag

### DIFF
--- a/server/app/services/applicant/question/MapQuestion.java
+++ b/server/app/services/applicant/question/MapQuestion.java
@@ -105,6 +105,10 @@ public final class MapQuestion extends AbstractQuestion {
     return getTagSetting() != null;
   }
 
+  public boolean hasTagText() {
+    return !getTagText().isBlank();
+  }
+
   public String getTagKey() {
     LocalizedQuestionSetting tag = getTagSetting();
     return tag != null ? tag.settingKey() : "";

--- a/server/app/views/questiontypes/MapQuestionFragment.html
+++ b/server/app/views/questiontypes/MapQuestionFragment.html
@@ -311,7 +311,7 @@
         class="cf-selected-locations-message"
       ></p>
       <div
-        th:if="${mapQuestion.hasTagSetting()}"
+        th:if="${mapQuestion.hasTagText()}"
         class="usa-alert usa-alert--warning cf-map-question-tag-alert cf-map-question-tag-alert-hidden"
         th:data-map-id="${mapId}"
         role="alert"


### PR DESCRIPTION
### Description

Fixes bug where tag alert was always showing even if the admin didn't add any tag text.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from `civiform/eng-admin` as FYI (if the primary reviewer is not an admin and this PR includes functionality changes)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [x] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [x] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [x] Noted in the PR description which, if any, code in this PR was generated by AI.

### Issue(s) this completes

Fixes #11820 
