### PR TITLE
Remove focus outline from main content on click

### DIFF
--- a/server/app/assets/stylesheets/northstar/_uswds-theme-custom-styles.scss
+++ b/server/app/assets/stylesheets/northstar/_uswds-theme-custom-styles.scss
@@ -865,3 +865,9 @@ main {
 .opacity-40:hover {
   opacity: 1;
 }
+
+// Remove focus outline from main content when focused via skip navigation
+// The tabindex is set for skip nav accessibility, but the outline is visually distracting
+main#main-content {
+  outline: none;
+}


### PR DESCRIPTION
### Description

Removes the focus outline that appears when clicking the main header "Apply for government programs online".

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [X] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [X] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [ ] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.



### Issue(s) this completes

Fixes #10939
