### PR TITLE
Remove tailwind clamp plugin

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -18,7 +18,6 @@
         "swagger-ui-dist": "^5.18.2"
       },
       "devDependencies": {
-        "@tailwindcss/line-clamp": "0.4.4",
         "@tsconfig/recommended": "1.0.13",
         "@types/cleave.js": "1.4.12",
         "@types/markdown-it": "14.1.2",
@@ -2072,15 +2071,6 @@
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@tailwindcss/line-clamp": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/line-clamp/-/line-clamp-0.4.4.tgz",
-      "integrity": "sha512-5U6SY5z8N42VtrCrKlsTAA35gy2VSyYtHWCsg1H87NU1SXnEfekTVlrga9fzUDrrHcGi2Lb5KenUWb4lRQT5/g==",
-      "dev": true,
-      "peerDependencies": {
-        "tailwindcss": ">=2.0.0 || >=3.0.0 || >=3.0.0-alpha.1"
-      }
     },
     "node_modules/@tsconfig/recommended": {
       "version": "1.0.13",
@@ -6378,6 +6368,7 @@
       "integrity": "sha512-E4t7DJ9pESL6E3I8nFjPa4xGUd3PmiWDLsDztS2qXSJWfHtbQnwAWylaBvSNY48I3vr8PTqIZlyK8TE3V3CA4Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.16",
         "@vitest/mocker": "4.0.16",

--- a/server/package.json
+++ b/server/package.json
@@ -16,7 +16,6 @@
   },
   "license": "CC0-1.0",
   "devDependencies": {
-    "@tailwindcss/line-clamp": "0.4.4",
     "@tsconfig/recommended": "1.0.13",
     "@types/cleave.js": "1.4.12",
     "@types/markdown-it": "14.1.2",

--- a/server/tailwind.config.js
+++ b/server/tailwind.config.js
@@ -64,8 +64,5 @@ module.exports = {
         11.5: '2.875rem',
       },
     },
-  },
-  plugins: [
-    require('@tailwindcss/line-clamp'),
-  ]
+  }
 }


### PR DESCRIPTION
Remove the tailwind clamp plugin. It is obsolete and has been merged into the main tailwind library.
