### PR TITLE
[North Star] Remove North Star check from relevantProgramsForApplicantInternal #11579

### DIFF
--- a/server/app/services/applicant/ApplicantService.java
+++ b/server/app/services/applicant/ApplicantService.java
@@ -1343,9 +1343,7 @@ public final class ApplicantService {
             relevantPrograms.setPreScreenerForm(applicantProgramDataBuilder.build());
           } else if (programType.equals(ProgramType.DEFAULT)
               || (programType.equals(ProgramType.EXTERNAL)
-                  && settingsManifest.getExternalProgramCardsEnabled(request)
-                  // TODO(#11579): North star clean up
-                  && settingsManifest.getNorthStarApplicantUi())) {
+                  && settingsManifest.getExternalProgramCardsEnabled(request))) {
             unappliedPrograms.add(applicantProgramDataBuilder.build());
           }
         });

--- a/server/test/services/applicant/ApplicantServiceTest.java
+++ b/server/test/services/applicant/ApplicantServiceTest.java
@@ -2811,14 +2811,10 @@ public class ApplicantServiceTest extends ResetPostgres {
                 ProgramType.EXTERNAL)
             .build();
 
-    // External program is not included in 'unapplied' list when request does not have the external
-    // program card feature
-    // enabled
+    // External program is not included in 'unapplied' list when external program card feature is
+    // disabled
     Request request =
-        fakeRequestBuilder()
-            .addCiviFormSetting("NORTH_STAR_APPLICANT_UI", "true")
-            .addCiviFormSetting("EXTERNAL_PROGRAM_CARDS_ENABLED", "false")
-            .build();
+        fakeRequestBuilder().addCiviFormSetting("EXTERNAL_PROGRAM_CARDS_ENABLED", "false").build();
     ApplicantService.ApplicationPrograms result =
         subject
             .relevantProgramsForApplicant(applicant.id, trustedIntermediaryProfile, request)
@@ -2828,13 +2824,10 @@ public class ApplicantServiceTest extends ResetPostgres {
     assertThat(result.unapplied().stream().map(p -> p.program().id()))
         .containsExactly(programDefinition.id());
 
-    // External program is included in 'unapplied' list when request has external program card and
-    // North Star features enabled
+    // External program is included in 'unapplied' list when external program card feature is
+    // enabled
     Request requestWithFeature =
-        fakeRequestBuilder()
-            .addCiviFormSetting("NORTH_STAR_APPLICANT_UI", "true")
-            .addCiviFormSetting("EXTERNAL_PROGRAM_CARDS_ENABLED", "true")
-            .build();
+        fakeRequestBuilder().addCiviFormSetting("EXTERNAL_PROGRAM_CARDS_ENABLED", "true").build();
     ApplicantService.ApplicationPrograms resultWithFeature =
         subject
             .relevantProgramsForApplicant(


### PR DESCRIPTION
### Description
- Removed the && settingsManifest.getNorthStarApplicantUi() check from the conditional logic
- Removed the TODO(#11579) comment
 - Simplified the logic: External programs are now included in the unapplied list when EXTERNAL_PROGRAM_CARDS_ENABLED=true (since North Star  is always enabled)

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [X] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [X] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [X] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.


### Instructions for manual testing

### 1. Verify External Programs Display (when feature enabled)
- Set environment variable: `EXTERNAL_PROGRAM_CARDS_ENABLED=true`
- Create a new external program OR use an existing one
  - If creating new: Set program display mode to "External" with an external link URL
- Log in as an applicant
- Navigate to the programs list page ("Programs and services")
- **Expected:** The external program appears on the page with a "View in new tab" button (with external link icon)

### 2. Verify External Programs Hidden (when feature disabled)
- Set environment variable: `EXTERNAL_PROGRAM_CARDS_ENABLED=false`
- Log in as an applicant
- Navigate to the programs list page
- **Expected:** External programs do NOT appear in the list

## Expected Behavior

- External programs visibility should be controlled ONLY by `EXTERNAL_PROGRAM_CARDS_ENABLED` setting
- External programs display with a "View in new tab" button (external link icon) instead of "View and apply"
- External programs appear on the main "Programs and services" page alongside regular programs
- North Star UI should always be used (no conditional rendering)
- No functional changes to program filtering or display logic

### Issue(s) this completes

Fixes #11579
