### PR TITLE
rename common intake form to pre screener form in junit tests

### DIFF
--- a/server/test/controllers/admin/AdminProgramControllerTest.java
+++ b/server/test/controllers/admin/AdminProgramControllerTest.java
@@ -211,8 +211,8 @@ public class AdminProgramControllerTest extends ResetPostgres {
   }
 
   @Test
-  public void create_showsErrorsBeforePromptingUserToConfirmCommonIntakeChange() {
-    ProgramBuilder.newActiveCommonIntakeForm("Old common intake").build();
+  public void create_showsErrorsBeforePromptingUserToConfirmPreScreenerChange() {
+    ProgramBuilder.newActivePreScreenerForm("Old pre-screener").build();
     Map<String, String> formData = new HashMap<>(DEFAULT_FORM_FIELDS);
     formData.put("localizedDisplayName", ""); // Empty name to force validation error
     formData.put("programTypeValue", ProgramType.COMMON_INTAKE_FORM.getValue());
@@ -226,8 +226,8 @@ public class AdminProgramControllerTest extends ResetPostgres {
   }
 
   @Test
-  public void create_promptsUserToConfirmCommonIntakeChange() {
-    ProgramBuilder.newActiveCommonIntakeForm("Old common intake").build();
+  public void create_promptsUserToConfirmPreScreenerChange() {
+    ProgramBuilder.newActivePreScreenerForm("Old pre-screener").build();
     Map<String, String> formData = new HashMap<>(DEFAULT_FORM_FIELDS);
     formData.put("programTypeValue", ProgramType.COMMON_INTAKE_FORM.getValue());
     formData.put("confirmedChangePreScreenerForm", "false");
@@ -239,7 +239,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
   }
 
   @Test
-  public void create_northStar_doesNotPromptUserToConfirmCommonIntakeChangeIfNoneExists() {
+  public void create_northStar_doesNotPromptUserToConfirmPreScreenerChangeIfNoneExists() {
     Map<String, String> formData = new HashMap<>(DEFAULT_FORM_FIELDS);
     formData.put("programTypeValue", ProgramType.COMMON_INTAKE_FORM.getValue());
     formData.put("confirmedChangePreScreenerForm", "false");
@@ -254,8 +254,8 @@ public class AdminProgramControllerTest extends ResetPostgres {
   }
 
   @Test
-  public void create_allowsChangingCommonIntakeAfterConfirming() {
-    ProgramBuilder.newActiveCommonIntakeForm("Old common intake").build();
+  public void create_allowsChangingPreScreenerAfterConfirming() {
+    ProgramBuilder.newActivePreScreenerForm("Old pre-screener").build();
 
     Map<String, String> formData = new HashMap<>(DEFAULT_FORM_FIELDS);
     formData.put("programTypeValue", ProgramType.COMMON_INTAKE_FORM.getValue());
@@ -470,10 +470,10 @@ public class AdminProgramControllerTest extends ResetPostgres {
   }
 
   @Test
-  public void update_showsErrorsBeforePromptingUserToConfirmCommonIntakeChange() throws Exception {
+  public void update_showsErrorsBeforePromptingUserToConfirmPreScreenerChange() throws Exception {
     ProgramModel program =
         ProgramBuilder.newDraftProgram("Existing One", "old description").build();
-    ProgramBuilder.newActiveCommonIntakeForm("Old common intake").build();
+    ProgramBuilder.newActivePreScreenerForm("Old pre-screener").build();
 
     Map<String, String> formData = new HashMap<>(DEFAULT_FORM_FIELDS);
     formData.put("localizedDisplayName", ""); // Empty name to force validation error
@@ -492,10 +492,10 @@ public class AdminProgramControllerTest extends ResetPostgres {
   }
 
   @Test
-  public void update_promptsUserToConfirmCommonIntakeChange() throws Exception {
+  public void update_promptsUserToConfirmPreScreenerChange() throws Exception {
     ProgramModel program =
         ProgramBuilder.newDraftProgram("Existing One", "old description").build();
-    ProgramBuilder.newActiveCommonIntakeForm("Old common intake").build();
+    ProgramBuilder.newActivePreScreenerForm("Old pre-screener").build();
 
     Map<String, String> formData = new HashMap<>(DEFAULT_FORM_FIELDS);
     formData.put("programTypeValue", ProgramType.COMMON_INTAKE_FORM.getValue());
@@ -512,7 +512,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
   }
 
   @Test
-  public void update_doesNotPromptUserToConfirmCommonIntakeChangeIfNoneExists() throws Exception {
+  public void update_doesNotPromptUserToConfirmPreScreenerChangeIfNoneExists() throws Exception {
     ProgramModel program =
         ProgramBuilder.newDraftProgram("Existing One", "old description").build();
 
@@ -536,11 +536,11 @@ public class AdminProgramControllerTest extends ResetPostgres {
   }
 
   @Test
-  public void update_northStar_allowsChangingCommonIntakeAfterConfirming() throws Exception {
+  public void update_northStar_allowsChangingPreScreenerAfterConfirming() throws Exception {
     ProgramModel program =
         ProgramBuilder.newDraftProgram("Existing One", "old description", "old short description")
             .build();
-    ProgramBuilder.newActiveCommonIntakeForm("Old common intake").build();
+    ProgramBuilder.newActivePreScreenerForm("Old pre-screener").build();
 
     String newProgramShortDescription = "External program short description";
 

--- a/server/test/controllers/applicant/ApplicantProgramsControllerTest.java
+++ b/server/test/controllers/applicant/ApplicantProgramsControllerTest.java
@@ -235,7 +235,7 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
 
   @Test
   public void indexWithApplicantId_withCommonIntakeform_includesStartHereButtonWithRedirect() {
-    ProgramModel program = resourceCreator().insertActiveCommonIntakeForm("benefits");
+    ProgramModel program = resourceCreator().insertActivePreScreenerForm("benefits");
 
     Result result =
         controller

--- a/server/test/controllers/applicant/ProgramSlugHandlerTest.java
+++ b/server/test/controllers/applicant/ProgramSlugHandlerTest.java
@@ -411,7 +411,7 @@ public class ProgramSlugHandlerTest extends WithMockedProfiles {
   @Test
   public void showProgramPreview_withPreScreener_loadsFirstBlockPage() {
     ProgramDefinition programDefinition =
-        ProgramBuilder.newActiveCommonIntakeForm("test pre-screener").buildDefinition();
+        ProgramBuilder.newActivePreScreenerForm("test pre-screener").buildDefinition();
 
     ApplicantModel applicant = createApplicantWithMockedProfile();
 

--- a/server/test/services/applicant/ApplicantServiceTest.java
+++ b/server/test/services/applicant/ApplicantServiceTest.java
@@ -2616,8 +2616,8 @@ public class ApplicantServiceTest extends ResetPostgres {
   @Test
   public void relevantProgramsForApplicant() {
     ApplicantModel applicant = createTestApplicant();
-    ProgramModel commonIntakeForm =
-        ProgramBuilder.newActiveCommonIntakeForm("common_intake_form")
+    ProgramModel preScreenerForm =
+        ProgramBuilder.newActivePreScreenerForm("pre_screener_form")
             .withBlock()
             .withRequiredQuestion(testQuestionBank.textApplicantFavoriteColor())
             .build();
@@ -2635,7 +2635,7 @@ public class ApplicantServiceTest extends ResetPostgres {
         ProgramBuilder.newActiveProgram("program_for_unapplied").withBlock().build();
 
     applicationRepository
-        .createOrUpdateDraft(applicant.id, commonIntakeForm.id)
+        .createOrUpdateDraft(applicant.id, preScreenerForm.id)
         .toCompletableFuture()
         .join();
     applicationRepository
@@ -2675,7 +2675,7 @@ public class ApplicantServiceTest extends ResetPostgres {
             result.unapplied().stream().map(ApplicantProgramData::latestSubmittedApplicationStatus))
         .containsExactly(Optional.empty(), Optional.empty());
     assertThat(result.preScreenerForm().isPresent()).isTrue();
-    assertThat(result.preScreenerForm().get().program().id()).isEqualTo(commonIntakeForm.id);
+    assertThat(result.preScreenerForm().get().program().id()).isEqualTo(preScreenerForm.id);
     assertThat(result.allPrograms())
         .containsExactlyInAnyOrder(
             result.preScreenerForm().get(),
@@ -2684,14 +2684,14 @@ public class ApplicantServiceTest extends ResetPostgres {
             result.unapplied().get(0),
             result.unapplied().get(1));
     assertThat(result.inProgressIncludingPreScreener().stream().map(p -> p.program().id()))
-        .containsExactlyInAnyOrder(commonIntakeForm.id, programForDraft.id);
+        .containsExactlyInAnyOrder(preScreenerForm.id, programForDraft.id);
   }
 
   @Test
   public void relevantProgramsWithoutApplicant() {
     // Note that setup() creates a test-program program in addition to these.
-    ProgramModel commonIntakeForm =
-        ProgramBuilder.newActiveCommonIntakeForm("common_intake_form")
+    ProgramModel preScreenerForm =
+        ProgramBuilder.newActivePreScreenerForm("pre_screener_form")
             .withBlock()
             .withRequiredQuestion(testQuestionBank.textApplicantFavoriteColor())
             .build();
@@ -2719,14 +2719,14 @@ public class ApplicantServiceTest extends ResetPostgres {
             result.unapplied().stream().map(ApplicantProgramData::latestSubmittedApplicationStatus))
         .containsExactly(Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
     assertThat(result.preScreenerForm().isPresent()).isTrue();
-    assertThat(result.preScreenerForm().get().program().id()).isEqualTo(commonIntakeForm.id);
+    assertThat(result.preScreenerForm().get().program().id()).isEqualTo(preScreenerForm.id);
     assertThat(result.allPrograms().stream().map(p -> p.program().id()))
         .containsExactlyInAnyOrder(
-            commonIntakeForm.id, program1.id, program2.id, program3.id, programDefinition.id());
+            preScreenerForm.id, program1.id, program2.id, program3.id, programDefinition.id());
   }
 
   @Test
-  public void relevantProgramsForApplicant_noCommonIntakeForm() {
+  public void relevantProgramsForApplicant_nopreScreenerForm() {
     ApplicantModel applicant = createTestApplicant();
     ProgramModel programForDraft =
         ProgramBuilder.newActiveProgram("program_for_draft")
@@ -2786,10 +2786,10 @@ public class ApplicantServiceTest extends ResetPostgres {
   }
 
   @Test
-  public void relevantProgramsForApplicant_commonIntakeFormHasCorrectLifecycleStage() {
+  public void relevantProgramsForApplicant_preScreenerFormHasCorrectLifecycleStage() {
     ApplicantModel applicant = createTestApplicant();
-    ProgramModel commonIntakeForm =
-        ProgramBuilder.newActiveCommonIntakeForm("common_intake_form")
+    ProgramModel preScreenerForm =
+        ProgramBuilder.newActivePreScreenerForm("pre_screener_form")
             .withBlock()
             .withRequiredQuestion(testQuestionBank.textApplicantFavoriteColor())
             .build();
@@ -2805,13 +2805,13 @@ public class ApplicantServiceTest extends ResetPostgres {
     assertThat(result.unapplied().stream().map(p -> p.program().id()))
         .containsExactlyInAnyOrder(programDefinition.id());
     assertThat(result.preScreenerForm().isPresent()).isTrue();
-    assertThat(result.preScreenerForm().get().program().id()).isEqualTo(commonIntakeForm.id);
+    assertThat(result.preScreenerForm().get().program().id()).isEqualTo(preScreenerForm.id);
     assertThat(result.preScreenerForm().get().latestApplicationLifecycleStage().isPresent())
         .isFalse();
 
     // CIF application in progress.
     applicationRepository
-        .createOrUpdateDraft(applicant.id, commonIntakeForm.id)
+        .createOrUpdateDraft(applicant.id, preScreenerForm.id)
         .toCompletableFuture()
         .join();
     result =
@@ -2824,7 +2824,7 @@ public class ApplicantServiceTest extends ResetPostgres {
     assertThat(result.unapplied().stream().map(p -> p.program().id()))
         .containsExactlyInAnyOrder(programDefinition.id());
     assertThat(result.preScreenerForm().isPresent()).isTrue();
-    assertThat(result.preScreenerForm().get().program().id()).isEqualTo(commonIntakeForm.id);
+    assertThat(result.preScreenerForm().get().program().id()).isEqualTo(preScreenerForm.id);
     assertThat(result.preScreenerForm().get().latestApplicationLifecycleStage().isPresent())
         .isTrue();
     assertThat(result.preScreenerForm().get().latestApplicationLifecycleStage().get())
@@ -2834,7 +2834,7 @@ public class ApplicantServiceTest extends ResetPostgres {
     applicationRepository
         .submitApplication(
             applicant.id,
-            commonIntakeForm.id,
+            preScreenerForm.id,
             Optional.empty(),
             EligibilityDetermination.NOT_COMPUTED)
         .toCompletableFuture()
@@ -2846,7 +2846,7 @@ public class ApplicantServiceTest extends ResetPostgres {
             .join();
     assertThat(result.inProgress()).isEmpty();
     assertThat(result.submitted().stream().map(p -> p.program().id()))
-        .containsExactly(commonIntakeForm.id);
+        .containsExactly(preScreenerForm.id);
     assertThat(result.unapplied().stream().map(p -> p.program().id()))
         .containsExactlyInAnyOrder(programDefinition.id());
   }
@@ -3794,7 +3794,7 @@ public class ApplicantServiceTest extends ResetPostgres {
     EligibilityDefinition unansweredQuestionEligibilityDefinition =
         createEligibilityDefinition(unansweredQuestion, "Sza");
 
-    // Setup program for answering questions (not necessarily a common intake program)
+    // Setup program for answering questions (not necessarily a pre-screener program)
     ProgramModel programForAnsweringQuestions =
         ProgramBuilder.newDraftProgram("other program")
             .withBlock()
@@ -4050,20 +4050,20 @@ public class ApplicantServiceTest extends ResetPostgres {
   }
 
   @Test
-  public void maybeEligibleProgramsForApplicant_doesNotIncludeCommonIntake() {
+  public void maybeEligibleProgramsForApplicant_doesNotIncludePreScreener() {
     // Set up applicant
     ApplicantModel applicant = subject.createApplicant().toCompletableFuture().join();
     applicant.setAccount(resourceCreator.insertAccount());
     applicant.save();
 
-    // Set up common intake form
+    // Set up pre-screener form
     NameQuestionDefinition question = createNameQuestion("question");
-    ProgramModel commonIntakeForm =
+    ProgramModel preScreenerForm =
         ProgramBuilder.newDraftProgram(
                 ProgramDefinition.builder()
                     .setId(new Random().nextLong())
-                    .setAdminName("common_intake_form")
-                    .setAdminDescription("common_intake_form")
+                    .setAdminName("pre_screener_form")
+                    .setAdminDescription("pre_screener_form")
                     .setExternalLink("https://usa.gov")
                     .setDisplayMode(DisplayMode.PUBLIC)
                     .setProgramType(ProgramType.COMMON_INTAKE_FORM)
@@ -4086,9 +4086,9 @@ public class ApplicantServiceTest extends ResetPostgres {
         "Allison",
         "Swift",
         "I",
-        commonIntakeForm.getProgramDefinition().getBlockDefinitionByIndex(0).orElseThrow().id(),
+        preScreenerForm.getProgramDefinition().getBlockDefinitionByIndex(0).orElseThrow().id(),
         applicant.id,
-        commonIntakeForm.id);
+        preScreenerForm.id);
 
     // We need at least one application for the ApplicantService to bother filling eligibility
     // statuses. It doesn't have to be the same one we're filling out.
@@ -4106,7 +4106,7 @@ public class ApplicantServiceTest extends ResetPostgres {
 
     var matchingProgramIds =
         result.stream().map(pd -> pd.program().id()).collect(ImmutableList.toImmutableList());
-    assertThat(matchingProgramIds).doesNotContain(commonIntakeForm.id);
+    assertThat(matchingProgramIds).doesNotContain(preScreenerForm.id);
   }
 
   @Test

--- a/server/test/services/program/ProgramServiceTest.java
+++ b/server/test/services/program/ProgramServiceTest.java
@@ -714,7 +714,7 @@ public class ProgramServiceTest extends ResetPostgres {
   }
 
   @Test
-  public void createProgram_clearsExistingCommonIntakeForm() {
+  public void createProgram_clearsExistingPreScreenerForm() {
     ps.createProgramDefinition(
         "name-one",
         "description",
@@ -732,9 +732,9 @@ public class ProgramServiceTest extends ResetPostgres {
         /* categoryIds= */ ImmutableList.of(),
         ImmutableList.of(new ApplicationStep("title", "description")));
 
-    Optional<ProgramDefinition> commonIntakeForm = ps.getPreScreenerForm();
-    assertThat(commonIntakeForm).isPresent();
-    assertThat(commonIntakeForm.get().adminName()).isEqualTo("name-one");
+    Optional<ProgramDefinition> preScreenerForm = ps.getPreScreenerForm();
+    assertThat(preScreenerForm).isPresent();
+    assertThat(preScreenerForm.get().adminName()).isEqualTo("name-one");
 
     ErrorAnd<ProgramDefinition, CiviFormError> result =
         ps.createProgramDefinition(
@@ -757,13 +757,13 @@ public class ProgramServiceTest extends ResetPostgres {
     assertThat(result.isError()).isFalse();
     assertThat(result.getResult().programType()).isEqualTo(ProgramType.COMMON_INTAKE_FORM);
 
-    commonIntakeForm = ps.getPreScreenerForm();
-    assertThat(commonIntakeForm).isPresent();
-    assertThat(commonIntakeForm.get().adminName()).isEqualTo("name-two");
-    Optional<ProgramDefinition> oldCommonIntake =
+    preScreenerForm = ps.getPreScreenerForm();
+    assertThat(preScreenerForm).isPresent();
+    assertThat(preScreenerForm.get().adminName()).isEqualTo("name-two");
+    Optional<ProgramDefinition> oldPreScreener =
         ps.getActiveAndDraftPrograms().getDraftProgramDefinition("name-one");
-    assertThat(oldCommonIntake).isPresent();
-    assertThat(oldCommonIntake.get().programType()).isEqualTo(ProgramType.DEFAULT);
+    assertThat(oldPreScreener).isPresent();
+    assertThat(oldPreScreener.get().programType()).isEqualTo(ProgramType.DEFAULT);
   }
 
   @Test
@@ -1037,7 +1037,7 @@ public class ProgramServiceTest extends ResetPostgres {
 
   @Test
   public void
-      validateProgramDataForCreate_noErrorForWhenMissingApplicationStepsForCommonIntakeForm() {
+      validateProgramDataForCreate_noErrorForWhenMissingApplicationStepsForPreScreenerForm() {
     ImmutableSet<CiviFormError> result =
         ps.validateProgramDataForCreate(
             "name-two",
@@ -1099,7 +1099,7 @@ public class ProgramServiceTest extends ResetPostgres {
   }
 
   @Test
-  public void checkApplicationStepErrors_commonIntakeProgram_returnsNoErrors() {
+  public void checkApplicationStepErrors_preScreenerProgram_returnsNoErrors() {
     ImmutableSet.Builder<CiviFormError> errorsBuilder = ImmutableSet.builder();
     ImmutableList<ApplicationStep> applicationSteps = ImmutableList.of();
     ImmutableSet<CiviFormError> errors =
@@ -1390,7 +1390,7 @@ public class ProgramServiceTest extends ResetPostgres {
   }
 
   @Test
-  public void updateProgram_clearsExistingCommonIntakeForm() throws Exception {
+  public void updateProgram_clearsExistingPreScreenerForm() throws Exception {
     ps.createProgramDefinition(
         "name-one",
         "description",
@@ -1408,9 +1408,9 @@ public class ProgramServiceTest extends ResetPostgres {
         /* categoryIds= */ ImmutableList.of(),
         ImmutableList.of(new ApplicationStep("title", "description")));
 
-    Optional<ProgramDefinition> commonIntakeForm = ps.getPreScreenerForm();
-    assertThat(commonIntakeForm).isPresent();
-    assertThat(commonIntakeForm.get().adminName()).isEqualTo("name-one");
+    Optional<ProgramDefinition> preScreenerForm = ps.getPreScreenerForm();
+    assertThat(preScreenerForm).isPresent();
+    assertThat(preScreenerForm.get().adminName()).isEqualTo("name-one");
 
     ProgramDefinition program = ProgramBuilder.newDraftProgram().buildDefinition();
     ErrorAnd<ProgramDefinition, CiviFormError> result =
@@ -1435,18 +1435,18 @@ public class ProgramServiceTest extends ResetPostgres {
     assertThat(result.hasResult()).isTrue();
     assertThat(result.isError()).isFalse();
     assertThat(result.getResult().programType()).isEqualTo(ProgramType.COMMON_INTAKE_FORM);
-    commonIntakeForm = ps.getPreScreenerForm();
-    assertThat(commonIntakeForm).isPresent();
-    assertThat(commonIntakeForm.get().adminName()).isEqualTo(program.adminName());
-    Optional<ProgramDefinition> oldCommonIntake =
+    preScreenerForm = ps.getPreScreenerForm();
+    assertThat(preScreenerForm).isPresent();
+    assertThat(preScreenerForm.get().adminName()).isEqualTo(program.adminName());
+    Optional<ProgramDefinition> oldPreScreener =
         ps.getActiveAndDraftPrograms().getDraftProgramDefinition("name-one");
-    assertThat(oldCommonIntake).isPresent();
-    assertThat(oldCommonIntake.get().programType()).isEqualTo(ProgramType.DEFAULT);
+    assertThat(oldPreScreener).isPresent();
+    assertThat(oldPreScreener.get().programType()).isEqualTo(ProgramType.DEFAULT);
   }
 
   @Test
-  public void updateProgram_allowsUpdatingCommonIntakeForm() throws Exception {
-    ErrorAnd<ProgramDefinition, CiviFormError> commonIntakeForm =
+  public void updateProgram_allowsUpdatingPreScreenerForm() throws Exception {
+    ErrorAnd<ProgramDefinition, CiviFormError> preScreenerForm =
         ps.createProgramDefinition(
             "name-one",
             "description",
@@ -1466,7 +1466,7 @@ public class ProgramServiceTest extends ResetPostgres {
 
     ErrorAnd<ProgramDefinition, CiviFormError> result =
         ps.updateProgramDefinition(
-            commonIntakeForm.getResult().id(),
+            preScreenerForm.getResult().id(),
             Locale.US,
             "a",
             "a",
@@ -1488,8 +1488,8 @@ public class ProgramServiceTest extends ResetPostgres {
   }
 
   @Test
-  public void updateProgram_allowsUpdatingCommonIntakeFormToDefaultProgram() throws Exception {
-    ErrorAnd<ProgramDefinition, CiviFormError> commonIntakeForm =
+  public void updateProgram_allowsUpdatingPreScreenerFormToDefaultProgram() throws Exception {
+    ErrorAnd<ProgramDefinition, CiviFormError> preScreenerForm =
         ps.createProgramDefinition(
             "name-one",
             "description",
@@ -1509,7 +1509,7 @@ public class ProgramServiceTest extends ResetPostgres {
 
     ErrorAnd<ProgramDefinition, CiviFormError> result =
         ps.updateProgramDefinition(
-            commonIntakeForm.getResult().id(),
+            preScreenerForm.getResult().id(),
             Locale.US,
             "a",
             "a",
@@ -1532,7 +1532,7 @@ public class ProgramServiceTest extends ResetPostgres {
   }
 
   @Test
-  public void updateProgram_clearsEligibilityConditionsWhenSettingCommonIntakeForm()
+  public void updateProgram_clearsEligibilityConditionsWhenSettingPreScreenerForm()
       throws Exception {
     QuestionDefinition question = nameQuestion;
     EligibilityDefinition eligibility =
@@ -3273,9 +3273,9 @@ public class ProgramServiceTest extends ResetPostgres {
   }
 
   @Test
-  public void updateLocalizations_applicationStepValidationIsSkippedForCommonIntakeProgram()
+  public void updateLocalizations_applicationStepValidationIsSkippedForPreScreenerProgram()
       throws Exception {
-    ProgramModel program = ProgramBuilder.newActiveCommonIntakeForm("prescreener").build();
+    ProgramModel program = ProgramBuilder.newActivePreScreenerForm("prescreener").build();
 
     LocalizationUpdate updateData =
         LocalizationUpdate.builder()
@@ -3653,9 +3653,9 @@ public class ProgramServiceTest extends ResetPostgres {
   }
 
   @Test
-  public void getCommonIntakeForm_ignoresObsoletePrograms() {
-    // No common intake form in the most recent version of any program, although some programs
-    // were previously marked as common intake.
+  public void getPreScreenerForm_ignoresObsoletePrograms() {
+    // No pre-screener form in the most recent version of any program, although some programs
+    // were previously marked as pre-screener.
     ProgramBuilder.newObsoleteProgram("one")
         .withProgramType(ProgramType.COMMON_INTAKE_FORM)
         .build();
@@ -3666,7 +3666,7 @@ public class ProgramServiceTest extends ResetPostgres {
   }
 
   @Test
-  public void getCommonIntakeForm_activeCommonIntake() {
+  public void getPreScreenerForm_activePreScreener() {
     ProgramBuilder.newObsoleteProgram("one")
         .withProgramType(ProgramType.COMMON_INTAKE_FORM)
         .build();
@@ -3677,7 +3677,7 @@ public class ProgramServiceTest extends ResetPostgres {
   }
 
   @Test
-  public void getCommonIntakeForm_draftCommonIntake() {
+  public void getPreScreenerForm_draftPreScreener() {
     ProgramBuilder.newObsoleteProgram("one")
         .withProgramType(ProgramType.COMMON_INTAKE_FORM)
         .build();

--- a/server/test/support/ProgramBuilder.java
+++ b/server/test/support/ProgramBuilder.java
@@ -231,7 +231,7 @@ public class ProgramBuilder {
    * Creates a {@link ProgramBuilder} with a new {@link ProgramModel} in the active state, with the
    * type ProgramType.COMMON_INTAKE_FORM.
    */
-  public static ProgramBuilder newActiveCommonIntakeForm(String name) {
+  public static ProgramBuilder newActivePreScreenerForm(String name) {
     return newActiveProgram(
         /* adminName= */ name,
         /* displayName= */ name,

--- a/server/test/support/ResourceCreator.java
+++ b/server/test/support/ResourceCreator.java
@@ -161,8 +161,8 @@ public class ResourceCreator {
     return ProgramBuilder.newActiveProgram().withLocalizedName(locale, name).build();
   }
 
-  public ProgramModel insertActiveCommonIntakeForm(String name) {
-    return ProgramBuilder.newActiveCommonIntakeForm(name).build();
+  public ProgramModel insertActivePreScreenerForm(String name) {
+    return ProgramBuilder.newActivePreScreenerForm(name).build();
   }
 
   public ProgramModel insertActiveExternalProgram(String name) {


### PR DESCRIPTION
### Description

Update a bunch of tests to use the `pre-screener` language rather than `common intake`.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.