### PR TITLE
Disable timeouts in application.dev.conf

### DIFF
--- a/server/conf/application.dev.conf
+++ b/server/conf/application.dev.conf
@@ -39,6 +39,12 @@ play.filters {
   }
 }
 
+# Disable timeouts so that debugging the app doesn't retry requests
+play.server.http.idleTimeout = infinite
+play.server.pekko.requestTimeout = infinite
+pekko.http.server.idle-timeout = infinite
+pekko.http.server.request-timeout = infinite
+
 # Bundler dev tooling
 bundler {
   useDevServer = true


### PR DESCRIPTION
When debugging the app, after a default timeout (somewhere around 30-60 seconds), a request that hasn't returned will be retried and your current breakpoint will get reset. This disables these timeouts to facilitate easier debugging

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [x] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [x] Noted in the PR description which, if any, code in this PR was generated by AI.
