### PR TITLE
Turn off session renewal in the callback controller

### DIFF
--- a/server/app/modules/SecurityModule.java
+++ b/server/app/modules/SecurityModule.java
@@ -73,7 +73,10 @@ public class SecurityModule extends AbstractModule {
     // After logging in you are redirected to '/', and auth autorenews.
     CallbackController callbackController = new CallbackController();
     callbackController.setDefaultUrl(routes.HomeController.index().url());
-    callbackController.setRenewSession(true);
+    // Since we use a cookie-backed session store in CiviFormSessionStoreFactory rather than
+    // server-side sessions, this prevents errors showing up in the log about
+    // being unable to renew the session.
+    callbackController.setRenewSession(false);
     bind(CallbackController.class).toInstance(callbackController);
 
     // you can logout by hitting the logout endpoint, you'll be redirected to root page.


### PR DESCRIPTION
Since we use a cookie-backed session store in CiviFormSessionStoreFactory rather than server-side sessions, this prevents errors from showing up in the log about being unable to renew the session.

"Session renewal" here is a means of mitigating session-fixation attacks, where the attacker can set a victim's session ID before login and then reuse that same ID after login.  This means creating a new session identity and then migrating the existing attributes into it. That concept exists for server-side sessions, where the browser only holds a session ID, but it doesn't really apply on a cookie-backed session store like `PlayCookieSessionStore`. Because all of the attributes exist inside the cookie itself (encrypted), there's no real session ID to rotate, and the cookie itself is rewritten every time the session changes anyway.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [x] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [x] Noted in the PR description which, if any, code in this PR was generated by AI.

### Instructions for manual testing

Without this change, you should pretty much always see the error message `ERROR o.p.c.e.DefaultCallbackLogic - Unable to renew the session. The session store may not support this feature` when doing `bin/run-dev`. With this change, you should no longer see that.

### Issue(s) this completes

https://github.com/civiform/civiform/issues/9847
