### PR TITLE
Explicitly set applicant creation time in test

### DIFF
--- a/server/test/models/AccountModelTest.java
+++ b/server/test/models/AccountModelTest.java
@@ -207,11 +207,16 @@ public class AccountModelTest extends ResetPostgres {
   public void getApplicantDisplayName_getsOldest() {
     ApplicantModel applicantOlder = new ApplicantModel();
     applicantOlder.setUserName("Older Applicant");
+    applicantOlder.save();
+    // Overwrite the automatically set time.
     applicantOlder.setWhenCreated(Instant.EPOCH);
     applicantOlder.save();
+
     ApplicantModel applicantNewer = new ApplicantModel();
     applicantNewer.setUserName("Newer Applicant");
-    applicantNewer.setWhenCreated(Instant.ofEpochSecond(1));
+    applicantNewer.save();
+    // Overwrite the automatically set time.
+    applicantNewer.setWhenCreated(Instant.ofEpochSecond(60));
     applicantNewer.save();
 
     AccountModel account = new AccountModel();
@@ -227,11 +232,16 @@ public class AccountModelTest extends ResetPostgres {
   public void representativeApplicant() {
     ApplicantModel applicantOlder = new ApplicantModel();
     applicantOlder.setUserName("Older Applicant");
+    applicantOlder.save();
+    // Overwrite the automatically set time.
     applicantOlder.setWhenCreated(Instant.EPOCH);
     applicantOlder.save();
+
     ApplicantModel applicantNewer = new ApplicantModel();
     applicantNewer.setUserName("Newer Applicant");
-    applicantNewer.setWhenCreated(Instant.ofEpochSecond(1));
+    applicantNewer.save();
+    // Overwrite the automatically set time.
+    applicantNewer.setWhenCreated(Instant.ofEpochSecond(60));
     applicantNewer.save();
 
     AccountModel account = new AccountModel();


### PR DESCRIPTION
### Description

Fix Flakey tests by explicitly setting timestamps and after the DB auto populates it.

The issue was due to the applicants being made at "the same time" from the database's perspective so they were given the same timestamp.


### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [ ] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

Fixes: #11984
