### PR TITLE
restore file upload tests

### DIFF
--- a/browser-test/src/applicant/questions/file.test.ts
+++ b/browser-test/src/applicant/questions/file.test.ts
@@ -298,8 +298,7 @@ test.describe('file upload applicant flow', {tag: ['@northstar']}, () => {
     const programName = 'Test program for multiple file upload'
     const fileUploadQuestionText = 'Required file upload question'
 
-    // TODO(9454): remove ".fixme" once https://github.com/civiform/civiform/issues/9454 is fixed
-    test.fixme('hides upload button at max', async ({
+    test('hides upload button at max', async ({
       applicantQuestions,
       applicantFileQuestion,
       page,
@@ -1146,10 +1145,10 @@ test.describe('file upload applicant flow', {tag: ['@northstar']}, () => {
 
     test.describe('back button', () => {
       // TODO(9521): Reinstate test when #9521 is fixed.
-      test.fixme('clicking back without file redirects to previous page', async ({
+      test('clicking back without file redirects to previous page', async ({
         applicantQuestions,
       }) => {
-        await applicantQuestions.clickApplyProgramButton(
+        await applicantQuestions.applyProgram(
           programName,
           /* northStarEnabled= */ true,
         )
@@ -1168,11 +1167,10 @@ test.describe('file upload applicant flow', {tag: ['@northstar']}, () => {
         await applicantQuestions.validateQuestionIsOnPage(emailQuestionText)
       })
 
-      // TODO(9524): Reinstate test when #9524 is fixed.
-      test.fixme('clicking back with file saves file and redirects to previous page', async ({
+      test('clicking back with file saves file and redirects to previous page', async ({
         applicantQuestions,
       }) => {
-        await applicantQuestions.clickApplyProgramButton(
+        await applicantQuestions.applyProgram(
           programName,
           /* northStarEnabled= */ true,
         )


### PR DESCRIPTION
### Description

Restores the file upload tests that were marked `fixme`.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

### Issue(s) this completes

Fixes #9454
