### PR TITLE
Program overview page changes for LoginOnly programs

### DIFF
--- a/browser-test/src/admin/admin_program_login_only.test.ts
+++ b/browser-test/src/admin/admin_program_login_only.test.ts
@@ -1,0 +1,63 @@
+import {test} from '../support/civiform_fixtures'
+import {loginAsAdmin} from '../support'
+import {ProgramLifecycle} from '../support/admin_programs'
+
+test.describe('login only program', () => {
+  test('default login only value for any program is false', async ({
+    page,
+    adminPrograms,
+  }) => {
+    await test.step('create new program and verify default', async () => {
+      await loginAsAdmin(page)
+      await adminPrograms.addProgram('default program')
+      await adminPrograms.goToProgramDescriptionPage(
+        'default program',
+        ProgramLifecycle.DRAFT,
+      )
+      await adminPrograms.expectLoginOnlyProgramIsChecked(false)
+    })
+  })
+
+  test('login only persists through publish', async ({page, adminPrograms}) => {
+    const programName = 'test program'
+
+    await test.step('create new program', async () => {
+      await loginAsAdmin(page)
+      await adminPrograms.addProgram(programName)
+    })
+
+    await test.step('set login only to true and publish', async () => {
+      await adminPrograms.goToProgramDescriptionPage(programName)
+      await adminPrograms.setProgramToLoginOnly(true)
+      await adminPrograms.submitProgramDetailsEdits()
+      await adminPrograms.publishAllDrafts()
+    })
+
+    await test.step('verify login only through publish', async () => {
+      await adminPrograms.goToProgramDescriptionPage(
+        programName,
+        ProgramLifecycle.ACTIVE,
+      )
+      await adminPrograms.expectLoginOnlyProgramIsChecked(true)
+      await adminPrograms.publishAllDrafts()
+    })
+
+    await test.step('set login only to false', async () => {
+      await adminPrograms.goToProgramDescriptionPage(
+        programName,
+        ProgramLifecycle.ACTIVE,
+      )
+      await adminPrograms.setProgramToLoginOnly(false)
+      await adminPrograms.submitProgramDetailsEdits()
+      await adminPrograms.publishAllDrafts()
+    })
+
+    await test.step('verify login only persists through publish', async () => {
+      await adminPrograms.goToProgramDescriptionPage(
+        programName,
+        ProgramLifecycle.ACTIVE,
+      )
+      await adminPrograms.expectLoginOnlyProgramIsChecked(false)
+    })
+  })
+})

--- a/browser-test/src/applicant/program_overview.test.ts
+++ b/browser-test/src/applicant/program_overview.test.ts
@@ -427,3 +427,70 @@ test.describe('Applicant program overview', {tag: ['@northstar']}, () => {
     )
   })
 })
+
+test.describe(
+  'Applicant program overview for login only program',
+  {tag: ['@northstar']},
+  () => {
+    const programName = 'loginonly'
+
+    test.beforeEach(async ({page, adminPrograms}) => {
+      await test.step('create a new program', async () => {
+        await loginAsAdmin(page)
+        await adminPrograms.addProgram(programName)
+        await adminPrograms.goToProgramDescriptionPage(programName)
+        await adminPrograms.setProgramToLoginOnly(true)
+        await adminPrograms.submitProgramDetailsEdits()
+        await adminPrograms.publishAllDrafts()
+        await logout(page)
+      })
+    })
+
+    test('login only program has no start application button when entering as guest', async ({
+      page,
+    }) => {
+      const programName = 'loginonly'
+
+      await page.goto(`/programs/${programName}`)
+      await expect(
+        page.getByRole('link', {name: 'Start an application'}).first(),
+      ).toBeHidden()
+
+      await expect(
+        page.getByRole('button', {name: 'Start application as a guest'}),
+      ).toBeHidden()
+
+      // there is a link and button with the same name, check both
+      await expect(
+        page
+          .getByRole('button', {name: 'Start application with an account'})
+          .first(),
+      ).toBeVisible()
+
+      await expect(
+        page
+          .getByRole('link', {name: 'Start application with an account'})
+          .first(),
+      ).toBeVisible()
+
+      // login only create account message
+      await expect(
+        page.getByLabel(
+          'For your information: To access your application later, you must create an account',
+        ),
+      ).toBeVisible()
+    })
+    test('login only program has start application button when entering as a logged in user', async ({
+      page,
+    }) => {
+      const programName = 'loginonly'
+
+      await loginAsTestUser(page)
+      await page.goto(`/programs/${programName}`)
+
+      await expect(
+        page.getByRole('link', {name: 'Start an application'}).first(),
+      ).toBeVisible()
+    })
+  },
+)

