### PR TITLE
remove help text from seeded static question

### DIFF
--- a/server/app/controllers/dev/seeding/SampleQuestionDefinitions.java
+++ b/server/app/controllers/dev/seeding/SampleQuestionDefinitions.java
@@ -388,7 +388,6 @@ public final class SampleQuestionDefinitions {
                           ## ما هي متطلبات الأهلية؟
                           يرجى الذهاب إلى [نا](https://www.example.com) لمزيد من المعلومات
                           """)))
-              .setQuestionHelpText(LocalizedStrings.withDefaultValue(""))
               .build());
 
   @VisibleForTesting


### PR DESCRIPTION
### Description

Removing the help text from our seeded static text question. Static text questions don't have help text and adding it during seeding makes the translations look weird:

<img width="1304" height="709" alt="image" src="https://github.com/user-attachments/assets/4d0db4ab-5276-455a-bf59-a459e59ce942" />


### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

### Instructions for manual testing

1. Seed sample programs + questions
2. Go to edit the static question text translations while it's still in draft mode
3. The translations box for help text should not show up