### PR TITLE
[DO NOT MERGE] keyboard nav for map icons

### DIFF
--- a/server/app/assets/javascripts/mapquestion/map_util.ts
+++ b/server/app/assets/javascripts/mapquestion/map_util.ts
@@ -78,6 +78,8 @@ export const LOCATIONS_LAYER = 'locations-layer'
 export const LOCATIONS_SOURCE = 'locations'
 export const SELECTED_LOCATION_ICON = 'locationMarkerIconSelected'
 export const POPUP_LAYER = 'open-popup'
+export const FOCUS_LAYER = 'focus-indicator-layer'
+export const FOCUS_SOURCE = 'focus-indicator'
 
 export const DEFAULT_MAP_STYLE: StyleSpecification = {
   version: 8,


### PR DESCRIPTION
This is just an AI-generated proof of concept for adding keyboard navigation for map icons.

Set `map_question_enabled=true`
To try, tab to the map canvas, click enter, and then you can navigate with the arrow keys.