### PR TITLE
add voiceover text when filter buttons are pressed

### DIFF
--- a/server/app/assets/javascripts/mapquestion/map_question_filters.ts
+++ b/server/app/assets/javascripts/mapquestion/map_question_filters.ts
@@ -34,22 +34,31 @@ export const initFilters = (
     }
   })
 
-  mapQuerySelector(mapId, CF_APPLY_FILTERS_BUTTON)?.addEventListener(
-    'click',
-    () => applyLocationFilters(mapId, mapElement, featureMap),
-  )
+  const applyFiltersButton = mapQuerySelector(mapId, CF_APPLY_FILTERS_BUTTON)
+  if (applyFiltersButton) {
+    applyFiltersButton.addEventListener('click', () => {
+      const isPressed =
+        applyFiltersButton.getAttribute('aria-pressed') === 'true'
+      applyFiltersButton.setAttribute('aria-pressed', (!isPressed).toString())
+      applyLocationFilters(mapId, mapElement, featureMap)
+    })
+  }
 
-  mapQuerySelector(mapId, CF_RESET_FILTERS_BUTTON)?.addEventListener(
-    'click',
-    () => {
+  const resetFiltersButton = mapQuerySelector(mapId, CF_RESET_FILTERS_BUTTON)
+
+  if (resetFiltersButton) {
+    resetFiltersButton.addEventListener('click', () => {
       queryMapSelectOptions(mapId).forEach((selectOption) => {
         const selectOptionElement = (selectOption as HTMLSelectElement) || null
         if (!selectOptionElement) return
         selectOptionElement.value = ''
       })
+      const isPressed =
+        resetFiltersButton.getAttribute('aria-pressed') === 'true'
+      resetFiltersButton.setAttribute('aria-pressed', (!isPressed).toString())
       applyLocationFilters(mapId, mapElement, featureMap, true)
-    },
-  )
+    })
+  }
 }
 
 const applyLocationFilters = (

--- a/server/app/views/questiontypes/MapQuestionFragment.html
+++ b/server/app/views/questiontypes/MapQuestionFragment.html
@@ -74,12 +74,14 @@
           class="usa-button margin-top-1 cf-apply-filters-button"
           th:data-map-id="${mapId}"
           th:text="#{map.applyFiltersButtonText}"
+          aria-pressed="false"
         ></button>
         <button
           type="button"
           class="usa-button usa-button--outline cf-reset-filters-button"
           th:data-map-id="${mapId}"
           th:text="#{map.resetFiltersButtonText}"
+          aria-pressed="false"
         ></button>
       </div>
     </div>


### PR DESCRIPTION
### Description

add aria-pressed to our apply filter and clear filter buttons with minimal typescript for changing state.. This allows screen readers to know the button is pressed. For osx it didnt say the name of the button, just that it was pressed but maybe that is just this specific screen reader since the aria documentation indicated it should say the button name as well.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from `civiform/eng-admin` as FYI (if the primary reviewer is not an admin and this PR includes functionality changes)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [x] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [x] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [x] Noted in the PR description which, if any, code in this PR was generated by AI.

#### Database evolutions

Read the guidelines [here](https://github.com/civiform/civiform/wiki/Database#writing-database-evolutions)

- [ ] Assigned two reviewers
- [ ] Guarded against already existing resources using `IF NOT EXISTS` and `IF EXISTS`
- [ ] Downs created to undo changes in Ups
- [ ] Every comment in script should begin with -- and not # --- unless it denotes Ups or Downs. See [here](https://www.playframework.com/documentation/2.9.x/Evolutions) for details.
- [ ] Tested both the Downs and the Ups scripts manually (When testing, include all comments from the evolution in your test script to ensure any syntax errors in the comments are caught.)
- [ ] Data migrations aren't being done (please use a [Durable Job](https://github.com/civiform/civiform/wiki/Database#durable-jobs-for-data-updates) if doing a data migration)
- [ ] Update the model documentation in our [wiki](https://github.com/civiform/civiform/wiki/Database) if necessary

#### Durable jobs

Read the docs [here](https://github.com/civiform/civiform/wiki/Database#durable-jobs-for-data-updates)

- [ ] Assigned two reviewers
- [ ] Included a rollback plan and a job to undo the data changes if appropriate

#### User visible changes

- [ ] Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
    - [ ] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
    - [ ] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Made equivalent changes in Thymeleaf for applicant-facing features and changes (or created an issue in the [Northstar epic](https://github.com/orgs/civiform/projects/1/views/94) to track that it's missing from Thymeleaf)
- [ ] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order
- [ ] Performed manual accessibility tests for any applicant-facing changes or any new admin-facing features. See [manual-accessibility-testing](https://github.com/civiform/civiform/wiki/Accessibility#manual-accessibility-testing)
- [ ] Manually tested with a right-to-left language

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/helper/feature-flags.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://github.com/civiform/civiform/wiki/Feature-Flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Instructions for manual testing

If instructions are needed for manual testing by reviewers, include them here.

### Issue(s) this completes

Fixes #11818