--- a/browser-test/src/support/admin_programs.ts
+++ b/browser-test/src/support/admin_programs.ts
@@ -987,6 +987,29 @@ export class AdminPrograms {
     }
   }
 
+  async expectLoginOnlyProgramIsChecked(isChecked: boolean) {
+    await expect(
+      this.page.getByRole('checkbox', {
+        name: 'Require applicants to log in to apply to this program',
+      }),
+    ).toBeChecked({checked: isChecked})
+  }
+
+  async setProgramToLoginOnly(checked: boolean) {
+    const checkbox = this.page.getByRole('checkbox', {
+      name: 'Require applicants to log in to apply to this program',
+    })
+    const isCurrentlyChecked = await checkbox.isChecked()
+
+    if (isCurrentlyChecked !== checked) {
+      // Note: We click on the label instead of directly interacting with the checkbox
+      // because USWDS styling hides the actual checkbox input and styles the label to
+      // look like a checkbox. The actual input element is visually hidden or positioned
+      // off-screen, making it inaccessible to Playwright's direct interactions.
+      await this.page.locator('label[for="login-only-applications"]').click()
+    }
+  }
+
   /**
    * Opens the export program page by clicking on a program's card action or
    * extra action (depending on the program lifecycle)

--- a/server/app/services/MessageKey.java
+++ b/server/app/services/MessageKey.java
@@ -24,6 +24,9 @@ public enum MessageKey {
   ADDRESS_VALIDATION_STREET_REQUIRED("validation.streetRequired"),
   ALERT_CREATE_ACCOUNT("alert.createAccount"), // North Star only
   ALERT_CREATE_ACCOUNT_DESCRIPTION("alert.createAccountDescription"), // North Star only
+  ALERT_LOGIN_ONLY("alert.loginOnly"), // North Star only
+  ALERT_LOGIN_ONLY_DESCRIPTION("alert.loginOnlyDescription"), // North Star only
+  ALERT_LOGIN_ONLY_CREATE_ACCOUNT("alert.createAccountForLoginOnly"), // North Star only
   ALERT_ELIGIBILITY_APPLICANT_ELIGIBLE_TITLE("alert.eligibility_applicant_eligible_title"),
   ALERT_ELIGIBILITY_APPLICANT_ELIGIBLE_TEXT("alert.eligibility_applicant_eligible_text"),
   ALERT_ELIGIBILITY_APPLICANT_NOT_ELIGIBLE_TITLE("alert.eligibility_applicant_not_eligible_title"),

--- a/server/app/views/applicant/CreateAccountAlertFragment.html
+++ b/server/app/views/applicant/CreateAccountAlertFragment.html
@@ -6,11 +6,17 @@
 >
   <div class="usa-alert__body">
     <h2
+      th:if="${!loginOnly}"
       class="usa-alert__heading"
       th:text="#{alert.createAccount}"
       th:aria-label="#{heading.informationAriaLabelPrefix(#{alert.createAccount})}"
     ></h2>
-
+    <h2
+      th:if="${loginOnly}"
+      class="usa-alert__heading"
+      th:text="#{alert.createAccountForLoginOnly}"
+      th:aria-label="#{heading.informationAriaLabelPrefix(#{alert.createAccountForLoginOnly})}"
+    ></h2>
     <p class="usa-alert__text" th:text="#{alert.createAccountDescription}"></p>
 
     <div class="content-spacing"></div>
@@ -28,8 +34,7 @@
     </div>
 
     <div class="text-medium-spacing"></div>
-
-    <p>
+    <p th:if="${!loginOnly}">
       <a
         class="usa-link"
         role="button"

--- a/server/app/views/applicant/NorthStarProgramOverviewView.java
+++ b/server/app/views/applicant/NorthStarProgramOverviewView.java
@@ -100,8 +100,8 @@ public class NorthStarProgramOverviewView extends NorthStarBaseView {
     }
 
     context.setVariable("showEligibilityAlert", showEligibilityAlert);
-
     context.setVariable("createAccountLink", controllers.routes.LoginController.register().url());
+    context.setVariable("loginOnly", programDefinition.loginOnly());
 
     // This works for logged-in and logged-out applicants
     String actionUrl = applicantRoutes.edit(profile, applicantId, programDefinition.id()).url();

--- a/server/app/views/applicant/ProgramOverviewTemplate.html
+++ b/server/app/views/applicant/ProgramOverviewTemplate.html
@@ -24,9 +24,23 @@
         <div class="grid-row">
           <div class="tablet:grid-col-8">
             <a
+              th:if="${!loginOnly}"
               th:href="${actionUrl}"
               class="usa-button"
               th:text="#{button.startApp}"
+            ></a>
+            <a
+              th:if="${loginOnly and !isGuest}"
+              th:href="${actionUrl}"
+              class="usa-button"
+              th:text="#{button.startApp}"
+            ></a>
+
+            <a
+              th:if="${loginOnly and isGuest}"
+              th:href="${createAccountLink}"
+              class="usa-button"
+              th:text="#{link.createAccountFromOverview}"
             ></a>
 
             <!--*/ Application steps */-->

