### PR TITLE
[North Star] Deprecate legacy Program Card Preview

### DIFF
--- a/server/app/controllers/admin/NorthStarProgramCardPreviewController.java
+++ b/server/app/controllers/admin/NorthStarProgramCardPreviewController.java
@@ -20,14 +20,12 @@ import services.applicant.ApplicantPersonalInfo.Representation;
 import services.applicant.ApplicantService.ApplicantProgramData;
 import services.program.ProgramDefinition;
 import services.program.ProgramService;
-import services.settings.SettingsManifest;
 import views.admin.programs.NorthStarProgramCardPreview;
 
 /** Controller for rendering a program card preview. */
 public final class NorthStarProgramCardPreviewController extends CiviFormController {
   private final NorthStarProgramCardPreview northStarProgramCardPreview;
   private final Messages messages;
-  private final SettingsManifest settingsManifest;
   private final ProgramService programService;
 
   @Inject
@@ -36,22 +34,16 @@ public final class NorthStarProgramCardPreviewController extends CiviFormControl
       VersionRepository versionRepository,
       NorthStarProgramCardPreview northStarProgramCardPreview,
       MessagesApi messagesApi,
-      SettingsManifest settingsManifest,
       ProgramService programService) {
     super(profileUtils, versionRepository);
     this.northStarProgramCardPreview = checkNotNull(northStarProgramCardPreview);
     this.messages = messagesApi.preferred(ImmutableList.of(Lang.defaultLang()));
-    this.settingsManifest = checkNotNull(settingsManifest);
     this.programService = checkNotNull(programService);
   }
 
   @Secure(authorizers = Authorizers.Labels.CIVIFORM_ADMIN)
   public String cardPreview(Http.Request request, long programId)
       throws InterruptedException, ExecutionException {
-    // TODO(#11570): North star clean up
-    if (!settingsManifest.getNorthStarApplicantUi()) {
-      return "";
-    }
 
     Representation representation = Representation.builder().build();
     ApplicantPersonalInfo api = ApplicantPersonalInfo.ofGuestUser(representation);


### PR DESCRIPTION
### Description

Remove legacy admin program card preview code path.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

### Instructions for manual testing

1. As an admin, create a new program and make sure the card preview on the "add an image" page is fully functional
2. As an admin, edit a program and make sure the card preview on the "Edit program image" page is fully functional

### Issue(s) this completes

Fixes #11570 
