### PR TITLE
[Accessibility] Checkboxes are not accessible when disabled

### DIFF
--- a/server/app/assets/javascripts/mapquestion/map_question_selection.ts
+++ b/server/app/assets/javascripts/mapquestion/map_question_selection.ts
@@ -23,10 +23,29 @@ import {
 
 let locationOffset = 0
 
+/**
+ * Prevents checking a checkbox if it has aria-disabled="true"
+ */
+const preventCheckIfDisabled = (event: Event): void => {
+  const input = event.target as HTMLInputElement
+  if (input.getAttribute('aria-disabled') === 'true') {
+    event.preventDefault()
+  }
+}
+
 export const initLocationSelection = (mapId: string): void => {
   // Initial update so the previously saved locations get displayed as selected
   updateSelectedLocations(mapId)
   updateAlertVisibility(mapId)
+
+  // Add event delegation to prevent clicking aria-disabled checkboxes
+  const locationsContainer = mapQuerySelector(
+    mapId,
+    CF_LOCATIONS_LIST_CONTAINER,
+  )
+  if (locationsContainer) {
+    locationsContainer.addEventListener('click', preventCheckIfDisabled)
+  }
 }
 
 export const updateSelectedLocations = (mapId: string): void => {
@@ -122,9 +141,10 @@ export const updateSelectedLocations = (mapId: string): void => {
     if (input) {
       // Only disable unchecked checkboxes when max is reached
       if (atMaxSelections && !input.checked) {
-        input.disabled = true
+        // Use aria-disabled instead of disabled to keep in tab order
+        input.setAttribute('aria-disabled', 'true')
       } else {
-        input.disabled = false
+        input.removeAttribute('aria-disabled')
       }
     }
   })

--- a/server/app/assets/stylesheets/northstar/_uswds-theme-custom-styles.scss
+++ b/server/app/assets/stylesheets/northstar/_uswds-theme-custom-styles.scss
@@ -99,6 +99,12 @@ it is around the label */
   @include u-maxw('mobile-lg');
 }
 
