### PR TITLE
Fixes eslint line issue on spacing

### DIFF
--- a/browser-test/src/admin/admin_application_download.test.ts
+++ b/browser-test/src/admin/admin_application_download.test.ts
@@ -127,6 +127,7 @@ test.describe('csv export for multioption question', () => {
     await seeding.seedQuestions()
     await page.goto('/')
   })
+
   test('multioption csv into its own column', async ({
     page,
     adminQuestions,
@@ -136,6 +137,7 @@ test.describe('csv export for multioption question', () => {
     const noApplyFilters = false
 
     const programName = 'Checkbox question program for export'
+
     await test.step('Setup program with multioption question', async () => {
       await loginAsAdmin(page)
       await adminQuestions.createCheckboxQuestion(

--- a/browser-test/src/admin/admin_application_statuses.test.ts
+++ b/browser-test/src/admin/admin_application_statuses.test.ts
@@ -26,6 +26,7 @@ test.describe('view program statuses', () => {
 
   test.describe('without program statuses', () => {
     const programWithoutStatusesName = 'Test program without statuses'
+
     test.beforeEach(async ({page, adminPrograms, applicantQuestions}) => {
       await loginAsAdmin(page)
 
@@ -772,6 +773,7 @@ test.describe('view program statuses', () => {
       )
     })
   })
+
   test.describe('email status updates work correctly with PAI flag on', () => {
     test.beforeEach(
       async ({
@@ -803,6 +805,7 @@ test.describe('view program statuses', () => {
         await logout(page)
       },
     )
+
     test('email is displayed and sent for guest user that has answered the PAI email question', async ({
       page,
       applicantQuestions,
@@ -844,6 +847,7 @@ test.describe('view program statuses', () => {
         await adminPrograms.expectStatusSelection(emailStatusName)
         await adminPrograms.expectUpdateStatusToast()
       })
+
       await test.step('verify status update email was sent to applicant', async () => {
         if (supportsEmailInspection()) {
           await adminPrograms.expectEmailSent(
@@ -855,6 +859,7 @@ test.describe('view program statuses', () => {
         }
       })
     })
+
     test('both email addresses are displayed and two emails are sent for a logged in user that has answered the PAI email question with a different email', async ({
       page,
       applicantQuestions,
@@ -902,6 +907,7 @@ test.describe('view program statuses', () => {
         await adminPrograms.confirmStatusUpdateModal(modal)
         await adminPrograms.expectUpdateStatusToast()
       })
+
       await test.step('verify status update email was sent to both email addresses', async () => {
         if (supportsEmailInspection()) {
           await adminPrograms.expectEmailSent(
@@ -919,6 +925,7 @@ test.describe('view program statuses', () => {
         }
       })
     })
+
     test('only one email is displayed and sent for a logged in user that has answered the PAI email question with the same email they used to login', async ({
       page,
       applicantQuestions,
@@ -958,6 +965,7 @@ test.describe('view program statuses', () => {
         await adminPrograms.confirmStatusUpdateModal(modal)
         await adminPrograms.expectUpdateStatusToast()
       })
+
       await test.step('verify status update email was sent to the applicant', async () => {
         if (supportsEmailInspection()) {
           await adminPrograms.expectEmailSent(
@@ -969,6 +977,7 @@ test.describe('view program statuses', () => {
         }
       })
     })
+
     test('Trusted Intermediary application shows correct Submitted By name', async ({
       page,
 

--- a/browser-test/src/admin/admin_bulk_update_statuses.test.ts
+++ b/browser-test/src/admin/admin_bulk_update_statuses.test.ts
@@ -62,6 +62,7 @@ test.describe('with program statuses', () => {
       approvedStatusName,
     )
   })
+
   test('if more than 100 applications, only the first page of applications undergo status update', async ({
     page,
     adminPrograms,
@@ -100,11 +101,13 @@ test.describe('with program statuses', () => {
     )
   })
 })
+
 test.describe('when email is configured for the status and applicant, a checkbox is shown to notify the applicant', () => {
   const programWithStatusesName = 'Test program with email statuses'
   const emailStatusName = 'Email status'
   const emailBody = 'Some email content'
   const noEmailStatusName = 'No email status'
+
   test.beforeEach(
     async ({page, adminPrograms, applicantQuestions, adminProgramStatuses}) => {
       await setupProgramsWithStatuses(
@@ -117,6 +120,7 @@ test.describe('when email is configured for the status and applicant, a checkbox
       await adminPrograms.viewApplications(programWithStatusesName)
     },
   )
+
   test('choosing not to notify applicants changes status and does not send email', async ({
     page,
     adminPrograms,
@@ -173,6 +177,7 @@ test.describe('when email is configured for the status and applicant, a checkbox
       )
     }
   })
+
   const setupProgramsWithStatuses = async (
     page: Page,
     adminPrograms: AdminPrograms,

--- a/browser-test/src/admin/admin_program_creation.test.ts
+++ b/browser-test/src/admin/admin_program_creation.test.ts
@@ -854,6 +854,7 @@ test.describe('program creation', () => {
       await adminProgramImage.clickContinueButton()
       await adminPrograms.addQuestionFromQuestionBank('text-question')
     })
+
     await test.step('click edit question link', async () => {
       await adminPrograms.editQuestion('text-question')
       await adminQuestions.expectQuestionEditPage('text-question')

--- a/browser-test/src/admin/admin_program_image.test.ts
+++ b/browser-test/src/admin/admin_program_image.test.ts
@@ -106,9 +106,11 @@ test.describe('Admin can manage program image', () => {
 
   test.describe('back button', () => {
     const programName = 'Back Test Program'
+
     test.beforeEach(async ({adminPrograms}) => {
       await adminPrograms.addProgram(programName)
     })
+
     test('back button redirects to block page if came from block page', async ({
       adminPrograms,
       adminProgramImage,
@@ -158,9 +160,11 @@ test.describe('Admin can manage program image', () => {
 
   test.describe('continue button', () => {
     const programName = 'Back Test Program'
+
     test.beforeEach(async ({adminPrograms}) => {
       await adminPrograms.addProgram(programName)
     })
+
     test('continue button shows if from program creation page', async ({
       adminProgramImage,
     }) => {

--- a/browser-test/src/admin/admin_program_migration.test.ts
+++ b/browser-test/src/admin/admin_program_migration.test.ts
@@ -77,6 +77,7 @@ test.describe('program migration', () => {
       expect(jsonPreview).toContain('"minLength" : 1')
       expect(jsonPreview).toContain('"maxLength" : 5')
     })
+
     await test.step('download json for program 2', async () => {
       const downloadedProgram = await adminProgramMigration.downloadJson()
       expect(downloadedProgram).toContain(programName)
@@ -91,6 +92,7 @@ test.describe('program migration', () => {
       expect(downloadedProgram).toContain('"minLength" : 1')
       expect(downloadedProgram).toContain('"maxLength" : 5')
     })
+
     await test.step('click back button to return to programs index page', async () => {
       await adminProgramMigration.clickBackButton()
       await adminPrograms.expectAdminProgramsPage()
@@ -342,6 +344,7 @@ test.describe('program migration', () => {
     })
 
     let downloadedComprehensiveProgram: string
+
     await test.step('export comprehensive program', async () => {
       await adminPrograms.goToExportProgramPage(
         'Comprehensive Sample Program',
@@ -591,6 +594,7 @@ test.describe('program migration', () => {
     })
 
     let downloadedComprehensiveProgram: string
+
     await test.step('export comprehensive program', async () => {
       await adminPrograms.goToExportProgramPage(
         'Comprehensive Sample Program',

--- a/browser-test/src/admin/admin_program_preview.test.ts
+++ b/browser-test/src/admin/admin_program_preview.test.ts
@@ -13,6 +13,7 @@ test.describe('admin preview as applicant', () => {
     applicantProgramOverview,
   }) => {
     const programName = 'test program'
+
     await test.step('create test program', async () => {
       await adminQuestions.addEmailQuestion({questionName: 'email-q'})
       await adminPrograms.addProgram(programName)

--- a/browser-test/src/admin/admin_program_visibility.test.ts
+++ b/browser-test/src/admin/admin_program_visibility.test.ts
@@ -285,6 +285,7 @@ test.describe('Validate program visibility is correct for applicants and TIs', (
     applicantQuestions,
   }) => {
     const programName = 'Disabled program'
+
     await test.step('login as a CiviForm admin and publish a disabled program', async () => {
       await loginAsAdmin(page)
 

--- a/browser-test/src/admin/admin_publish.test.ts
+++ b/browser-test/src/admin/admin_publish.test.ts
@@ -80,6 +80,7 @@ test.describe(
       const questionText = 'admin-publish-test-address-q'
       // adminPrograms.createNewVersion implicitly updates the question text to be suffixed with " new version".
       const draftQuestionText = `${questionText} new version`
+
       await test.step('Log in as a civiform admin and create a public program and a disabled program', async () => {
         await loginAsAdmin(page)
         await adminPrograms.addDisabledProgram(disabledProgram)

--- a/browser-test/src/applicant/applicant_application_index.test.ts
+++ b/browser-test/src/applicant/applicant_application_index.test.ts
@@ -93,6 +93,7 @@ test.describe('applicant program index page', () => {
     const skipLinkLocator: Locator = page.getByRole('link', {
       name: 'Skip to main content',
     })
+
     await test.step('Tab and verify focus on skip link', async () => {
       await page.keyboard.press('Tab')
       await expect(skipLinkLocator).toBeFocused()
@@ -253,6 +254,7 @@ test.describe('applicant program index page', () => {
       await test.step('publish programs with categories', async () => {
         await adminPrograms.publishAllDrafts()
       })
+
       await test.step('Navigate to homepage and check that cards in Programs and Services section have categories', async () => {
         await logout(page)
         await loginAsTestUser(page)
@@ -938,6 +940,7 @@ test.describe('applicant program index page with images', () => {
     )
 
     await loginAsTestUser(page)
+
     await test.step('verify no available programs info alert appears', async () => {
       await expect(
         page.getByText(

--- a/browser-test/src/applicant/applicant_breadcrumb_nav.test.ts
+++ b/browser-test/src/applicant/applicant_breadcrumb_nav.test.ts
@@ -37,6 +37,7 @@ test.describe('Applicant breadcrumb navigation', () => {
         programName,
       )
     })
+
     await test.step('verify accessibility', async () => {
       await validateAccessibility(page)
     })
@@ -58,6 +59,7 @@ test.describe('Applicant breadcrumb navigation', () => {
         programName,
       )
     })
+
     await test.step('verify accessibility', async () => {
       await validateAccessibility(page)
     })

--- a/browser-test/src/applicant/application_address_correction.test.ts
+++ b/browser-test/src/applicant/application_address_correction.test.ts
@@ -222,6 +222,7 @@ test.describe('address correction single-block, single-address program', () => {
         await applicantQuestions.clickConfirmAddress()
         await applicantQuestions.clickSubmitApplication()
       })
+
       await logout(page)
     })
 
@@ -264,9 +265,11 @@ test.describe('address correction single-block, single-address program', () => {
         )
         await applicantQuestions.clickContinue()
       })
+
       await test.step('Validate review page is shown', async () => {
         await applicantQuestions.expectReviewPage()
       })
+
       await logout(page)
     })
   }
@@ -278,6 +281,7 @@ test.describe('address correction single-block, single-address program', () => {
     test.slow()
 
     await disableFeatureFlag(page, 'esri_address_correction_enabled')
+
     await test.step('Answer address question', async () => {
       await applicantQuestions.applyProgram(singleBlockSingleAddressProgram)
 
@@ -290,6 +294,7 @@ test.describe('address correction single-block, single-address program', () => {
       )
       await applicantQuestions.clickContinue()
     })
+
     await test.step('Validate review page is shown and user can submit', async () => {
       await applicantQuestions.expectQuestionAnsweredOnReviewPage(
         addressWithCorrectionText,
@@ -297,6 +302,7 @@ test.describe('address correction single-block, single-address program', () => {
       )
       await applicantQuestions.clickSubmitApplication()
     })
+
     await logout(page)
   })
 })
@@ -365,11 +371,13 @@ if (isLocalDevEnvironment()) {
 
         await applicantQuestions.clickContinue()
       })
+
       await test.step('Validate review page is shown and user can submit', async () => {
         await applicantQuestions.expectReviewPage()
 
         await applicantQuestions.clickSubmitApplication()
       })
+
       await logout(page)
     })
   })
@@ -469,6 +477,7 @@ if (isLocalDevEnvironment()) {
         )
         await applicantQuestions.clickContinue()
       })
+
       await test.step('Validate address correction page shown and user can finish application', async () => {
         await applicantQuestions.expectVerifyAddressPage(true)
         await applicantQuestions.clickConfirmAddress()
@@ -480,6 +489,7 @@ if (isLocalDevEnvironment()) {
         )
         await applicantQuestions.clickSubmitApplication()
       })
+
       await logout(page)
     })
   })
@@ -693,6 +703,7 @@ if (isLocalDevEnvironment()) {
             '92373',
           )
         })
+
         await test.step('Navigate back and validate verify address page', async () => {
           await applicantQuestions.clickBack()
 
@@ -718,6 +729,7 @@ if (isLocalDevEnvironment()) {
             '92373',
           )
         })
+
         await test.step('Navigate back and validate verify address page', async () => {
           await applicantQuestions.clickBack()
 
@@ -760,6 +772,7 @@ if (isLocalDevEnvironment()) {
             '92373',
           )
         })
+
         await test.step('Navigate back and validate verify address page', async () => {
           await applicantQuestions.clickBack()
           await applicantQuestions.expectVerifyAddressPage(true)
@@ -806,6 +819,7 @@ if (isLocalDevEnvironment()) {
           await applicantQuestions.clickBack()
           await applicantQuestions.expectVerifyAddressPage(false)
         })
+
         await test.step('Confirm address suggestion and validate we are taken to the previous page', async () => {
           await applicantQuestions.clickConfirmAddress()
 
@@ -841,11 +855,13 @@ if (isLocalDevEnvironment()) {
             '92373',
           )
         })
+
         await test.step('Navigate back and validate verify address page', async () => {
           await applicantQuestions.clickBack()
 
           await applicantQuestions.validateQuestionIsOnPage(emailQuestionText)
         })
+
         await test.step('Navigate to and validate review page', async () => {
           await applicantQuestions.clickReview()
           await applicantQuestions.expectQuestionAnsweredOnReviewPage(
@@ -853,6 +869,7 @@ if (isLocalDevEnvironment()) {
             'Address In Area',
           )
         })
+
         await logout(page)
       })
     })
@@ -876,6 +893,7 @@ if (isLocalDevEnvironment()) {
             '98109',
           )
         })
+
         await test.step('Click review and validate verify address page', async () => {
           await applicantQuestions.clickReview()
 
@@ -901,6 +919,7 @@ if (isLocalDevEnvironment()) {
             '92373',
           )
         })
+
         await test.step('Click review and validate verify address page', async () => {
           await applicantQuestions.clickReview()
 
@@ -931,6 +950,7 @@ if (isLocalDevEnvironment()) {
           await applicantQuestions.clickReview()
           await applicantQuestions.expectVerifyAddressPage(true)
         })
+
         await test.step('Confirm original address and validate review page', async () => {
           // Opt to keep the original address entered
           await applicantQuestions.selectAddressSuggestion('Legit Address')
@@ -967,10 +987,12 @@ if (isLocalDevEnvironment()) {
             '92373',
           )
         })
+
         await test.step('Click review and validate verify address page', async () => {
           await applicantQuestions.clickReview()
           await applicantQuestions.expectVerifyAddressPage(true)
         })
+
         await test.step('Confirm suggested address and validate review page', async () => {
           await applicantQuestions.selectAddressSuggestion(
             'Address With No Service Area Features',
@@ -984,6 +1006,7 @@ if (isLocalDevEnvironment()) {
             'Address With No Service Area Features',
           )
         })
+
         await logout(page)
       })
 
@@ -1005,6 +1028,7 @@ if (isLocalDevEnvironment()) {
             '98109',
           )
         })
+
         await test.step('Click review and validate verify address page', async () => {
           await applicantQuestions.clickReview()
           await applicantQuestions.expectVerifyAddressPage(false)
@@ -1045,6 +1069,7 @@ if (isLocalDevEnvironment()) {
             '92373',
           )
         })
+
         await test.step('Click review and validate review page', async () => {
           await applicantQuestions.clickReview()
 
@@ -1079,6 +1104,7 @@ if (isLocalDevEnvironment()) {
             '92373',
           )
         })
+
         await test.step('Click continue and validate address correction page', async () => {
           await applicantQuestions.clickContinue()
 
@@ -1104,6 +1130,7 @@ if (isLocalDevEnvironment()) {
             '92373',
           )
         })
+
         await test.step('Click continue and validate address correction page', async () => {
           await applicantQuestions.clickContinue()
 
@@ -1128,6 +1155,7 @@ if (isLocalDevEnvironment()) {
             '92373',
           )
         })
+
         await test.step('Click continue and validate address correction page shown', async () => {
           await applicantQuestions.clickContinue()
           await applicantQuestions.expectVerifyAddressPage(true)
@@ -1166,10 +1194,12 @@ if (isLocalDevEnvironment()) {
             '92373',
           )
         })
+
         await test.step('Click continue and validate address correction page shown', async () => {
           await applicantQuestions.clickContinue()
           await applicantQuestions.expectVerifyAddressPage(true)
         })
+
         await test.step('Confirm address selection and validate next page', async () => {
           // Opt for one of the suggested addresses
           await applicantQuestions.selectAddressSuggestion(
@@ -1180,6 +1210,7 @@ if (isLocalDevEnvironment()) {
           // Verify we're taken to the next page, which has the number question
           await applicantQuestions.validateQuestionIsOnPage(numberQuestionText)
         })
+
         await test.step('Click review and validate review page', async () => {
           await applicantQuestions.clickReview()
           await applicantQuestions.expectQuestionAnsweredOnReviewPage(
@@ -1206,16 +1237,19 @@ if (isLocalDevEnvironment()) {
             '98109',
           )
         })
+
         await test.step('Click continue and validate address correction page shown', async () => {
           await applicantQuestions.clickContinue()
           await applicantQuestions.expectVerifyAddressPage(false)
         })
+
         await test.step('Confirm address and validate next page', async () => {
           await applicantQuestions.clickConfirmAddress()
 
           // Verify we're taken to the next page, which has the number question
           await applicantQuestions.validateQuestionIsOnPage(numberQuestionText)
         })
+
         await test.step('Click review and validate review page', async () => {
           await applicantQuestions.clickReview()
           await applicantQuestions.expectQuestionAnsweredOnReviewPage(
@@ -1245,11 +1279,13 @@ if (isLocalDevEnvironment()) {
             '92373',
           )
         })
+
         await test.step('Click continue and validate next page shown', async () => {
           await applicantQuestions.clickContinue()
 
           await applicantQuestions.validateQuestionIsOnPage(numberQuestionText)
         })
+
         await test.step('Click review and validate review page', async () => {
           await applicantQuestions.clickReview()
           await applicantQuestions.expectQuestionAnsweredOnReviewPage(
@@ -1257,6 +1293,7 @@ if (isLocalDevEnvironment()) {
             'Address In Area',
           )
         })
+
         await logout(page)
       })
     })
@@ -1280,6 +1317,7 @@ if (isLocalDevEnvironment()) {
             '92373',
           )
         })
+
         await test.step('Click continue and validate address correction page shown', async () => {
           await applicantQuestions.clickContinue()
           await applicantQuestions.expectVerifyAddressPage(true)

--- a/browser-test/src/applicant/navigation/application_navigation_with_eligibility_conditions.test.ts
+++ b/browser-test/src/applicant/navigation/application_navigation_with_eligibility_conditions.test.ts
@@ -225,6 +225,7 @@ test.describe('Applicant navigation flow', () => {
           {mobileScreenshot: true},
         )
       })
+
       await test.step('verify ineligibility message on review page of overlapping program', async () => {
         await applicantQuestions.clickApplyProgramButton(fullProgramName)
         await applicantProgramOverview.startApplicationFromProgramOverviewPage(

--- a/browser-test/src/applicant/program_overview.test.ts
+++ b/browser-test/src/applicant/program_overview.test.ts
@@ -90,6 +90,7 @@ test.describe('Applicant program overview', () => {
       await applicantQuestions.answerTextQuestion('first answer')
       await applicantQuestions.clickContinue()
     })
+
     test('takes guests and logged in users to the program overview', async ({
       page,
       applicantQuestions,
@@ -477,6 +478,7 @@ test.describe('Applicant program overview for login only program', () => {
       ),
     ).toBeVisible()
   })
+
   test('login only program has start application button when entering as a logged in user', async ({
     page,
   }) => {

--- a/browser-test/src/applicant/program_summary.test.ts
+++ b/browser-test/src/applicant/program_summary.test.ts
@@ -217,6 +217,7 @@ test.describe('Applicant navigation flow', () => {
     })
   })
 })
+
 test.describe('guest cannot see program summary page for login only program', () => {
   const programName = 'loginonly'
 
@@ -247,6 +248,7 @@ test.describe('guest cannot see program summary page for login only program', ()
     applicantQuestions,
   }) => {
     let reviewPageURL: string
+
     await test.step('logged in user navigates to review page', async () => {
       await loginAsTestUser(page)
       await page.goto(`/programs/${programName}`)

--- a/browser-test/src/applicant/questions/file.test.ts
+++ b/browser-test/src/applicant/questions/file.test.ts
@@ -299,6 +299,7 @@ test.describe('file upload applicant flow', () => {
         await applicantFileQuestion.expectFileInputEnabled()
       })
     })
+
     test('shows correct hint text based on max files', async ({
       applicantQuestions,
       page,
@@ -452,6 +453,7 @@ test.describe('file upload applicant flow', () => {
         '.cf-question-fileupload',
       )
     })
+
     test('can upload multiple files', async ({
       page,
       applicantQuestions,
@@ -1232,6 +1234,7 @@ test.describe('file upload applicant flow', () => {
     })
   })
 })
+
 test.describe('for login only program, guest cannot see file upload question', () => {
   const programName = 'loginonly'
 
@@ -1261,6 +1264,7 @@ test.describe('for login only program, guest cannot see file upload question', (
     applicantQuestions,
   }) => {
     let fileuploadURL: string
+
     await test.step('logged in user navigates to file upload question', async () => {
       await loginAsTestUser(page)
       await page.goto(`/programs/${programName}`)

--- a/browser-test/src/applicant/questions/yes_no.test.ts
+++ b/browser-test/src/applicant/questions/yes_no.test.ts
@@ -86,6 +86,7 @@ test.describe('Yes/no question for applicant flow', () => {
   test.describe('yes/no question with options not displayed to applicant', () => {
     const programName =
       'Test program for single yes/no question with some options hidden'
+
     test.beforeEach(async ({page, adminQuestions, adminPrograms}) => {
       await loginAsAdmin(page)
 


### PR DESCRIPTION
Fixes eslint error on line spacing requirements. This just add new lines where `eslint --fix` deems appropriate. This is probably a new rule that was added at some point. Since the formatter only runs on changed files we can end up missing thing when new rules are added.