### PR TITLE
Limit email to 50 recipients

### DIFF
--- a/server/app/services/email/aws/SimpleEmail.java
+++ b/server/app/services/email/aws/SimpleEmail.java
@@ -76,6 +76,14 @@ public final class SimpleEmail implements EmailSendClient {
     if (toAddresses.isEmpty()) {
       return;
     }
+
+    if (toAddresses.size() > 50) {
+      logger.warn(
+          "Attempting to send an email with AWS, but it has too many recipients. The email will"
+              + " only be sent to the first 50 email addresses.");
+      toAddresses = toAddresses.stream().limit(50).collect(ImmutableList.toImmutableList());
+    }
+
     Histogram.Timer timer = emailSendMetrics.getEmailExecutionTime().startTimer();
 
     // Add some messaging to non-prod emails to make it easier to


### PR DESCRIPTION
The send email function with AWS SES will throw an exception with more than 50 recipients are on a single email.

This will log a warning and truncate the recipient list to a maximum of 50 as a stop gap until a more robust solution can be dealt with.

There are currently no unit tests directly testing this email class. Localstack doesn't run in the unit tests and a NullClient is used anyway. There also isn't a way great way to check anything. More changes to the email test need to be done to get useful tests than I'm going to do right now. I also don't see the point of writing tests of mocks on mocks on mocks. 

Related to #11938