### PR TITLE
Fixing flaky AccountModelTest

### DIFF
--- a/server/test/models/AccountModelTest.java
+++ b/server/test/models/AccountModelTest.java
@@ -234,6 +234,7 @@ public class AccountModelTest extends ResetPostgres {
     // Put Older second to check that the order doesn't matter
     account.setApplicants(ImmutableList.of(applicantNewer, applicantOlder));
     account.save();
+    account.refresh();
 
     Optional<ApplicantModel> optionalGot = account.representativeApplicant();
     assertThat(optionalGot).isPresent();


### PR DESCRIPTION
### Description

The AccountModel tests were failing as it read from the DB before updating. model.refresh() will prevent this behavior.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [ ] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.


### Issue(s) this completes

Fixes #11984