### PR TITLE
Make auto project assigning action smarter

### DIFF
--- a/.github/workflows/assign_issues_to_project.yaml
+++ b/.github/workflows/assign_issues_to_project.yaml
@@ -12,7 +12,17 @@ jobs:
     name: Add issue to project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
+      - name: Get project found of issue
+        id: check-projects
+        env:
+          GH_TOKEN: ${{ secrets.CIVIFORM_GITHUB_AUTOMATION_PERSONAL_ACCESS_TOKEN }}
+        run: |
+          PROJECT_COUNT=$(gh issue view ${{ github.event.issue.number }} --repo ${{ github.repository }} --json projectItems --jq '.projectItems | length')
+          echo "project_count=${PROJECT_COUNT}" >> $GITHUB_OUTPUT
+
+      - name: Add issue to project when one is not already assigned
+        if: steps.check-projects.outputs.project_count == '0'
+        uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
         with:
           project-url: https://github.com/orgs/civiform/projects/1
           github-token: ${{ secrets.CIVIFORM_GITHUB_AUTOMATION_PERSONAL_ACCESS_TOKEN }}


### PR DESCRIPTION
Checks the issue to see if it already has a project assigned. If it does, skip assigning the default project.

Tested in a private personal repo. May need to tweak perms on the token, but I suspect not.