### PR TITLE
[Session Timeout] update logic for when session warning modals show

### DIFF
--- a/server/app/assets/javascripts/session.test.ts
+++ b/server/app/assets/javascripts/session.test.ts
@@ -731,6 +731,7 @@ describe('SessionTimeoutHandler', () => {
         expect(setWarningModalVisibleSpy).toHaveBeenCalledWith(
           WarningType.TOTAL_LENGTH,
           true,
+          expect.any(Number),
         )
       })
 


### PR DESCRIPTION
### Description

Fixes some of the logic/edge case bugs I found while testing session warning modals.

This PR will not affect the build unless you include SessionTimeoutFilter in application.conf.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

### Instructions for manual testing

1. Update application.conf to add SessionTimeoutFilter after ValidAccountFilter 
```
  enabled += filters.ValidAccountFilter
  enabled += filters.SessionTimeoutFilter
```
2. Update `application.dev.conf` to enable session_replay_protection_enabled.
```
session_replay_protection_enabled=true
```

#### Test that session storage gets reset by:
1. Update session timeout variables in `application.dev.conf`:
(these settings bypass the inactivity modal so we can test the session length modal)
```
session_inactivity_timeout_minutes = 10
session_inactivity_warning_threshold_minutes = 1
session_duration_warning_threshold_minutes = 1
maximum_session_duration_minutes = 2
```
2. Start the application locally
3. In the admin settings panel, set SESSION_TIMEOUT_ENABLED to true
> 1. Start an application
> 2. Wait ~1 mins
> 3. Confirm the session expiration warning modal has popped up
> 4. Wait ~1 min
> 5. Confirm you are logged out
> 6. Log back in
> 7. Repeat (this PR makes sure that you can do the same thing a second time in the same tab)
  Test:
  timeout (line 110)

#### Inactivity modal doesn't appear when session expires before inactivity:
1. Update session timeout variables in `application.dev.conf`:
(these settings set the inactivity warning to trigger at a time that doesn't make sense)
```
session_inactivity_timeout_minutes = 5
session_inactivity_warning_threshold_minutes = 3
session_duration_warning_threshold_minutes = 2
maximum_session_duration_minutes = 3
```
2. Start the application locally
3. In the admin settings panel, set SESSION_TIMEOUT_ENABLED to true
> 1. Start an application
> 2. Wait ~1 mins
> 3. Confirm the session expiration warning modal has popped up
> 4. Wait ~2 min
> 5. Confirm you are logged out (and confirm you didn't see the session inactivity modal)

### Issue(s) this completes

Fixes #12550; Fixes #12551;
