### PR TITLE
[North Star] add group labels to name, date, and address questions

### DIFF
--- a/server/app/views/questiontypes/AddressQuestionFragment.html
+++ b/server/app/views/questiontypes/AddressQuestionFragment.html
@@ -8,6 +8,7 @@
   class="cf-question-address"
   th:classappend="${hasGroupErrors ? 'cf-question-field-with-error' : ''}"
   data-testid="questionRoot"
+  th:aria-labelledby="|${questionId}-title ${questionId}-description|"
 >
   <fieldset class="usa-fieldset">
     <div class="cf-question-header">

--- a/server/app/views/questiontypes/DateQuestionFragment.html
+++ b/server/app/views/questiontypes/DateQuestionFragment.html
@@ -3,15 +3,14 @@
   th:with="dateQuestion=${question.createDateQuestion()},
            fieldErrors=${dateQuestion.getValidationErrors().get(dateQuestion.getDatePath())},
            questionErrors=${dateQuestion.getValidationErrors().get(question.getContextualizedPath())},
-           hasErrors=${questionRendererParams.shouldShowErrors() && !dateQuestion.getValidationErrors().isEmpty()}"
+           hasErrors=${questionRendererParams.shouldShowErrors() && !dateQuestion.getValidationErrors().isEmpty()},
+           questionId=${'id-' + #strings.randomAlphanumeric(8)}"
   class="cf-question-date cf-applicant-question-field"
   th:classappend="${hasErrors ? 'cf-question-field-with-error' : ''}"
   data-testid="questionRoot"
+  th:aria-labelledby="|${questionId}-title ${questionId}-description|"
 >
-  <fieldset
-    class="usa-fieldset"
-    th:with="questionId=${'id-' + #strings.randomAlphanumeric(8)}"
-  >
+  <fieldset class="usa-fieldset">
     <!--/* Title and Help Text */-->
     <div
       th:replace="~{questiontypes/QuestionBaseFragment :: titleAndHelpTextMultipleInput(${question}, ${questionId})}"

--- a/server/app/views/questiontypes/NameQuestionFragment.html
+++ b/server/app/views/questiontypes/NameQuestionFragment.html
@@ -9,6 +9,7 @@
   class="cf-question-name"
   th:classappend="${hasGroupErrors ? 'cf-question-field-with-error' : ''}"
   data-testid="questionRoot"
+  th:aria-labelledby="|${questionId}-title ${questionId}-description|"
 >
   <!--/* Title and Help Text */-->
   <div class="cf-question-header">


### PR DESCRIPTION
### Description

Adds `aria-labelledby` to name, date, and address questions questions so that the question is read out by a screen reader when you tab into the group.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

### Instructions for manual testing

1. Start applying to the Comprehensive Sample Program.
1. Turn the screen reader on.
1. Tab to one of the fields on the address/name/date question.
1. Confirm the screen reader reads the question and the name of the field, along with the help text and error description.

### Issue(s) this completes

Fixes #10221