### PR TITLE
Fixing local browser test running

### DIFF
--- a/browser-test/browser-test-compose.yml
+++ b/browser-test/browser-test-compose.yml
@@ -31,5 +31,6 @@ services:
       - BASE_URL=${BASE_URL:-http://civiform:9000}
       - LOCALSTACK_URL=http://localhost.localstack.cloud:4566
       - CIVIFORM_TIME_ZONE_ID
+      - USE_BUNDLER_DEV_SERVER=false
     command: ~runBrowserTestsServer
     entrypoint: ./entrypoint.sh -jvm-debug "0.0.0.0:9457"


### PR DESCRIPTION
### Description

Add to the browser test docker compose environment variables `USE_BUNDLER_DEV_SERVER=false`.

While running correctly in CI, it stopped working locally after my original tests.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [ ] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
