### PR TITLE
[Expanded logic] Mark unfilled questions as invalid

### DIFF
--- a/browser-test/src/admin/admin_predicates_expanded.test.ts
+++ b/browser-test/src/admin/admin_predicates_expanded.test.ts
@@ -361,6 +361,17 @@ test.describe('create and edit predicates', () => {
       )
     })
 
+    await test.step('Leave question unselected and check validation', async () => {
+      await adminPredicates.clickSaveAndExitButton()
+
+      await expect(
+        page.locator('#condition-1-subcondition-1-question'),
+      ).toContainClass('usa-input--error')
+      await expect(page.locator('#edit-predicate')).toContainText(
+        'Error: You must select a question.',
+      )
+    })
+
     await test.step('Select question, save, and check predicate validation', async () => {
       await adminPredicates.selectQuestion(1, 1, questionText)
       await expect(

--- a/server/app/controllers/admin/AdminProgramBlockPredicatesController.java
+++ b/server/app/controllers/admin/AdminProgramBlockPredicatesController.java
@@ -798,6 +798,8 @@ public class AdminProgramBlockPredicatesController extends CiviFormController {
                     .blockId(blockDefinitionId)
                     .predicateUseCase(PredicateUseCase.valueOf(predicateUseCase))
                     .conditions(validatedConditionsList)
+                    .predicateLogicalOperator(
+                        getLogicalOperatorFromFormData("root", ImmutableMap.copyOf(form.rawData())))
                     .build()))
             .as(Http.MimeTypes.HTML);
       }
@@ -1464,7 +1466,9 @@ public class AdminProgramBlockPredicatesController extends CiviFormController {
     String questionFieldName = fieldNamePrefix + "-question";
     String questionFieldValue = formData.get(questionFieldName);
     if (!StringUtils.isNumeric(questionFieldValue) || !formData.containsKey(questionFieldName)) {
-      return subconditionBuilder.build();
+      ImmutableList<String> invalidInputIds =
+          validateInputFields ? ImmutableList.of(questionFieldName) : ImmutableList.of();
+      return subconditionBuilder.invalidInputIds(invalidInputIds).build();
     }
 
     Long questionId = Long.valueOf(questionFieldValue);

--- a/server/app/views/admin/programs/predicates/EditSubconditionFragment.html
+++ b/server/app/views/admin/programs/predicates/EditSubconditionFragment.html
@@ -18,20 +18,33 @@
           class="usa-sr-only"
           th:text="${'Condition ' + conditionId + ' subcondition ' + subconditionId}"
         ></legend>
-        <div class="usa-form-group margin-top-0">
+        <div
+          class="usa-form-group margin-top-0"
+          th:with="questionIsInvalid=${model.invalidInputIds.contains(questionDropdownId)},
+          questionErrorMessageId=${'condition-' + conditionId + '-subcondition-' + subconditionId + '-questionError'}"
+        >
           <label class="usa-label" th:for="${questionDropdownId}"
             >[[#{label.predicateQuestion}]]<span class="usa-hint--required"
               >*</span
             ></label
           >
+          <span
+            class="usa-error-message"
+            th:if="${questionIsInvalid}"
+            th:id="${questionErrorMessageId}"
+            th:text="#{toast.errorMessageOutline(#{validation.questionRequired})}"
+          ></span>
           <select
             class="usa-select cf-predicate-question-select"
+            th:classappend="${questionIsInvalid} ? 'usa-input--error' : ''"
             th:id="${questionDropdownId}"
             th:name="${questionDropdownId}"
             th:data-scalar-target-id="${scalarDropDownId}"
             th:hx-post="${model.hxEditSubconditionEndpoint()}"
             th:hx-vals='|{"conditionId": "${conditionId}", "subconditionId": "${subconditionId}"}|'
             th:hx-target="${'#predicate-condition-' + conditionId + '-subcondition-list'}"
+            th:aria-invalid="${questionIsInvalid}"
+            th:aria-describedby="${questionIsInvalid ? questionErrorMessageId : ''}"
             hx-swap="outerHTML"
             th:data-should-autofocus="${model.autofocus}"
           >

--- a/server/app/views/admin/programs/predicates/PredicateValuesInputFragment.html
+++ b/server/app/views/admin/programs/predicates/PredicateValuesInputFragment.html
@@ -20,7 +20,7 @@
     <span
       class="usa-error-message"
       th:id="${errorMessageId}"
-      th:if="${!model.invalidInputIds.isEmpty() && !model.isMultiValueQuestion()}"
+      th:if="${model.hasSelectedQuestion && !model.invalidInputIds.isEmpty() && !model.isMultiValueQuestion()}"
     >
       [[#{toast.errorMessageOutline(#{validation.fieldIsRequired})}]]
     </span>

--- a/server/conf/i18n/messages
+++ b/server/conf/i18n/messages
@@ -632,6 +632,8 @@ content.markdownSupported=Markdown is supported
 
 # Error message for when the admin leaves a multi-select question blank in admin predicate edit.
 validation.selectionRequired=You must select at least one option.
+# Error message for when the admin leaves a question unselected in admin predicate edit.
+validation.questionRequired=You must select a question.
 
 #----------------------------------------------------------#
 # ADDRESS QUESTION - text when viewing an address question #

--- a/server/test/controllers/admin/AdminProgramBlockPredicatesControllerTest.java
+++ b/server/test/controllers/admin/AdminProgramBlockPredicatesControllerTest.java
@@ -420,6 +420,89 @@ public class AdminProgramBlockPredicatesControllerTest extends ResetPostgres {
   }
 
   @Test
+  public void update_eligibilityMessage_unselectedQuestion_returnsCurrentPage() throws Exception {
+    when(settingsManifest.getExpandedFormLogicEnabled(any())).thenReturn(true);
+    ProgramModel programWithEligibilityMessage =
+        ProgramBuilder.newDraftProgram("new program")
+            .withBlock("Screen 1")
+            .withRequiredQuestion(testQuestionBank.nameApplicantName())
+            .build();
+
+    Result result =
+        controller.updatePredicate(
+            fakeRequestBuilder()
+                .bodyForm(
+                    ImmutableMap.of(
+                        "predicateAction",
+                        PredicateAction.ELIGIBLE_BLOCK.name(),
+                        "root-node-type",
+                        "AND",
+                        "condition-1-node-type",
+                        "AND",
+                        "condition-1-subcondition-1-question",
+                        "-Select-",
+                        "eligibilityMessage",
+                        ""))
+                .build(),
+            programWithEligibilityMessage.id,
+            /* blockDefinitionId= */ 1L,
+            PredicateUseCase.ELIGIBILITY.name());
+
+    assertThat(result.status()).isEqualTo(OK);
+    assertThat(result.header("HX-Redirect")).isEmpty();
+    String content = Helpers.contentAsString(result);
+    assertThat(content).contains("Error: You must select a question.");
+  }
+
+  @Test
+  public void update_eligibilityMessage_unfilledValueAndUnselectedQuestion_returnsCurrentPage()
+      throws Exception {
+    when(settingsManifest.getExpandedFormLogicEnabled(any())).thenReturn(true);
+    ProgramModel programWithEligibilityMessage =
+        ProgramBuilder.newDraftProgram("new program")
+            .withBlock("Screen 1")
+            .withRequiredQuestion(testQuestionBank.nameApplicantName())
+            .build();
+
+    Result result =
+        controller.updatePredicate(
+            fakeRequestBuilder()
+                .bodyForm(
+                    ImmutableMap.of(
+                        "predicateAction",
+                        PredicateAction.ELIGIBLE_BLOCK.name(),
+                        "root-node-type",
+                        "AND",
+                        "condition-1-node-type",
+                        "AND",
+                        "condition-2-node-type",
+                        "AND",
+                        "condition-1-subcondition-1-question",
+                        String.valueOf(testQuestionBank.nameApplicantName().id),
+                        "condition-1-subcondition-1-scalar",
+                        Scalar.FIRST_NAME.name(),
+                        "condition-1-subcondition-1-operator",
+                        Operator.EQUAL_TO.name(),
+                        "condition-1-subcondition-1-value",
+                        "",
+                        "condition-2-subcondition-1-question",
+                        "-Select-",
+                        "eligibilityMessage",
+                        ""))
+                .build(),
+            programWithEligibilityMessage.id,
+            /* blockDefinitionId= */ 1L,
+            PredicateUseCase.ELIGIBILITY.name());
+
+    assertThat(result.status()).isEqualTo(OK);
+    assertThat(result.header("HX-Redirect")).isEmpty();
+    String content = Helpers.contentAsString(result);
+    // Multiple invalid fields should be present.
+    assertThat(content).contains("Error: This field is required.");
+    assertThat(content).contains("Error: You must select a question.");
+  }
+
+  @Test
   public void update_eligibilityMessage_savesEmptyMessage() throws Exception {
     when(settingsManifest.getExpandedFormLogicEnabled(any())).thenReturn(true);
     ProgramModel programWithEligibilityMessage =


### PR DESCRIPTION
### Description

When an admin tries to submit a predicate with no selected question, mark the question select dropdown as invalid and show an error message.

Summary of changes:
- Add logic to populate `invalidFieldIds` with the dropdown ID for unselected questions
- Add error message and logic to invalidate question dropdown if unselected.
- Bugfix: `predicateLogicalOperator` was missing from the returned HTMX partial for validation errors, causing issues in cases with multiple conditions. Populate this value and add test coverage.
- Add Java and browser tests

https://github.com/user-attachments/assets/11aa4f23-62b3-4b8b-b6e0-e6627c6fca8c


### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

User visible changes
- [x]  Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
- [x] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
- [x] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order
- [x] Performed manual accessibility tests for any applicant-facing changes or any new admin-facing features. See [manual-accessibility-testing](https://github.com/civiform/civiform/wiki/Accessibility#manual-accessibility-testing)
- [ ] Manually tested with a right-to-left language

### Issue(s) this completes

Fixes #12533
