### PR TITLE
use PRE_SCREENER_FORM rather than COMMON_INTAKE_FORM for program type

### DIFF
--- a/server/app/controllers/admin/AdminProgramController.java
+++ b/server/app/controllers/admin/AdminProgramController.java
@@ -143,7 +143,7 @@ public final class AdminProgramController extends CiviFormController {
 
     // If the user needs to confirm that they want to change the pre-screener form from a different
     // program to this one, show the confirmation dialog.
-    if (programData.getProgramType().equals(ProgramType.COMMON_INTAKE_FORM)
+    if (programData.getProgramType().equals(ProgramType.PRE_SCREENER_FORM)
         && !programData.getConfirmedChangePreScreenerForm()) {
       Optional<ProgramDefinition> maybePreScreenerForm = programService.getPreScreenerForm();
       if (maybePreScreenerForm.isPresent()) {
@@ -285,7 +285,7 @@ public final class AdminProgramController extends CiviFormController {
 
     // If the user needs to confirm that they want to change the pre-screener form from a different
     // program to this one, show the confirmation dialog.
-    if (programData.getProgramType().equals(ProgramType.COMMON_INTAKE_FORM)
+    if (programData.getProgramType().equals(ProgramType.PRE_SCREENER_FORM)
         && !programData.getConfirmedChangePreScreenerForm()) {
       Optional<ProgramDefinition> maybePreScreenerForm = programService.getPreScreenerForm();
       if (maybePreScreenerForm.isPresent()

--- a/server/app/controllers/applicant/ProgramSlugHandler.java
+++ b/server/app/controllers/applicant/ProgramSlugHandler.java
@@ -228,7 +228,7 @@ public final class ProgramSlugHandler {
     }
 
     // For pre-screener forms, redirect to the first block edit page
-    if (activeProgramDefinition.programType().equals(ProgramType.COMMON_INTAKE_FORM)) {
+    if (activeProgramDefinition.programType().equals(ProgramType.PRE_SCREENER_FORM)) {
       return Results.redirect(
               applicantRoutes.edit(profile, applicantId, activeProgramDefinition.id()))
           .flashing(FlashKey.REDIRECTED_FROM_PROGRAM_SLUG, programSlug)

--- a/server/app/services/applicant/ApplicantService.java
+++ b/server/app/services/applicant/ApplicantService.java
@@ -1360,7 +1360,7 @@ public final class ApplicantService {
           }
 
           ProgramType programType = program.programType();
-          if (programType.equals(ProgramType.COMMON_INTAKE_FORM)) {
+          if (programType.equals(ProgramType.PRE_SCREENER_FORM)) {
             relevantPrograms.setPreScreenerForm(applicantProgramDataBuilder.build());
           } else if (programType.equals(ProgramType.DEFAULT)
               || (programType.equals(ProgramType.EXTERNAL)

--- a/server/app/services/program/ProgramDefinition.java
+++ b/server/app/services/program/ProgramDefinition.java
@@ -816,7 +816,7 @@ public abstract class ProgramDefinition {
 
   @JsonIgnore
   public boolean isPreScreenerForm() {
-    return this.programType() == ProgramType.COMMON_INTAKE_FORM;
+    return this.programType() == ProgramType.PRE_SCREENER_FORM;
   }
 
   /**

--- a/server/app/services/program/ProgramService.java
+++ b/server/app/services/program/ProgramService.java
@@ -378,11 +378,10 @@ public final class ProgramService {
    *     submit an application, and false if an application can submit an application even if they
    *     don't meet some/all of the eligibility criteria.
    * @param loginOnly true if only logged in applicants can apply to the program.
-   * @param programType ProgramType for this Program. If this is set to COMMON_INTAKE_FORM and there
+   * @param programType ProgramType for this Program. If this is set to PRE_SCREENER_FORM and there
    *     is already another active or draft program with {@link
-   *     services.program.ProgramType#COMMON_INTAKE_FORM}, that program's ProgramType will be
-   *     changed to {@link services.program.ProgramType#DEFAULT}, creating a new draft of it if
-   *     necessary.
+   *     services.program.ProgramType#PRE_SCREENER_FORM}, that program's ProgramType will be changed
+   *     to {@link services.program.ProgramType#DEFAULT}, creating a new draft of it if necessary.
    * @param tiGroups The List of TiOrgs who have visibility to program in SELECT_TI display mode
    * @return the {@link ProgramDefinition} that was created if succeeded, or a set of errors if
    *     failed
@@ -429,7 +428,7 @@ public final class ProgramService {
       return ErrorAnd.error(maybeEmptyBlock.getErrors());
     }
 
-    if (programType.equals(ProgramType.COMMON_INTAKE_FORM) && getPreScreenerForm().isPresent()) {
+    if (programType.equals(ProgramType.PRE_SCREENER_FORM) && getPreScreenerForm().isPresent()) {
       clearPreScreenerForm();
     }
     ProgramAcls programAcls = new ProgramAcls(new HashSet<>(tiGroups));
@@ -556,10 +555,10 @@ public final class ProgramService {
    *     submit an application, and false if an application can submit an application even if they
    *     don't meet some/all of the eligibility criteria.
    * @param loginOnly true if an applicant must be logged in before applying to a program.
-   * @param programType ProgramType for this Program. If this is set to COMMON_INTAKE_FORM and there
-   *     is already another active or draft program with {@link ProgramType#COMMON_INTAKE_FORM},
-   *     that program's ProgramType will be changed to {@link ProgramType#DEFAULT}, creating a new
-   *     draft of it if necessary.
+   * @param programType ProgramType for this Program. If this is set to PRE_SCREENER_FORM and there
+   *     is already another active or draft program with {@link ProgramType#PRE_SCREENER_FORM}, that
+   *     program's ProgramType will be changed to {@link ProgramType#DEFAULT}, creating a new draft
+   *     of it if necessary.
    * @param tiGroups the TI Orgs having visibility to the program for SELECT_TI display_mode
    * @return the {@link ProgramDefinition} that was updated if succeeded, or a set of errors if
    *     failed
@@ -599,7 +598,7 @@ public final class ProgramService {
       return ErrorAnd.error(errors);
     }
 
-    if (programType.equals(ProgramType.COMMON_INTAKE_FORM)) {
+    if (programType.equals(ProgramType.PRE_SCREENER_FORM)) {
       Optional<ProgramDefinition> maybePreScreenerForm = getPreScreenerForm();
       if (maybePreScreenerForm.isPresent()
           && !programDefinition.adminName().equals(maybePreScreenerForm.get().adminName())) {
@@ -613,7 +612,7 @@ public final class ProgramService {
     applicationSteps =
         preserveApplicationStepTranslations(applicationSteps, programDefinition.applicationSteps());
 
-    if (programType.equals(ProgramType.COMMON_INTAKE_FORM)
+    if (programType.equals(ProgramType.PRE_SCREENER_FORM)
         && !programDefinition.isPreScreenerForm()) {
       programDefinition = removeAllEligibilityPredicates(programDefinition);
     }
@@ -921,7 +920,7 @@ public final class ProgramService {
       ImmutableSet.Builder<CiviFormError> errorsBuilder,
       ImmutableList<ApplicationStep> applicationSteps) {
     // Pre-screener and external programs don't have application steps.
-    if (programType == ProgramType.COMMON_INTAKE_FORM || programType == ProgramType.EXTERNAL) {
+    if (programType == ProgramType.PRE_SCREENER_FORM || programType == ProgramType.EXTERNAL) {
       return errorsBuilder;
     }
 

--- a/server/app/services/program/ProgramType.java
+++ b/server/app/services/program/ProgramType.java
@@ -4,12 +4,12 @@ import io.ebean.annotation.DbEnumType;
 import io.ebean.annotation.DbEnumValue;
 
 /**
- * ProgramType for a Program. Most Programs are a regular DEFAULT program. A COMMON_INTAKE_FORM
+ * ProgramType for a Program. Most Programs are a regular DEFAULT program. A PRE_SCREENER_FORM
  * Program is an intake screener for other programs.
  */
 public enum ProgramType {
   DEFAULT("default"),
-  COMMON_INTAKE_FORM("common_intake_form"),
+  PRE_SCREENER_FORM("common_intake_form"),
   EXTERNAL("external");
 
   private final String dbValue;

--- a/server/app/views/admin/programs/ProgramAdministratorProgramListView.java
+++ b/server/app/views/admin/programs/ProgramAdministratorProgramListView.java
@@ -76,7 +76,7 @@ public final class ProgramAdministratorProgramListView extends BaseHtmlView {
 
     ProgramType programType = activeProgram.programType();
     if (programType.equals(ProgramType.DEFAULT)
-        || programType.equals(ProgramType.COMMON_INTAKE_FORM)) {
+        || programType.equals(ProgramType.PRE_SCREENER_FORM)) {
       actionsBuilder.add(renderShareLink(activeProgram));
       actionsBuilder.add(renderViewApplicationsLink(activeProgram));
     }

--- a/server/app/views/admin/programs/ProgramBlocksView.java
+++ b/server/app/views/admin/programs/ProgramBlocksView.java
@@ -589,7 +589,7 @@ public final class ProgramBlocksView extends ProgramBaseView {
             settingsManifest.getExpandedFormLogicEnabled(request));
 
     Optional<DivTag> maybeEligibilityPredicateDisplay = Optional.empty();
-    if (!program.programType().equals(ProgramType.COMMON_INTAKE_FORM)) {
+    if (!program.programType().equals(ProgramType.PRE_SCREENER_FORM)) {
       maybeEligibilityPredicateDisplay =
           Optional.of(
               renderEligibilityPredicate(

--- a/server/app/views/admin/programs/ProgramFormBuilder.java
+++ b/server/app/views/admin/programs/ProgramFormBuilder.java
@@ -169,7 +169,7 @@ public class ProgramFormBuilder extends BaseHtmlView {
       ImmutableList<Long> categories,
       ImmutableList<Map<String, String>> applicationSteps) {
     boolean isDefaultProgram = programType.equals(ProgramType.DEFAULT);
-    boolean isPreScreenerForm = programType.equals(ProgramType.COMMON_INTAKE_FORM);
+    boolean isPreScreenerForm = programType.equals(ProgramType.PRE_SCREENER_FORM);
     boolean isExternalProgram = programType.equals(ProgramType.EXTERNAL);
     boolean isExternalProgramCardsEnabled =
         settingsManifest.getExternalProgramCardsEnabled(request);
@@ -412,7 +412,7 @@ public class ProgramFormBuilder extends BaseHtmlView {
       // program, since an external program cannot change type after creation.
       if (programEditStatus.equals(ProgramEditStatus.EDIT)) {
         switch (programType) {
-          case DEFAULT, COMMON_INTAKE_FORM -> {
+          case DEFAULT, PRE_SCREENER_FORM -> {
             defaultProgramFieldDisabled = false;
             preScreenerFieldDisabled = false;
             externalProgramFieldDisabled = true;
@@ -454,8 +454,8 @@ public class ProgramFormBuilder extends BaseHtmlView {
                   buildUSWDSRadioOption(
                       /* id= */ "pre-screener-program-option",
                       /* name= */ PROGRAM_TYPE_FIELD_NAME,
-                      /* value= */ ProgramType.COMMON_INTAKE_FORM.getValue(),
-                      /* isChecked= */ programType.equals(ProgramType.COMMON_INTAKE_FORM),
+                      /* value= */ ProgramType.PRE_SCREENER_FORM.getValue(),
+                      /* isChecked= */ programType.equals(ProgramType.PRE_SCREENER_FORM),
                       /* isDisabled= */ preScreenerFieldDisabled,
                       /* label= */ "Pre-screener",
                       /* description */ Optional.of(
@@ -473,8 +473,8 @@ public class ProgramFormBuilder extends BaseHtmlView {
                               .withClasses("usa-checkbox__input")
                               .withType("checkbox")
                               .withName(PROGRAM_TYPE_FIELD_NAME)
-                              .withValue(ProgramType.COMMON_INTAKE_FORM.getValue())
-                              .withCondChecked(programType.equals(ProgramType.COMMON_INTAKE_FORM)),
+                              .withValue(ProgramType.PRE_SCREENER_FORM.getValue())
+                              .withCondChecked(programType.equals(ProgramType.PRE_SCREENER_FORM)),
                           label("Set program as pre-screener")
                               .withFor("pre-screener-checkbox")
                               .withClasses("usa-checkbox__label"),

--- a/server/app/views/admin/programs/ProgramIndexView.java
+++ b/server/app/views/admin/programs/ProgramIndexView.java
@@ -708,7 +708,7 @@ public final class ProgramIndexView extends BaseHtmlView {
               .url();
 
       String buttonText =
-          programType.equals(ProgramType.COMMON_INTAKE_FORM) ? "Forms" : "Applications";
+          programType.equals(ProgramType.PRE_SCREENER_FORM) ? "Forms" : "Applications";
       ButtonTag button =
           makeSvgTextButton(buttonText, Icons.TEXT_SNIPPET).withClass(ButtonStyles.CLEAR_WITH_ICON);
       return Optional.of(asRedirectElement(button, editLink));

--- a/server/app/views/admin/programs/ProgramMetaDataEditView.java
+++ b/server/app/views/admin/programs/ProgramMetaDataEditView.java
@@ -118,7 +118,7 @@ public final class ProgramMetaDataEditView extends ProgramFormBuilder {
                             .with(makeCsrfTokenInputTag(request))
                             .condWith(
                                 programType.equals(ProgramType.DEFAULT)
-                                    || programType.equals(ProgramType.COMMON_INTAKE_FORM),
+                                    || programType.equals(ProgramType.PRE_SCREENER_FORM),
                                 buildManageQuestionLink(existingProgram.id()))
                             .withAction(
                                 controllers.admin.routes.AdminProgramController.update(

--- a/server/app/views/applicant/ApplicantProgramSummaryView.java
+++ b/server/app/views/applicant/ApplicantProgramSummaryView.java
@@ -58,7 +58,7 @@ public final class ApplicantProgramSummaryView extends ApplicantBaseView {
 
     // Create a string such as "Program appplication summary - Pet Assistance Program"
     String summarySubstring =
-        params.programType().equals(ProgramType.COMMON_INTAKE_FORM)
+        params.programType().equals(ProgramType.PRE_SCREENER_FORM)
             ? params.messages().at(MessageKey.TITLE_PRE_SCREENER_SUMMARY.getKeyName())
             : params.messages().at(MessageKey.TITLE_PROGRAM_SUMMARY.getKeyName());
     String pageTitle = String.format("%s — %s", summarySubstring, params.programTitle());

--- a/server/app/views/applicant/programindex/ProgramCardsSectionFragment.html
+++ b/server/app/views/applicant/programindex/ProgramCardsSectionFragment.html
@@ -36,7 +36,7 @@
     <th:block th:each="card : ${section.cards()}">
       <!-- Standard cards and pre-screener card (after it is started) -->
       <li
-        th:replace="${card.programType().toString() == 'COMMON_INTAKE_FORM'} ? ~{applicant/programindex/ProgramCardsFragment :: submittedOrInProgressPreScreenerCard(${card})} : ~{applicant/programindex/ProgramCardsFragment :: card(${card}, ${sectionType} ?: 'DEFAULT')}"
+        th:replace="${card.programType().toString() == 'PRE_SCREENER_FORM'} ? ~{applicant/programindex/ProgramCardsFragment :: submittedOrInProgressPreScreenerCard(${card})} : ~{applicant/programindex/ProgramCardsFragment :: card(${card}, ${sectionType} ?: 'DEFAULT')}"
       ></li>
     </th:block>
   </ul>

--- a/server/app/views/applicant/programindex/ProgramCardsSectionParamsFactory.java
+++ b/server/app/views/applicant/programindex/ProgramCardsSectionParamsFactory.java
@@ -273,7 +273,7 @@ public final class ProgramCardsSectionParamsFactory {
       }
       // If they are completing the pre-screener form for the first time, skip the program overview
       // page
-    } else if (programType.equals(ProgramType.COMMON_INTAKE_FORM)) {
+    } else if (programType.equals(ProgramType.PRE_SCREENER_FORM)) {
       actionUrl =
           haveApplicant
               ? applicantRoutes.edit(profile.get(), applicantId.get(), programId).url()

--- a/server/app/views/components/ProgramCardFactory.java
+++ b/server/app/views/components/ProgramCardFactory.java
@@ -229,7 +229,7 @@ public final class ProgramCardFactory {
     Icons icon;
     String label;
     switch (programType) {
-      case COMMON_INTAKE_FORM:
+      case PRE_SCREENER_FORM:
         icon = Icons.CHECK;
         label = "Pre-Screener";
         break;
@@ -277,7 +277,7 @@ public final class ProgramCardFactory {
     Comparator<ProgramCardData> c =
         Comparator.comparingInt(
             (cardData) ->
-                getDisplayProgram(cardData).programType().equals(ProgramType.COMMON_INTAKE_FORM)
+                getDisplayProgram(cardData).programType().equals(ProgramType.PRE_SCREENER_FORM)
                     ? 0
                     : 1);
     return c.thenComparing(

--- a/server/test/controllers/admin/AdminProgramControllerTest.java
+++ b/server/test/controllers/admin/AdminProgramControllerTest.java
@@ -215,7 +215,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
     ProgramBuilder.newActivePreScreenerForm("Old pre-screener").build();
     Map<String, String> formData = new HashMap<>(DEFAULT_FORM_FIELDS);
     formData.put("localizedDisplayName", ""); // Empty name to force validation error
-    formData.put("programTypeValue", ProgramType.COMMON_INTAKE_FORM.getValue());
+    formData.put("programTypeValue", ProgramType.PRE_SCREENER_FORM.getValue());
     formData.put("confirmedChangePreScreenerForm", "false");
 
     Result result = controller.create(fakeRequestBuilder().bodyForm(formData).build());
@@ -229,7 +229,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
   public void create_promptsUserToConfirmPreScreenerChange() {
     ProgramBuilder.newActivePreScreenerForm("Old pre-screener").build();
     Map<String, String> formData = new HashMap<>(DEFAULT_FORM_FIELDS);
-    formData.put("programTypeValue", ProgramType.COMMON_INTAKE_FORM.getValue());
+    formData.put("programTypeValue", ProgramType.PRE_SCREENER_FORM.getValue());
     formData.put("confirmedChangePreScreenerForm", "false");
 
     Result result = controller.create(fakeRequestBuilder().bodyForm(formData).build());
@@ -241,7 +241,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
   @Test
   public void create_doesNotPromptUserToConfirmPreScreenerChangeIfNoneExists() {
     Map<String, String> formData = new HashMap<>(DEFAULT_FORM_FIELDS);
-    formData.put("programTypeValue", ProgramType.COMMON_INTAKE_FORM.getValue());
+    formData.put("programTypeValue", ProgramType.PRE_SCREENER_FORM.getValue());
     formData.put("confirmedChangePreScreenerForm", "false");
 
     Result result = controller.create(fakeRequestBuilder().bodyForm(formData).build());
@@ -258,7 +258,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
     ProgramBuilder.newActivePreScreenerForm("Old pre-screener").build();
 
     Map<String, String> formData = new HashMap<>(DEFAULT_FORM_FIELDS);
-    formData.put("programTypeValue", ProgramType.COMMON_INTAKE_FORM.getValue());
+    formData.put("programTypeValue", ProgramType.PRE_SCREENER_FORM.getValue());
     formData.put("confirmedChangePreScreenerForm", "true");
     formData.put("tiGroups[]", "1");
 
@@ -400,7 +400,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
     formData.put("adminDescription", "New program slug");
     formData.put("localizedDisplayDescription", "New program description");
     formData.put("localizedShortDescription", "New external short program description");
-    formData.put("programTypeValue", ProgramType.COMMON_INTAKE_FORM.getValue());
+    formData.put("programTypeValue", ProgramType.PRE_SCREENER_FORM.getValue());
     formData.put("tiGroups[]", "1");
 
     controller.update(
@@ -477,7 +477,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
 
     Map<String, String> formData = new HashMap<>(DEFAULT_FORM_FIELDS);
     formData.put("localizedDisplayName", ""); // Empty name to force validation error
-    formData.put("programTypeValue", ProgramType.COMMON_INTAKE_FORM.getValue());
+    formData.put("programTypeValue", ProgramType.PRE_SCREENER_FORM.getValue());
     formData.put("confirmedChangePreScreenerForm", "false");
 
     Result result =
@@ -498,7 +498,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
     ProgramBuilder.newActivePreScreenerForm("Old pre-screener").build();
 
     Map<String, String> formData = new HashMap<>(DEFAULT_FORM_FIELDS);
-    formData.put("programTypeValue", ProgramType.COMMON_INTAKE_FORM.getValue());
+    formData.put("programTypeValue", ProgramType.PRE_SCREENER_FORM.getValue());
     formData.put("confirmedChangePreScreenerForm", "false");
 
     Result result =
@@ -517,7 +517,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
         ProgramBuilder.newDraftProgram("Existing One", "old description").build();
 
     Map<String, String> formData = new HashMap<>(DEFAULT_FORM_FIELDS);
-    formData.put("programTypeValue", ProgramType.COMMON_INTAKE_FORM.getValue());
+    formData.put("programTypeValue", ProgramType.PRE_SCREENER_FORM.getValue());
     formData.put("confirmedChangePreScreenerForm", "false");
 
     Result result =
@@ -546,7 +546,7 @@ public class AdminProgramControllerTest extends ResetPostgres {
 
     Map<String, String> formData = new HashMap<>(DEFAULT_FORM_FIELDS);
     formData.put("localizedShortDescription", newProgramShortDescription);
-    formData.put("programTypeValue", ProgramType.COMMON_INTAKE_FORM.getValue());
+    formData.put("programTypeValue", ProgramType.PRE_SCREENER_FORM.getValue());
     formData.put("confirmedChangePreScreenerForm", "true");
 
     Result result =

--- a/server/test/controllers/applicant/EligibilityAlertSettingsCalculatorTest.java
+++ b/server/test/controllers/applicant/EligibilityAlertSettingsCalculatorTest.java
@@ -367,7 +367,7 @@ public class EligibilityAlertSettingsCalculatorTest {
             .setAdminDescription("")
             .setExternalLink("")
             .setDisplayMode(DisplayMode.PUBLIC)
-            .setProgramType(ProgramType.COMMON_INTAKE_FORM)
+            .setProgramType(ProgramType.PRE_SCREENER_FORM)
             .setEligibilityIsGating(true)
             .setLoginOnly(false)
             .setAcls(new ProgramAcls())

--- a/server/test/models/ProgramModelTest.java
+++ b/server/test/models/ProgramModelTest.java
@@ -87,7 +87,7 @@ public class ProgramModelTest extends ResetPostgres {
             .setDisplayMode(DisplayMode.PUBLIC)
             .setNotificationPreferences(
                 ImmutableList.of(ProgramNotificationPreference.EMAIL_PROGRAM_ADMIN_ALL_SUBMISSIONS))
-            .setProgramType(ProgramType.COMMON_INTAKE_FORM)
+            .setProgramType(ProgramType.PRE_SCREENER_FORM)
             .setEligibilityIsGating(false)
             .setAcls(new ProgramAcls(tiOrgList))
             .setLocalizedSummaryImageDescription(
@@ -120,8 +120,7 @@ public class ProgramModelTest extends ResetPostgres {
         .isEqualTo("program-card-images/program-1/testFile.png");
     assertThat(found.getProgramDefinition().blockDefinitions().get(0).name())
         .isEqualTo("First Block");
-    assertThat(found.getProgramDefinition().programType())
-        .isEqualTo(ProgramType.COMMON_INTAKE_FORM);
+    assertThat(found.getProgramDefinition().programType()).isEqualTo(ProgramType.PRE_SCREENER_FORM);
     assertThat(found.getProgramDefinition().eligibilityIsGating()).isEqualTo(false);
     assertThat(found.getProgramDefinition().acls().getTiProgramViewAcls()).contains(1L);
     assertThat(found.getProgramDefinition().acls().getTiProgramViewAcls()).contains(3L);

--- a/server/test/services/applicant/ApplicantServiceTest.java
+++ b/server/test/services/applicant/ApplicantServiceTest.java
@@ -4066,7 +4066,7 @@ public class ApplicantServiceTest extends ResetPostgres {
                     .setAdminDescription("pre_screener_form")
                     .setExternalLink("https://usa.gov")
                     .setDisplayMode(DisplayMode.PUBLIC)
-                    .setProgramType(ProgramType.COMMON_INTAKE_FORM)
+                    .setProgramType(ProgramType.PRE_SCREENER_FORM)
                     .setEligibilityIsGating(false)
                     .setLoginOnly(false)
                     .setAcls(new ProgramAcls())

--- a/server/test/services/migration/ProgramMigrationServiceTest.java
+++ b/server/test/services/migration/ProgramMigrationServiceTest.java
@@ -391,7 +391,7 @@ public final class ProgramMigrationServiceTest extends ResetPostgres {
   public void prepForExport_clearsPreScreenerSetting() {
     ProgramDefinition program =
         ProgramBuilder.newActiveProgram()
-            .withProgramType(ProgramType.COMMON_INTAKE_FORM)
+            .withProgramType(ProgramType.PRE_SCREENER_FORM)
             .build()
             .getProgramDefinition();
 

--- a/server/test/services/program/ProgramDefinitionTest.java
+++ b/server/test/services/program/ProgramDefinitionTest.java
@@ -1639,7 +1639,7 @@ public class ProgramDefinitionTest extends ResetPostgres {
             .setDisplayMode(DisplayMode.PUBLIC)
             .setNotificationPreferences(
                 ImmutableList.of(ProgramNotificationPreference.EMAIL_PROGRAM_ADMIN_ALL_SUBMISSIONS))
-            .setProgramType(ProgramType.COMMON_INTAKE_FORM)
+            .setProgramType(ProgramType.PRE_SCREENER_FORM)
             .setEligibilityIsGating(true)
             .setLoginOnly(false)
             .setAcls(new ProgramAcls(ImmutableSet.of(987L, 65L, 4321L)))
@@ -1697,7 +1697,7 @@ public class ProgramDefinitionTest extends ResetPostgres {
     assertThat(result.notificationPreferences())
         .containsExactlyInAnyOrder(
             ProgramNotificationPreference.EMAIL_PROGRAM_ADMIN_ALL_SUBMISSIONS);
-    assertThat(result.programType()).isEqualTo(ProgramType.COMMON_INTAKE_FORM);
+    assertThat(result.programType()).isEqualTo(ProgramType.PRE_SCREENER_FORM);
     assertThat(result.eligibilityIsGating()).isTrue();
     assertThat(result.acls().getTiProgramViewAcls()).containsExactlyInAnyOrder(987L, 65L, 4321L);
 

--- a/server/test/services/program/ProgramServiceTest.java
+++ b/server/test/services/program/ProgramServiceTest.java
@@ -665,7 +665,7 @@ public class ProgramServiceTest extends ResetPostgres {
             ImmutableList.of(),
             /* eligibilityIsGating= */ true,
             /* loginOnly= */ false,
-            ProgramType.COMMON_INTAKE_FORM,
+            ProgramType.PRE_SCREENER_FORM,
             ImmutableList.of(),
             /* categoryIds= */ ImmutableList.of(),
             ImmutableList.of(new ApplicationStep("title", "description")));
@@ -690,7 +690,7 @@ public class ProgramServiceTest extends ResetPostgres {
             ImmutableList.of(),
             /* eligibilityIsGating= */ false,
             /* loginOnly= */ false,
-            ProgramType.COMMON_INTAKE_FORM,
+            ProgramType.PRE_SCREENER_FORM,
             ImmutableList.of(),
             /* categoryIds= */ ImmutableList.of(),
             ImmutableList.of(new ApplicationStep("title", "description")));
@@ -714,7 +714,7 @@ public class ProgramServiceTest extends ResetPostgres {
         ImmutableList.of(),
         /* eligibilityIsGating= */ true,
         /* loginOnly= */ false,
-        ProgramType.COMMON_INTAKE_FORM,
+        ProgramType.PRE_SCREENER_FORM,
         ImmutableList.of(),
         /* categoryIds= */ ImmutableList.of(),
         ImmutableList.of(new ApplicationStep("title", "description")));
@@ -755,7 +755,7 @@ public class ProgramServiceTest extends ResetPostgres {
         ImmutableList.of(),
         /* eligibilityIsGating= */ true,
         /* loginOnly= */ false,
-        ProgramType.COMMON_INTAKE_FORM,
+        ProgramType.PRE_SCREENER_FORM,
         ImmutableList.of(),
         /* categoryIds= */ ImmutableList.of(),
         ImmutableList.of(new ApplicationStep("title", "description")));
@@ -777,13 +777,13 @@ public class ProgramServiceTest extends ResetPostgres {
             ImmutableList.of(),
             /* eligibilityIsGating= */ true,
             /* loginOnly= */ false,
-            ProgramType.COMMON_INTAKE_FORM,
+            ProgramType.PRE_SCREENER_FORM,
             ImmutableList.of(),
             /* categoryIds= */ ImmutableList.of(),
             ImmutableList.of(new ApplicationStep("title", "description")));
     assertThat(result.hasResult()).isTrue();
     assertThat(result.isError()).isFalse();
-    assertThat(result.getResult().programType()).isEqualTo(ProgramType.COMMON_INTAKE_FORM);
+    assertThat(result.getResult().programType()).isEqualTo(ProgramType.PRE_SCREENER_FORM);
 
     preScreenerForm = ps.getPreScreenerForm();
     assertThat(preScreenerForm).isPresent();
@@ -1078,7 +1078,7 @@ public class ProgramServiceTest extends ResetPostgres {
             ImmutableList.of(),
             ImmutableList.of(),
             ImmutableMap.of(),
-            ProgramType.COMMON_INTAKE_FORM);
+            ProgramType.PRE_SCREENER_FORM);
 
     assertThat(result).isEmpty();
   }
@@ -1132,7 +1132,7 @@ public class ProgramServiceTest extends ResetPostgres {
     ImmutableList<ApplicationStep> applicationSteps = ImmutableList.of();
     ImmutableSet<CiviFormError> errors =
         ps.checkApplicationStepErrors(
-                ProgramType.COMMON_INTAKE_FORM, errorsBuilder, applicationSteps)
+                ProgramType.PRE_SCREENER_FORM, errorsBuilder, applicationSteps)
             .build();
 
     assertThat(errors.size()).isEqualTo(0);
@@ -1448,7 +1448,7 @@ public class ProgramServiceTest extends ResetPostgres {
         ImmutableList.of(),
         /* eligibilityIsGating= */ true,
         /* loginOnly= */ false,
-        ProgramType.COMMON_INTAKE_FORM,
+        ProgramType.PRE_SCREENER_FORM,
         ImmutableList.of(),
         /* categoryIds= */ ImmutableList.of(),
         ImmutableList.of(new ApplicationStep("title", "description")));
@@ -1472,14 +1472,14 @@ public class ProgramServiceTest extends ResetPostgres {
             ImmutableList.of(),
             /* eligibilityIsGating= */ true,
             /* loginOnly= */ false,
-            ProgramType.COMMON_INTAKE_FORM,
+            ProgramType.PRE_SCREENER_FORM,
             ImmutableList.of(),
             /* categoryIds= */ ImmutableList.of(),
             ImmutableList.of(new ApplicationStep("title", "description")));
 
     assertThat(result.hasResult()).isTrue();
     assertThat(result.isError()).isFalse();
-    assertThat(result.getResult().programType()).isEqualTo(ProgramType.COMMON_INTAKE_FORM);
+    assertThat(result.getResult().programType()).isEqualTo(ProgramType.PRE_SCREENER_FORM);
     preScreenerForm = ps.getPreScreenerForm();
     assertThat(preScreenerForm).isPresent();
     assertThat(preScreenerForm.get().adminName()).isEqualTo(program.adminName());
@@ -1504,7 +1504,7 @@ public class ProgramServiceTest extends ResetPostgres {
             ImmutableList.of(),
             /* eligibilityIsGating= */ true,
             /* loginOnly= */ false,
-            ProgramType.COMMON_INTAKE_FORM,
+            ProgramType.PRE_SCREENER_FORM,
             ImmutableList.of(),
             /* categoryIds= */ ImmutableList.of(),
             ImmutableList.of(new ApplicationStep("title", "description")));
@@ -1523,7 +1523,7 @@ public class ProgramServiceTest extends ResetPostgres {
             ImmutableList.of(),
             /* eligibilityIsGating= */ true,
             /* loginOnly= */ false,
-            ProgramType.COMMON_INTAKE_FORM,
+            ProgramType.PRE_SCREENER_FORM,
             ImmutableList.of(),
             /* categoryIds= */ ImmutableList.of(),
             ImmutableList.of(new ApplicationStep("title", "description")));
@@ -1547,7 +1547,7 @@ public class ProgramServiceTest extends ResetPostgres {
             ImmutableList.of(),
             /* eligibilityIsGating= */ true,
             /* loginOnly= */ false,
-            ProgramType.COMMON_INTAKE_FORM,
+            ProgramType.PRE_SCREENER_FORM,
             ImmutableList.of(),
             /* categoryIds= */ ImmutableList.of(),
             ImmutableList.of(new ApplicationStep("title", "description")));
@@ -1614,14 +1614,14 @@ public class ProgramServiceTest extends ResetPostgres {
             ImmutableList.of(),
             /* eligibilityIsGating= */ true,
             /* loginOnly= */ false,
-            ProgramType.COMMON_INTAKE_FORM,
+            ProgramType.PRE_SCREENER_FORM,
             ImmutableList.of(),
             /* categoryIds= */ ImmutableList.of(),
             ImmutableList.of(new ApplicationStep("title", "description")));
 
     assertThat(result.hasResult()).isTrue();
     assertThat(result.isError()).isFalse();
-    assertThat(result.getResult().programType()).isEqualTo(ProgramType.COMMON_INTAKE_FORM);
+    assertThat(result.getResult().programType()).isEqualTo(ProgramType.PRE_SCREENER_FORM);
     assertThat(result.getResult().getBlockCount()).isEqualTo(2);
     assertThat(result.getResult().getBlockDefinitionByIndex(0).get().eligibilityDefinition())
         .isNotPresent();
@@ -2715,7 +2715,7 @@ public class ProgramServiceTest extends ResetPostgres {
             .build();
     ProgramDefinition program =
         ProgramBuilder.newDraftProgram()
-            .withProgramType(ProgramType.COMMON_INTAKE_FORM)
+            .withProgramType(ProgramType.PRE_SCREENER_FORM)
             .withBlock()
             .withRequiredQuestionDefinition(question)
             .buildDefinition();
@@ -2723,7 +2723,7 @@ public class ProgramServiceTest extends ResetPostgres {
     assertThatExceptionOfType(EligibilityNotValidForProgramTypeException.class)
         .isThrownBy(
             () -> ps.setBlockEligibilityDefinition(program.id(), 1L, Optional.of(eligibility)))
-        .withMessage("Eligibility conditions cannot be set for ProgramType COMMON_INTAKE_FORM");
+        .withMessage("Eligibility conditions cannot be set for ProgramType PRE_SCREENER_FORM");
   }
 
   @Test
@@ -3701,10 +3701,8 @@ public class ProgramServiceTest extends ResetPostgres {
   public void getPreScreenerForm_ignoresObsoletePrograms() {
     // No pre-screener form in the most recent version of any program, although some programs
     // were previously marked as pre-screener.
-    ProgramBuilder.newObsoleteProgram("one")
-        .withProgramType(ProgramType.COMMON_INTAKE_FORM)
-        .build();
-    ProgramBuilder.newActiveProgram("two").withProgramType(ProgramType.COMMON_INTAKE_FORM).build();
+    ProgramBuilder.newObsoleteProgram("one").withProgramType(ProgramType.PRE_SCREENER_FORM).build();
+    ProgramBuilder.newActiveProgram("two").withProgramType(ProgramType.PRE_SCREENER_FORM).build();
     ProgramBuilder.newDraftProgram("two").withProgramType(ProgramType.DEFAULT).build();
 
     assertThat(ps.getPreScreenerForm()).isNotPresent();
@@ -3712,10 +3710,8 @@ public class ProgramServiceTest extends ResetPostgres {
 
   @Test
   public void getPreScreenerForm_activePreScreener() {
-    ProgramBuilder.newObsoleteProgram("one")
-        .withProgramType(ProgramType.COMMON_INTAKE_FORM)
-        .build();
-    ProgramBuilder.newActiveProgram("two").withProgramType(ProgramType.COMMON_INTAKE_FORM).build();
+    ProgramBuilder.newObsoleteProgram("one").withProgramType(ProgramType.PRE_SCREENER_FORM).build();
+    ProgramBuilder.newActiveProgram("two").withProgramType(ProgramType.PRE_SCREENER_FORM).build();
 
     assertThat(ps.getPreScreenerForm()).isPresent();
     assertThat(ps.getPreScreenerForm().get().adminName()).isEqualTo("two");
@@ -3723,11 +3719,9 @@ public class ProgramServiceTest extends ResetPostgres {
 
   @Test
   public void getPreScreenerForm_draftPreScreener() {
-    ProgramBuilder.newObsoleteProgram("one")
-        .withProgramType(ProgramType.COMMON_INTAKE_FORM)
-        .build();
+    ProgramBuilder.newObsoleteProgram("one").withProgramType(ProgramType.PRE_SCREENER_FORM).build();
     ProgramBuilder.newActiveProgram("two").withProgramType(ProgramType.DEFAULT).build();
-    ProgramBuilder.newDraftProgram("two").withProgramType(ProgramType.COMMON_INTAKE_FORM).build();
+    ProgramBuilder.newDraftProgram("two").withProgramType(ProgramType.PRE_SCREENER_FORM).build();
 
     assertThat(ps.getPreScreenerForm()).isPresent();
     assertThat(ps.getPreScreenerForm().get().adminName()).isEqualTo("two");

--- a/server/test/support/ProgramBuilder.java
+++ b/server/test/support/ProgramBuilder.java
@@ -229,7 +229,7 @@ public class ProgramBuilder {
 
   /**
    * Creates a {@link ProgramBuilder} with a new {@link ProgramModel} in the active state, with the
-   * type ProgramType.COMMON_INTAKE_FORM.
+   * type ProgramType.PRE_SCREENER_FORM.
    */
   public static ProgramBuilder newActivePreScreenerForm(String name) {
     return newActiveProgram(
@@ -237,7 +237,7 @@ public class ProgramBuilder {
         /* displayName= */ name,
         /* description= */ "",
         /* displayMode= */ DisplayMode.PUBLIC,
-        ProgramType.COMMON_INTAKE_FORM);
+        ProgramType.PRE_SCREENER_FORM);
   }
 
   /** Creates a {@link ProgramBuilder} with a new {@link ProgramModel} in active state. */

--- a/server/test/views/applicant/programindex/ProgramCardsSectionParamsFactoryTest.java
+++ b/server/test/views/applicant/programindex/ProgramCardsSectionParamsFactoryTest.java
@@ -141,7 +141,7 @@ public class ProgramCardsSectionParamsFactoryTest extends ResetPostgres {
             applicantRoutes,
             /* programId= */ 1L,
             /* programSlug= */ "fake-program",
-            ProgramType.COMMON_INTAKE_FORM,
+            ProgramType.PRE_SCREENER_FORM,
             /* programExternalLink= */ "",
             // empty lifecycle stage means this is their first time filling out this application
             /* optionalLifecycleStage= */ Optional.empty(),
@@ -158,7 +158,7 @@ public class ProgramCardsSectionParamsFactoryTest extends ResetPostgres {
             applicantRoutes,
             /* programId= */ 1L,
             /* programSlug= */ "fake-program",
-            ProgramType.COMMON_INTAKE_FORM,
+            ProgramType.PRE_SCREENER_FORM,
             /* programExternalLink= */ "",
             // empty lifecycle stage means this is their first time filling out this application
             /* optionalLifecycleStage= */ Optional.empty(),


### PR DESCRIPTION
### Description

The codebase (and product) uses the language pre-screener, so I'm updating the name of the program type to be pre-screener (without changing the value that's stored in the db because that's too impactful of a change).

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.
