### PR TITLE
Rewrite translations test for more helpful failure messages

### DIFF
--- a/server/test/conf/MessagesTest.java
+++ b/server/test/conf/MessagesTest.java
@@ -115,7 +115,7 @@ public class MessagesTest {
     Map<String, String> entriesInPrimaryLanguageFile = entriesInFile(PRIMARY_LANGUAGE_FILE_PATH);
 
     assertThat(entriesInPrimaryLanguageFile)
-        .withFailMessage("Prohibited characters found in primary language file..")
+        .withFailMessage("Prohibited characters found in primary language file.")
         .allSatisfy(
             (key, value) -> {
               assertThat(key).doesNotContain(PROHIBITED_CHARACTERS);
@@ -129,30 +129,29 @@ public class MessagesTest {
       String foreignLanguageFile) throws Exception {
     Map<String, String> entriesInforeignLanguageFile = entriesInFile(foreignLanguageFile);
 
-    assertThat(entriesInforeignLanguageFile)
-        .withFailMessage("Prohibited characters found in " + foreignLanguageFile + ".")
-        .allSatisfy(
-            (key, value) -> {
-              assertThat(key).doesNotContain(PROHIBITED_CHARACTERS);
-              for (String prohibitedChar : PROHIBITED_CHARACTERS) {
-                if (value.contains(prohibitedChar)) {
-                  // German language has a different set of quotes, so we expect to see the left
-                  // quote, but want to make sure the low right quote is also present.
-                  if (foreignLanguageFile.endsWith("de")) {
-                    if (value.contains(LEFT_DOUBLE_QUOTATION_MARK)
-                        && value.contains(LOW_RIGHT_DOUBLE_QUOTATION_MARK)) {
-                      continue;
-                    }
-                  }
-                  assertThat(value)
-                      .withFailMessage(
-                          String.format(
-                              "Value for key '%s' contains prohibited character '%s'",
-                              key, prohibitedChar))
-                      .doesNotContain(PROHIBITED_CHARACTERS);
-                }
-              }
-            });
+    for (Map.Entry<String, String> entry : entriesInforeignLanguageFile.entrySet()) {
+      String key = (String) entry.getKey();
+      String value = (String) entry.getValue();
+
+      assertThat(key).doesNotContain(PROHIBITED_CHARACTERS);
+      for (String prohibitedChar : PROHIBITED_CHARACTERS) {
+        if (value.contains(prohibitedChar)) {
+          // German language has a different set of quotes, so we expect to see the left
+          // quote, but want to make sure the low right quote is also present.
+          if (foreignLanguageFile.endsWith("de")) {
+            if (value.contains(LEFT_DOUBLE_QUOTATION_MARK)
+                && value.contains(LOW_RIGHT_DOUBLE_QUOTATION_MARK)) {
+              continue;
+            }
+          }
+          assertThat(value)
+              .withFailMessage(
+                  String.format(
+                      "Value for key '%s' contains prohibited character '%s'", key, prohibitedChar))
+              .doesNotContain(PROHIBITED_CHARACTERS);
+        }
+      }
+    }
   }
 
   @Test


### PR DESCRIPTION
### Description

Using `allSatisfy` on this test meant it would only show the generic failure message `"Prohibited characters found in " + foreignLanguageFile + "."` The more specific failure message `"Value for key '%s' contains prohibited character '%s'"` was getting swallowed which made it hard to find where the error was.

There might be a way to get the individual error messages to show up as is, but I couldn't figure it out. Also printing the language file name is redundant because the test logs tell us which param was used:
<img width="1766" height="122" alt="image" src="https://github.com/user-attachments/assets/17fbfb02-68e5-4cdc-9814-4624a15958ad" />


### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

