### PR TITLE
replace question count with repeated set

### DIFF
--- a/browser-test/src/end_to_end_enumerators.test.ts
+++ b/browser-test/src/end_to_end_enumerators.test.ts
@@ -9,7 +9,7 @@ import {
   validateScreenshot,
   waitForPageJsLoad,
 } from './support'
-import {Page} from 'playwright'
+import {Locator, Page} from 'playwright'
 
 test.describe('End to end enumerator test', () => {
   const programName = 'Ete enumerator program'
@@ -647,6 +647,7 @@ test.describe('End to end enumerator test with enumerators feature flag on', () 
       })
 
       let initialBlockCount: number
+      let enumeratorBlockLink: Locator
       await test.step('Record how many blocks are present in the block order panel', async () => {
         initialBlockCount = await page
           .getByRole('link', {name: /^Screen /})
@@ -673,7 +674,7 @@ test.describe('End to end enumerator test with enumerators feature flag on', () 
       })
 
       await test.step('Validate that the enumerator block says repeated set', async () => {
-        const enumeratorBlockLink = page
+        enumeratorBlockLink = page
           .getByRole('link', {name: /^Screen /})
           .nth(initialBlockCount) // zero-indexed
 
@@ -683,9 +684,6 @@ test.describe('End to end enumerator test with enumerators feature flag on', () 
       })
 
       await test.step('Click on the enumerator block in the block order panel', async () => {
-        const enumeratorBlockLink = page
-          .getByRole('link', {name: /^Screen /})
-          .nth(initialBlockCount) // zero-indexed
         await enumeratorBlockLink.click()
         await waitForPageJsLoad(page)
       })

--- a/server/app/views/admin/programs/ProgramBlocksView.java
+++ b/server/app/views/admin/programs/ProgramBlocksView.java
@@ -378,8 +378,7 @@ public final class ProgramBlocksView extends ProgramBaseView {
       int numQuestions = blockDefinition.getQuestionCount();
       String questionCountText = String.format("Question count: %d", numQuestions);
       if (settingsManifest.getEnumeratorImprovementsEnabled(request)
-          && blockDefinition.isEnumerator().isPresent()
-          && blockDefinition.isEnumerator().get()) {
+          && blockDefinition.getIsEnumerator()) {
         questionCountText = (level > 0) ? "Nested repeated set" : "Repeated set";
       }
       String blockName = blockDefinition.name();


### PR DESCRIPTION
### Description

 Replace “Question count” with “Repeated Set” in the side menu on the left.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [ ] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [ ] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

#### Database evolutions

Read the guidelines [here](https://github.com/civiform/civiform/wiki/Database#writing-database-evolutions)

- [ ] Assigned two reviewers
- [ ] Guarded against already existing resources using `IF NOT EXISTS` and `IF EXISTS`
- [ ] Downs created to undo changes in Ups
- [ ] Every comment in script should begin with -- and not # --- unless it denotes Ups or Downs. See [here](https://www.playframework.com/documentation/2.9.x/Evolutions) for details.
- [ ] Tested both the Downs and the Ups scripts manually (When testing, include all comments from the evolution in your test script to ensure any syntax errors in the comments are caught.)
- [ ] Data migrations aren't being done (please use a [Durable Job](https://github.com/civiform/civiform/wiki/Database#durable-jobs-for-data-updates) if doing a data migration)
- [ ] Update the model documentation in our [wiki](https://github.com/civiform/civiform/wiki/Database) if necessary

#### Durable jobs

Read the docs [here](https://github.com/civiform/civiform/wiki/Database#durable-jobs-for-data-updates)

- [ ] Assigned two reviewers
- [ ] Included a rollback plan and a job to undo the data changes if appropriate

#### User visible changes

- [ ] Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
  - [ ] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [ ] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Made equivalent changes in Thymeleaf for applicant-facing features and changes (or created an issue in the [Northstar epic](https://github.com/orgs/civiform/projects/1/views/94) to track that it's missing from Thymeleaf)
- [ ] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order
- [ ] Performed manual accessibility tests for any applicant-facing changes or any new admin-facing features. See [manual-accessibility-testing](https://github.com/civiform/civiform/wiki/Accessibility#manual-accessibility-testing)
- [ ] Manually tested with a right-to-left language

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/helper/feature-flags.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://github.com/civiform/civiform/wiki/Feature-Flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Instructions for manual testing

If instructions are needed for manual testing by reviewers, include them here.

### Issue(s) this completes

Fixes #12013
