### PR TITLE
Unify the admin header to the thymeleaf version

### DIFF
--- a/server/app/views/BaseHtmlLayout.java
+++ b/server/app/views/BaseHtmlLayout.java
@@ -26,6 +26,8 @@ import j2html.tags.specialized.SectionTag;
 import j2html.tags.specialized.SpanTag;
 import java.util.Optional;
 import javax.inject.Inject;
+import modules.ThymeleafModule;
+import org.thymeleaf.TemplateEngine;
 import play.i18n.Messages;
 import play.mvc.Http;
 import play.twirl.api.Content;
@@ -60,13 +62,17 @@ public class BaseHtmlLayout {
   private final Optional<String> measurementId;
   private final boolean isDevOrStaging;
   private final boolean addNoindexMetaTag;
+  protected final ThymeleafModule.PlayThymeleafContextFactory playThymeleafContextFactory;
+  protected final TemplateEngine templateEngine;
 
   @Inject
   public BaseHtmlLayout(
       ViewUtils viewUtils,
       SettingsManifest settingsManifest,
       DeploymentType deploymentType,
-      BundledAssetsFinder bundledAssetsFinder) {
+      BundledAssetsFinder bundledAssetsFinder,
+      ThymeleafModule.PlayThymeleafContextFactory playThymeleafContextFactory,
+      TemplateEngine templateEngine) {
     this.viewUtils = checkNotNull(viewUtils);
     this.settingsManifest = checkNotNull(settingsManifest);
     this.measurementId = settingsManifest.getMeasurementId();
@@ -76,6 +82,8 @@ public class BaseHtmlLayout {
 
     civiformImageTag = settingsManifest.getCiviformImageTag().get();
     this.bundledAssetsFinder = checkNotNull(bundledAssetsFinder);
+    this.templateEngine = checkNotNull(templateEngine);
+    this.playThymeleafContextFactory = checkNotNull(playThymeleafContextFactory);
   }
 
   /** Creates a new {@link HtmlBundle} with default css, scripts, and toast messages. */

--- a/server/app/views/HtmlBundle.java
+++ b/server/app/views/HtmlBundle.java
@@ -6,7 +6,6 @@ import static j2html.TagCreator.document;
 import static j2html.TagCreator.each;
 import static j2html.TagCreator.footer;
 import static j2html.TagCreator.head;
-import static j2html.TagCreator.header;
 import static j2html.TagCreator.html;
 import static j2html.TagCreator.link;
 import static j2html.TagCreator.main;
@@ -15,12 +14,12 @@ import static j2html.TagCreator.title;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
+import j2html.tags.DomContent;
 import j2html.tags.Tag;
 import j2html.tags.specialized.BodyTag;
 import j2html.tags.specialized.DivTag;
 import j2html.tags.specialized.FooterTag;
 import j2html.tags.specialized.HeadTag;
-import j2html.tags.specialized.HeaderTag;
 import j2html.tags.specialized.HtmlTag;
 import j2html.tags.specialized.LinkTag;
 import j2html.tags.specialized.MainTag;
@@ -29,6 +28,7 @@ import j2html.tags.specialized.ScriptTag;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -55,8 +55,7 @@ public final class HtmlBundle {
   private final ArrayList<ScriptTag> footerScripts = new ArrayList<>();
   private final ArrayList<String> footerStyles = new ArrayList<>();
   private final ArrayList<ScriptTag> headScripts = new ArrayList<>();
-  private final ArrayList<Tag> headerContent = new ArrayList<>();
-  private final ArrayList<String> headerStyles = new ArrayList<>();
+  private final ArrayList<DomContent> headerContent = new ArrayList<>();
   private final ArrayList<Tag> mainContent = new ArrayList<>();
   private final ArrayList<String> mainStyles = new ArrayList<>();
   private final ArrayList<MetaTag> metadata = new ArrayList<>();
@@ -104,7 +103,7 @@ public final class HtmlBundle {
     return this;
   }
 
-  public HtmlBundle addHeaderContent(Tag... tags) {
+  public HtmlBundle addHeaderContent(DomContent... tags) {
     headerContent.addAll(Arrays.asList(tags));
     return this;
   }
@@ -194,7 +193,9 @@ public final class HtmlBundle {
     BodyTag bodyTag = j2html.TagCreator.body();
 
     pageNotProductionBannerTag.ifPresent(bodyTag::with);
-    bodyTag.with(renderHeader(), renderMain(), renderModals());
+
+    bodyTag.with(renderHeader());
+    bodyTag.with(renderMain(), renderModals());
 
     Optional<DivTag> uswdsModal = renderUswdsModals();
     uswdsModal.ifPresent(bodyTag::with);
@@ -261,16 +262,9 @@ public final class HtmlBundle {
         .with(CspUtil.applyCspToStyles(request, stylesheets));
   }
 
-  private HeaderTag renderHeader() {
-    // TODO: Sort toastMessages by priority before displaying.
-    HeaderTag headerTag =
-        header().with(each(toastMessages, ToastMessage::getContainerTag)).with(headerContent);
-
-    if (headerStyles.size() > 0) {
-      headerTag.withClasses(headerStyles.toArray(new String[0]));
-    }
-
-    return headerTag;
+  private List<DomContent> renderHeader() {
+    headerContent.add(0, each(toastMessages, ToastMessage::getContainerTag));
+    return headerContent;
   }
 
   private MainTag renderMain() {

--- a/server/app/views/admin/AdminLayout.java
+++ b/server/app/views/admin/AdminLayout.java
@@ -5,26 +5,21 @@ import static j2html.TagCreator.a;
 import static j2html.TagCreator.button;
 import static j2html.TagCreator.div;
 import static j2html.TagCreator.header;
-import static j2html.TagCreator.li;
-import static j2html.TagCreator.nav;
-import static j2html.TagCreator.span;
+import static j2html.TagCreator.rawHtml;
 import static j2html.TagCreator.text;
-import static j2html.TagCreator.ul;
 import static views.BaseHtmlView.asRedirectElement;
 import static views.ViewUtils.makeSvgTextButton;
 
 import auth.CiviFormProfile;
+import auth.ProfileUtils;
 import controllers.admin.routes;
-import j2html.tags.specialized.ATag;
 import j2html.tags.specialized.ButtonTag;
 import j2html.tags.specialized.DivTag;
-import j2html.tags.specialized.HeaderTag;
-import j2html.tags.specialized.LiTag;
-import j2html.tags.specialized.NavTag;
-import j2html.tags.specialized.UlTag;
+import java.util.Locale;
 import java.util.Optional;
+import modules.ThymeleafModule;
+import org.thymeleaf.TemplateEngine;
 import play.i18n.MessagesApi;
-import play.mvc.Http;
 import play.twirl.api.Content;
 import services.BundledAssetsFinder;
 import services.DeploymentType;
@@ -34,17 +29,12 @@ import views.BaseHtmlLayout;
 import views.HtmlBundle;
 import views.JsBundle;
 import views.ViewUtils;
+import views.admin.shared.AdminCommonHeader;
 import views.components.Icons;
 import views.style.AdminStyles;
 
 /** Contains methods rendering common compoments used across admin pages. */
 public final class AdminLayout extends BaseHtmlLayout {
-
-  private enum AdminType {
-    CIVIFORM_ADMIN,
-    PROGRAM_ADMIN
-  }
-
   public enum NavPage {
     /** Used when no page is set */
     NULL_PAGE,
@@ -61,8 +51,7 @@ public final class AdminLayout extends BaseHtmlLayout {
   private final NavPage activeNavPage;
   private final TranslationLocales translationLocales;
   private final MessagesApi messagesApi;
-
-  private AdminType primaryAdminType = AdminType.CIVIFORM_ADMIN;
+  private final ProfileUtils profileUtils;
 
   AdminLayout(
       ViewUtils viewUtils,
@@ -71,21 +60,21 @@ public final class AdminLayout extends BaseHtmlLayout {
       TranslationLocales translationLocales,
       DeploymentType deploymentType,
       BundledAssetsFinder bundledAssetsFinder,
-      MessagesApi messagesApi) {
-    super(viewUtils, settingsManifest, deploymentType, bundledAssetsFinder);
+      MessagesApi messagesApi,
+      ThymeleafModule.PlayThymeleafContextFactory playThymeleafContextFactory,
+      TemplateEngine templateEngine,
+      ProfileUtils profileUtils) {
+    super(
+        viewUtils,
+        settingsManifest,
+        deploymentType,
+        bundledAssetsFinder,
+        playThymeleafContextFactory,
+        templateEngine);
     this.activeNavPage = activeNavPage;
     this.translationLocales = checkNotNull(translationLocales);
     this.messagesApi = checkNotNull(messagesApi);
-  }
-
-  /**
-   * Sets this layout's admin type based on the CiviFormProfile, used to determine which navigation
-   * to include.
-   */
-  public AdminLayout setAdminType(CiviFormProfile profile) {
-    primaryAdminType =
-        profile.isOnlyProgramAdmin() ? AdminType.PROGRAM_ADMIN : AdminType.CIVIFORM_ADMIN;
-    return this;
+    this.profileUtils = checkNotNull(profileUtils);
   }
 
   public Content renderCentered(HtmlBundle bundle) {
@@ -113,9 +102,21 @@ public final class AdminLayout extends BaseHtmlLayout {
 
   @Override
   public HtmlBundle getBundle(HtmlBundle bundle) {
-    return super.getBundle(bundle)
-        .addHeaderContent(renderNavBar(bundle.getRequest()))
-        .setJsBundle(JsBundle.ADMIN);
+    ThymeleafModule.PlayThymeleafContext context =
+        new ThymeleafModule.PlayThymeleafContext(Locale.getDefault());
+    CiviFormProfile profile = profileUtils.currentUserProfile(bundle.getRequest());
+
+    context.setVariable(
+        "adminCommonHeader",
+        AdminCommonHeader.builder()
+            .activeNavPage(activeNavPage)
+            .isOnlyProgramAdmin(profile.isOnlyProgramAdmin())
+            .isApiBridgeEnabled(settingsManifest.getApiBridgeEnabled(bundle.getRequest()))
+            .build());
+
+    var header = templateEngine.process("admin/shared/AdminCommonHeader.html", context);
+
+    return super.getBundle(bundle).addHeaderContent(rawHtml(header)).setJsBundle(JsBundle.ADMIN);
   }
 
   /**
@@ -148,198 +149,5 @@ public final class AdminLayout extends BaseHtmlLayout {
             .withHref(goBackUrl)
             .withClasses("text-blue-600", "hover:text-blue-500", "inline-flex", "items-center"))
         .withClasses("grid-row");
-  }
-
-  private NavTag renderNavBar(Http.RequestHeader request) {
-    DivTag headerIcon =
-        div(
-            a().withHref(controllers.routes.HomeController.index().url())
-                .with(
-                    div(span("C"), span("F").withClasses("text-light"))
-                        .withClasses(
-                            "bg-base-dark",
-                            "width-4",
-                            "margin-05",
-                            "font-sans-lg",
-                            "radius-md",
-                            "grid-row",
-                            "flex-align-center",
-                            "flex-justify-center",
-                            "text-white"))
-                .withClasses("text-no-underline", "text-white", "text-base-lightest"));
-
-    DivTag headerTitle =
-        div()
-            .withClasses("font-sans-lg", "padding-y-0", "margin-right-2")
-            .with(span("Civi"), span("Form").withClasses("text-light"));
-
-    NavTag navBar =
-        nav()
-            .condWith(
-                !settingsManifest.getShowNotProductionBannerEnabled(request),
-                getGovBanner(Optional.empty()))
-            .withClasses("position-fixed", "top-0", "width-full", "z-10");
-
-    HeaderTag headerAccordion =
-        header()
-            .withClasses("usa-header", "usa-header--basic", "display-inline-block", "width-full")
-            .with(
-                nav().attr("aria-label", "Primary navigation").with(createAdminHeaderUl(request)));
-
-    DivTag adminHeader =
-        div()
-            .with(headerIcon, headerTitle, headerAccordion)
-            .withClasses(
-                "shadow-1",
-                "bg-white",
-                "text-base-darker",
-                "padding-x-2",
-                "grid-row",
-                "flex-no-wrap",
-                "flex-align-center");
-
-    return navBar.with(adminHeader);
-  }
-
-  private UlTag createAdminHeaderUl(Http.RequestHeader request) {
-
-    UlTag adminHeaderUl =
-        ul().withClasses(
-                "usa-nav__primary",
-                "usa-accordion",
-                "grid-row",
-                "flex-align-center",
-                "padding-y-105");
-
-    String logoutLink = org.pac4j.play.routes.LogoutController.logout().url();
-    String questionLink =
-        controllers.admin.routes.AdminQuestionController.index(Optional.empty()).url();
-    String programLink = controllers.admin.routes.AdminProgramController.index().url();
-    String programAdminProgramsLink = controllers.admin.routes.ProgramAdminController.index().url();
-    String intermediaryLink = routes.TrustedIntermediaryManagementController.index().url();
-    String apiKeysLink = controllers.admin.routes.AdminApiKeysController.index().url();
-    String apiDocsLink = controllers.docs.routes.ApiDocsController.index().url();
-    String apiBridgeDiscoveryLink =
-        controllers.admin.apibridge.routes.DiscoveryController.discovery().url();
-    String reportingLink = controllers.admin.routes.AdminReportingController.index().url();
-    String settingsLink = controllers.admin.routes.AdminSettingsController.index().url();
-
-    LiTag programsNavItem =
-        createTopNavItem(
-            "Programs", programLink, NavPage.PROGRAMS.equals(activeNavPage), Optional.empty());
-
-    LiTag programAdminProgramsHeaderLink =
-        createTopNavItem(
-            "Programs",
-            programAdminProgramsLink,
-            NavPage.PROGRAMS.equals(activeNavPage),
-            Optional.empty());
-
-    LiTag questionsNavItem =
-        createTopNavItem(
-            "Questions", questionLink, NavPage.QUESTIONS.equals(activeNavPage), Optional.empty());
-
-    LiTag intermediariesNavItem =
-        createTopNavItem(
-            "Intermediaries",
-            intermediaryLink,
-            NavPage.INTERMEDIARIES.equals(activeNavPage),
-            Optional.empty());
-
-    LiTag reportingNavItem =
-        createTopNavItem(
-            "Reporting", reportingLink, NavPage.REPORTING.equals(activeNavPage), Optional.empty());
-
-    LiTag settingsNavItem =
-        li(
-            a(Icons.svg(Icons.COG)
-                    .withClasses("height-3", "width-3", "opacity-75", "hover:opacity-100"))
-                .withHref(settingsLink)
-                .withClasses("cf-admin-heading-nav-item-settings-icon"));
-
-    LiTag logoutNavItem =
-        createTopNavItem("Logout", logoutLink, false, Optional.of("logout-button"));
-
-    String apiNavItemDropdownId = "admin-api-nav-item";
-
-    LiTag apiNavItemDropdown =
-        createTopNavItemWithDropdown(
-                "API",
-                apiNavItemDropdownId,
-                NavPage.API_KEYS.equals(activeNavPage) || NavPage.API_DOCS.equals(activeNavPage))
-            .with(
-                ul().withId(apiNavItemDropdownId)
-                    .withClasses("usa-nav__submenu")
-                    .with(
-                        createDropdownSubItem(
-                            "API Keys", apiKeysLink, NavPage.API_KEYS.equals(activeNavPage)))
-                    .with(
-                        createDropdownSubItem(
-                            "Documentation", apiDocsLink, NavPage.API_DOCS.equals(activeNavPage)))
-                    .condWith(
-                        getSettingsManifest().getApiBridgeEnabled(request),
-                        createDropdownSubItem(
-                            "Bridge Discovery",
-                            apiBridgeDiscoveryLink,
-                            NavPage.API_BRIDGE_DISCOVERY.equals(activeNavPage))));
-
-    LiTag programAdminApiNavItemDropdown =
-        createTopNavItemWithDropdown(
-                "API", apiNavItemDropdownId, NavPage.API_DOCS.equals(activeNavPage))
-            .with(
-                ul().withId(apiNavItemDropdownId)
-                    .withClasses("usa-nav__submenu")
-                    .with(
-                        createDropdownSubItem(
-                            "Documentation", apiDocsLink, NavPage.API_DOCS.equals(activeNavPage))));
-
-    switch (primaryAdminType) {
-      case CIVIFORM_ADMIN ->
-          adminHeaderUl.with(
-              programsNavItem,
-              questionsNavItem,
-              intermediariesNavItem,
-              reportingNavItem,
-              apiNavItemDropdown,
-              settingsNavItem.withClasses("usa-nav__primary-item", "margin-left-auto"),
-              logoutNavItem);
-      case PROGRAM_ADMIN ->
-          adminHeaderUl.with(
-              programAdminProgramsHeaderLink,
-              reportingNavItem,
-              programAdminApiNavItemDropdown,
-              logoutNavItem.withClasses("usa-nav__primary-item", "margin-left-auto"));
-    }
-
-    return adminHeaderUl;
-  }
-
-  private LiTag createTopNavItem(String text, String href, Boolean active, Optional<String> id) {
-    ATag aTag =
-        a(span(text).withClasses("text-normal", "font-sans-md", "line-height-sans-6"))
-            .withHref(href)
-            .withClasses("usa-nav__link", "cf-admin-heading-nav-item", active ? "usa-current" : "");
-
-    id.ifPresent(x -> aTag.withId(x));
-
-    return li(aTag).withClasses("usa-nav__primary-item");
-  }
-
-  private LiTag createTopNavItemWithDropdown(String text, String ariaControlsId, Boolean active) {
-    return li(button(span(text).withClasses("text-normal", "font-sans-md", "line-height-sans-6"))
-            .withType("button")
-            .attr("aria-expanded", false)
-            .attr("aria-controls", ariaControlsId)
-            .withClasses(
-                "usa-accordion__button",
-                "usa-nav__link",
-                "cf-admin-heading-nav-item",
-                active ? "usa-current" : ""))
-        .withClasses("usa-nav__primary-item");
-  }
-
-  private LiTag createDropdownSubItem(String text, String href, Boolean active) {
-    return li(a(span(text)).withHref(href))
-        .withClasses("usa-nav__submenu-item", active ? "text-bold" : "");
   }
 }

--- a/server/app/views/admin/AdminLayoutFactory.java
+++ b/server/app/views/admin/AdminLayoutFactory.java
@@ -1,6 +1,11 @@
 package views.admin;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import auth.ProfileUtils;
 import com.google.inject.Inject;
+import modules.ThymeleafModule;
+import org.thymeleaf.TemplateEngine;
 import play.i18n.MessagesApi;
 import services.BundledAssetsFinder;
 import services.DeploymentType;
@@ -16,6 +21,9 @@ public final class AdminLayoutFactory {
   private final DeploymentType deploymentType;
   private final BundledAssetsFinder bundledAssetsFinder;
   private final MessagesApi messagesApi;
+  private final ThymeleafModule.PlayThymeleafContextFactory playThymeleafContextFactory;
+  private final ProfileUtils profileUtils;
+  private final TemplateEngine templateEngine;
 
   @Inject
   public AdminLayoutFactory(
@@ -24,13 +32,20 @@ public final class AdminLayoutFactory {
       TranslationLocales translationLocales,
       DeploymentType deploymentType,
       BundledAssetsFinder bundledAssetsFinder,
-      MessagesApi messagesApi) {
+      MessagesApi messagesApi,
+      ThymeleafModule.PlayThymeleafContextFactory playThymeleafContextFactory,
+      TemplateEngine templateEngine,
+      ProfileUtils profileUtils) {
     this.viewUtils = viewUtils;
     this.settingsManifest = settingsManifest;
     this.translationLocales = translationLocales;
     this.deploymentType = deploymentType;
     this.bundledAssetsFinder = bundledAssetsFinder;
     this.messagesApi = messagesApi;
+    this.templateEngine = checkNotNull(templateEngine);
+    this.playThymeleafContextFactory = checkNotNull(playThymeleafContextFactory);
+
+    this.profileUtils = checkNotNull(profileUtils);
   }
 
   public AdminLayout getLayout(AdminLayout.NavPage navPage) {
@@ -41,6 +56,9 @@ public final class AdminLayoutFactory {
         translationLocales,
         deploymentType,
         bundledAssetsFinder,
-        messagesApi);
+        messagesApi,
+        playThymeleafContextFactory,
+        templateEngine,
+        profileUtils);
   }
 }

--- a/server/app/views/admin/programs/ProgramAdministratorProgramListView.java
+++ b/server/app/views/admin/programs/ProgramAdministratorProgramListView.java
@@ -49,10 +49,6 @@ public final class ProgramAdministratorProgramListView extends BaseHtmlView {
       ActiveAndDraftPrograms programs,
       List<String> authorizedPrograms,
       Optional<CiviFormProfile> civiformProfile) {
-    if (civiformProfile.isPresent()) {
-      layout.setAdminType(civiformProfile.get());
-    }
-
     String title = "Your programs";
     DivTag contentDiv =
         div()

--- a/server/app/views/admin/programs/ProgramApplicationTableView.java
+++ b/server/app/views/admin/programs/ProgramApplicationTableView.java
@@ -165,7 +165,6 @@ public class ProgramApplicationTableView extends BaseHtmlView {
 
     HtmlBundle htmlBundle =
         layout
-            .setAdminType(profile)
             .getBundle(request)
             .setTitle(program.adminName() + " - Applications")
             .addMainContent(makeCsrfTokenInputTag(request), applicationListDiv);

--- a/server/app/views/admin/programs/ProgramApplicationView.java
+++ b/server/app/views/admin/programs/ProgramApplicationView.java
@@ -167,7 +167,6 @@ public final class ProgramApplicationView extends BaseHtmlView {
 
     HtmlBundle htmlBundle =
         layout
-            .setAdminType(profile)
             .getBundle(request)
             .setTitle(programName + " - " + applicantNameWithApplicationId)
             .addMainContent(contentDiv)

--- a/server/app/views/admin/programs/ProgramIndexView.java
+++ b/server/app/views/admin/programs/ProgramIndexView.java
@@ -87,10 +87,6 @@ public final class ProgramIndexView extends BaseHtmlView {
       Http.Request request,
       ProgramTab selectedTab,
       Optional<CiviFormProfile> profile) {
-    if (profile.isPresent()) {
-      layout.setAdminType(profile.get());
-    }
-
     String pageTitle = "Program dashboard";
 
     // Revisit if we introduce internationalization because the word order could change in other

--- a/server/app/views/admin/reporting/AdminReportingIndexView.java
+++ b/server/app/views/admin/reporting/AdminReportingIndexView.java
@@ -56,8 +56,7 @@ public final class AdminReportingIndexView extends BaseHtmlView {
     contentDiv.with(renderAggregatedProgramStats(totalSubmissionsByProgram));
     contentDiv.with(renderAllApplicationsMonthlyStats(allApplicationsMonthlyStats));
 
-    HtmlBundle htmlBundle =
-        layout.setAdminType(profile).getBundle(request).setTitle(title).addMainContent(contentDiv);
+    HtmlBundle htmlBundle = layout.getBundle(request).setTitle(title).addMainContent(contentDiv);
     return layout.renderCentered(htmlBundle);
   }
 

--- a/server/app/views/admin/reporting/AdminReportingShowView.java
+++ b/server/app/views/admin/reporting/AdminReportingShowView.java
@@ -80,8 +80,7 @@ public class AdminReportingShowView extends BaseHtmlView {
         renderProgramMonthlyStats(
             programSlug, monthlyStats.monthlySubmissionsForProgram(programName)));
 
-    HtmlBundle htmlBundle =
-        layout.setAdminType(profile).getBundle(request).setTitle(title).addMainContent(contentDiv);
+    HtmlBundle htmlBundle = layout.getBundle(request).setTitle(title).addMainContent(contentDiv);
     return layout.renderCentered(htmlBundle);
   }
 

--- a/server/app/views/admin/shared/AdminCommonHeader.html
+++ b/server/app/views/admin/shared/AdminCommonHeader.html
@@ -1,7 +1,7 @@
 <!--/*@thymesVar id="adminCommonHeader" type="views.admin.shared.AdminCommonHeader"*/-->
 <th:block xmlns:cf="https://civiform.us/2024/html/icon">
   <header class="z-100">
-    <nav class="position-fixed width-full shadow-1">
+    <nav class="position-fixed width-full top-0 shadow-1">
       <section
         class="usa-banner cf-admin-heading-background-color"
         aria-label="This is an official government website."
@@ -133,7 +133,7 @@
                 <a
                   th:href="${adminCommonHeader.questionsUrl()}"
                   class="usa-nav__link cf-admin-heading-nav-item"
-                  th:classappend="${adminCommonHeader.activeNavPage().name() == 'Questions'} ? 'usa-current' : ''"
+                  th:classappend="${adminCommonHeader.activeNavPage().name() == 'QUESTIONS'} ? 'usa-current' : ''"
                   ><span class="text-normal font-sans-md line-height-sans-6"
                     >Questions</span
                   ></a
@@ -146,7 +146,7 @@
                 <a
                   th:href="${adminCommonHeader.intermediaryUrl()}"
                   class="usa-nav__link cf-admin-heading-nav-item"
-                  th:classappend="${adminCommonHeader.activeNavPage().name() == 'Intermediaries'} ? 'usa-current' : ''"
+                  th:classappend="${adminCommonHeader.activeNavPage().name() == 'INTERMEDIARIES'} ? 'usa-current' : ''"
                   ><span class="text-normal font-sans-md line-height-sans-6"
                     >Intermediaries</span
                   ></a
@@ -159,7 +159,7 @@
                 <a
                   th:href="${adminCommonHeader.reportingUrl()}"
                   class="usa-nav__link cf-admin-heading-nav-item"
-                  th:classappend="${adminCommonHeader.activeNavPage().name() == 'Reporting'} ? 'usa-current' : ''"
+                  th:classappend="${adminCommonHeader.activeNavPage().name() == 'REPORTING'} ? 'usa-current' : ''"
                   ><span class="text-normal font-sans-md line-height-sans-6"
                     >Reporting</span
                   ></a

--- a/server/app/views/admin/shared/AdminCommonHeader.java
+++ b/server/app/views/admin/shared/AdminCommonHeader.java
@@ -87,7 +87,7 @@ public record AdminCommonHeader(
 
   public Boolean isApiPage() {
     return switch (activeNavPage()) {
-      case API_DOCS, API_KEYS -> true;
+      case API_DOCS, API_KEYS, API_BRIDGE_DISCOVERY -> true;
       default -> false;
     };
   }

--- a/server/app/views/docs/ApiDocsView.java
+++ b/server/app/views/docs/ApiDocsView.java
@@ -22,8 +22,6 @@ import static j2html.TagCreator.text;
 import static j2html.TagCreator.ul;
 import static services.export.JsonPrettifier.asPrettyJsonString;
 
-import auth.CiviFormProfile;
-import auth.ProfileUtils;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import j2html.tags.DomContent;
@@ -47,7 +45,6 @@ import services.export.ProgramJsonSampler;
 import services.program.ProgramDefinition;
 import services.question.types.MultiOptionQuestionDefinition;
 import services.question.types.QuestionDefinition;
-import views.BaseHtmlLayout;
 import views.BaseHtmlView;
 import views.HtmlBundle;
 import views.admin.AdminLayout;
@@ -68,22 +65,16 @@ public class ApiDocsView extends BaseHtmlView {
   private static final String CODE_STYLES =
       StyleUtils.joinStyles("bg-slate-200", "p-0.5", "rounded-md");
 
-  private final ProfileUtils profileUtils;
-  private final BaseHtmlLayout unauthenticatedlayout;
-  private final AdminLayout authenticatedlayout;
+  private final AdminLayout layout;
   private final ProgramJsonSampler programJsonSampler;
   private final ExportServiceRepository exportServiceRepository;
 
   @Inject
   public ApiDocsView(
-      ProfileUtils profileUtils,
-      BaseHtmlLayout unauthenticatedlayout,
       AdminLayoutFactory layoutFactory,
       ProgramJsonSampler programJsonSampler,
       ExportServiceRepository exportServiceRepository) {
-    this.profileUtils = profileUtils;
-    this.unauthenticatedlayout = unauthenticatedlayout;
-    this.authenticatedlayout = layoutFactory.getLayout(NavPage.API_DOCS);
+    this.layout = layoutFactory.getLayout(NavPage.API_DOCS);
     this.programJsonSampler = programJsonSampler;
     this.exportServiceRepository = exportServiceRepository;
   }
@@ -93,17 +84,6 @@ public class ApiDocsView extends BaseHtmlView {
       String selectedProgramSlug,
       Optional<ProgramDefinition> programDefinition,
       ImmutableSet<String> allProgramSlugs) {
-    BaseHtmlLayout layout;
-
-    Optional<CiviFormProfile> currentUserProfile = profileUtils.optionalCurrentUserProfile(request);
-    if (currentUserProfile.isPresent()
-        && (currentUserProfile.get().isCiviFormAdmin()
-            || currentUserProfile.get().isProgramAdmin())) {
-      layout = authenticatedlayout.setAdminType(currentUserProfile.get());
-    } else {
-      // CiviFormProfileFilter does not apply to API docs views, so there may be no profile
-      layout = unauthenticatedlayout;
-    }
 
     HtmlBundle bundle =
         layout

--- a/server/app/views/trustedintermediary/ApplicantLayout.java
+++ b/server/app/views/trustedintermediary/ApplicantLayout.java
@@ -39,8 +39,10 @@ import java.util.Arrays;
 import java.util.Locale;
 import java.util.Optional;
 import javax.inject.Inject;
+import modules.ThymeleafModule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.thymeleaf.TemplateEngine;
 import play.i18n.Messages;
 import play.i18n.MessagesApi;
 import play.mvc.Http;
@@ -105,8 +107,16 @@ public class ApplicantLayout extends BaseHtmlLayout {
       BundledAssetsFinder bundledAssetsFinder,
       PageNotProductionBanner pageNotProductionBanner,
       MessagesApi messagesApi,
-      ApplicantRoutes applicantRoutes) {
-    super(viewUtils, settingsManifest, deploymentType, bundledAssetsFinder);
+      ApplicantRoutes applicantRoutes,
+      ThymeleafModule.PlayThymeleafContextFactory playThymeleafContextFactory,
+      TemplateEngine templateEngine) {
+    super(
+        viewUtils,
+        settingsManifest,
+        deploymentType,
+        bundledAssetsFinder,
+        playThymeleafContextFactory,
+        templateEngine);
     this.layout = layout;
     this.profileUtils = checkNotNull(profileUtils);
     this.languageSelector = checkNotNull(languageSelector);

--- a/server/test/views/BaseHtmlLayoutTest.java
+++ b/server/test/views/BaseHtmlLayoutTest.java
@@ -11,8 +11,10 @@ import j2html.tags.specialized.LinkTag;
 import j2html.tags.specialized.SectionTag;
 import java.util.HashMap;
 import java.util.Optional;
+import modules.ThymeleafModule;
 import org.junit.Before;
 import org.junit.Test;
+import org.thymeleaf.TemplateEngine;
 import play.twirl.api.Content;
 import repository.ResetPostgres;
 import services.BundledAssetsFinder;
@@ -37,7 +39,9 @@ public class BaseHtmlLayoutTest extends ResetPostgres {
             instanceOf(ViewUtils.class),
             new SettingsManifest(ConfigFactory.parseMap(DEFAULT_CONFIG)),
             instanceOf(DeploymentType.class),
-            instanceOf(BundledAssetsFinder.class));
+            instanceOf(BundledAssetsFinder.class),
+            instanceOf(ThymeleafModule.PlayThymeleafContextFactory.class),
+            instanceOf(TemplateEngine.class));
   }
 
   @Test
@@ -69,7 +73,9 @@ public class BaseHtmlLayoutTest extends ResetPostgres {
             instanceOf(ViewUtils.class),
             new SettingsManifest(ConfigFactory.parseMap(config)),
             instanceOf(DeploymentType.class),
-            instanceOf(BundledAssetsFinder.class));
+            instanceOf(BundledAssetsFinder.class),
+            instanceOf(ThymeleafModule.PlayThymeleafContextFactory.class),
+            instanceOf(TemplateEngine.class));
     HtmlBundle bundle = layout.getBundle(fakeRequestBuilder().cspNonce("my-nonce").build());
     Content content = layout.render(bundle);
 

--- a/server/test/views/admin/AdminLayoutTest.java
+++ b/server/test/views/admin/AdminLayoutTest.java
@@ -6,13 +6,16 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static support.FakeRequestBuilder.fakeRequestBuilder;
 
+import auth.ProfileUtils;
 import com.google.common.collect.ImmutableList;
 import controllers.admin.routes;
 import j2html.tags.specialized.ButtonTag;
 import java.util.Locale;
 import java.util.Optional;
+import modules.ThymeleafModule;
 import org.junit.Before;
 import org.junit.Test;
+import org.thymeleaf.TemplateEngine;
 import play.i18n.Messages;
 import play.i18n.MessagesApi;
 import play.mvc.Http;
@@ -32,6 +35,7 @@ public class AdminLayoutTest extends ResetPostgres {
   private SettingsManifest settingsManifest;
   private TranslationLocales translationLocales;
   private AdminLayout adminLayout;
+  private ProfileUtils profileUtils;
 
   @Before
   public void setUp() {
@@ -50,7 +54,10 @@ public class AdminLayoutTest extends ResetPostgres {
             translationLocales,
             instanceOf(DeploymentType.class),
             instanceOf(BundledAssetsFinder.class),
-            instanceOf(MessagesApi.class));
+            instanceOf(MessagesApi.class),
+            instanceOf(ThymeleafModule.PlayThymeleafContextFactory.class),
+            instanceOf(TemplateEngine.class),
+            profileUtils);
   }
 
   @Test
@@ -116,6 +123,7 @@ public class AdminLayoutTest extends ResetPostgres {
     MessagesApi messagesApi = mock(MessagesApi.class);
     when(messagesApi.preferred(any(Http.RequestHeader.class))).thenReturn(messages);
 
+    profileUtils = mock(ProfileUtils.class);
     adminLayout =
         new AdminLayout(
             instanceOf(ViewUtils.class),
@@ -124,7 +132,10 @@ public class AdminLayoutTest extends ResetPostgres {
             translationLocales,
             instanceOf(DeploymentType.class),
             instanceOf(BundledAssetsFinder.class),
-            messagesApi);
+            messagesApi,
+            instanceOf(ThymeleafModule.PlayThymeleafContextFactory.class),
+            instanceOf(TemplateEngine.class),
+            profileUtils);
 
     // Create bundle with the request
     Http.Request request = fakeRequestBuilder().build();

--- a/server/test/views/applicant/ApplicantLayoutTest.java
+++ b/server/test/views/applicant/ApplicantLayoutTest.java
@@ -11,8 +11,10 @@ import auth.ProfileUtils;
 import controllers.LanguageUtils;
 import controllers.applicant.ApplicantRoutes;
 import java.util.Optional;
+import modules.ThymeleafModule;
 import org.junit.Before;
 import org.junit.Test;
+import org.thymeleaf.TemplateEngine;
 import play.i18n.Messages;
 import play.i18n.MessagesApi;
 import play.mvc.Http;
@@ -60,7 +62,9 @@ public class ApplicantLayoutTest extends ResetPostgres {
             instanceOf(BundledAssetsFinder.class),
             instanceOf(PageNotProductionBanner.class),
             messagesApi,
-            instanceOf(ApplicantRoutes.class));
+            instanceOf(ApplicantRoutes.class),
+            instanceOf(ThymeleafModule.PlayThymeleafContextFactory.class),
+            instanceOf(TemplateEngine.class));
   }
 
   @Test

--- a/server/test/views/trustedintermediary/EditTiClientViewTest.java
+++ b/server/test/views/trustedintermediary/EditTiClientViewTest.java
@@ -15,8 +15,10 @@ import java.util.Optional;
 import models.AccountModel;
 import models.ApplicantModel;
 import models.TrustedIntermediaryGroupModel;
+import modules.ThymeleafModule;
 import org.junit.Before;
 import org.junit.Test;
+import org.thymeleaf.TemplateEngine;
 import play.i18n.Lang;
 import play.i18n.Messages;
 import play.i18n.MessagesApi;
@@ -75,7 +77,9 @@ public class EditTiClientViewTest extends WithMockedProfiles {
             instanceOf(BundledAssetsFinder.class),
             instanceOf(PageNotProductionBanner.class),
             mock(MessagesApi.class),
-            instanceOf(ApplicantRoutes.class));
+            instanceOf(ApplicantRoutes.class),
+            instanceOf(ThymeleafModule.PlayThymeleafContextFactory.class),
+            instanceOf(TemplateEngine.class));
 
     view =
         new EditTiClientView(

--- a/server/test/views/trustedintermediary/TrustedIntermediaryClientListViewTest.java
+++ b/server/test/views/trustedintermediary/TrustedIntermediaryClientListViewTest.java
@@ -16,8 +16,10 @@ import java.util.Optional;
 import models.AccountModel;
 import models.ApplicantModel;
 import models.TrustedIntermediaryGroupModel;
+import modules.ThymeleafModule;
 import org.junit.Before;
 import org.junit.Test;
+import org.thymeleaf.TemplateEngine;
 import play.i18n.Lang;
 import play.i18n.Messages;
 import play.i18n.MessagesApi;
@@ -78,7 +80,9 @@ public class TrustedIntermediaryClientListViewTest extends WithMockedProfiles {
             instanceOf(BundledAssetsFinder.class),
             instanceOf(PageNotProductionBanner.class),
             mock(MessagesApi.class),
-            instanceOf(ApplicantRoutes.class));
+            instanceOf(ApplicantRoutes.class),
+            instanceOf(ThymeleafModule.PlayThymeleafContextFactory.class),
+            instanceOf(TemplateEngine.class));
 
     view =
         new TrustedIntermediaryClientListView(


### PR DESCRIPTION
This removes the j2html header and instead renders the Thymeleaf version unifying them into a single place. It's a precursor to redoing the header for the admin.



### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [ ] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [ ] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.
