### PR TITLE
Update tsconfig to more modern settings

### DIFF
--- a/server/app/assets/javascripts/admin_application_view.ts
+++ b/server/app/assets/javascripts/admin_application_view.ts
@@ -1,5 +1,5 @@
 import {addEventListenerToElements, assertNotNull, formatText} from './util'
-import * as DOMPurify from 'dompurify'
+import DOMPurify from 'dompurify'
 
 class AdminApplicationView {
   private static APPLICATION_STATUS_SELECTOR =

--- a/server/app/assets/javascripts/preview.ts
+++ b/server/app/assets/javascripts/preview.ts
@@ -4,7 +4,7 @@ import {
   YesNoOptionValue,
 } from './admin_yes_no_question_option'
 import {assertNotNull, formatText, formatTextHtml} from './util'
-import * as DOMPurify from 'dompurify'
+import DOMPurify from 'dompurify'
 
 // This doesn't include all the possible question types, just the ones we need to
 // handle specially in the preview controller.

--- a/server/app/assets/javascripts/util.ts
+++ b/server/app/assets/javascripts/util.ts
@@ -1,5 +1,5 @@
-import MarkdownIt = require('markdown-it')
-import DOMPurify = require('dompurify')
+import MarkdownIt from 'markdown-it'
+import DOMPurify from 'dompurify'
 
 /** @fileoverview Collection of generic util functions used throughout the
  * codebase.

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,12 +1,13 @@
 {
   "extends": "@tsconfig/recommended/tsconfig.json",
   "compilerOptions": {
-    "lib": ["es2019", "dom"],
-    // While we support only latest browsers (chrome, firefox, safari, edge)
-    // we can't use ES2015+ or above because it breaks unit tests. We have
-    // security unit tests which use webdriver which in turn uses HtmlUnitDriver
-    // to evalute html and that thing doesn't support modern JS.
-    "target": "es5",
+    "lib": ["es2022", "dom"],
+    "target": "es2022",
+    // Improve module compatibility with modern bundlers like Webpack.
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    // Allow importing JSON and other non-TS assets if needed.
+    "resolveJsonModule": true,
     "sourceMap": true,
     "mapRoot": "/assets/javascripts",
     "sourceRoot": "/assets/javascripts",


### PR DESCRIPTION
Bring tsconfig forward to more modern settings. Prep for future clean up down the road. 

The old comment about being stuck on an old version because of HtmlUnitDriver was out of date.

The few minor changes in ts code are due to use of old style imports that now fail to compile. 