### PR TITLE
Fix error message to say "Program ID" instead of "Program URL"

### DIFF
--- a/server/app/services/program/ProgramService.java
+++ b/server/app/services/program/ProgramService.java
@@ -76,11 +76,11 @@ public final class ProgramService {
       "A program visibility option must be selected";
   private static final String INVALID_NOTIFICATION_PREFERENCE_MSG =
       "One or more notification preferences are invalid";
-  private static final String MISSING_ADMIN_NAME_MSG = "A program URL is required";
+  private static final String MISSING_ADMIN_NAME_MSG = "A program ID is required";
   private static final String INVALID_ADMIN_NAME_MSG =
-      "A program URL may only contain lowercase letters, numbers, and dashes";
+      "A program ID may only contain lowercase letters, numbers, and dashes";
   private static final String INVALID_PROGRAM_SLUG_MSG =
-      "A program URL must contain at least one letter";
+      "A program ID must contain at least one letter";
   private static final String INVALID_CATEGORY_MSG = "Only existing category ids are allowed";
   private static final String INVALID_PROGRAM_LINK_FORMAT_MSG =
       "A program link must begin with 'http://' or 'https://'";


### PR DESCRIPTION
## Summary
- Updated error messages to reference "Program ID" instead of "Program URL"
- The field in the admin UI is labeled "Program ID" but the validation error messages were incorrectly referring to it as "program URL", causing confusion

## Changes Made
- Modified `server/app/services/program/ProgramService.java`:
  - `MISSING_ADMIN_NAME_MSG`: "A program URL is required" → "A program ID is required"
  - `INVALID_ADMIN_NAME_MSG`: "A program URL may only contain..." → "A program ID may only contain..."
  - `INVALID_PROGRAM_SLUG_MSG`: "A program URL must contain..." → "A program ID must contain..."

## Test Plan
- Verified the error messages are only used for validation of the Program ID field
- No functional changes, only string text updates

Fixes #12031