### PR TITLE
[North Star] clean up browser test helpers 5

### DIFF
--- a/browser-test/src/admin/admin_predicates.test.ts
+++ b/browser-test/src/admin/admin_predicates.test.ts
@@ -1831,7 +1831,7 @@ test.describe('create and edit predicates', () => {
       await applicantQuestions.clickContinue()
       await applicantQuestions.expectMayBeEligibileAlertToBeVisible()
 
-      await applicantQuestions.clickReview(true)
+      await applicantQuestions.clickReview()
       await validateScreenshot(page, 'review-page-no-ineligible-banner')
       await validateToastMessage(page, '')
       await applicantQuestions.clickContinue()

--- a/browser-test/src/applicant/applicant_application_index.test.ts
+++ b/browser-test/src/applicant/applicant_application_index.test.ts
@@ -705,7 +705,7 @@ test.describe('applicant program index page', () => {
       await applicantQuestions.gotoApplicantHomePage()
 
       await applicantQuestions.clickApplyProgramButton('Benefits finder')
-      await applicantQuestions.clickReview(true)
+      await applicantQuestions.clickReview()
       expect(await page.innerText('h2')).toContain('Review and submit')
     })
   })
@@ -731,7 +731,7 @@ test.describe('applicant program index page', () => {
 
     await test.step('Check that the question repeated in the program with two questions shows previously answered', async () => {
       await applicantQuestions.applyProgram(primaryProgramName, true)
-      await applicantQuestions.clickReview(true)
+      await applicantQuestions.clickReview()
       await applicantQuestions.northStarValidatePreviouslyAnsweredText(
         firstQuestionText,
       )

--- a/browser-test/src/applicant/application_address_correction.test.ts
+++ b/browser-test/src/applicant/application_address_correction.test.ts
@@ -687,7 +687,7 @@ if (isLocalDevEnvironment()) {
             programName,
             /* northStarEnabled= */ true,
           )
-          await applicantQuestions.clickReview(/* northStarEnabled= */ true)
+          await applicantQuestions.clickReview()
           await applicantQuestions.editQuestionFromReviewPage(
             addressQuestionText,
             /* northStarEnabled= */ true,
@@ -717,7 +717,7 @@ if (isLocalDevEnvironment()) {
             programName,
             /* northStarEnabled= */ true,
           )
-          await applicantQuestions.clickReview(/* northStarEnabled= */ true)
+          await applicantQuestions.clickReview()
           await applicantQuestions.editQuestionFromReviewPage(
             addressQuestionText,
             /* northStarEnabled= */ true,
@@ -746,7 +746,7 @@ if (isLocalDevEnvironment()) {
             programName,
             /* northStarEnabled= */ true,
           )
-          await applicantQuestions.clickReview(/* northStarEnabled= */ true)
+          await applicantQuestions.clickReview()
 
           await applicantQuestions.editQuestionFromReviewPage(
             addressQuestionText,
@@ -776,7 +776,7 @@ if (isLocalDevEnvironment()) {
 
         await test.step('Navigate to and validate review page', async () => {
           // Verify the original address was saved
-          await applicantQuestions.clickReview(/* northStarEnabled= */ true)
+          await applicantQuestions.clickReview()
           await applicantQuestions.expectQuestionAnsweredOnReviewPageNorthstar(
             addressQuestionText,
             'Legit Address',
@@ -792,7 +792,7 @@ if (isLocalDevEnvironment()) {
             programName,
             /* northStarEnabled= */ true,
           )
-          await applicantQuestions.clickReview(/* northStarEnabled= */ true)
+          await applicantQuestions.clickReview()
 
           await applicantQuestions.editQuestionFromReviewPage(
             addressQuestionText,
@@ -821,7 +821,7 @@ if (isLocalDevEnvironment()) {
         })
 
         await test.step('Navigate to and validate review page', async () => {
-          await applicantQuestions.clickReview(/* northStarEnabled= */ true)
+          await applicantQuestions.clickReview()
           await applicantQuestions.expectQuestionAnsweredOnReviewPageNorthstar(
             addressQuestionText,
             'Address With No Service Area Features',
@@ -837,7 +837,7 @@ if (isLocalDevEnvironment()) {
             programName,
             /* northStarEnabled= */ true,
           )
-          await applicantQuestions.clickReview(/* northStarEnabled= */ true)
+          await applicantQuestions.clickReview()
 
           await applicantQuestions.editQuestionFromReviewPage(
             addressQuestionText,
@@ -863,7 +863,7 @@ if (isLocalDevEnvironment()) {
         })
 
         await test.step('Navigate to and validate review page', async () => {
-          await applicantQuestions.clickReview(/* northStarEnabled= */ true)
+          await applicantQuestions.clickReview()
           await applicantQuestions.expectQuestionAnsweredOnReviewPageNorthstar(
             addressQuestionText,
             'Bogus Address',
@@ -880,7 +880,7 @@ if (isLocalDevEnvironment()) {
             programName,
             /* northStarEnabled= */ true,
           )
-          await applicantQuestions.clickReview(/* northStarEnabled= */ true)
+          await applicantQuestions.clickReview()
           await applicantQuestions.editQuestionFromReviewPage(
             addressQuestionText,
             /* northStarEnabled= */ true,
@@ -901,7 +901,7 @@ if (isLocalDevEnvironment()) {
           await applicantQuestions.validateQuestionIsOnPage(emailQuestionText)
         })
         await test.step('Navigate to and validate review page', async () => {
-          await applicantQuestions.clickReview(/* northStarEnabled= */ true)
+          await applicantQuestions.clickReview()
           await applicantQuestions.expectQuestionAnsweredOnReviewPageNorthstar(
             addressQuestionText,
             'Address In Area',
@@ -920,7 +920,7 @@ if (isLocalDevEnvironment()) {
             programName,
             /* northStarEnabled= */ true,
           )
-          await applicantQuestions.clickReview(/* northStarEnabled= */ true)
+          await applicantQuestions.clickReview()
           await applicantQuestions.editQuestionFromReviewPage(
             addressQuestionText,
             /* northStarEnabled= */ true,
@@ -935,7 +935,7 @@ if (isLocalDevEnvironment()) {
           )
         })
         await test.step('Click review and validate verify address page', async () => {
-          await applicantQuestions.clickReview(/* northStarEnabled= */ true)
+          await applicantQuestions.clickReview()
 
           await applicantQuestions.expectVerifyAddressPage(false)
         })
@@ -946,7 +946,7 @@ if (isLocalDevEnvironment()) {
       }) => {
         await test.step('Answer address question', async () => {
           await applicantQuestions.applyProgram(programName, true)
-          await applicantQuestions.clickReview(/* northStarEnabled= */ true)
+          await applicantQuestions.clickReview()
           await applicantQuestions.editQuestionFromReviewPage(
             addressQuestionText,
             /* northStarEnabled= */ true,
@@ -961,7 +961,7 @@ if (isLocalDevEnvironment()) {
           )
         })
         await test.step('Click review and validate verify address page', async () => {
-          await applicantQuestions.clickReview(/* northStarEnabled= */ true)
+          await applicantQuestions.clickReview()
 
           await applicantQuestions.expectVerifyAddressPage(true)
         })
@@ -976,7 +976,7 @@ if (isLocalDevEnvironment()) {
             programName,
             /* northStarEnabled= */ true,
           )
-          await applicantQuestions.clickReview(/* northStarEnabled= */ true)
+          await applicantQuestions.clickReview()
           await applicantQuestions.editQuestionFromReviewPage(
             addressQuestionText,
             /* northStarEnabled= */ true,
@@ -991,7 +991,7 @@ if (isLocalDevEnvironment()) {
         })
 
         await test.step('Click review and validate verify address page', async () => {
-          await applicantQuestions.clickReview(/* northStarEnabled= */ true)
+          await applicantQuestions.clickReview()
           await applicantQuestions.expectVerifyAddressPage(true)
         })
         await test.step('Confirm original address and validate review page', async () => {
@@ -1020,7 +1020,7 @@ if (isLocalDevEnvironment()) {
       }) => {
         await test.step('Answer address question', async () => {
           await applicantQuestions.applyProgram(programName, true)
-          await applicantQuestions.clickReview(/* northStarEnabled= */ true)
+          await applicantQuestions.clickReview()
           await applicantQuestions.editQuestionFromReviewPage(
             addressQuestionText,
             /* northStarEnabled= */ true,
@@ -1034,7 +1034,7 @@ if (isLocalDevEnvironment()) {
           )
         })
         await test.step('Click review and validate verify address page', async () => {
-          await applicantQuestions.clickReview(/* northStarEnabled= */ true)
+          await applicantQuestions.clickReview()
           await applicantQuestions.expectVerifyAddressPage(true)
         })
         await test.step('Confirm suggested address and validate review page', async () => {
@@ -1064,7 +1064,7 @@ if (isLocalDevEnvironment()) {
             programName,
             /* northStarEnabled= */ true,
           )
-          await applicantQuestions.clickReview(/* northStarEnabled= */ true)
+          await applicantQuestions.clickReview()
           await applicantQuestions.editQuestionFromReviewPage(
             addressQuestionText,
             /* northStarEnabled= */ true,
@@ -1078,7 +1078,7 @@ if (isLocalDevEnvironment()) {
           )
         })
         await test.step('Click review and validate verify address page', async () => {
-          await applicantQuestions.clickReview(/* northStarEnabled= */ true)
+          await applicantQuestions.clickReview()
           await applicantQuestions.expectVerifyAddressPage(false)
         })
 
@@ -1108,7 +1108,7 @@ if (isLocalDevEnvironment()) {
             programName,
             /* northStarEnabled= */ true,
           )
-          await applicantQuestions.clickReview(/* northStarEnabled= */ true)
+          await applicantQuestions.clickReview()
           await applicantQuestions.editQuestionFromReviewPage(
             addressQuestionText,
             /* northStarEnabled= */ true,
@@ -1124,7 +1124,7 @@ if (isLocalDevEnvironment()) {
           )
         })
         await test.step('Click review and validate review page', async () => {
-          await applicantQuestions.clickReview(/* northStarEnabled= */ true)
+          await applicantQuestions.clickReview()
 
           await applicantQuestions.expectReviewPage(
             /* northStarEnabled= */ true,
@@ -1149,7 +1149,7 @@ if (isLocalDevEnvironment()) {
             programName,
             /* northStarEnabled= */ true,
           )
-          await applicantQuestions.clickReview(/* northStarEnabled= */ true)
+          await applicantQuestions.clickReview()
           await applicantQuestions.editQuestionFromReviewPage(
             addressQuestionText,
             /* northStarEnabled= */ true,
@@ -1178,7 +1178,7 @@ if (isLocalDevEnvironment()) {
             programName,
             /* northStarEnabled= */ true,
           )
-          await applicantQuestions.clickReview(/* northStarEnabled= */ true)
+          await applicantQuestions.clickReview()
           await applicantQuestions.editQuestionFromReviewPage(
             addressQuestionText,
             /* northStarEnabled= */ true,
@@ -1207,7 +1207,7 @@ if (isLocalDevEnvironment()) {
             programName,
             /* northStarEnabled= */ true,
           )
-          await applicantQuestions.clickReview(/* northStarEnabled= */ true)
+          await applicantQuestions.clickReview()
           await applicantQuestions.editQuestionFromReviewPage(
             addressQuestionText,
             /* northStarEnabled= */ true,
@@ -1233,7 +1233,7 @@ if (isLocalDevEnvironment()) {
         })
 
         await test.step('Click review and validate review page', async () => {
-          await applicantQuestions.clickReview(/* northStarEnabled= */ true)
+          await applicantQuestions.clickReview()
           await applicantQuestions.expectQuestionAnsweredOnReviewPageNorthstar(
             addressQuestionText,
             'Legit Address',
@@ -1249,7 +1249,7 @@ if (isLocalDevEnvironment()) {
             programName,
             /* northStarEnabled= */ true,
           )
-          await applicantQuestions.clickReview(/* northStarEnabled= */ true)
+          await applicantQuestions.clickReview()
           await applicantQuestions.editQuestionFromReviewPage(
             addressQuestionText,
             /* northStarEnabled= */ true,
@@ -1277,7 +1277,7 @@ if (isLocalDevEnvironment()) {
           await applicantQuestions.validateQuestionIsOnPage(numberQuestionText)
         })
         await test.step('Click review and validate review page', async () => {
-          await applicantQuestions.clickReview(/* northStarEnabled= */ true)
+          await applicantQuestions.clickReview()
           await applicantQuestions.expectQuestionAnsweredOnReviewPageNorthstar(
             addressQuestionText,
             'Address With No Service Area Features',
@@ -1293,7 +1293,7 @@ if (isLocalDevEnvironment()) {
             programName,
             /* northStarEnabled= */ true,
           )
-          await applicantQuestions.clickReview(/* northStarEnabled= */ true)
+          await applicantQuestions.clickReview()
           await applicantQuestions.editQuestionFromReviewPage(
             addressQuestionText,
             /* northStarEnabled= */ true,
@@ -1317,7 +1317,7 @@ if (isLocalDevEnvironment()) {
           await applicantQuestions.validateQuestionIsOnPage(numberQuestionText)
         })
         await test.step('Click review and validate review page', async () => {
-          await applicantQuestions.clickReview(/* northStarEnabled= */ true)
+          await applicantQuestions.clickReview()
           await applicantQuestions.expectQuestionAnsweredOnReviewPageNorthstar(
             addressQuestionText,
             'Bogus Address',
@@ -1334,7 +1334,7 @@ if (isLocalDevEnvironment()) {
             programName,
             /* northStarEnabled= */ true,
           )
-          await applicantQuestions.clickReview(/* northStarEnabled= */ true)
+          await applicantQuestions.clickReview()
           await applicantQuestions.editQuestionFromReviewPage(
             addressQuestionText,
             /* northStarEnabled= */ true,
@@ -1355,7 +1355,7 @@ if (isLocalDevEnvironment()) {
           await applicantQuestions.validateQuestionIsOnPage(numberQuestionText)
         })
         await test.step('Click review and validate review page', async () => {
-          await applicantQuestions.clickReview(/* northStarEnabled= */ true)
+          await applicantQuestions.clickReview()
           await applicantQuestions.expectQuestionAnsweredOnReviewPageNorthstar(
             addressQuestionText,
             'Address In Area',
@@ -1374,7 +1374,7 @@ if (isLocalDevEnvironment()) {
             programName,
             /* northStarEnabled= */ true,
           )
-          await applicantQuestions.clickReview(/* northStarEnabled= */ true)
+          await applicantQuestions.clickReview()
           await applicantQuestions.editQuestionFromReviewPage(
             addressQuestionText,
             /* northStarEnabled= */ true,
@@ -1408,7 +1408,7 @@ if (isLocalDevEnvironment()) {
             programName,
             /* northStarEnabled= */ true,
           )
-          await applicantQuestions.clickReview(/* northStarEnabled= */ true)
+          await applicantQuestions.clickReview()
           await applicantQuestions.editQuestionFromReviewPage(
             addressQuestionText,
             /* northStarEnabled= */ true,

--- a/browser-test/src/applicant/application_download.test.ts
+++ b/browser-test/src/applicant/application_download.test.ts
@@ -35,9 +35,7 @@ test.describe('Applicant application download test', () => {
     await applicantQuestions.answerNameQuestion('sarah', 'smith')
     await applicantQuestions.clickContinue()
     await applicantQuestions.submitFromReviewPage(/* northStarEnabled= */ true)
-    await applicantQuestions.downloadFromConfirmationPage(
-      /* northStarEnabled= */ true,
-    )
+    await applicantQuestions.downloadFromConfirmationPage()
 
     await logout(page)
     await loginAsProgramAdmin(page)

--- a/browser-test/src/applicant/application_version_fast_forward.test.ts
+++ b/browser-test/src/applicant/application_version_fast_forward.test.ts
@@ -1264,7 +1264,7 @@ class FastForwardApplicantActor {
    * Must be on an application edit page
    */
   async gotoReviewPage() {
-    await this.applicantQuestions.clickReview(true)
+    await this.applicantQuestions.clickReview()
   }
 
   /**

--- a/browser-test/src/applicant/ineligible.test.ts
+++ b/browser-test/src/applicant/ineligible.test.ts
@@ -92,9 +92,7 @@ test.describe('North Star Ineligible Page Tests', () => {
     })
 
     await test.step('Expect application submitted page', async () => {
-      await applicantQuestions.expectConfirmationPage(
-        /* northStarEnabled= */ true,
-      )
+      await applicantQuestions.expectConfirmationPage()
     })
   })
 
@@ -227,9 +225,7 @@ test.describe('North Star Ineligible Page Tests', () => {
     })
 
     await test.step('Expect application submitted page', async () => {
-      await applicantQuestions.expectConfirmationPage(
-        /* northStarEnabled= */ true,
-      )
+      await applicantQuestions.expectConfirmationPage()
     })
   })
 

--- a/browser-test/src/applicant/navigation/application_navigation_buttons.test.ts
+++ b/browser-test/src/applicant/navigation/application_navigation_buttons.test.ts
@@ -194,7 +194,7 @@ test.describe('Applicant navigation flow', () => {
         // answer was saved
         await applicantQuestions.clickBack()
 
-        await applicantQuestions.clickReview(/* northStarEnabled= */ true)
+        await applicantQuestions.clickReview()
         await applicantQuestions.expectReviewPage(/* northStarEnabled= */ true)
         await applicantQuestions.expectQuestionAnsweredOnReviewPage(
           addressQuestionText,
@@ -259,9 +259,7 @@ test.describe('Applicant navigation flow', () => {
           /* northStarEnabled= */ true,
         )
 
-        await applicantQuestions.clickStayAndFixAnswers(
-          /* northStarEnabled= */ true,
-        )
+        await applicantQuestions.clickStayAndFixAnswers()
 
         // Verify the previously filled in answers are present
         // await applicantQuestions.checkDateQuestionValue('')
@@ -311,9 +309,7 @@ test.describe('Applicant navigation flow', () => {
 
         // Proceed to the previous page (which will be the review page,
         // since this is the first block), acknowledging that answers won't be saved
-        await applicantQuestions.clickPreviousWithoutSaving(
-          /* northStarEnabled= */ true,
-        )
+        await applicantQuestions.clickPreviousWithoutSaving()
 
         await applicantQuestions.expectReviewPage(/* northStarEnabled= */ true)
         await applicantQuestions.validateNoPreviouslyAnsweredText(
@@ -355,9 +351,7 @@ test.describe('Applicant navigation flow', () => {
         )
 
         // Proceed to the previous page and verify the first block answers are present
-        await applicantQuestions.clickPreviousWithoutSaving(
-          /* northStarEnabled= */ true,
-        )
+        await applicantQuestions.clickPreviousWithoutSaving()
         // This is the static question block, so continue to the previous block
         await applicantQuestions.clickBack()
 
@@ -383,7 +377,7 @@ test.describe('Applicant navigation flow', () => {
             '1',
           )
           await applicantQuestions.answerEmailQuestion('test1@gmail.com')
-          await applicantQuestions.clickReview(/* northStarEnabled= */ true)
+          await applicantQuestions.clickReview()
         })
 
         await test.step('delete answers on first block', async () => {
@@ -416,7 +410,7 @@ test.describe('Applicant navigation flow', () => {
             '1',
           )
           await applicantQuestions.answerEmailQuestion('test1@gmail.com')
-          await applicantQuestions.clickReview(/* northStarEnabled= */ true)
+          await applicantQuestions.clickReview()
 
           await applicantQuestions.editBlock('Screen 3')
           await applicantQuestions.answerAddressQuestion(
@@ -426,7 +420,7 @@ test.describe('Applicant navigation flow', () => {
             'WA',
             '54321',
           )
-          await applicantQuestions.clickReview(/* northStarEnabled= */ true)
+          await applicantQuestions.clickReview()
         })
 
         // We require that all questions be seen before an applicant can submit an application,
@@ -437,7 +431,7 @@ test.describe('Applicant navigation flow', () => {
         })
 
         await test.step('answer only required questions on block with both required and optional', async () => {
-          await applicantQuestions.clickReview(/* northStarEnabled= */ true)
+          await applicantQuestions.clickReview()
           // This block has a required phone question and optional currency question.
           // Only answer the required question, then use the "Previous" button.
           await applicantQuestions.editBlock('Screen 5')
@@ -447,13 +441,11 @@ test.describe('Applicant navigation flow', () => {
 
         // Verify that the optional questions were marked as seen and we can now submit the application
         await test.step('can submit application', async () => {
-          await applicantQuestions.clickReview(/* northStarEnabled= */ true)
+          await applicantQuestions.clickReview()
           await applicantQuestions.submitFromReviewPage(
             /* northStarEnabled= */ true,
           )
-          await applicantQuestions.expectConfirmationPage(
-            /* northStarEnabled= */ true,
-          )
+          await applicantQuestions.expectConfirmationPage()
         })
       })
     })
@@ -598,9 +590,7 @@ test.describe('Applicant navigation flow', () => {
           await applicantQuestions.submitFromReviewPage(
             /* northStarEnabled= */ true,
           )
-          await applicantQuestions.expectConfirmationPage(
-            /* northStarEnabled= */ true,
-          )
+          await applicantQuestions.expectConfirmationPage()
         })
       })
 
@@ -661,9 +651,7 @@ test.describe('Applicant navigation flow', () => {
           await applicantQuestions.submitFromReviewPage(
             /* northStarEnabled= */ true,
           )
-          await applicantQuestions.expectConfirmationPage(
-            /* northStarEnabled= */ true,
-          )
+          await applicantQuestions.expectConfirmationPage()
         })
       })
 
@@ -675,14 +663,14 @@ test.describe('Applicant navigation flow', () => {
         await applicantProgramOverview.startApplicationFromProgramOverviewPage(
           programName,
         )
-        await applicantQuestions.clickReview(/* northStarEnabled= */ true)
+        await applicantQuestions.clickReview()
 
         await test.step('answer screen 4', async () => {
           await applicantQuestions.editBlock('Screen 4')
 
           await applicantQuestions.validateQuestionIsOnPage(radioQuestionText)
           await applicantQuestions.answerRadioButtonQuestion('one')
-          await applicantQuestions.clickReview(/* northStarEnabled= */ true)
+          await applicantQuestions.clickReview()
         })
 
         await test.step('answer screen 1', async () => {
@@ -693,7 +681,7 @@ test.describe('Applicant navigation flow', () => {
             '1',
           )
           await applicantQuestions.answerEmailQuestion('test1@gmail.com')
-          await applicantQuestions.clickReview(/* northStarEnabled= */ true)
+          await applicantQuestions.clickReview()
         })
 
         // Re-answering questions by clicking "Edit" on the review page puts the application
@@ -767,9 +755,7 @@ test.describe('Applicant navigation flow', () => {
           await applicantQuestions.submitFromReviewPage(
             /* northStarEnabled= */ true,
           )
-          await applicantQuestions.expectConfirmationPage(
-            /* northStarEnabled= */ true,
-          )
+          await applicantQuestions.expectConfirmationPage()
         })
       })
     })
@@ -789,7 +775,7 @@ test.describe('Applicant navigation flow', () => {
         )
         await applicantQuestions.answerEmailQuestion('test1@gmail.com')
 
-        await applicantQuestions.clickReview(/* northStarEnabled= */ true)
+        await applicantQuestions.clickReview()
 
         await applicantQuestions.expectReviewPage(/* northStarEnabled= */ true)
         await applicantQuestions.expectQuestionAnsweredOnReviewPage(
@@ -812,7 +798,7 @@ test.describe('Applicant navigation flow', () => {
         // Intentionally do NOT answer the date question
         await applicantQuestions.answerEmailQuestion('test1@gmail.com')
 
-        await applicantQuestions.clickReview(/* northStarEnabled= */ true)
+        await applicantQuestions.clickReview()
 
         // The date question is required, so expect the error modal.
         await applicantQuestions.expectErrorOnReviewModal(
@@ -831,7 +817,7 @@ test.describe('Applicant navigation flow', () => {
         // If the applicant has never answered this block before and doesn't fill in any
         // answers now, we shouldn't show the error modal and should just go straight to
         // the review page -- see issue #6987.
-        await applicantQuestions.clickReview(/* northStarEnabled= */ true)
+        await applicantQuestions.clickReview()
 
         await applicantQuestions.expectReviewPage(/* northStarEnabled= */ true)
       })
@@ -846,14 +832,12 @@ test.describe('Applicant navigation flow', () => {
         // Intentionally do NOT answer the date question
         await applicantQuestions.answerEmailQuestion('test1@gmail.com')
 
-        await applicantQuestions.clickReview(/* northStarEnabled= */ true)
+        await applicantQuestions.clickReview()
         await applicantQuestions.expectErrorOnReviewModal(
           /* northStarEnabled= */ true,
         )
 
-        await applicantQuestions.clickStayAndFixAnswers(
-          /* northStarEnabled= */ true,
-        )
+        await applicantQuestions.clickStayAndFixAnswers()
 
         // Verify the previously filled in answers are present
         await applicantQuestions.checkMemorableDateQuestionValue('', '', '')
@@ -866,7 +850,7 @@ test.describe('Applicant navigation flow', () => {
           '1',
         )
 
-        await applicantQuestions.clickReview(/* northStarEnabled= */ true)
+        await applicantQuestions.clickReview()
 
         // Verify we're taken to the review page and the answers were saved
         await applicantQuestions.expectQuestionAnsweredOnReviewPage(
@@ -893,15 +877,13 @@ test.describe('Applicant navigation flow', () => {
         )
         await applicantQuestions.answerEmailQuestion('')
 
-        await applicantQuestions.clickReview(/* northStarEnabled= */ true)
+        await applicantQuestions.clickReview()
         await applicantQuestions.expectErrorOnReviewModal(
           /* northStarEnabled= */ true,
         )
 
         // Proceed to the Review page, acknowledging that answers won't be saved
-        await applicantQuestions.clickReviewWithoutSaving(
-          /* northStarEnabled= */ true,
-        )
+        await applicantQuestions.clickReviewWithoutSaving()
 
         await applicantQuestions.expectReviewPage(/* northStarEnabled= */ true)
         await applicantQuestions.validateNoPreviouslyAnsweredText(
@@ -926,7 +908,7 @@ test.describe('Applicant navigation flow', () => {
             '1',
           )
           await applicantQuestions.answerEmailQuestion('test1@gmail.com')
-          await applicantQuestions.clickReview(/* northStarEnabled= */ true)
+          await applicantQuestions.clickReview()
         })
 
         await test.step('delete answers on first block', async () => {
@@ -938,7 +920,7 @@ test.describe('Applicant navigation flow', () => {
         await test.step('review button should show error modal', async () => {
           // Because the questions were previously answered and the date and email questions are required,
           // we don't let the user save the deletion of answers.
-          await applicantQuestions.clickReview(/* northStarEnabled= */ true)
+          await applicantQuestions.clickReview()
           await applicantQuestions.expectErrorOnReviewModal(
             /* northStarEnabled= */ true,
           )
@@ -959,7 +941,7 @@ test.describe('Applicant navigation flow', () => {
             '1',
           )
           await applicantQuestions.answerEmailQuestion('test1@gmail.com')
-          await applicantQuestions.clickReview(/* northStarEnabled= */ true)
+          await applicantQuestions.clickReview()
 
           await applicantQuestions.editBlock('Screen 3')
           await applicantQuestions.answerAddressQuestion(
@@ -969,14 +951,14 @@ test.describe('Applicant navigation flow', () => {
             'WA',
             '54321',
           )
-          await applicantQuestions.clickReview(/* northStarEnabled= */ true)
+          await applicantQuestions.clickReview()
         })
 
         // We require that all questions be seen before an applicant can submit an application,
         // so open the optional question but don't fill in any answer, then use the "Review" button.
         await test.step('open optional question block but do not answer', async () => {
           await applicantQuestions.editBlock('Screen 4')
-          await applicantQuestions.clickReview(/* northStarEnabled= */ true)
+          await applicantQuestions.clickReview()
         })
 
         await test.step('answer only required questions on block with both required and optional', async () => {
@@ -984,7 +966,7 @@ test.describe('Applicant navigation flow', () => {
           // Only answer the required question, then use the "Review" button.
           await applicantQuestions.editBlock('Screen 5')
           await applicantQuestions.answerPhoneQuestion('4256373270')
-          await applicantQuestions.clickReview(/* northStarEnabled= */ true)
+          await applicantQuestions.clickReview()
         })
 
         // Verify that the optional questions were marked as seen and we can now submit the application
@@ -992,9 +974,7 @@ test.describe('Applicant navigation flow', () => {
           await applicantQuestions.submitFromReviewPage(
             /* northStarEnabled= */ true,
           )
-          await applicantQuestions.expectConfirmationPage(
-            /* northStarEnabled= */ true,
-          )
+          await applicantQuestions.expectConfirmationPage()
         })
       })
     })

--- a/browser-test/src/applicant/navigation/application_navigation_with_eligibility_conditions.test.ts
+++ b/browser-test/src/applicant/navigation/application_navigation_with_eligibility_conditions.test.ts
@@ -73,7 +73,7 @@ test.describe('Applicant navigation flow', () => {
       await applicantProgramOverview.startApplicationFromProgramOverviewPage(
         fullProgramName,
       )
-      await applicantQuestions.clickReview(/* northStarEnabled= */ true)
+      await applicantQuestions.clickReview()
       await applicantQuestions.expectMayNotBeEligibleAlertToBeHidden()
     })
 
@@ -99,7 +99,7 @@ test.describe('Applicant navigation flow', () => {
 
       await test.step('verify not eligible alert is shown on review page', async () => {
         await applicantQuestions.clickApplyProgramButton(fullProgramName)
-        await applicantQuestions.clickReview(/* northStarEnabled= */ true)
+        await applicantQuestions.clickReview()
 
         await applicantQuestions.expectMayNotBeEligibileAlertToBeVisible()
         await applicantQuestions.expectIneligibleQuestionInReviewPageAlert(
@@ -158,7 +158,7 @@ test.describe('Applicant navigation flow', () => {
       })
 
       await test.step('fill out application without submitting and verify message on review page', async () => {
-        await applicantQuestions.clickReview(/* northStarEnabled= */ true)
+        await applicantQuestions.clickReview()
         await applicantQuestions.expectMayBeEligibileAlertToBeVisible()
         await validateScreenshot(page, 'application-eligible-review-page', {
           mobileScreenshot: true,
@@ -242,7 +242,7 @@ test.describe('Applicant navigation flow', () => {
         await applicantProgramOverview.startApplicationFromProgramOverviewPage(
           fullProgramName,
         )
-        await applicantQuestions.clickReview(/* northStarEnabled= */ true)
+        await applicantQuestions.clickReview()
         await applicantQuestions.expectMayNotBeEligibileAlertToBeVisible()
         await applicantQuestions.expectIneligibleQuestionInReviewPageAlert(
           AdminQuestions.NUMBER_QUESTION_TEXT,

--- a/browser-test/src/applicant/questions/file.test.ts
+++ b/browser-test/src/applicant/questions/file.test.ts
@@ -579,7 +579,7 @@ test.describe('file upload applicant flow', () => {
       )
 
       // there is a "review and exit" button
-      await applicantQuestions.clickReview(/* northStarEnabled= */ true)
+      await applicantQuestions.clickReview()
 
       await applicantQuestions.expectQuestionAnsweredOnReviewPage(
         fileUploadQuestionText,
@@ -1098,7 +1098,7 @@ test.describe('file upload applicant flow', () => {
           fileUploadQuestionText,
         )
 
-        await applicantQuestions.clickReview(/* northStarEnabled= */ true)
+        await applicantQuestions.clickReview()
         await applicantQuestions.expectReviewPage(/* northStarEnabled= */ true)
       })
 
@@ -1130,7 +1130,7 @@ test.describe('file upload applicant flow', () => {
           'sample.txt',
         )
 
-        await applicantQuestions.clickReview(/* northStarEnabled= */ true)
+        await applicantQuestions.clickReview()
 
         // Verify we're taken to the review page
         await applicantQuestions.expectReviewPage(/* northStarEnabled= */ true)
@@ -1194,7 +1194,7 @@ test.describe('file upload applicant flow', () => {
         await applicantQuestions.validateQuestionIsOnPage(emailQuestionText)
 
         // Verify the file was saved
-        await applicantQuestions.clickReview(/* northStarEnabled= */ true)
+        await applicantQuestions.clickReview()
         await applicantQuestions.expectReviewPage(/* northStarEnabled= */ true)
 
         await applicantQuestions.expectQuestionAnsweredOnReviewPage(
@@ -1270,7 +1270,7 @@ test.describe('file upload applicant flow', () => {
         await applicantQuestions.validateQuestionIsOnPage(numberQuestionText)
 
         // Verify the file was saved
-        await applicantQuestions.clickReview(/* northStarEnabled= */ true)
+        await applicantQuestions.clickReview()
         await applicantQuestions.expectReviewPage(/* northStarEnabled= */ true)
         await applicantQuestions.expectQuestionAnsweredOnReviewPage(
           fileUploadQuestionText,
@@ -1304,7 +1304,7 @@ test.describe('file upload applicant flow', () => {
         // take us to the next unseen block, we want the third block to remain unseen.
         // So, we instead click "Review" here to save the file and go to the review page
         // without seeing the third block.
-        await applicantQuestions.clickReview(/* northStarEnabled= */ true)
+        await applicantQuestions.clickReview()
 
         // Re-open the file upload question
         await applicantQuestions.expectReviewPage(/* northStarEnabled= */ true)
@@ -1320,7 +1320,7 @@ test.describe('file upload applicant flow', () => {
         await applicantQuestions.validateQuestionIsOnPage(numberQuestionText)
 
         // Verify the old file is still present
-        await applicantQuestions.clickReview(/* northStarEnabled= */ true)
+        await applicantQuestions.clickReview()
         await applicantQuestions.expectReviewPage(/* northStarEnabled= */ true)
         await applicantQuestions.expectQuestionAnsweredOnReviewPage(
           fileUploadQuestionText,
@@ -1352,7 +1352,7 @@ test.describe('file upload applicant flow', () => {
         // take us to the next unseen block, we want the third block to remain unseen.
         // So, we instead click "Review" here to save the file and go to the review page
         // without seeing the third block.
-        await applicantQuestions.clickReview(/* northStarEnabled= */ true)
+        await applicantQuestions.clickReview()
 
         // Re-open the file upload question
         await applicantQuestions.expectReviewPage(/* northStarEnabled= */ true)
@@ -1376,7 +1376,7 @@ test.describe('file upload applicant flow', () => {
         await applicantQuestions.validateQuestionIsOnPage(numberQuestionText)
 
         // Verify the old file is still used
-        await applicantQuestions.clickReview(/* northStarEnabled= */ true)
+        await applicantQuestions.clickReview()
         await applicantQuestions.expectReviewPage(/* northStarEnabled= */ true)
         await applicantQuestions.expectQuestionAnsweredOnReviewPage(
           fileUploadQuestionText,

--- a/browser-test/src/applicant/upsell.test.ts
+++ b/browser-test/src/applicant/upsell.test.ts
@@ -286,9 +286,7 @@ test.describe('Upsell tests', () => {
           name: "You've submitted your " + programName + ' application',
         }),
       ).toBeVisible()
-      await applicantQuestions.expectConfirmationPage(
-        /* northStarEnabled= */ true,
-      )
+      await applicantQuestions.expectConfirmationPage()
       await expect(
         page.getByText(customConfirmationMarkupMatcher),
       ).toBeVisible()

--- a/browser-test/src/end_to_end_enumerators.test.ts
+++ b/browser-test/src/end_to_end_enumerators.test.ts
@@ -278,7 +278,7 @@ test.describe('End to end enumerator test', () => {
       await applicantQuestions.clickContinue()
       await applicantQuestions.answerNameQuestion('Tweety', 'Bird')
       await applicantQuestions.clickContinue()
-      await applicantQuestions.clickReview(/* northStarEnabled= */ true)
+      await applicantQuestions.clickReview()
 
       // Review page should contain Daffy Duck and newly added Tweety Bird.
       await expect(page.locator('.application-summary')).toContainText(

--- a/browser-test/src/support/applicant_questions.ts
+++ b/browser-test/src/support/applicant_questions.ts
@@ -614,10 +614,8 @@ export class ApplicantQuestions {
     await waitForPageJsLoad(this.page)
   }
 
-  async clickReview(northStarEnabled = false) {
-    const reviewButton = northStarEnabled
-      ? 'text="Review and submit"'
-      : 'text="Review"'
+  async clickReview() {
+    const reviewButton = 'text="Review and submit"'
     await this.page.click(reviewButton)
     await waitForPageJsLoad(this.page)
   }
@@ -638,10 +636,8 @@ export class ApplicantQuestions {
     ).toBeVisible()
   }
 
-  async clickDownload(northStarEnabled = false) {
-    const downloadButton = northStarEnabled
-      ? 'text="Download your application"'
-      : 'text="Download PDF"'
+  async clickDownload() {
+    const downloadButton = 'text="Download your application"'
     const [downloadEvent] = await Promise.all([
       this.page.waitForEvent('download'),
       this.page.click(downloadButton),
@@ -781,7 +777,7 @@ export class ApplicantQuestions {
 
   async returnToProgramsFromSubmissionPage(northStarEnabled = false) {
     // Assert that we're on the submission page.
-    await this.expectConfirmationPage(northStarEnabled)
+    await this.expectConfirmationPage()
     if (northStarEnabled) {
       await this.clickBackToHomepageButton()
     } else {
@@ -817,16 +813,8 @@ export class ApplicantQuestions {
     }
   }
 
-  async expectConfirmationPage(northStarEnabled = false) {
-    if (northStarEnabled) {
-      await expect(
-        this.page.getByText('Your application details'),
-      ).toBeVisible()
-    } else {
-      expect(await this.page.innerText('h1')).toContain(
-        'Application confirmation',
-      )
-    }
+  async expectConfirmationPage() {
+    await expect(this.page.getByText('Your application details')).toBeVisible()
   }
 
   async expectPreScreenerReviewPage() {
@@ -1062,11 +1050,11 @@ export class ApplicantQuestions {
     }
   }
 
-  async downloadFromConfirmationPage(northStarEnabled = false): Promise<void> {
+  async downloadFromConfirmationPage(): Promise<void> {
     // Assert that we're on the confirmation page.
-    await this.expectConfirmationPage(northStarEnabled)
+    await this.expectConfirmationPage()
     // Click on the download button
-    await this.clickDownload(northStarEnabled)
+    await this.clickDownload()
   }
 
   async validateHeader(lang: string) {
@@ -1156,10 +1144,8 @@ export class ApplicantQuestions {
     }
   }
 
-  async clickReviewWithoutSaving(northStarEnabled = false) {
-    const buttonText = northStarEnabled
-      ? 'Go to the review page without saving'
-      : 'Continue to review page without saving'
+  async clickReviewWithoutSaving() {
+    const buttonText = 'Go to the review page without saving'
     await this.page.click(`button:has-text("${buttonText}")`)
   }
 
@@ -1193,17 +1179,13 @@ export class ApplicantQuestions {
     }
   }
 
-  async clickPreviousWithoutSaving(northStarEnabled = false) {
-    const buttonText = northStarEnabled
-      ? 'Go to the previous page without saving'
-      : 'Continue to previous questions without saving'
+  async clickPreviousWithoutSaving() {
+    const buttonText = 'Go to the previous page without saving'
     await this.page.click(`button:has-text("${buttonText}")`)
   }
 
-  async clickStayAndFixAnswers(northStarEnabled = false) {
-    const buttonText = northStarEnabled
-      ? 'Stay here and fix your answers'
-      : 'Stay and fix your answers'
+  async clickStayAndFixAnswers() {
+    const buttonText = 'Stay here and fix your answers'
     await this.page.click(`button:has-text("${buttonText}")`)
   }
 

--- a/browser-test/src/trusted_intermediary.test.ts
+++ b/browser-test/src/trusted_intermediary.test.ts
@@ -178,7 +178,7 @@ test.describe('Trusted intermediaries', () => {
       await applicantQuestions.answerTextQuestion('second answer')
       await applicantQuestions.clickContinue()
       await applicantQuestions.submitFromReviewPage(true)
-      await applicantQuestions.expectConfirmationPage(true)
+      await applicantQuestions.expectConfirmationPage()
       await applicantQuestions.clickBackToHomepageButton()
       await tiDashboard.clickOnViewApplications()
       await applicantQuestions.expectProgramsinCorrectSections(
@@ -1333,7 +1333,7 @@ test.describe('Trusted intermediaries', () => {
       await test.step('submitting the application without changing any values succeeds', async () => {
         await applicantQuestions.clickContinue()
         await applicantQuestions.submitFromReviewPage(true)
-        await applicantQuestions.expectConfirmationPage(true)
+        await applicantQuestions.expectConfirmationPage()
       })
     })
 
@@ -1374,7 +1374,7 @@ test.describe('Trusted intermediaries', () => {
 
       await test.step('submitting the application with changed values succeeds', async () => {
         await applicantQuestions.submitFromReviewPage(true)
-        await applicantQuestions.expectConfirmationPage(true)
+        await applicantQuestions.expectConfirmationPage()
       })
     })
 


### PR DESCRIPTION
### Description

Since North Star is now default, we no longer need support methods with specific North Star logic. Remove North Star logic from browser test support. Part 5!

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.