### PR TITLE
Cleanup playwright setup

### DIFF
--- a/browser-test/package-lock.json
+++ b/browser-test/package-lock.json
@@ -18,7 +18,6 @@
         "eslint-config-prettier": "10.1.8",
         "eslint-plugin-no-unsanitized": "^4.0.2",
         "eslint-plugin-playwright": "2.4.0",
-        "playwright": "1.57.0",
         "sharp": "0.34.5",
         "ts-node": "10.9.2",
         "ts-node-dev": "2.0.0",

--- a/browser-test/package.json
+++ b/browser-test/package.json
@@ -18,7 +18,6 @@
     "eslint-config-prettier": "10.1.8",
     "eslint-plugin-no-unsanitized": "^4.0.2",
     "eslint-plugin-playwright": "2.4.0",
-    "playwright": "1.57.0",
     "sharp": "0.34.5",
     "ts-node": "10.9.2",
     "ts-node-dev": "2.0.0",

--- a/browser-test/src/admin/admin_application_statuses.test.ts
+++ b/browser-test/src/admin/admin_application_statuses.test.ts
@@ -1,4 +1,4 @@
-import {Page} from 'playwright'
+import {Page} from '@playwright/test'
 import {test, expect} from '../support/civiform_fixtures'
 import {
   AdminPrograms,

--- a/browser-test/src/admin/admin_bulk_update_statuses.test.ts
+++ b/browser-test/src/admin/admin_bulk_update_statuses.test.ts
@@ -1,5 +1,5 @@
 import {test, expect} from '../support/civiform_fixtures'
-import {Page} from 'playwright'
+import {Page} from '@playwright/test'
 import {
   loginAsAdmin,
   loginAsProgramAdmin,

--- a/browser-test/src/admin/admin_program_creation.test.ts
+++ b/browser-test/src/admin/admin_program_creation.test.ts
@@ -13,7 +13,7 @@ import {
   ProgramVisibility,
 } from '../support/admin_programs'
 import {dismissModal, waitForAnyModalLocator} from '../support/wait'
-import {Page} from 'playwright'
+import {Page} from '@playwright/test'
 
 test.describe('program creation', () => {
   // TODO(#10363): Remove test once external program cards feature is rolled out

--- a/browser-test/src/applicant/applicant_application_index.test.ts
+++ b/browser-test/src/applicant/applicant_application_index.test.ts
@@ -15,7 +15,7 @@ import {
   validateScreenshot,
   waitForPageJsLoad,
 } from '../support'
-import {Locator, Page} from 'playwright'
+import {Locator, Page} from '@playwright/test'
 import {ProgramCategories, ProgramVisibility} from '../support/admin_programs'
 import {BASE_URL} from '../support/config'
 

--- a/browser-test/src/applicant/questions/map.test.ts
+++ b/browser-test/src/applicant/questions/map.test.ts
@@ -8,7 +8,7 @@ import {
   validateAccessibility,
   validateScreenshot,
 } from '../../support'
-import {Page} from 'playwright'
+import {Page} from '@playwright/test'
 import * as path from 'path'
 
 // number of locations expected to be visible per page

--- a/browser-test/src/applicant/questions/static_text.test.ts
+++ b/browser-test/src/applicant/questions/static_text.test.ts
@@ -1,4 +1,4 @@
-import {Page} from 'playwright'
+import {Page} from '@playwright/test'
 import {test, expect} from '../../support/civiform_fixtures'
 import {
   AdminQuestions,

--- a/browser-test/src/applicant/upsell.test.ts
+++ b/browser-test/src/applicant/upsell.test.ts
@@ -12,7 +12,7 @@ import {
   AdminPrograms,
   ApplicantQuestions,
 } from '../support'
-import {Page} from 'playwright'
+import {Page} from '@playwright/test'
 
 test.describe('Upsell tests', () => {
   const programName = 'Sample program'

--- a/browser-test/src/end_to_end_enumerators.test.ts
+++ b/browser-test/src/end_to_end_enumerators.test.ts
@@ -9,7 +9,7 @@ import {
   validateScreenshot,
   waitForPageJsLoad,
 } from './support'
-import {Locator, Page} from 'playwright'
+import {Locator, Page} from '@playwright/test'
 
 test.describe('End to end enumerator test', () => {
   const programName = 'Ete enumerator program'

--- a/browser-test/src/security.test.ts
+++ b/browser-test/src/security.test.ts
@@ -1,4 +1,4 @@
-import {Page} from 'playwright'
+import {Page} from '@playwright/test'
 import {test, expect} from './support/civiform_fixtures'
 import {loginAsAdmin} from './support'
 import {loginAsProgramAdmin} from './support'

--- a/browser-test/src/support/admin_api_keys.ts
+++ b/browser-test/src/support/admin_api_keys.ts
@@ -1,5 +1,5 @@
 import {APIRequestContext, expect} from '@playwright/test'
-import {Page} from 'playwright'
+import {Page} from '@playwright/test'
 import {waitForPageJsLoad} from './wait'
 
 type CreateApiKeyParamsType = {

--- a/browser-test/src/support/admin_predicates.ts
+++ b/browser-test/src/support/admin_predicates.ts
@@ -1,5 +1,5 @@
 import {expect} from '@playwright/test'
-import {Page} from 'playwright'
+import {Page} from '@playwright/test'
 import {waitForHtmxReady} from './wait'
 
 // For legacy predicate view.

--- a/browser-test/src/support/admin_program_image.ts
+++ b/browser-test/src/support/admin_program_image.ts
@@ -1,5 +1,5 @@
-import {expect} from '@playwright/test'
-import {Page} from 'playwright'
+import {expect} from '../support/civiform_fixtures'
+import {Page} from '@playwright/test'
 import {waitForPageJsLoad} from './wait'
 import {dismissToast} from '.'
 

--- a/browser-test/src/support/admin_program_statuses.ts
+++ b/browser-test/src/support/admin_program_statuses.ts
@@ -1,5 +1,5 @@
-import {expect, Locator} from '@playwright/test'
-import {Page} from 'playwright'
+import {expect} from './civiform_fixtures'
+import {Page, Locator} from '@playwright/test'
 import {dismissModal, waitForAnyModalLocator, waitForPageJsLoad} from './wait'
 
 export class AdminProgramStatuses {

--- a/browser-test/src/support/admin_programs.ts
+++ b/browser-test/src/support/admin_programs.ts
@@ -1,5 +1,5 @@
 import {expect} from './civiform_fixtures'
-import {ElementHandle, Page, Locator} from 'playwright'
+import {ElementHandle, Page, Locator} from '@playwright/test'
 import {readFileSync} from 'fs'
 import {
   clickAndWaitForModal,

--- a/browser-test/src/support/admin_questions.ts
+++ b/browser-test/src/support/admin_questions.ts
@@ -1,5 +1,5 @@
-import {expect} from '@playwright/test'
-import {ElementHandle, Page} from 'playwright'
+import {expect} from './civiform_fixtures'
+import {ElementHandle, Page} from '@playwright/test'
 import {
   dismissModal,
   waitForAnyModal,

--- a/browser-test/src/support/admin_settings.ts
+++ b/browser-test/src/support/admin_settings.ts
@@ -1,5 +1,5 @@
-import {expect} from '@playwright/test'
-import {Page} from 'playwright'
+import {expect} from './civiform_fixtures'
+import {Page} from '@playwright/test'
 import {BASE_URL} from './config'
 
 export class AdminSettings {

--- a/browser-test/src/support/admin_ti_groups.ts
+++ b/browser-test/src/support/admin_ti_groups.ts
@@ -1,5 +1,5 @@
-import {expect} from '@playwright/test'
-import {Page} from 'playwright'
+import {expect} from './civiform_fixtures'
+import {Page} from '@playwright/test'
 
 export class AdminTIGroups {
   private page!: Page

--- a/browser-test/src/support/admin_translations.ts
+++ b/browser-test/src/support/admin_translations.ts
@@ -1,5 +1,5 @@
-import {expect} from '@playwright/test'
-import {Page} from 'playwright'
+import {expect} from './civiform_fixtures'
+import {Page} from '@playwright/test'
 import {waitForPageJsLoad} from './wait'
 
 type ProgramStatusTranslationParams = {

--- a/browser-test/src/support/applicant_file_question.ts
+++ b/browser-test/src/support/applicant_file_question.ts
@@ -1,5 +1,5 @@
-import {expect} from '@playwright/test'
-import {Page} from 'playwright'
+import {expect} from './civiform_fixtures'
+import {Page} from '@playwright/test'
 
 /** Class for working with the file upload question that applicants see. */
 export class ApplicantFileQuestion {

--- a/browser-test/src/support/applicant_questions.ts
+++ b/browser-test/src/support/applicant_questions.ts
@@ -1,5 +1,5 @@
-import {expect, Locator} from '@playwright/test'
-import {Page} from 'playwright'
+import {expect} from './civiform_fixtures'
+import {Page, Locator} from '@playwright/test'
 import {readFileSync, writeFileSync, unlinkSync} from 'fs'
 import {
   waitForAnyModalLocator,

--- a/browser-test/src/support/browser_error_watcher.ts
+++ b/browser-test/src/support/browser_error_watcher.ts
@@ -1,4 +1,4 @@
-import {Page} from 'playwright'
+import {Page} from '@playwright/test'
 
 interface ErrorOnPage {
   message: string

--- a/browser-test/src/support/screenshots.ts
+++ b/browser-test/src/support/screenshots.ts
@@ -1,4 +1,4 @@
-import {Page, Locator} from 'playwright'
+import {Page, Locator} from '@playwright/test'
 import {test, expect} from './civiform_fixtures'
 import {DISABLE_SCREENSHOTS} from './config'
 import * as path from 'path'

--- a/browser-test/src/support/ti_dashboard.ts
+++ b/browser-test/src/support/ti_dashboard.ts
@@ -1,5 +1,5 @@
-import {expect} from '@playwright/test'
-import {Page} from 'playwright'
+import {expect} from './civiform_fixtures'
+import {Page} from '@playwright/test'
 import {waitForPageJsLoad} from './wait'
 
 /*

--- a/browser-test/src/support/wait.ts
+++ b/browser-test/src/support/wait.ts
@@ -1,5 +1,5 @@
-import {ElementHandle, Frame, Page} from 'playwright'
-import {expect, Locator} from 'playwright/test'
+import {ElementHandle, Frame, Page, Locator} from '@playwright/test'
+import {expect} from './civiform_fixtures'
 
 /**
  * Civiform attaches JS event handlers after pages load, so after any action

--- a/browser-test/src/tsconfig.json
+++ b/browser-test/src/tsconfig.json
@@ -5,7 +5,7 @@
     "strict": true,
     "module": "commonjs",
     "noEmit": true,
-    "types": ["playwright", "node"],
+    "types": ["@playwright/test", "node"],
     "sourceMap": true
   },
   "include": [".", "../playwright.config.ts"]


### PR DESCRIPTION
We don't need both the `playwright` and `@playwright/test` packages. The recommended package to use for a basic test project is `@playwright/test`.

This removes the `playwright` package and normalizes the imports to use `@playwright/test`.

Additionally this fixes imports of `expect` to only come from the `./civiform_fixtures` module.
