### PR TITLE
Prevent dependencies from from upgrading to Jackson v3

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -39,9 +39,11 @@
       groupName: "guava",
       matchPackageNames: ["com.google.guava{/,}**"],
     },
+    // Keep jackson on v2 until Play supports v3.
     {
       groupName: "jackson",
       matchPackageNames: ["com.fasterxml.jackson{/,}**"],
+      allowedVersions: "< 3.0.0"
     },
     {
       groupName: "jdk and jre",


### PR DESCRIPTION
We've started seeing some libraries release version updates that need Jackson v3. Play uses Jackson v2.x and we need to wait for it to support the new version.