--- a/server/test/conf/MessagesTest.java
+++ b/server/test/conf/MessagesTest.java
@@ -162,18 +162,7 @@ public class MessagesTest {
     ImmutableList<String> messageKeys =
         Arrays.stream(MessageKey.values()).map(MessageKey::getKeyName).collect(toImmutableList());
 
-    ImmutableList<String> untranslatedKeys =
-        ImmutableList.of(
-            "alert.createAccountForLoginOnly", "alert.loginOnly", "alert.loginOnlyDescription");
-
-    // TODO(#11806) remove when translations are completed.
-    ImmutableList<String> messageKeysAndUntranslatedKeys =
-        Stream.of(messageKeys, untranslatedKeys)
-            .flatMap(ImmutableList::stream)
-            .collect(toImmutableList());
-
-    assertThat(keysInPrimaryFile)
-        .containsExactlyInAnyOrderElementsOf(messageKeysAndUntranslatedKeys);
+    assertThat(keysInPrimaryFile).containsExactlyInAnyOrderElementsOf(messageKeys);
   }
 
   private static Set<String> keysInFile(String filePath) throws Exception {


### PR DESCRIPTION
### Description

Program Overview page changes for loginOnly programs
TDD- https://docs.google.com/document/d/1Rt8DTMUrSGV1Nn2TvstdR5E2Zp8nTz7NEUj3fmgEJxk/edit?tab=t.0#heading=h.bknox3ib8wpb

## Release notes

Program Overview page changes for loginOnly programs

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.


#### User visible changes

- [x] Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
  - [ ] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [ ] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Made equivalent changes in Thymeleaf for applicant-facing features and changes (or created an issue in the [Northstar epic](https://github.com/orgs/civiform/projects/1/views/94) to track that it's missing from Thymeleaf)
- [ ] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order
- [ ] Performed manual accessibility tests for any applicant-facing changes or any new admin-facing features. See [manual-accessibility-testing](https://github.com/civiform/civiform/wiki/Accessibility#manual-accessibility-testing)
- [ ] Manually tested with a right-to-left language


### Instructions for manual testing

1. Create a new program and check "login required" to true in program details page.
2. Publish program
3. Login as a guest, you shouldn't see the "Start an application" button.
4. You should only see "Start an application with an account" button as a guest.
5. Logged in guest will work as normal in overview page. 

### Issue(s) this completes

Fixes #11875