### PR TITLE
[Expanded logic] Update text based on eligibility gating

### DIFF
--- a/browser-test/src/admin/admin_predicates_expanded.test.ts
+++ b/browser-test/src/admin/admin_predicates_expanded.test.ts
@@ -1,6 +1,7 @@
 import {expect, test} from '../support/civiform_fixtures'
 import {enableFeatureFlag, loginAsAdmin, validateScreenshot} from '../support'
 import {waitForHtmxReady} from '../support/wait'
+import {Eligibility} from '../support/admin_programs'
 import {QuestionType} from '../support/admin_questions'
 import {
   MultiValueSpec,
@@ -347,6 +348,9 @@ test.describe('create and edit predicates', () => {
         'Screen 1',
         /* expandedFormLogicEnabled= */ true,
       )
+      await expect(page.locator('#edit-predicate')).toContainText(
+        'Applicants who do not meet the minimum requirements will be blocked from submitting an application.',
+      )
 
       await adminPredicates.expectEligibilityNullState()
     })
@@ -390,6 +394,42 @@ test.describe('create and edit predicates', () => {
       await validateScreenshot(
         page.locator('#condition-1'),
         'edit-eligibility-predicate-with-validation-error',
+      )
+    })
+  })
+
+  test('Create a non-blocking eligibility predicate', async ({
+    page,
+    adminQuestions,
+    adminPrograms,
+  }) => {
+    await loginAsAdmin(page)
+    const programName = 'Create a non-blocking eligibility predicate'
+
+    await test.step('Create a program with a question to use in the predicate', async () => {
+      const questionName = 'predicate-q'
+      await adminQuestions.addTextQuestion({
+        questionName: questionName,
+      })
+      await adminPrograms.addProgram(programName, {
+        eligibility: Eligibility.IS_NOT_GATING,
+      })
+      await adminPrograms.editProgramBlockUsingSpec(programName, {
+        name: 'Screen 1',
+        description: 'first screen',
+        questions: [{name: questionName}],
+      })
+    })
+
+    await test.step('Validate eligibility description text', async () => {
+      await adminPrograms.goToEditBlockEligibilityPredicatePage(
+        programName,
+        'Screen 1',
+        /* expandedFormLogicEnabled= */ true,
+      )
+
+      await expect(page.locator('#edit-predicate')).toContainText(
+        'Applicants can submit an application even if they do not meet the minimum requirements.',
       )
     })
   })

--- a/server/app/views/admin/programs/predicates/EditPredicatePageView.html
+++ b/server/app/views/admin/programs/predicates/EditPredicatePageView.html
@@ -27,7 +27,13 @@
           [[#{content.predicateVisibilityDescription}]]
         </p>
         <p th:case="'ELIGIBILITY'" class="margin-top-05">
-          [[#{content.predicateEligibilityDescription}]]
+          [[#{content.predicateEligibilityDescription.v2}]]
+          <span th:if="${model.programDefinition.eligibilityIsGating()}">
+            [[#{content.blockIneligibleApplicants}]]
+          </span>
+          <span th:unless="${model.programDefinition.eligibilityIsGating()}">
+            [[#{content.allowIneligibleApplicants}]]
+          </span>
           <a
             th:href="${model.programEditUrl()}"
             class="usa-link"

--- a/server/conf/i18n/messages
+++ b/server/conf/i18n/messages
@@ -560,6 +560,12 @@ link.backToEditProgramBlock=Back to edit {0}
 content.predicateVisibilityDescription=Configure when this screen is shown or hidden for applicants based on responses to questions on preceding screens.
 # Long form description for configuring an eligibility condition and how it can be used to determine if an applicant qualifies for the program. This text is followed by a link to edit the program, the full sentence reads "You can change this in the program settings."
 content.predicateEligibilityDescription=Add eligibility conditions to determine if an applicant qualifies for the program based on responses to questions on this screen. Applicants who do not meet the minimum requirements will be blocked from submitting an application. You can change this in the
+# Long form description for configuring an eligibility condition and how it can be used to determine if an applicant qualitifies for the program.
+content.predicateEligibilityDescription.v2=Add eligibility conditions to determine if an applicant qualifies for the program based on responses to questions on this screen.
+# Text informing admins that ineligible applicants will be blocked from submitting an application. This text is followed by a link to edit the program, the full sentence reads "You can change this in the program settings."
+content.blockIneligibleApplicants=Applicants who do not meet the minimum requirements will be blocked from submitting an application. You can change this in the
+# Text informing admins that ineligible applicants will still be able to submit an application. This text is followed by a link to edit the program, the full sentence reads "You can change this in the program settings."
+content.allowIneligibleApplicants=Applicants can submit an application even if they do not meet the minimum requirements. You can change this in the
 # Link to edit the program. This text is appended to the long form description for eligibility conditions. The full sentence reads "You can change this in the program settings."
 link.programSettings=program settings
 


### PR DESCRIPTION
### Description

Small UI fix for a bug found during testing. The eligibility logic "explainer text" letting admins know what happens if applicants are ineligible was not updating based on the program settings.

Introduce Thymeleaf logic and new messages to update explainer text when the program settings are changed. Add browser tests.

[Screen recording 2026-01-29 2.45.17 PM.webm](https://github.com/user-attachments/assets/099ab6af-4757-45f6-a444-0dc2378a2bd1)

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

#### User visible changes

- [x] Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
  - [x] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [ ] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [x] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [x] Manually tested at 200% size
- [ ] Manually evaluated tab order
- [ ] Performed manual accessibility tests for any applicant-facing changes or any new admin-facing features. See [manual-accessibility-testing](https://github.com/civiform/civiform/wiki/Accessibility#manual-accessibility-testing)
- [ ] Manually tested with a right-to-left language

### Issue(s) this completes

Related to #11882
