### PR TITLE
Assert 200 when setting feature flag

### DIFF
--- a/browser-test/src/applicant/application_version_fast_forward.test.ts
+++ b/browser-test/src/applicant/application_version_fast_forward.test.ts
@@ -9,7 +9,6 @@ import {
   logout,
   closeWarningMessage,
   AdminPredicates,
-  enableFeatureFlag,
   testUserDisplayName,
 } from '../support'
 import {ProgramVisibility, QuestionSpec} from '../support/admin_programs'
@@ -43,16 +42,6 @@ test.describe(
       const programAdminActor = await FastForwardProgramAdminActor.create(
         programName,
         browser,
-      )
-
-      await enableFeatureFlag(
-        civiformAdminActor.getPage(),
-        'FASTFORWARD_ENABLED',
-      )
-      await enableFeatureFlag(applicantActor.getPage(), 'FASTFORWARD_ENABLED')
-      await enableFeatureFlag(
-        programAdminActor.getPage(),
-        'FASTFORWARD_ENABLED',
       )
 
       /*
@@ -520,12 +509,6 @@ test.describe(
         programName,
         browser,
       )
-
-      await enableFeatureFlag(
-        civiformAdminActor.getPage(),
-        'FASTFORWARD_ENABLED',
-      )
-      await enableFeatureFlag(applicantActor.getPage(), 'FASTFORWARD_ENABLED')
 
       /*
 

--- a/browser-test/src/support/index.ts
+++ b/browser-test/src/support/index.ts
@@ -155,6 +155,7 @@ async function loginAsTestUserSeattleStaging(page: Page, loginButton: string) {
   await page.fill('input[name=userName]', TEST_USER_LOGIN)
   await page.fill('input[name=password]', TEST_USER_PASSWORD)
   await page.click('button:has-text("Login"):not([disabled])')
+  // eslint-disable-next-line playwright/no-wait-for-navigation
   await page.waitForNavigation({waitUntil: 'networkidle'})
 }
 
@@ -257,13 +258,19 @@ export const selectApplicantLanguageNorthstar = async (
 
 export const disableFeatureFlag = async (page: Page, flag: string) => {
   await test.step(`Disable feature flag: ${flag}`, async () => {
-    await page.goto(`/dev/feature/${flag}/disable`)
+    const response = await page.goto(`/dev/feature/${flag}/disable`)
+    expect(response?.status(), {
+      message: `Could not disable feature flag '${flag}'. Make sure the flag exists.`,
+    }).toBe(200)
   })
 }
 
 export const enableFeatureFlag = async (page: Page, flag: string) => {
   await test.step(`Enable feature flag: ${flag}`, async () => {
-    await page.goto(`/dev/feature/${flag}/enable`)
+    const response = await page.goto(`/dev/feature/${flag}/enable`)
+    expect(response?.status(), {
+      message: `Could not enable feature flag '${flag}'. Make sure the flag exists.`,
+    }).toBe(200)
   })
 }
 
@@ -430,7 +437,7 @@ export const normalizeElements = async (page: Frame | Page) => {
         ) {
           continue
         } else {
-          element.textContent = replacement(element.textContent!)
+          element.textContent = replacement(element.textContent)
         }
       }
     }


### PR DESCRIPTION
Fail the test if trying to enable or disable a feature flag that does not exist.

Removing call to a feature flag that does not exist.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
