### PR TITLE
[Expanded logic] Populate CSV values on predicate load

### DIFF
--- a/browser-test/src/admin/admin_predicates_expanded.test.ts
+++ b/browser-test/src/admin/admin_predicates_expanded.test.ts
@@ -1078,6 +1078,7 @@ test.describe('create and edit predicates', () => {
       QuestionType.CHECKBOX,
       QuestionType.DATE,
       QuestionType.NAME,
+      QuestionType.TEXT,
     ]
     const testQuestionData = questionTypes
       .filter((key) => PROGRAM_SAMPLE_QUESTIONS.has(key))
@@ -1104,6 +1105,11 @@ test.describe('create and edit predicates', () => {
     const nameValues = assertNotNull(
       testQuestionData.find(
         (question) => question.questionType === QuestionType.NAME,
+      ),
+    ).questionValue
+    const textValues = assertNotNull(
+      testQuestionData.find(
+        (question) => question.questionType === QuestionType.TEXT,
       ),
     ).questionValue
 
@@ -1136,6 +1142,13 @@ test.describe('create and edit predicates', () => {
         subconditionId: 2,
         questionText: addressValues.questionText,
         value: {},
+      },
+      {
+        conditionId: 2,
+        subconditionId: 3,
+        questionText: textValues.questionText,
+        operator: 'IN',
+        value: {firstValue: 'alpha,beta,gamma'},
       },
     ]
 
@@ -1181,6 +1194,7 @@ test.describe('create and edit predicates', () => {
 
       await adminPredicates.addAndExpectCondition(2)
       await adminPredicates.addAndExpectSubcondition(2, 2)
+      await adminPredicates.addAndExpectSubcondition(2, 3)
 
       await adminPredicates.configureSubconditions(subconditionConfigs)
     })
@@ -1199,7 +1213,7 @@ test.describe('create and edit predicates', () => {
 
     await test.step('validate state', async () => {
       await adminPredicates.expectConditionAndSubconditions(1, [1, 2])
-      await adminPredicates.expectConditionAndSubconditions(2, [1, 2])
+      await adminPredicates.expectConditionAndSubconditions(2, [1, 2, 3])
 
       // Checking values
       await expect(
@@ -1226,7 +1240,7 @@ test.describe('create and edit predicates', () => {
 
     await test.step('re-validate state', async () => {
       await adminPredicates.expectConditionAndSubconditions(1, [1, 2])
-      await adminPredicates.expectConditionAndSubconditions(2, [1, 2])
+      await adminPredicates.expectConditionAndSubconditions(2, [1, 2, 3])
 
       // Checking values
       await expect(

--- a/server/app/controllers/admin/AdminProgramBlockPredicatesController.java
+++ b/server/app/controllers/admin/AdminProgramBlockPredicatesController.java
@@ -493,13 +493,14 @@ public class AdminProgramBlockPredicatesController extends CiviFormController {
         leafNode.comparedValue().toSelectedValue(selectedQuestion.getQuestionType());
 
     // Grab user-entered text to populate text fields.
-    // For cases where we expect multi-value inputs (like checkbox questions),
-    // we use "valueOptions" below and the text fields aren't shown.
     Optional<String> firstValueOptional =
         switch (userEnteredValue.getKind()) {
           case SINGLE -> Optional.of(userEnteredValue.single());
           case PAIR -> Optional.of(userEnteredValue.pair().first());
-          case MULTIPLE -> Optional.empty();
+          case MULTIPLE ->
+              userEnteredValue.multiple().isEmpty()
+                  ? Optional.empty()
+                  : Optional.of(String.join(",", userEnteredValue.multiple()));
         };
 
     Optional<String> secondValueOptional =


### PR DESCRIPTION
### Description

This PR fixes a bug which prevented CSV values (IN / NOT_IN operators) from populating when editing an existing predicate.

Fix: For multiple-value cases, populate the `userSelectedValue` field with the CSV value string. We didn't have this previously because other multiple-value cases don't need this field filled, but this missed the CSV case. This way, the CSV-value won't show up for question types like Checkbox, Radio Button, etc. but will show up for predicates with a CSV input field.

Add test coverage.

[Screen recording 2026-01-26 2.54.44 PM.webm](https://github.com/user-attachments/assets/a2319267-3dda-4c16-980e-fe02939b075a)

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [ ] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [ ] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

### Instructions for manual testing

1. In predicate edit, select a question type that supports CSV operators like IN / NOT_IN
2. Fill all values, and click 'Save and Exit'.
3. Click 'Edit Predicate', and values should be filled correctly.

### Issue(s) this completes

Fixes #12527 
