### PR TITLE
Change external url in browser tests

### DIFF
--- a/browser-test/src/applicant/applicant_application_index.test.ts
+++ b/browser-test/src/applicant/applicant_application_index.test.ts
@@ -1188,9 +1188,9 @@ test.describe('applicant program index page with images', () => {
     applicantQuestions,
   }) => {
     const externalProgramAName = 'External Program A'
-    const externalProgramALink = 'https://www.usa.gov'
+    const externalProgramALink = `${BASE_URL}/programs`
     const externalProgramBName = 'External Program B'
-    const externalProgramBLink = 'https://civiform.us'
+    const externalProgramBLink = `${BASE_URL}/programs#simulated_difference`
 
     await test.step('add external programs', async () => {
       await enableFeatureFlag(page, 'external_program_cards_enabled')
@@ -1308,7 +1308,7 @@ test.describe('applicant program index page with images', () => {
     seeding,
   }) => {
     const externalProgramName = 'External Program'
-    const externalProgramLink = 'https://civiform.us'
+    const externalProgramLink = `${BASE_URL}/programs`
 
     await test.step('enable required features', async () => {
       await enableFeatureFlag(page, 'external_program_cards_enabled')


### PR DESCRIPTION
Change the url used to test external program links open in a new tab from an outside website to the civiform program page. We only need to test it opened so the actual page doesn't matter. 

I believe the test timeouts are due to external pages taking too long to load in CI. 