### PR TITLE
update common intake to pre screener in program views

### DIFF
--- a/server/app/controllers/admin/AdminProgramController.java
+++ b/server/app/controllers/admin/AdminProgramController.java
@@ -141,15 +141,15 @@ public final class AdminProgramController extends CiviFormController {
       return ok(newOneView.render(request, programData, message));
     }
 
-    // If the user needs to confirm that they want to change the common intake form from a different
+    // If the user needs to confirm that they want to change the pre-screener form from a different
     // program to this one, show the confirmation dialog.
     if (programData.getProgramType().equals(ProgramType.COMMON_INTAKE_FORM)
         && !programData.getConfirmedChangePreScreenerForm()) {
-      Optional<ProgramDefinition> maybeCommonIntakeForm = programService.getPreScreenerForm();
-      if (maybeCommonIntakeForm.isPresent()) {
+      Optional<ProgramDefinition> maybePreScreenerForm = programService.getPreScreenerForm();
+      if (maybePreScreenerForm.isPresent()) {
         return ok(
-            newOneView.renderChangeCommonIntakeConfirmation(
-                request, programData, maybeCommonIntakeForm.get().localizedName().getDefault()));
+            newOneView.renderChangePreScreenerConfirmation(
+                request, programData, maybePreScreenerForm.get().localizedName().getDefault()));
       }
     }
 
@@ -283,20 +283,20 @@ public final class AdminProgramController extends CiviFormController {
           editView.render(request, programDefinition, programEditStatus, programData, message));
     }
 
-    // If the user needs to confirm that they want to change the common intake form from a different
+    // If the user needs to confirm that they want to change the pre-screener form from a different
     // program to this one, show the confirmation dialog.
     if (programData.getProgramType().equals(ProgramType.COMMON_INTAKE_FORM)
         && !programData.getConfirmedChangePreScreenerForm()) {
-      Optional<ProgramDefinition> maybeCommonIntakeForm = programService.getPreScreenerForm();
-      if (maybeCommonIntakeForm.isPresent()
-          && !maybeCommonIntakeForm.get().adminName().equals(programDefinition.adminName())) {
+      Optional<ProgramDefinition> maybePreScreenerForm = programService.getPreScreenerForm();
+      if (maybePreScreenerForm.isPresent()
+          && !maybePreScreenerForm.get().adminName().equals(programDefinition.adminName())) {
         return ok(
-            editView.renderChangeCommonIntakeConfirmation(
+            editView.renderChangePreScreenerConfirmation(
                 request,
                 programDefinition,
                 programEditStatus,
                 programData,
-                maybeCommonIntakeForm.get().localizedName().getDefault()));
+                maybePreScreenerForm.get().localizedName().getDefault()));
       }
     }
 

