### PR TITLE
Deleting a filter causes an error

### DIFF
--- a/server/app/views/admin/questions/MapQuestionSettingsFiltersListPartial.html
+++ b/server/app/views/admin/questions/MapQuestionSettingsFiltersListPartial.html
@@ -1,0 +1,5 @@
+<div th:each="filter, i : ${model.filters}">
+  <div
+    th:insert="~{admin/questions/MapQuestionSettingsFragment :: filterInput(${i.index}, ${model.possibleKeys}, ${model.hxDeleteMapQuestionFilterEndpoint}, ${filter.key}, ${filter.displayName})}"
+  ></div>
+</div>

--- a/server/app/views/admin/questions/MapQuestionSettingsFiltersListPartialView.java
+++ b/server/app/views/admin/questions/MapQuestionSettingsFiltersListPartialView.java
@@ -1,0 +1,23 @@
+package views.admin.questions;
+
+import javax.inject.Inject;
+import modules.ThymeleafModule;
+import org.thymeleaf.TemplateEngine;
+import services.settings.SettingsManifest;
+import views.admin.BaseView;
+
+public final class MapQuestionSettingsFiltersListPartialView
+    extends BaseView<MapQuestionSettingsFiltersListPartialViewModel> {
+  @Inject
+  public MapQuestionSettingsFiltersListPartialView(
+      TemplateEngine templateEngine,
+      ThymeleafModule.PlayThymeleafContextFactory playThymeleafContextFactory,
+      SettingsManifest settingsManifest) {
+    super(templateEngine, playThymeleafContextFactory, settingsManifest);
+  }
+
+  @Override
+  protected String pageTemplate() {
+    return "admin/questions/MapQuestionSettingsFiltersListPartial.html";
+  }
+}

--- a/server/app/views/admin/questions/MapQuestionSettingsFiltersListPartialViewModel.java
+++ b/server/app/views/admin/questions/MapQuestionSettingsFiltersListPartialViewModel.java
@@ -1,0 +1,19 @@
+package views.admin.questions;
+
+import controllers.admin.routes;
+import forms.MapQuestionForm;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import views.admin.BaseViewModel;
+
+@Getter
+@AllArgsConstructor
+public final class MapQuestionSettingsFiltersListPartialViewModel implements BaseViewModel {
+  private List<String> possibleKeys;
+  private List<MapQuestionForm.Setting> filters;
+
+  public String hxDeleteMapQuestionFilterEndpoint() {
+    return routes.AdminQuestionController.deleteMapQuestionFilter().url();
+  }
+}

--- a/server/app/views/admin/questions/MapQuestionSettingsFragment.html
+++ b/server/app/views/admin/questions/MapQuestionSettingsFragment.html
@@ -103,8 +103,10 @@
       class="cf-map-question-filter-button usa-button usa-button--unstyled flex-align-self-end"
       aria-label="Delete filter"
       th:hx-post="${hxDeleteMapFilterEndpoint}"
-      th:hx-target="${'closest div[class*=filter-input]'}"
-      hx-swap="outerHTML"
+      th:hx-vals='|{"filterIndex": ${index}}|'
+      hx-include="closest form"
+      hx-target="#filters"
+      hx-swap="innerHTML"
     >
       <cf:icon type="icon-delete" />
     </button>


### PR DESCRIPTION
### Description

When deleting a filter from map question settings, the form would show validation errors ("filter key and value can't be empty") on save. This occurred because HTMX removed the DOM element but didn't re-index the remaining filters, creating gaps in the array indices.

- Modified MapQuestionSettingsFragment.html to target the entire filters container instead of individual filter elements
- Created MapQuestionSettingsFiltersListPartial templates to render the complete filter list with sequential indices
- Updated AdminQuestionController.deleteMapQuestionFilter() to remove the specified filter and re-render all remaining filters with corrected indices
- Added unit test to verify filter deletion and re-indexing


### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [X] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [X] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [X] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [X] Created unit and/or browser tests which fail without the change (if possible)
- [X] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

#### Database evolutions

Read the guidelines [here](https://github.com/civiform/civiform/wiki/Database#writing-database-evolutions)

- [ ] Assigned two reviewers
- [ ] Guarded against already existing resources using `IF NOT EXISTS` and `IF EXISTS`
- [ ] Downs created to undo changes in Ups
- [ ] Every comment in script should begin with -- and not # --- unless it denotes Ups or Downs. See [here](https://www.playframework.com/documentation/2.9.x/Evolutions) for details.
- [ ] Tested both the Downs and the Ups scripts manually (When testing, include all comments from the evolution in your test script to ensure any syntax errors in the comments are caught.)
- [ ] Data migrations aren't being done (please use a [Durable Job](https://github.com/civiform/civiform/wiki/Database#durable-jobs-for-data-updates) if doing a data migration)
- [ ] Update the model documentation in our [wiki](https://github.com/civiform/civiform/wiki/Database) if necessary

#### Durable jobs

Read the docs [here](https://github.com/civiform/civiform/wiki/Database#durable-jobs-for-data-updates)

- [ ] Assigned two reviewers
- [ ] Included a rollback plan and a job to undo the data changes if appropriate

#### User visible changes

- [ ] Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
  - [ ] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [ ] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Made equivalent changes in Thymeleaf for applicant-facing features and changes (or created an issue in the [Northstar epic](https://github.com/orgs/civiform/projects/1/views/94) to track that it's missing from Thymeleaf)
- [ ] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order
- [ ] Performed manual accessibility tests for any applicant-facing changes or any new admin-facing features. See [manual-accessibility-testing](https://github.com/civiform/civiform/wiki/Accessibility#manual-accessibility-testing)
- [ ] Manually tested with a right-to-left language

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/helper/feature-flags.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://github.com/civiform/civiform/wiki/Feature-Flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Instructions for manual testing

If instructions are needed for manual testing by reviewers, include them here.

### Issue(s) this completes

Fixes #  Fixes #11939 