+/* Style aria-disabled checkboxes to appear disabled */
+.cf-location-checkbox-input[aria-disabled='true'] + label {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 /*
  * Make the file input element for program image upload fill the area it's given.
  * (This overrides the default USWDS style of a max-width of 30rem.)


### PR DESCRIPTION
### Description

Fix disabled state accessibility for map selection checkboxes

 **The Problem:**
When users reach the maximum number of selections in a map question, remaining checkboxes become functionally disabled but lacked visual indication for the users who might attempt to interact with checkboxes only to discover they're disabled, violating WCAG accessibility guidelines for perceivable user interface components.


### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [X] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [X] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [X] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

#### Database evolutions

Read the guidelines [here](https://github.com/civiform/civiform/wiki/Database#writing-database-evolutions)

- [ ] Assigned two reviewers
- [ ] Guarded against already existing resources using `IF NOT EXISTS` and `IF EXISTS`
- [ ] Downs created to undo changes in Ups
- [ ] Every comment in script should begin with -- and not # --- unless it denotes Ups or Downs. See [here](https://www.playframework.com/documentation/2.9.x/Evolutions) for details.
- [ ] Tested both the Downs and the Ups scripts manually (When testing, include all comments from the evolution in your test script to ensure any syntax errors in the comments are caught.)
- [ ] Data migrations aren't being done (please use a [Durable Job](https://github.com/civiform/civiform/wiki/Database#durable-jobs-for-data-updates) if doing a data migration)
- [ ] Update the model documentation in our [wiki](https://github.com/civiform/civiform/wiki/Database) if necessary

#### Durable jobs

Read the docs [here](https://github.com/civiform/civiform/wiki/Database#durable-jobs-for-data-updates)

- [ ] Assigned two reviewers
- [ ] Included a rollback plan and a job to undo the data changes if appropriate

#### User visible changes

- [ ] Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
  - [ ] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [ ] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Made equivalent changes in Thymeleaf for applicant-facing features and changes (or created an issue in the [Northstar epic](https://github.com/orgs/civiform/projects/1/views/94) to track that it's missing from Thymeleaf)
- [ ] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order
- [ ] Performed manual accessibility tests for any applicant-facing changes or any new admin-facing features. See [manual-accessibility-testing](https://github.com/civiform/civiform/wiki/Accessibility#manual-accessibility-testing)
- [ ] Manually tested with a right-to-left language

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/helper/feature-flags.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://github.com/civiform/civiform/wiki/Feature-Flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Instructions for manual testing

  ### Setup
  1. Create a test program with a map question
  2. Configure the map question with:
     - Minimum selections: 1
     - Maximum selections: 2 (or any number less than total available locations)

  ### Test Cases

 #### Test 1: Keyboard navigation with maximum selections reached
  1. Navigate to the applicant view of the program
  2. Proceed to program with the map question
  3. Use **Tab** key to navigate to the checkboxes
  4. Use **Space** key to select locations until you reach the maximum (e.g., 2 selections)
  5. Continue using **Tab** to navigate through remaining checkboxes
  6. **Expected Result**:
     - Focus indicator should be visible on all checkboxes (both enabled and disabled)
     - Disabled checkboxes should be visually distinguishable from enabled ones (reduced opacity)
     - User should clearly see which checkboxes are unavailable without needing to attempt selection

  #### Test 2: Keyboard interaction with disabled checkboxes
  1. With maximum selections reached via keyboard, tab to an unselected/disabled checkbox
  2. Press **Space** to attempt selection
  3. **Expected Result**:
     - Checkbox should remain unchecked (functional behavior should prevent selection)
     - Visual disabled styling provides advance notice that selection is unavailable
     - No confusing behavior where checkbox appears available but doesn't respond

  #### Test 3: Visual feedback during keyboard navigation
  1. With maximum selections reached, use **Tab** to move focus between checkboxes
  2. Observe the visual state of focused disabled checkboxes vs enabled checkboxes
  3. **Expected Result**:
     - Disabled checkboxes maintain reduced opacity even when focused
     - Clear visual distinction between "focused but disabled" and "focused and enabled"
     - User can identify disabled state before attempting interaction

  #### Test 4: Keyboard re-enabling flow
  1. With maximum selections reached, use **Tab** to navigate back to a selected checkbox
  2. Press **Space** to deselect it
  3. **Expected Result**:
     - Previously disabled checkboxes should return to normal appearance (full opacity)
     - User can visually confirm that options are now available again
     - Can successfully select a previously disabled checkbox using **Space** key

  #### Test 5: Screen reader + keyboard navigation
  1. Enable a screen reader
  2. Navigate to the map question and select maximum locations using keyboard
  3. Tab through the disabled checkboxes
  4. **Expected Result**:
     - Screen reader should announce disabled state for unavailable checkboxes
     - Visual styling reinforces the audible announcement
     - Combined visual + audible feedback provides complete accessibility

  #### Test 6: Mouse vs keyboard consistency
  1. Reach maximum selections using keyboard (Tab + Space)
  2. Hover mouse over disabled checkbox
  3. **Expected Result**:
     - Visual disabled state (opacity) is consistent whether using mouse or keyboard
     - Cursor changes to "not-allowed" on hover, providing additional mouse-user feedback
     - Keyboard users get equivalent information through visual styling

  ### Accessibility Testing Tools (recommended)
  - Run axe DevTools to verify no new accessibility issues

### Screenshots
![screen-reader-1](https://github.com/user-attachments/assets/7da17f04-5c39-4b72-a282-7cccbc215b37)
![screenshot-1](https://github.com/user-attachments/assets/845c7fc1-ff0e-4e5c-86e4-7c0a712000e0)




### Issue(s) this completes

Fixes #11922 
