### PR TITLE
[North Star] Default to display ProgramOverviewView

### DIFF
--- a/server/app/controllers/applicant/ProgramSlugHandler.java
+++ b/server/app/controllers/applicant/ProgramSlugHandler.java
@@ -254,7 +254,7 @@ public final class ProgramSlugHandler {
     }
 
     // If the program is disabled, redirect to review page which will trigger the
-    // ProgramDisabledAction. Otherwise, always show the North Star program overview.
+    // ProgramDisabledAction. Otherwise, always show the program overview.
     if (activeProgramDefinition.displayMode() == DisplayMode.DISABLED) {
       return redirectToReviewPage(
           controller, activeProgramDefinition.id(), applicantId, programSlug, request, profile);

--- a/server/test/controllers/applicant/ProgramSlugHandlerTest.java
+++ b/server/test/controllers/applicant/ProgramSlugHandlerTest.java
@@ -181,9 +181,10 @@ public class ProgramSlugHandlerTest extends WithMockedProfiles {
             .showProgram(controller, fakeRequest(), programDefinition.slug())
             .toCompletableFuture()
             .join();
-    // With North Star always enabled, should show program overview page
     assertThat(result.status()).isEqualTo(OK);
     assertThat(result.contentType()).hasValue("text/html");
+    String content = contentAsString(result);
+    assertThat(content).contains("<title>test program - Program Overview</title>");
   }
 
   @Test
@@ -218,13 +219,14 @@ public class ProgramSlugHandlerTest extends WithMockedProfiles {
             .showProgram(controller, fakeRequest(), programDefinition.slug())
             .toCompletableFuture()
             .join();
-    // With North Star always enabled, should show program overview page
     assertThat(result.status()).isEqualTo(OK);
     assertThat(result.contentType()).hasValue("text/html");
+    String content = contentAsString(result);
+    assertThat(content).contains("<title>test program - Program Overview</title>");
   }
 
   @Test
-  public void showProgram_withNorthStarEnabled_whenApplicationStarted_loadsProgramOverview() {
+  public void showProgram_whenApplicationStarted_loadsProgramOverview() {
     ProgramDefinition programDefinition =
         ProgramBuilder.newActiveProgram("test program", "desc").buildDefinition();
 
@@ -272,7 +274,7 @@ public class ProgramSlugHandlerTest extends WithMockedProfiles {
   }
 
   @Test
-  public void showProgram_withNorthStarEnabled_whenNoApplication_loadsProgramOverview() {
+  public void showProgram_whenNoApplication_loadsProgramOverview() {
     ProgramDefinition programDefinition =
         ProgramBuilder.newActiveProgram("test program", "desc").buildDefinition();
     createApplicantWithMockedProfile();
@@ -315,7 +317,7 @@ public class ProgramSlugHandlerTest extends WithMockedProfiles {
   }
 
   @Test
-  public void showProgram_withNorthStarEnabled_whenApplicationSubmitted_loadsProgramOverview() {
+  public void showProgram_whenApplicationSubmitted_loadsProgramOverview() {
     ProgramDefinition programDefinition =
         ProgramBuilder.newActiveProgram("test program", "desc").buildDefinition();
 
@@ -363,7 +365,7 @@ public class ProgramSlugHandlerTest extends WithMockedProfiles {
   }
 
   @Test
-  public void showProgramPreview_withNorthStarEnabled_loadsProgramOverview() {
+  public void showProgramPreview_loadsProgramOverview() {
     ProgramDefinition programDefinition =
         ProgramBuilder.newActiveProgram("test program", "desc").buildDefinition();
 


### PR DESCRIPTION
### Description
This is part of the North Star cleanup effort to remove legacy UI code paths.
Removed the `getNorthStarApplicantUi()` conditional check and always display the North Star program overview page. 

- **ProgramSlugHandler.java**: Removed `SettingsManifest` dependency and simplified logic to always show North Star program overview (unless program is DISABLED)
- **ProgramSlugHandlerTest.java**: Updated constructor calls and test expectations to reflect always-on North Star behavior

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [X] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [X] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [X] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

#### Database evolutions

Read the guidelines [here](https://github.com/civiform/civiform/wiki/Database#writing-database-evolutions)

- [ ] Assigned two reviewers
- [ ] Guarded against already existing resources using `IF NOT EXISTS` and `IF EXISTS`
- [ ] Downs created to undo changes in Ups
- [ ] Every comment in script should begin with -- and not # --- unless it denotes Ups or Downs. See [here](https://www.playframework.com/documentation/2.9.x/Evolutions) for details.
- [ ] Tested both the Downs and the Ups scripts manually (When testing, include all comments from the evolution in your test script to ensure any syntax errors in the comments are caught.)
- [ ] Data migrations aren't being done (please use a [Durable Job](https://github.com/civiform/civiform/wiki/Database#durable-jobs-for-data-updates) if doing a data migration)
- [ ] Update the model documentation in our [wiki](https://github.com/civiform/civiform/wiki/Database) if necessary

#### Durable jobs

Read the docs [here](https://github.com/civiform/civiform/wiki/Database#durable-jobs-for-data-updates)

- [ ] Assigned two reviewers
- [ ] Included a rollback plan and a job to undo the data changes if appropriate

#### User visible changes

- [ ] Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
  - [ ] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [ ] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Made equivalent changes in Thymeleaf for applicant-facing features and changes (or created an issue in the [Northstar epic](https://github.com/orgs/civiform/projects/1/views/94) to track that it's missing from Thymeleaf)
- [ ] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order
- [ ] Performed manual accessibility tests for any applicant-facing changes or any new admin-facing features. See [manual-accessibility-testing](https://github.com/civiform/civiform/wiki/Accessibility#manual-accessibility-testing)
- [ ] Manually tested with a right-to-left language

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/helper/feature-flags.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://github.com/civiform/civiform/wiki/Feature-Flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Instructions for manual testing

If instructions are needed for manual testing by reviewers, include them here.

### Issue(s) this completes

Fixes #11582