--- a/server/app/views/admin/programs/ProgramFormBuilder.java
+++ b/server/app/views/admin/programs/ProgramFormBuilder.java
@@ -169,16 +169,16 @@ public class ProgramFormBuilder extends BaseHtmlView {
       ImmutableList<Long> categories,
       ImmutableList<Map<String, String>> applicationSteps) {
     boolean isDefaultProgram = programType.equals(ProgramType.DEFAULT);
-    boolean isCommonIntakeForm = programType.equals(ProgramType.COMMON_INTAKE_FORM);
+    boolean isPreScreenerForm = programType.equals(ProgramType.COMMON_INTAKE_FORM);
     boolean isExternalProgram = programType.equals(ProgramType.EXTERNAL);
     boolean isExternalProgramCardsEnabled =
         settingsManifest.getExternalProgramCardsEnabled(request);
 
-    boolean disableProgramEligibility = isCommonIntakeForm || isExternalProgram;
-    boolean disableLongDescription = isCommonIntakeForm || isExternalProgram;
-    boolean disableExternalLink = isDefaultProgram || isCommonIntakeForm;
+    boolean disableProgramEligibility = isPreScreenerForm || isExternalProgram;
+    boolean disableLongDescription = isPreScreenerForm || isExternalProgram;
+    boolean disableExternalLink = isDefaultProgram || isPreScreenerForm;
     boolean disableEmailNotifications = isExternalProgram;
-    boolean disableApplicationSteps = isCommonIntakeForm || isExternalProgram;
+    boolean disableApplicationSteps = isPreScreenerForm || isExternalProgram;
     boolean disableConfirmationMessage = isExternalProgram;
 
     List<CategoryModel> categoryOptions = categoryRepository.listCategories();
@@ -252,7 +252,7 @@ public class ProgramFormBuilder extends BaseHtmlView {
             // Program categories
             iff(
                 !categoryOptions.isEmpty(),
-                showCategoryCheckboxes(categoryOptions, categories, isCommonIntakeForm)),
+                showCategoryCheckboxes(categoryOptions, categories, isPreScreenerForm)),
             // Program visibility
             fieldset(
                     legend("Program visibility")
@@ -402,24 +402,24 @@ public class ProgramFormBuilder extends BaseHtmlView {
     if (isExternalProgramCardsEnabled) {
       // When creating a program, program type fields (if visible) are never disabled.
       boolean defaultProgramFieldDisabled = false;
-      boolean commonIntakeFieldDisabled = false;
+      boolean preScreenerFieldDisabled = false;
       boolean externalProgramFieldDisabled = false;
 
       // When editing a program:
-      //   - external program field is disabled when program type is default or common intake form,
+      //   - external program field is disabled when program type is default or pre-screener form,
       // since a program can be changed to external after creation.
-      //   - common intake and default program fields are disabled when program type is external
+      //   - pre-screener and default program fields are disabled when program type is external
       // program, since an external program cannot change type after creation.
       if (programEditStatus.equals(ProgramEditStatus.EDIT)) {
         switch (programType) {
           case DEFAULT, COMMON_INTAKE_FORM -> {
             defaultProgramFieldDisabled = false;
-            commonIntakeFieldDisabled = false;
+            preScreenerFieldDisabled = false;
             externalProgramFieldDisabled = true;
           }
           case EXTERNAL -> {
             defaultProgramFieldDisabled = true;
-            commonIntakeFieldDisabled = true;
+            preScreenerFieldDisabled = true;
             externalProgramFieldDisabled = false;
           }
         }
@@ -456,7 +456,7 @@ public class ProgramFormBuilder extends BaseHtmlView {
                       /* name= */ PROGRAM_TYPE_FIELD_NAME,
                       /* value= */ ProgramType.COMMON_INTAKE_FORM.getValue(),
                       /* isChecked= */ programType.equals(ProgramType.COMMON_INTAKE_FORM),
-                      /* isDisabled= */ commonIntakeFieldDisabled,
+                      /* isDisabled= */ preScreenerFieldDisabled,
                       /* label= */ "Pre-screener",
                       /* description */ Optional.of(
                           "This program informational card will always appear at the top of the"
@@ -658,13 +658,13 @@ public class ProgramFormBuilder extends BaseHtmlView {
             p(fieldText).withClasses(BaseStyles.FORM_FIELD));
   }
 
-  protected Modal buildConfirmCommonIntakeChangeModal(String existingCommonIntakeFormDisplayName) {
+  protected Modal buildConfirmPreScreenerChangeModal(String existingPreScreenerFormDisplayName) {
     DivTag content =
         div()
             .withClasses("flex-row", "space-y-6")
             .with(
                 p("The pre-screener will be updated from ")
-                    .with(span(existingCommonIntakeFormDisplayName).withClass("font-bold"))
+                    .with(span(existingPreScreenerFormDisplayName).withClass("font-bold"))
                     .withText(" to the current program."))
             .with(p("Would you like to confirm the change?"))
             .with(

--- a/server/app/views/admin/programs/ProgramMetaDataEditView.java
+++ b/server/app/views/admin/programs/ProgramMetaDataEditView.java
@@ -74,22 +74,22 @@ public final class ProgramMetaDataEditView extends ProgramFormBuilder {
 
   /**
    * Renders the edit form with a modal that confirms whether or not the user wants to change which
-   * program is set to be the common intake form. Fields are pre-populated based on the content of
+   * program is set to be the pre-screener form. Fields are pre-populated based on the content of
    * programForm.
    */
-  public Content renderChangeCommonIntakeConfirmation(
+  public Content renderChangePreScreenerConfirmation(
       Request request,
       ProgramDefinition existingProgram,
       ProgramEditStatus programEditStatus,
       ProgramForm programForm,
-      String existingCommonIntakeFormDisplayName) {
+      String existingPreScreenerFormDisplayName) {
     return render(
         request,
         existingProgram,
         programEditStatus,
         Optional.of(programForm),
         Optional.empty(),
-        Optional.of(buildConfirmCommonIntakeChangeModal(existingCommonIntakeFormDisplayName)));
+        Optional.of(buildConfirmPreScreenerChangeModal(existingPreScreenerFormDisplayName)));
   }
 
   private Content render(

--- a/server/app/views/admin/programs/ProgramNewOneView.java
+++ b/server/app/views/admin/programs/ProgramNewOneView.java
@@ -60,16 +60,16 @@ public final class ProgramNewOneView extends ProgramFormBuilder {
 
   /**
    * Renders the create form with a modal that confirms whether or not the user wants to change
-   * which program is set to be the common intake form. Fields are pre-populated based on the
-   * content of programForm.
+   * which program is set to be the pre-screener form. Fields are pre-populated based on the content
+   * of programForm.
    */
-  public Content renderChangeCommonIntakeConfirmation(
-      Request request, ProgramForm programForm, String existingCommonIntakeFormDisplayName) {
+  public Content renderChangePreScreenerConfirmation(
+      Request request, ProgramForm programForm, String existingPreScreenerFormDisplayName) {
     return render(
         request,
         programForm,
         /* toastMessage= */ Optional.empty(),
-        Optional.of(buildConfirmCommonIntakeChangeModal(existingCommonIntakeFormDisplayName)));
+        Optional.of(buildConfirmPreScreenerChangeModal(existingPreScreenerFormDisplayName)));
   }
 
   private Content render(


### PR DESCRIPTION
### Description

Removing some common intake language in favor of "pre-screener". This is just to reduce confusion for developers as the user-facing name is pre-screener. Hoping to eventually have it all say pre-screener.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.
