### PR TITLE
Replace with non-deprecated URI creation syntax

### DIFF
--- a/server/app/auth/oidc/applicant/Auth0ClientProvider.java
+++ b/server/app/auth/oidc/applicant/Auth0ClientProvider.java
@@ -4,7 +4,7 @@ import auth.oidc.CiviformOidcLogoutActionBuilder;
 import auth.oidc.OidcClientProviderParams;
 import com.google.inject.Inject;
 import java.net.MalformedURLException;
-import java.net.URL;
+import java.net.URI;
 import java.util.Optional;
 import org.pac4j.oidc.client.OidcClient;
 
@@ -34,9 +34,9 @@ public class Auth0ClientProvider extends GenericOidcClientProvider {
     // Instead, we need to set it to /v2/logout ourselves:
     // https://auth0.com/docs/api/authentication#logout
     try {
-      URL discoveryUri = new URL(getDiscoveryURI());
-      return Optional.of(new URL(discoveryUri, "/v2/logout").toString());
-    } catch (MalformedURLException e) {
+      URI discoveryUri = URI.create(getDiscoveryURI());
+      return Optional.of(discoveryUri.resolve("/v2/logout").toURL().toString());
+    } catch (MalformedURLException | IllegalArgumentException e) {
       throw new IllegalArgumentException("Unparseable discovery URI used for applicant OIDC", e);
     }
   }

--- a/server/app/services/cloud/azure/AzureApplicantStorage.java
+++ b/server/app/services/cloud/azure/AzureApplicantStorage.java
@@ -4,7 +4,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.typesafe.config.Config;
-import java.net.URL;
+import java.net.URI;
 import java.time.Duration;
 import java.time.ZoneId;
 import java.util.Optional;
@@ -85,7 +85,7 @@ public class AzureApplicantStorage implements ApplicantStorageClient {
     String signedUrl = String.format("%s?%s", blobUrl, sasToken);
 
     try {
-      return new URL(signedUrl).toString();
+      return URI.create(signedUrl).toURL().toString();
     } catch (java.net.MalformedURLException e) {
       throw new RuntimeException(e);
     }

--- a/server/app/services/cloud/generic_s3/AbstractS3ApplicantStorage.java
+++ b/server/app/services/cloud/generic_s3/AbstractS3ApplicantStorage.java
@@ -7,6 +7,7 @@ import static services.cloud.aws.AwsStorageUtils.PRESIGNED_URL_DURATION;
 
 import com.typesafe.config.Config;
 import controllers.applicant.ApplicantRequestedAction;
+import java.net.URI;
 import java.net.URL;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -132,7 +133,7 @@ public abstract class AbstractS3ApplicantStorage implements ApplicantStorageClie
           Mockito.mock(PresignedGetObjectRequest.class);
       URL fakeUrl;
       try {
-        fakeUrl = new URL("http://fake-url");
+        fakeUrl = URI.create("http://fake-url").toURL();
       } catch (java.net.MalformedURLException e) {
         throw new RuntimeException(e);
       }

--- a/server/app/services/geojson/GeoJsonClient.java
+++ b/server/app/services/geojson/GeoJsonClient.java
@@ -5,8 +5,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.net.MalformedURLException;
-import java.net.URISyntaxException;
-import java.net.URL;
+import java.net.URI;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import javax.inject.Inject;
@@ -45,10 +44,9 @@ public final class GeoJsonClient {
     }
 
     try {
-      URL url = new URL(endpoint);
-      url.toURI();
+      String url = URI.create(endpoint).toURL().toString();
 
-      return ws.url(endpoint)
+      return ws.url(url)
           .get()
           .thenApplyAsync(
               res -> {
@@ -84,7 +82,7 @@ public final class GeoJsonClient {
                   throw new GeoJsonProcessingException("Invalid GeoJSON format");
                 }
               });
-    } catch (MalformedURLException | URISyntaxException | IllegalArgumentException e) {
+    } catch (MalformedURLException | IllegalArgumentException e) {
       logger.error("Invalid GeoJSON endpoint: ", e);
       return CompletableFuture.failedFuture(
           new MalformedURLException("Not a valid URL, try retyping"));


### PR DESCRIPTION
### Description

`new URL(string)` is deprecated in future versions of Java. This is prep for migrating to Java 25.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
