### PR TITLE
Adding a11y bug issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/a11y_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/a11y_bug_report.md
@@ -5,13 +5,14 @@ title: ''
 labels: bug, a11y, needs-triage
 assignees: ''
 ---
+
 Before reporting a bug, please check the list of known accessibility issues on the [a11y issue board](https://github.com/orgs/civiform/projects/1/views/52).
 
 **Describe the bug**
 A clear and concise description of what the bug is.
 
 **WCAG Success Criterion**
-If possible, link to the WCAG Success Criterion that the bug breaks.  Select from [this list](https://www.w3.org/TR/WCAG21/).
+If possible, link to the WCAG Success Criterion that the bug breaks. Select from [this list](https://www.w3.org/TR/WCAG21/).
 
 **To Reproduce**
 Steps to reproduce the behavior:
@@ -22,7 +23,7 @@ Steps to reproduce the behavior:
 4. See error
 
 **Expected behavior**
-A clear and concise description of what you expected to happen.  You can draw from our [dev wiki accessibility testing guidance](https://github.com/civiform/civiform/wiki/Accessibility).
+A clear and concise description of what you expected to happen. You can draw from our [dev wiki accessibility testing guidance](https://github.com/civiform/civiform/wiki/Accessibility).
 
 **Screenshots**
 If applicable, add a screenshot video to demonstrate the problem.


### PR DESCRIPTION
### Description

Adding an issue template for reporting an accessibility bug.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.
