### PR TITLE
[North Star] Clean up browser test helpers 6

### DIFF
--- a/browser-test/src/admin/admin_application_download.test.ts
+++ b/browser-test/src/admin/admin_application_download.test.ts
@@ -396,7 +396,7 @@ test.describe('csv json pdf download test- two applications', () => {
       await applicantQuestions.answerCheckboxQuestion(['red'])
       await applicantQuestions.clickContinue()
       await applicantQuestions.submitFromReviewPage()
-      await applicantQuestions.returnToProgramsFromSubmissionPage(true)
+      await applicantQuestions.returnToProgramsFromSubmissionPage()
 
       // Apply to the program again as the same user
       await applicantQuestions.clickApplyProgramButton(programName)

--- a/browser-test/src/admin/admin_predicates.test.ts
+++ b/browser-test/src/admin/admin_predicates.test.ts
@@ -415,7 +415,7 @@ test.describe('create and edit predicates', () => {
     // Initially fill out the first screen so that it is ineligible
     await applicantQuestions.answerTextQuestion('ineligble')
     await applicantQuestions.clickContinue()
-    await applicantQuestions.expectIneligiblePage(true)
+    await applicantQuestions.expectIneligiblePage()
     await validateScreenshot(page, 'ineligible')
 
     // Verify that the program details link goes to the program overview page
@@ -1775,11 +1775,9 @@ test.describe('create and edit predicates', () => {
       // "hidden" first name is not allowed.
       await applicantQuestions.answerNameQuestion('hidden', 'next', 'screen')
       await applicantQuestions.clickContinue()
-      await applicantQuestions.expectIneligiblePage(true)
-      await applicantQuestions.expectIneligibleQuestionNorthStar(
-        'name question text',
-      )
-      await applicantQuestions.expectIneligibleQuestionsCountNorthStar(1)
+      await applicantQuestions.expectIneligiblePage()
+      await applicantQuestions.expectIneligibleQuestion('name question text')
+      await applicantQuestions.expectIneligibleQuestionsCount(1)
       await page.goBack()
       await applicantQuestions.answerNameQuestion('show', 'next', 'screen')
       await applicantQuestions.clickContinue()
@@ -1791,11 +1789,9 @@ test.describe('create and edit predicates', () => {
       // "blue" or "green" are allowed.
       await applicantQuestions.answerTextQuestion('red')
       await applicantQuestions.clickContinue()
-      await applicantQuestions.expectIneligiblePage(true)
-      await applicantQuestions.expectIneligibleQuestionNorthStar(
-        'text question text',
-      )
-      await applicantQuestions.expectIneligibleQuestionsCountNorthStar(1)
+      await applicantQuestions.expectIneligiblePage()
+      await applicantQuestions.expectIneligibleQuestion('text question text')
+      await applicantQuestions.expectIneligibleQuestionsCount(1)
       await page.goBack()
       await applicantQuestions.answerTextQuestion('blue')
       await applicantQuestions.clickContinue()
@@ -1806,11 +1802,9 @@ test.describe('create and edit predicates', () => {
       // 42 is allowed.
       await applicantQuestions.answerNumberQuestion('1')
       await applicantQuestions.clickContinue()
-      await applicantQuestions.expectIneligiblePage(true)
-      await applicantQuestions.expectIneligibleQuestionNorthStar(
-        'number question text',
-      )
-      await applicantQuestions.expectIneligibleQuestionsCountNorthStar(1)
+      await applicantQuestions.expectIneligiblePage()
+      await applicantQuestions.expectIneligibleQuestion('number question text')
+      await applicantQuestions.expectIneligibleQuestionsCount(1)
       await page.goBack()
       await applicantQuestions.answerNumberQuestion('42')
       await applicantQuestions.clickContinue()
@@ -1821,11 +1815,9 @@ test.describe('create and edit predicates', () => {
       // 123 or 456 are allowed.
       await applicantQuestions.answerNumberQuestion('11111')
       await applicantQuestions.clickContinue()
-      await applicantQuestions.expectIneligiblePage(true)
-      await applicantQuestions.expectIneligibleQuestionNorthStar(
-        'number question text',
-      )
-      await applicantQuestions.expectIneligibleQuestionsCountNorthStar(1)
+      await applicantQuestions.expectIneligiblePage()
+      await applicantQuestions.expectIneligibleQuestion('number question text')
+      await applicantQuestions.expectIneligibleQuestionsCount(1)
       await page.goBack()
       await applicantQuestions.answerNumberQuestion('123')
       await applicantQuestions.clickContinue()
@@ -1841,11 +1833,11 @@ test.describe('create and edit predicates', () => {
       // Greater than 100.01 is allowed
       await applicantQuestions.answerCurrencyQuestion('100.01')
       await applicantQuestions.clickContinue()
-      await applicantQuestions.expectIneligiblePage(true)
-      await applicantQuestions.expectIneligibleQuestionNorthStar(
+      await applicantQuestions.expectIneligiblePage()
+      await applicantQuestions.expectIneligibleQuestion(
         'currency question text',
       )
-      await applicantQuestions.expectIneligibleQuestionsCountNorthStar(1)
+      await applicantQuestions.expectIneligibleQuestionsCount(1)
       await page.goBack()
       await applicantQuestions.answerCurrencyQuestion('100.02')
       await applicantQuestions.clickContinue()
@@ -1860,11 +1852,9 @@ test.describe('create and edit predicates', () => {
         '01',
       )
       await applicantQuestions.clickContinue()
-      await applicantQuestions.expectIneligiblePage(true)
-      await applicantQuestions.expectIneligibleQuestionNorthStar(
-        'date question text',
-      )
-      await applicantQuestions.expectIneligibleQuestionsCountNorthStar(1)
+      await applicantQuestions.expectIneligiblePage()
+      await applicantQuestions.expectIneligibleQuestion('date question text')
+      await applicantQuestions.expectIneligibleQuestionsCount(1)
       await page.goBack()
       await applicantQuestions.answerMemorableDateQuestion(
         '2020',
@@ -1883,11 +1873,9 @@ test.describe('create and edit predicates', () => {
         '31',
       )
       await applicantQuestions.clickContinue()
-      await applicantQuestions.expectIneligiblePage(true)
-      await applicantQuestions.expectIneligibleQuestionNorthStar(
-        'date question text',
-      )
-      await applicantQuestions.expectIneligibleQuestionsCountNorthStar(1)
+      await applicantQuestions.expectIneligiblePage()
+      await applicantQuestions.expectIneligibleQuestion('date question text')
+      await applicantQuestions.expectIneligibleQuestionsCount(1)
       await page.goBack()
       await applicantQuestions.answerMemorableDateQuestion(
         '2023',
@@ -1906,11 +1894,9 @@ test.describe('create and edit predicates', () => {
         '31',
       )
       await applicantQuestions.clickContinue()
-      await applicantQuestions.expectIneligiblePage(true)
-      await applicantQuestions.expectIneligibleQuestionNorthStar(
-        'date question text',
-      )
-      await applicantQuestions.expectIneligibleQuestionsCountNorthStar(1)
+      await applicantQuestions.expectIneligiblePage()
+      await applicantQuestions.expectIneligibleQuestion('date question text')
+      await applicantQuestions.expectIneligibleQuestionsCount(1)
       await page.goBack()
       await applicantQuestions.answerMemorableDateQuestion(
         '1930',
@@ -1928,11 +1914,9 @@ test.describe('create and edit predicates', () => {
         '31',
       )
       await applicantQuestions.clickContinue()
-      await applicantQuestions.expectIneligiblePage(true)
-      await applicantQuestions.expectIneligibleQuestionNorthStar(
-        'date question text',
-      )
-      await applicantQuestions.expectIneligibleQuestionsCountNorthStar(1)
+      await applicantQuestions.expectIneligiblePage()
+      await applicantQuestions.expectIneligibleQuestion('date question text')
+      await applicantQuestions.expectIneligibleQuestionsCount(1)
       await page.goBack()
       await applicantQuestions.answerMemorableDateQuestion(
         '2022',
@@ -1950,11 +1934,9 @@ test.describe('create and edit predicates', () => {
         '31',
       )
       await applicantQuestions.clickContinue()
-      await applicantQuestions.expectIneligiblePage(true)
-      await applicantQuestions.expectIneligibleQuestionNorthStar(
-        'date question text',
-      )
-      await applicantQuestions.expectIneligibleQuestionsCountNorthStar(1)
+      await applicantQuestions.expectIneligiblePage()
+      await applicantQuestions.expectIneligibleQuestion('date question text')
+      await applicantQuestions.expectIneligibleQuestionsCount(1)
       await page.goBack()
       await applicantQuestions.answerMemorableDateQuestion(
         '2000',
@@ -1968,19 +1950,18 @@ test.describe('create and edit predicates', () => {
       // "dog" or "cat" are allowed.
       await applicantQuestions.answerCheckboxQuestion(['rabbit'])
       await applicantQuestions.clickContinue()
-      await applicantQuestions.expectIneligiblePage(true)
-      await applicantQuestions.expectIneligibleQuestionNorthStar(
+      await applicantQuestions.expectIneligiblePage()
+      await applicantQuestions.expectIneligibleQuestion(
         'checkbox question text',
       )
-      await applicantQuestions.expectIneligibleQuestionsCountNorthStar(1)
+      await applicantQuestions.expectIneligibleQuestionsCount(1)
 
-      await applicantQuestions.clickGoBackAndEditOnIneligiblePageNorthStar()
+      await applicantQuestions.clickGoBackAndEditOnIneligiblePage()
       await validateScreenshot(page, 'review-page-has-ineligible-banner')
       await applicantQuestions.expectMayNotBeEligibileAlertToBeVisible()
 
       await applicantQuestions.editQuestionFromReviewPage(
         'checkbox question text',
-        /* northStarEnabled= */ true,
       )
       await applicantQuestions.answerCheckboxQuestion(['cat'])
       await applicantQuestions.clickContinue()
@@ -1990,11 +1971,9 @@ test.describe('create and edit predicates', () => {
       // Age between 1 and 90 is allowed
       await applicantQuestions.answerNumberQuestion('5')
       await applicantQuestions.clickContinue()
-      await applicantQuestions.expectIneligiblePage(true)
-      await applicantQuestions.expectIneligibleQuestionNorthStar(
-        'number question text',
-      )
-      await applicantQuestions.expectIneligibleQuestionsCountNorthStar(1)
+      await applicantQuestions.expectIneligiblePage()
+      await applicantQuestions.expectIneligibleQuestion('number question text')
+      await applicantQuestions.expectIneligibleQuestionsCount(1)
       await page.goBack()
       await applicantQuestions.answerNumberQuestion('15')
       await applicantQuestions.clickContinue()
@@ -2008,11 +1987,9 @@ test.describe('create and edit predicates', () => {
         '01',
       )
       await applicantQuestions.clickContinue()
-      await applicantQuestions.expectIneligiblePage(true)
-      await applicantQuestions.expectIneligibleQuestionNorthStar(
-        'date question text',
-      )
-      await applicantQuestions.expectIneligibleQuestionsCountNorthStar(1)
+      await applicantQuestions.expectIneligiblePage()
+      await applicantQuestions.expectIneligibleQuestion('date question text')
+      await applicantQuestions.expectIneligibleQuestionsCount(1)
       await page.goBack()
       await applicantQuestions.answerMemorableDateQuestion(
         '2022',
@@ -2026,11 +2003,11 @@ test.describe('create and edit predicates', () => {
       // currency between 4.25 and 9.99 is allowed
       await applicantQuestions.answerCurrencyQuestion('2.00')
       await applicantQuestions.clickContinue()
-      await applicantQuestions.expectIneligiblePage(true)
-      await applicantQuestions.expectIneligibleQuestionNorthStar(
+      await applicantQuestions.expectIneligiblePage()
+      await applicantQuestions.expectIneligibleQuestion(
         'currency question text',
       )
-      await applicantQuestions.expectIneligibleQuestionsCountNorthStar(1)
+      await applicantQuestions.expectIneligibleQuestionsCount(1)
       await page.goBack()
       await applicantQuestions.answerCurrencyQuestion('5.50')
       await applicantQuestions.clickContinue()
@@ -2103,20 +2080,19 @@ test.describe('create and edit predicates', () => {
     // 'Hidden' name is ineligible
     await applicantQuestions.answerNameQuestion('hidden', 'next', 'screen')
     await applicantQuestions.clickContinue()
-    await applicantQuestions.expectIneligiblePage(true)
-    await applicantQuestions.expectIneligibleQuestionsCountNorthStar(1)
-    await applicantQuestions.clickGoBackAndEditOnIneligiblePageNorthStar()
+    await applicantQuestions.expectIneligiblePage()
+    await applicantQuestions.expectIneligibleQuestionsCount(1)
+    await applicantQuestions.clickGoBackAndEditOnIneligiblePage()
 
     // Less than or equal to 100.01 is ineligible
     await applicantQuestions.editQuestionFromReviewPage(
       'currency question text',
-      /* northStarEnabled= */ true,
     )
     await applicantQuestions.answerCurrencyQuestion('100.01')
     await applicantQuestions.clickContinue()
 
-    await applicantQuestions.expectIneligiblePage(true)
-    await applicantQuestions.expectIneligibleQuestionsCountNorthStar(2)
+    await applicantQuestions.expectIneligiblePage()
+    await applicantQuestions.expectIneligibleQuestionsCount(2)
     await validateAccessibility(page)
     await validateScreenshot(page, 'ineligible-multiple-eligibility-questions')
   })

--- a/browser-test/src/applicant/applicant_application_index.test.ts
+++ b/browser-test/src/applicant/applicant_application_index.test.ts
@@ -180,9 +180,7 @@ test.describe('applicant program index page', () => {
       await applicantQuestions.answerTextQuestion('second answer')
       await applicantQuestions.clickContinue()
       await applicantQuestions.clickSubmitApplication()
-      await applicantQuestions.returnToProgramsFromSubmissionPage(
-        /* northStarEnabled= */ true,
-      )
+      await applicantQuestions.returnToProgramsFromSubmissionPage()
     })
 
     await test.step('Expect submitted tag shows on program card', async () => {
@@ -423,7 +421,7 @@ test.describe('applicant program index page', () => {
         await applicantQuestions.answerTextQuestion('second answer')
         await applicantQuestions.clickContinue()
         await applicantQuestions.submitFromReviewPage()
-        await applicantQuestions.returnToProgramsFromSubmissionPage(true)
+        await applicantQuestions.returnToProgramsFromSubmissionPage()
         await applicantQuestions.expectProgramsinCorrectSections(
           {
             expectedProgramsInMyApplicationsSection: [primaryProgramName],
@@ -686,13 +684,11 @@ test.describe('applicant program index page', () => {
       await applicantQuestions.gotoApplicantHomePage()
 
       await validateScreenshot(page, 'pre-screener-form-sections')
-      await applicantQuestions.expectProgramsNorthstar({
+      await applicantQuestions.expectPrograms({
         wantNotStartedPrograms: [otherProgramName],
         wantInProgressOrSubmittedPrograms: [primaryProgramName],
       })
-      await applicantQuestions.expectPreScreenerFormNorthstar(
-        preScreenerFormProgramName,
-      )
+      await applicantQuestions.expectPreScreenerForm(preScreenerFormProgramName)
     })
 
     test('shows a different title for the pre-screener form', async ({
@@ -718,12 +714,10 @@ test.describe('applicant program index page', () => {
       await applicantQuestions.applyProgram(otherProgramName, true)
       await applicantQuestions.answerTextQuestion('first answer')
       await applicantQuestions.clickContinue()
-      await applicantQuestions.northStarValidatePreviouslyAnsweredText(
-        firstQuestionText,
-      )
+      await applicantQuestions.validatePreviouslyAnsweredText(firstQuestionText)
       await applicantQuestions.submitFromReviewPage()
-      await applicantQuestions.returnToProgramsFromSubmissionPage(true)
-      await applicantQuestions.expectProgramsNorthstar({
+      await applicantQuestions.returnToProgramsFromSubmissionPage()
+      await applicantQuestions.expectPrograms({
         wantNotStartedPrograms: [primaryProgramName],
         wantInProgressOrSubmittedPrograms: [otherProgramName],
       })
@@ -732,9 +726,7 @@ test.describe('applicant program index page', () => {
     await test.step('Check that the question repeated in the program with two questions shows previously answered', async () => {
       await applicantQuestions.applyProgram(primaryProgramName, true)
       await applicantQuestions.clickReview()
-      await applicantQuestions.northStarValidatePreviouslyAnsweredText(
-        firstQuestionText,
-      )
+      await applicantQuestions.validatePreviouslyAnsweredText(firstQuestionText)
 
       await applicantQuestions.northStarValidateNoPreviouslyAnsweredText(
         secondQuestionText,
@@ -748,16 +740,14 @@ test.describe('applicant program index page', () => {
       await applicantQuestions.clickContinue()
       await applicantQuestions.submitFromReviewPage()
 
-      await applicantQuestions.returnToProgramsFromSubmissionPage(true)
+      await applicantQuestions.returnToProgramsFromSubmissionPage()
       await applicantQuestions.clickApplyProgramButton(otherProgramName)
-      await applicantQuestions.northStarValidatePreviouslyAnsweredText(
-        firstQuestionText,
-      )
+      await applicantQuestions.validatePreviouslyAnsweredText(firstQuestionText)
       await applicantQuestions.clickSubmitApplication()
     })
 
     await test.step('Change first response on second program and check that the other program shows the previously answered text too', async () => {
-      await applicantQuestions.returnToProgramsFromSubmissionPage(true)
+      await applicantQuestions.returnToProgramsFromSubmissionPage()
       await applicantQuestions.clickApplyProgramButton(primaryProgramName)
       await page
         .getByRole('listitem')
@@ -768,12 +758,10 @@ test.describe('applicant program index page', () => {
       await applicantQuestions.clickContinue()
       await applicantQuestions.submitFromReviewPage()
 
-      await applicantQuestions.returnToProgramsFromSubmissionPage(true)
+      await applicantQuestions.returnToProgramsFromSubmissionPage()
       await applicantQuestions.clickApplyProgramButton(otherProgramName)
 
-      await applicantQuestions.northStarValidatePreviouslyAnsweredText(
-        firstQuestionText,
-      )
+      await applicantQuestions.validatePreviouslyAnsweredText(firstQuestionText)
       await validateScreenshot(page, 'other-program-shows-previously-answered')
     })
   })

--- a/browser-test/src/applicant/application_address_correction.test.ts
+++ b/browser-test/src/applicant/application_address_correction.test.ts
@@ -120,10 +120,7 @@ test.describe('address correction single-block, single-address program', () => {
       applicantQuestions,
     }) => {
       await test.step('Answer address question', async () => {
-        await applicantQuestions.applyProgram(
-          singleBlockSingleAddressProgram,
-          /* northStarEnabled= */ true,
-        )
+        await applicantQuestions.applyProgram(singleBlockSingleAddressProgram)
 
         await test.step('Set language to Arabic', async () => {
           await selectApplicantLanguage(page, 'ar')
@@ -690,7 +687,6 @@ if (isLocalDevEnvironment()) {
           await applicantQuestions.clickReview()
           await applicantQuestions.editQuestionFromReviewPage(
             addressQuestionText,
-            /* northStarEnabled= */ true,
           )
 
           await applicantQuestions.answerAddressQuestion(
@@ -720,7 +716,6 @@ if (isLocalDevEnvironment()) {
           await applicantQuestions.clickReview()
           await applicantQuestions.editQuestionFromReviewPage(
             addressQuestionText,
-            /* northStarEnabled= */ true,
           )
 
           await applicantQuestions.answerAddressQuestion(
@@ -750,7 +745,6 @@ if (isLocalDevEnvironment()) {
 
           await applicantQuestions.editQuestionFromReviewPage(
             addressQuestionText,
-            true,
           )
           await applicantQuestions.answerAddressQuestion(
             'Legit Address',
@@ -796,7 +790,6 @@ if (isLocalDevEnvironment()) {
 
           await applicantQuestions.editQuestionFromReviewPage(
             addressQuestionText,
-            /* northStarEnabled= */ true,
           )
           await applicantQuestions.answerAddressQuestion(
             'Legit Address',
@@ -841,7 +834,6 @@ if (isLocalDevEnvironment()) {
 
           await applicantQuestions.editQuestionFromReviewPage(
             addressQuestionText,
-            /* northStarEnabled= */ true,
           )
           await applicantQuestions.answerAddressQuestion(
             'Bogus Address',
@@ -883,7 +875,6 @@ if (isLocalDevEnvironment()) {
           await applicantQuestions.clickReview()
           await applicantQuestions.editQuestionFromReviewPage(
             addressQuestionText,
-            /* northStarEnabled= */ true,
           )
           // Fill out application with address that is contained in findAddressCandidates.json
           // (the list of suggestions returned from FakeEsriClient.fetchAddressSuggestions())
@@ -923,7 +914,6 @@ if (isLocalDevEnvironment()) {
           await applicantQuestions.clickReview()
           await applicantQuestions.editQuestionFromReviewPage(
             addressQuestionText,
-            /* northStarEnabled= */ true,
           )
 
           await applicantQuestions.answerAddressQuestion(
@@ -949,7 +939,6 @@ if (isLocalDevEnvironment()) {
           await applicantQuestions.clickReview()
           await applicantQuestions.editQuestionFromReviewPage(
             addressQuestionText,
-            /* northStarEnabled= */ true,
           )
 
           await applicantQuestions.answerAddressQuestion(
@@ -979,7 +968,6 @@ if (isLocalDevEnvironment()) {
           await applicantQuestions.clickReview()
           await applicantQuestions.editQuestionFromReviewPage(
             addressQuestionText,
-            /* northStarEnabled= */ true,
           )
           await applicantQuestions.answerAddressQuestion(
             'Legit Address',
@@ -1021,7 +1009,6 @@ if (isLocalDevEnvironment()) {
           await applicantQuestions.clickReview()
           await applicantQuestions.editQuestionFromReviewPage(
             addressQuestionText,
-            /* northStarEnabled= */ true,
           )
           await applicantQuestions.answerAddressQuestion(
             'Legit Address',
@@ -1063,7 +1050,6 @@ if (isLocalDevEnvironment()) {
           await applicantQuestions.clickReview()
           await applicantQuestions.editQuestionFromReviewPage(
             addressQuestionText,
-            /* northStarEnabled= */ true,
           )
           await applicantQuestions.answerAddressQuestion(
             'Bogus Address',
@@ -1105,7 +1091,6 @@ if (isLocalDevEnvironment()) {
           await applicantQuestions.clickReview()
           await applicantQuestions.editQuestionFromReviewPage(
             addressQuestionText,
-            /* northStarEnabled= */ true,
           )
           // Fill out application with address that is contained in findAddressCandidates.json
           // (the list of suggestions returned from FakeEsriClient.fetchAddressSuggestions())
@@ -1144,7 +1129,6 @@ if (isLocalDevEnvironment()) {
           await applicantQuestions.clickReview()
           await applicantQuestions.editQuestionFromReviewPage(
             addressQuestionText,
-            /* northStarEnabled= */ true,
           )
 
           await applicantQuestions.answerAddressQuestion(
@@ -1173,7 +1157,6 @@ if (isLocalDevEnvironment()) {
           await applicantQuestions.clickReview()
           await applicantQuestions.editQuestionFromReviewPage(
             addressQuestionText,
-            /* northStarEnabled= */ true,
           )
 
           await applicantQuestions.answerAddressQuestion(
@@ -1202,7 +1185,6 @@ if (isLocalDevEnvironment()) {
           await applicantQuestions.clickReview()
           await applicantQuestions.editQuestionFromReviewPage(
             addressQuestionText,
-            /* northStarEnabled= */ true,
           )
           await applicantQuestions.answerAddressQuestion(
             'Legit Address',
@@ -1244,7 +1226,6 @@ if (isLocalDevEnvironment()) {
           await applicantQuestions.clickReview()
           await applicantQuestions.editQuestionFromReviewPage(
             addressQuestionText,
-            /* northStarEnabled= */ true,
           )
           await applicantQuestions.answerAddressQuestion(
             'Legit Address',
@@ -1288,7 +1269,6 @@ if (isLocalDevEnvironment()) {
           await applicantQuestions.clickReview()
           await applicantQuestions.editQuestionFromReviewPage(
             addressQuestionText,
-            /* northStarEnabled= */ true,
           )
           await applicantQuestions.answerAddressQuestion(
             'Bogus Address',
@@ -1329,7 +1309,6 @@ if (isLocalDevEnvironment()) {
           await applicantQuestions.clickReview()
           await applicantQuestions.editQuestionFromReviewPage(
             addressQuestionText,
-            /* northStarEnabled= */ true,
           )
           // Fill out application with address that is contained in findAddressCandidates.json
           // (the list of suggestions returned from FakeEsriClient.fetchAddressSuggestions())
@@ -1369,7 +1348,6 @@ if (isLocalDevEnvironment()) {
           await applicantQuestions.clickReview()
           await applicantQuestions.editQuestionFromReviewPage(
             addressQuestionText,
-            /* northStarEnabled= */ true,
           )
 
           await applicantQuestions.answerAddressQuestion(
@@ -1403,7 +1381,6 @@ if (isLocalDevEnvironment()) {
           await applicantQuestions.clickReview()
           await applicantQuestions.editQuestionFromReviewPage(
             addressQuestionText,
-            /* northStarEnabled= */ true,
           )
 
           await applicantQuestions.answerAddressQuestion(

--- a/browser-test/src/applicant/application_review.test.ts
+++ b/browser-test/src/applicant/application_review.test.ts
@@ -480,7 +480,7 @@ test.describe('Program admin review of submitted applications', () => {
       await applicantQuestions.answerNameQuestion('Gus', 'Guest')
       await applicantQuestions.clickContinue()
       await applicantQuestions.submitFromReviewPage()
-      await applicantQuestions.returnToProgramsFromSubmissionPage(true)
+      await applicantQuestions.returnToProgramsFromSubmissionPage()
     })
 
     await test.step('View application as Program Admin again', async () => {
@@ -565,7 +565,6 @@ test.describe('Program admin review of submitted applications', () => {
         'oneLast',
         'one@email.com',
         '4152321234',
-        true,
       )
       await applicantQuestions.completeApplicationWithPaiQuestions(
         programName,
@@ -574,7 +573,6 @@ test.describe('Program admin review of submitted applications', () => {
         'twoLast',
         'two@email.com',
         '4153231234',
-        true,
       )
       await applicantQuestions.completeApplicationWithPaiQuestions(
         programName,
@@ -583,7 +581,6 @@ test.describe('Program admin review of submitted applications', () => {
         'threeLast',
         'three@email.com',
         '5102321234',
-        true,
       )
     })
 

--- a/browser-test/src/applicant/ineligible.test.ts
+++ b/browser-test/src/applicant/ineligible.test.ts
@@ -68,7 +68,7 @@ test.describe('North Star Ineligible Page Tests', () => {
     })
 
     await test.step('Expect ineligible page part 1', async () => {
-      await applicantQuestions.expectIneligiblePage(/* northStar= */ true)
+      await applicantQuestions.expectIneligiblePage()
       await expect(page.getByText(questionText)).toBeVisible()
     })
 
@@ -113,7 +113,7 @@ test.describe('North Star Ineligible Page Tests', () => {
     // When North Star is finalized, this test should navigate question -> review -> ineligible
     // Until then, the test must navigate question -> submit -> ineligible -> review -> ineligible
     await test.step('Expect ineligible page', async () => {
-      await applicantQuestions.expectIneligiblePage(/* northStar= */ true)
+      await applicantQuestions.expectIneligiblePage()
       await expect(page.getByText(questionText)).toBeVisible()
     })
 
@@ -123,7 +123,7 @@ test.describe('North Star Ineligible Page Tests', () => {
     })
 
     await test.step('Expect ineligible page again', async () => {
-      await applicantQuestions.expectIneligiblePage(/* northStar= */ true)
+      await applicantQuestions.expectIneligiblePage()
       await expect(page.getByText(questionText)).toBeVisible()
     })
   })
@@ -269,7 +269,7 @@ test.describe('North Star Ineligible Page Tests', () => {
     })
 
     await test.step('Expect ineligible page', async () => {
-      await applicantQuestions.expectIneligiblePage(/* northStar= */ true)
+      await applicantQuestions.expectIneligiblePage()
       await expect(page.getByText(questionText)).toBeVisible()
     })
 
@@ -299,7 +299,7 @@ test.describe('North Star Ineligible Page Tests', () => {
     })
 
     await test.step('Expect ineligible page', async () => {
-      await applicantQuestions.expectIneligiblePage(/* northStar= */ true)
+      await applicantQuestions.expectIneligiblePage()
       await expect(page.getByText(questionText)).toBeVisible()
     })
 
@@ -311,7 +311,7 @@ test.describe('North Star Ineligible Page Tests', () => {
     })
 
     await test.step('Expect ineligible page again', async () => {
-      await applicantQuestions.expectIneligiblePage(/* northStar= */ true)
+      await applicantQuestions.expectIneligiblePage()
       await expect(page.getByText(questionText)).toBeVisible()
     })
 
@@ -341,7 +341,7 @@ test.describe('North Star Ineligible Page Tests', () => {
     })
 
     await test.step('Expect ineligible page', async () => {
-      await applicantQuestions.expectIneligiblePage(/* northStar= */ true)
+      await applicantQuestions.expectIneligiblePage()
       await expect(page.getByText(questionText)).toBeVisible()
     })
 
@@ -351,7 +351,7 @@ test.describe('North Star Ineligible Page Tests', () => {
     })
 
     await test.step('Expect ineligible page again', async () => {
-      await applicantQuestions.expectIneligiblePage(/* northStar= */ true)
+      await applicantQuestions.expectIneligiblePage()
       await expect(page.getByText(questionText)).toBeVisible()
     })
 

--- a/browser-test/src/applicant/navigation/application_navigation_buttons.test.ts
+++ b/browser-test/src/applicant/navigation/application_navigation_buttons.test.ts
@@ -216,9 +216,7 @@ test.describe('Applicant navigation flow', () => {
         await applicantQuestions.clickBack()
 
         // The date question is required, so expect the error modal.
-        await applicantQuestions.expectErrorOnPreviousModal(
-          /* northStarEnabled= */ true,
-        )
+        await applicantQuestions.expectErrorOnPreviousModal()
 
         await validateAccessibility(page)
         await validateScreenshot(page, 'error-on-previous-modal', {
@@ -255,9 +253,7 @@ test.describe('Applicant navigation flow', () => {
         await applicantQuestions.answerEmailQuestion('test1@gmail.com')
 
         await applicantQuestions.clickBack()
-        await applicantQuestions.expectErrorOnPreviousModal(
-          /* northStarEnabled= */ true,
-        )
+        await applicantQuestions.expectErrorOnPreviousModal()
 
         await applicantQuestions.clickStayAndFixAnswers()
 
@@ -303,9 +299,7 @@ test.describe('Applicant navigation flow', () => {
         await applicantQuestions.answerEmailQuestion('')
 
         await applicantQuestions.clickBack()
-        await applicantQuestions.expectErrorOnPreviousModal(
-          /* northStarEnabled= */ true,
-        )
+        await applicantQuestions.expectErrorOnPreviousModal()
 
         // Proceed to the previous page (which will be the review page,
         // since this is the first block), acknowledging that answers won't be saved
@@ -346,9 +340,7 @@ test.describe('Applicant navigation flow', () => {
           '',
         )
         await applicantQuestions.clickBack()
-        await applicantQuestions.expectErrorOnPreviousModal(
-          /* northStarEnabled= */ true,
-        )
+        await applicantQuestions.expectErrorOnPreviousModal()
 
         // Proceed to the previous page and verify the first block answers are present
         await applicantQuestions.clickPreviousWithoutSaving()
@@ -390,9 +382,7 @@ test.describe('Applicant navigation flow', () => {
           // Because the questions were previously answered and the date and email questions are required,
           // we don't let the user save the deletion of answers.
           await applicantQuestions.clickBack()
-          await applicantQuestions.expectErrorOnPreviousModal(
-            /* northStarEnabled= */ true,
-          )
+          await applicantQuestions.expectErrorOnPreviousModal()
         })
       })
 
@@ -785,9 +775,7 @@ test.describe('Applicant navigation flow', () => {
         await applicantQuestions.clickReview()
 
         // The date question is required, so expect the error modal.
-        await applicantQuestions.expectErrorOnReviewModal(
-          /* northStarEnabled= */ true,
-        )
+        await applicantQuestions.expectErrorOnReviewModal()
       })
 
       test('clicking review with no answers does not show error modal', async ({
@@ -817,9 +805,7 @@ test.describe('Applicant navigation flow', () => {
         await applicantQuestions.answerEmailQuestion('test1@gmail.com')
 
         await applicantQuestions.clickReview()
-        await applicantQuestions.expectErrorOnReviewModal(
-          /* northStarEnabled= */ true,
-        )
+        await applicantQuestions.expectErrorOnReviewModal()
 
         await applicantQuestions.clickStayAndFixAnswers()
 
@@ -862,9 +848,7 @@ test.describe('Applicant navigation flow', () => {
         await applicantQuestions.answerEmailQuestion('')
 
         await applicantQuestions.clickReview()
-        await applicantQuestions.expectErrorOnReviewModal(
-          /* northStarEnabled= */ true,
-        )
+        await applicantQuestions.expectErrorOnReviewModal()
 
         // Proceed to the Review page, acknowledging that answers won't be saved
         await applicantQuestions.clickReviewWithoutSaving()
@@ -905,9 +889,7 @@ test.describe('Applicant navigation flow', () => {
           // Because the questions were previously answered and the date and email questions are required,
           // we don't let the user save the deletion of answers.
           await applicantQuestions.clickReview()
-          await applicantQuestions.expectErrorOnReviewModal(
-            /* northStarEnabled= */ true,
-          )
+          await applicantQuestions.expectErrorOnReviewModal()
         })
       })
 

--- a/browser-test/src/applicant/navigation/application_navigation_pre_screener.test.ts
+++ b/browser-test/src/applicant/navigation/application_navigation_pre_screener.test.ts
@@ -85,7 +85,7 @@ test.describe('Applicant navigation flow', () => {
       await applicantQuestions.clickContinue()
       await applicantQuestions.clickSubmitApplication()
 
-      await applicantQuestions.expectPreScreenerConfirmationPageNorthStar(
+      await applicantQuestions.expectPreScreenerConfirmationPage(
         /* wantUpsell= */ false,
         /* wantTrustedIntermediary= */ false,
         /* wantEligiblePrograms= */ [],
@@ -110,7 +110,7 @@ test.describe('Applicant navigation flow', () => {
       await applicantQuestions.clickContinue()
       await applicantQuestions.clickSubmitApplication()
 
-      await applicantQuestions.expectPreScreenerConfirmationPageNorthStar(
+      await applicantQuestions.expectPreScreenerConfirmationPage(
         /* wantUpsell= */ false,
         /* wantTrustedIntermediary= */ false,
         /* wantEligiblePrograms= */ [secondProgramName],
@@ -134,7 +134,7 @@ test.describe('Applicant navigation flow', () => {
       await applicantQuestions.clickContinue()
       await applicantQuestions.clickSubmitApplication()
 
-      await applicantQuestions.expectPreScreenerConfirmationPageNorthStar(
+      await applicantQuestions.expectPreScreenerConfirmationPage(
         /* wantUpsell= */ true,
         /* wantTrustedIntermediary= */ false,
         /* wantEligiblePrograms= */ [],
@@ -161,7 +161,7 @@ test.describe('Applicant navigation flow', () => {
       await applicantQuestions.clickContinue()
       await applicantQuestions.clickSubmitApplication()
 
-      await applicantQuestions.expectPreScreenerConfirmationPageNorthStar(
+      await applicantQuestions.expectPreScreenerConfirmationPage(
         /* wantUpsell= */ true,
         /* wantTrustedIntermediary= */ false,
         /* wantEligiblePrograms= */ [secondProgramName],
@@ -187,7 +187,7 @@ test.describe('Applicant navigation flow', () => {
       await applicantQuestions.clickContinue()
       await applicantQuestions.clickSubmitApplication()
 
-      await applicantQuestions.expectPreScreenerConfirmationPageNorthStar(
+      await applicantQuestions.expectPreScreenerConfirmationPage(
         /* wantUpsell= */ true,
         /* wantTrustedIntermediary= */ false,
         /* wantEligiblePrograms= */ [secondProgramName],
@@ -220,7 +220,7 @@ test.describe('Applicant navigation flow', () => {
       await applicantQuestions.clickContinue()
       await applicantQuestions.clickSubmitApplication()
 
-      await applicantQuestions.expectPreScreenerConfirmationPageNorthStar(
+      await applicantQuestions.expectPreScreenerConfirmationPage(
         /* wantUpsell= */ true,
         /* wantTrustedIntermediary= */ false,
         /* wantEligiblePrograms= */ [secondProgramName],
@@ -277,7 +277,7 @@ test.describe('Applicant navigation flow', () => {
       await applicantQuestions.clickContinue()
       await applicantQuestions.clickSubmitApplication()
 
-      await applicantQuestions.expectPreScreenerConfirmationPageNorthStar(
+      await applicantQuestions.expectPreScreenerConfirmationPage(
         /* wantUpsell= */ false,
         /* wantTrustedIntermediary= */ true,
         /* wantEligiblePrograms= */ [],
@@ -315,7 +315,7 @@ test.describe('Applicant navigation flow', () => {
       await applicantQuestions.clickContinue()
       await applicantQuestions.clickSubmitApplication()
 
-      await applicantQuestions.expectPreScreenerConfirmationPageNorthStar(
+      await applicantQuestions.expectPreScreenerConfirmationPage(
         /* wantUpsell= */ false,
         /* wantTrustedIntermediary= */ true,
         /* wantEligiblePrograms= */ [secondProgramName],

--- a/browser-test/src/applicant/navigation/application_navigation_with_eligibility_conditions.test.ts
+++ b/browser-test/src/applicant/navigation/application_navigation_with_eligibility_conditions.test.ts
@@ -89,7 +89,7 @@ test.describe('Applicant navigation flow', () => {
       await test.step('fill out application with ineligible answer', async () => {
         await applicantQuestions.answerNumberQuestion('1')
         await applicantQuestions.clickContinue()
-        await applicantQuestions.expectIneligiblePage(/* northStar= */ true)
+        await applicantQuestions.expectIneligiblePage()
       })
 
       await test.step('Verify no eligibility tags on in-progress application', async () => {
@@ -539,9 +539,7 @@ test.describe('Applicant navigation flow', () => {
         )
         await applicantQuestions.answerTextQuestion('bar')
         await applicantQuestions.clickContinue()
-        await applicantQuestions.expectIneligiblePage(
-          /* northStarEnabled= */ true,
-        )
+        await applicantQuestions.expectIneligiblePage()
         await validateScreenshot(page, 'ineligible-page-with-markdown', {
           mobileScreenshot: true,
         })

--- a/browser-test/src/applicant/program_summary.test.ts
+++ b/browser-test/src/applicant/program_summary.test.ts
@@ -220,10 +220,7 @@ test.describe('Applicant navigation flow', () => {
       await expect(page.getByText(fileName)).toBeVisible()
 
       const downloadedFileContent =
-        await applicantQuestions.downloadSingleQuestionFromReviewPage(
-          /* northStarEnabled= */ true,
-          fileName,
-        )
+        await applicantQuestions.downloadSingleQuestionFromReviewPage(fileName)
       expect(downloadedFileContent).toEqual(fileContent)
     })
   })

--- a/browser-test/src/applicant/questions/address.test.ts
+++ b/browser-test/src/applicant/questions/address.test.ts
@@ -51,9 +51,7 @@ test.describe('address applicant flow', () => {
 
         await applicantQuestions.clickContinue()
         await applicantQuestions.submitFromReviewPage()
-        await applicantQuestions.expectConfirmationPage(
-          /* northStarEnabled= */ true,
-        )
+        await applicantQuestions.expectConfirmationPage()
       })
     })
 
@@ -194,9 +192,7 @@ test.describe('address applicant flow', () => {
         await applicantQuestions.clickContinue()
 
         await applicantQuestions.submitFromReviewPage()
-        await applicantQuestions.expectConfirmationPage(
-          /* northStarEnabled= */ true,
-        )
+        await applicantQuestions.expectConfirmationPage()
       })
     })
 
@@ -330,9 +326,7 @@ test.describe('address applicant flow', () => {
         await applicantQuestions.clickContinue()
 
         await applicantQuestions.submitFromReviewPage()
-        await applicantQuestions.expectConfirmationPage(
-          /* northStarEnabled= */ true,
-        )
+        await applicantQuestions.expectConfirmationPage()
       })
     })
 

--- a/browser-test/src/applicant/questions/checkbox.test.ts
+++ b/browser-test/src/applicant/questions/checkbox.test.ts
@@ -220,10 +220,7 @@ test.describe('Checkbox question for applicant flow', () => {
         await logout(page)
       })
 
-      await applicantQuestions.applyProgram(
-        longTextProgramName,
-        /* northStarEnabled= */ true,
-      )
+      await applicantQuestions.applyProgram(longTextProgramName)
       await validateScreenshot(
         page.locator('main'),
         'checkbox-options-long-text-applicant',

--- a/browser-test/src/applicant/questions/file.test.ts
+++ b/browser-test/src/applicant/questions/file.test.ts
@@ -256,7 +256,6 @@ test.describe('file upload applicant flow', () => {
       // Re-open the file upload question
       await applicantQuestions.editQuestionFromReviewPage(
         fileUploadQuestionText,
-        /* northStarEnabled= */ true,
       )
 
       // Verify the previously uploaded file name is shown on the block page
@@ -286,7 +285,6 @@ test.describe('file upload applicant flow', () => {
       await applicantQuestions.expectReviewPage()
       await applicantQuestions.editQuestionFromReviewPage(
         fileUploadQuestionText,
-        /* northStarEnabled= */ true,
       )
 
       // A required file upload question should never show a Delete button
@@ -641,7 +639,6 @@ test.describe('file upload applicant flow', () => {
       // Re-open the file upload question
       await applicantQuestions.editQuestionFromReviewPage(
         fileUploadQuestionText,
-        /* northStarEnabled= */ true,
       )
 
       // Verify the previously uploaded file name is shown on the block page
@@ -937,7 +934,6 @@ test.describe('file upload applicant flow', () => {
       // Re-open the file upload question
       await applicantQuestions.editQuestionFromReviewPage(
         fileUploadQuestionText,
-        /* northStarEnabled= */ true,
       )
 
       // Verify the previously uploaded file name is shown on the block page
@@ -968,7 +964,6 @@ test.describe('file upload applicant flow', () => {
       await applicantQuestions.expectReviewPage()
       await applicantQuestions.editQuestionFromReviewPage(
         fileUploadQuestionText,
-        /* northStarEnabled= */ true,
       )
 
       await applicantFileQuestion.expectHasContinueForm()
@@ -994,7 +989,6 @@ test.describe('file upload applicant flow', () => {
       await applicantQuestions.expectReviewPage()
       await applicantQuestions.editQuestionFromReviewPage(
         fileUploadQuestionText,
-        /* northStarEnabled= */ true,
       )
 
       await applicantFileQuestion.removeFileUpload('testFileName.txt')
@@ -1078,10 +1072,7 @@ test.describe('file upload applicant flow', () => {
         applicantQuestions,
         applicantProgramOverview,
       }) => {
-        await applicantQuestions.clickApplyProgramButton(
-          programName,
-          /* northStarEnabled= */ true,
-        )
+        await applicantQuestions.clickApplyProgramButton(programName)
         await applicantProgramOverview.startApplicationFromProgramOverviewPage(
           programName,
         )
@@ -1102,10 +1093,7 @@ test.describe('file upload applicant flow', () => {
         applicantQuestions,
         applicantProgramOverview,
       }) => {
-        await applicantQuestions.clickApplyProgramButton(
-          programName,
-          /* northStarEnabled= */ true,
-        )
+        await applicantQuestions.clickApplyProgramButton(programName)
         await applicantProgramOverview.startApplicationFromProgramOverviewPage(
           programName,
         )
@@ -1144,10 +1132,7 @@ test.describe('file upload applicant flow', () => {
       test('clicking back without file redirects to previous page', async ({
         applicantQuestions,
       }) => {
-        await applicantQuestions.applyProgram(
-          programName,
-          /* northStarEnabled= */ true,
-        )
+        await applicantQuestions.applyProgram(programName)
         await applicantQuestions.expectQuestionOnReviewPageNorthstar(
           emailQuestionText,
         )
@@ -1166,10 +1151,7 @@ test.describe('file upload applicant flow', () => {
       test('clicking back with file saves file and redirects to previous page', async ({
         applicantQuestions,
       }) => {
-        await applicantQuestions.applyProgram(
-          programName,
-          /* northStarEnabled= */ true,
-        )
+        await applicantQuestions.applyProgram(programName)
         await applicantQuestions.expectQuestionOnReviewPageNorthstar(
           emailQuestionText,
         )
@@ -1205,10 +1187,7 @@ test.describe('file upload applicant flow', () => {
         applicantQuestions,
         applicantProgramOverview,
       }) => {
-        await applicantQuestions.clickApplyProgramButton(
-          programName,
-          /* northStarEnabled= */ true,
-        )
+        await applicantQuestions.clickApplyProgramButton(programName)
         await applicantProgramOverview.startApplicationFromProgramOverviewPage(
           programName,
         )
@@ -1239,10 +1218,7 @@ test.describe('file upload applicant flow', () => {
         applicantQuestions,
         applicantProgramOverview,
       }) => {
-        await applicantQuestions.clickApplyProgramButton(
-          programName,
-          /* northStarEnabled= */ true,
-        )
+        await applicantQuestions.clickApplyProgramButton(programName)
         await applicantProgramOverview.startApplicationFromProgramOverviewPage(
           programName,
         )
@@ -1282,10 +1258,7 @@ test.describe('file upload applicant flow', () => {
         // First, open the email block so that the email block is considered answered
         // and we're not taken back to it when we click "Continue".
         // (see test case 'clicking continue button redirects to first unseen block').
-        await applicantQuestions.applyProgram(
-          programName,
-          /* northStarEnabled= */ true,
-        )
+        await applicantQuestions.applyProgram(programName)
         await applicantQuestions.clickContinue()
 
         // Answer the file upload question
@@ -1306,7 +1279,6 @@ test.describe('file upload applicant flow', () => {
         await applicantQuestions.expectReviewPage()
         await applicantQuestions.editQuestionFromReviewPage(
           fileUploadQuestionText,
-          /* northStarEnabled= */ true,
         )
 
         // Click "Continue"
@@ -1330,10 +1302,7 @@ test.describe('file upload applicant flow', () => {
         // First, open the email block so that the email block is considered answered
         // and we're not taken back to it when we click "Continue".
         // (see test case 'clicking continue button redirects to first unseen block').
-        await applicantQuestions.applyProgram(
-          programName,
-          /* northStarEnabled= */ true,
-        )
+        await applicantQuestions.applyProgram(programName)
         await applicantQuestions.clickContinue()
 
         // Answer the file upload question
@@ -1354,7 +1323,6 @@ test.describe('file upload applicant flow', () => {
         await applicantQuestions.expectReviewPage()
         await applicantQuestions.editQuestionFromReviewPage(
           fileUploadQuestionText,
-          /* northStarEnabled= */ true,
         )
 
         // Upload a new file
@@ -1381,7 +1349,6 @@ test.describe('file upload applicant flow', () => {
 
         const downloadedFileContent =
           await applicantQuestions.downloadSingleQuestionFromReviewPage(
-            /* northStarEnabled= */ true,
             'old.txt',
           )
         expect(downloadedFileContent).toEqual('some old text')

--- a/browser-test/src/applicant/questions/name.test.ts
+++ b/browser-test/src/applicant/questions/name.test.ts
@@ -306,10 +306,7 @@ test.describe('name applicant flow', () => {
         page,
         applicantQuestions,
       }) => {
-        await applicantQuestions.applyProgram(
-          programName,
-          /* northStarEnabled= */ true,
-        )
+        await applicantQuestions.applyProgram(programName)
 
         await test.step('name question has suffix field available and no default value selected', async () => {
           await expect(page.getByLabel('Suffix')).toBeVisible()
@@ -327,10 +324,7 @@ test.describe('name applicant flow', () => {
         page,
         applicantQuestions,
       }) => {
-        await applicantQuestions.applyProgram(
-          programName,
-          /* northStarEnabled= */ true,
-        )
+        await applicantQuestions.applyProgram(programName)
 
         await test.step('anwers name question with suffix', async () => {
           await applicantQuestions.answerNameQuestion(
@@ -350,10 +344,7 @@ test.describe('name applicant flow', () => {
         page,
         applicantQuestions,
       }) => {
-        await applicantQuestions.applyProgram(
-          programName,
-          /* northStarEnabled= */ true,
-        )
+        await applicantQuestions.applyProgram(programName)
 
         await test.step('anwers name question with suffix', async () => {
           await applicantQuestions.answerNameQuestion('Ann', 'Gates', 'Quiroz')

--- a/browser-test/src/applicant/questions/radio_button.test.ts
+++ b/browser-test/src/applicant/questions/radio_button.test.ts
@@ -234,10 +234,7 @@ test.describe('Radio button question for applicant flow', () => {
       )
       await logout(page)
 
-      await applicantQuestions.applyProgram(
-        longTextProgramName,
-        /* northStarEnabled= */ true,
-      )
+      await applicantQuestions.applyProgram(longTextProgramName)
       await validateScreenshot(
         page.getByTestId('questionRoot'),
         'radio-options-long-text-applicant',

--- a/browser-test/src/applicant/questions/static_text.test.ts
+++ b/browser-test/src/applicant/questions/static_text.test.ts
@@ -34,10 +34,7 @@ test.describe('Static text question for applicant flow', () => {
   })
 
   test('parses markdown', async ({page, applicantQuestions}) => {
-    await applicantQuestions.applyProgram(
-      programName,
-      /* northStarEnabled= */ true,
-    )
+    await applicantQuestions.applyProgram(programName)
     await validateScreenshot(
       page.getByTestId('staticQuestionRoot'),
       'markdown-text',
@@ -47,10 +44,7 @@ test.describe('Static text question for applicant flow', () => {
   })
 
   test('has no accessiblity violations', async ({page, applicantQuestions}) => {
-    await applicantQuestions.applyProgram(
-      programName,
-      /* northStarEnabled= */ true,
-    )
+    await applicantQuestions.applyProgram(programName)
     await validateAccessibility(page)
   })
 })

--- a/browser-test/src/end_to_end_enumerators.test.ts
+++ b/browser-test/src/end_to_end_enumerators.test.ts
@@ -116,10 +116,7 @@ test.describe('End to end enumerator test', () => {
 
       // Correspondingly, removing an element happens without a page refresh. Remove an
       // element and add another to ensure that element IDs remain unique.
-      await applicantQuestions.deleteEnumeratorEntityByIndex(
-        1,
-        /* northStarEnabled= */ true,
-      )
+      await applicantQuestions.deleteEnumeratorEntityByIndex(1)
       await applicantQuestions.addEnumeratorAnswer('Porky')
       await validateAccessibility(page)
     })
@@ -143,10 +140,7 @@ test.describe('End to end enumerator test', () => {
       await applicantQuestions.addEnumeratorAnswer('Goofy')
 
       // Remove the middle entry, the remaining entries should re-index
-      await applicantQuestions.deleteEnumeratorEntityByIndex(
-        1,
-        /* northStarEnabled= */ true,
-      )
+      await applicantQuestions.deleteEnumeratorEntityByIndex(1)
       await validateScreenshot(page, 'enumerator-indexes-after-removing-field')
     })
 
@@ -209,10 +203,7 @@ test.describe('End to end enumerator test', () => {
 
       // Remove one of the 'Banker' entries and add 'Painter'.
       // the value attribute of the inputs isn't set, so we're clicking the second one.
-      await applicantQuestions.deleteEnumeratorEntityByIndex(
-        1,
-        /* northStarEnabled= */ true,
-      )
+      await applicantQuestions.deleteEnumeratorEntityByIndex(1)
       await applicantQuestions.addEnumeratorAnswer('Painter')
       await applicantQuestions.clickContinue()
 
@@ -244,10 +235,7 @@ test.describe('End to end enumerator test', () => {
       await expect(page.locator('.application-summary')).toContainText('12')
 
       // Go back to delete enumerator answers
-      await applicantQuestions.editQuestionFromReviewPage(
-        'Household members',
-        /* northStarEnabled= */ true,
-      )
+      await applicantQuestions.editQuestionFromReviewPage('Household members')
       await waitForPageJsLoad(page)
 
       await applicantQuestions.deleteEnumeratorEntity('Bugs')
@@ -269,10 +257,7 @@ test.describe('End to end enumerator test', () => {
       )
 
       // Go back and add an enumerator answer.
-      await applicantQuestions.editQuestionFromReviewPage(
-        'Household members',
-        /* northStarEnabled= */ true,
-      )
+      await applicantQuestions.editQuestionFromReviewPage('Household members')
       await waitForPageJsLoad(page)
       await applicantQuestions.addEnumeratorAnswer('Tweety')
       await applicantQuestions.clickContinue()

--- a/browser-test/src/support/applicant_file_question.ts
+++ b/browser-test/src/support/applicant_file_question.ts
@@ -25,23 +25,7 @@ export class ApplicantFileQuestion {
     await expect(this.page.locator(this.questionErrorLocator)).toBeHidden()
   }
 
-  async expectFileSelectionErrorShown() {
-    await expect(
-      this.page.locator(this.fileSelectionErrorLocator),
-    ).toBeVisible()
-  }
-
   async expectFileSelectionErrorHidden() {
-    await expect(this.page.locator(this.fileSelectionErrorLocator)).toBeHidden()
-  }
-
-  async expectNorthStarNoFileSelectedErrorShown() {
-    await expect(
-      this.page.locator(this.fileSelectionErrorLocator),
-    ).toBeVisible()
-  }
-
-  async expectNorthStarNoFileSelectedErrorHidden() {
     await expect(this.page.locator(this.fileSelectionErrorLocator)).toBeHidden()
   }
 

--- a/browser-test/src/trusted_intermediary.test.ts
+++ b/browser-test/src/trusted_intermediary.test.ts
@@ -1304,10 +1304,7 @@ test.describe('Trusted intermediaries', () => {
       })
 
       await test.step('verify client info is pre-populated in the application form', async () => {
-        await applicantQuestions.editQuestionFromReviewPage(
-          'Date of birth',
-          true,
-        )
+        await applicantQuestions.editQuestionFromReviewPage('Date of birth')
 
         await expect(page.getByRole('textbox', {name: 'Day'})).toHaveValue('1')
         await expect(page.getByRole('textbox', {name: 'Year'})).toHaveValue(


### PR DESCRIPTION
### Description

Since North Star is now default, we no longer need support methods with specific North Star logic. Remove North Star logic from browser test support. Part 6!

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.