### PR TITLE
Use default USWDS focus styles for checkboxes and radio buttons

### DIFF
--- a/server/app/assets/stylesheets/northstar/_uswds-theme-custom-styles.scss
+++ b/server/app/assets/stylesheets/northstar/_uswds-theme-custom-styles.scss
@@ -65,21 +65,6 @@ svg {
   padding-inline-end: 1rem;
 }
 
-/* Rather than having a focus outline around the checkbox or radio button,
-it is around the label */
-.usa-checkbox__input:focus + [class*='__label']::before,
-.usa-radio__input:focus + [class*='__label']::before {
-  outline: 2px solid rgba(0, 0, 0, 0);
-  outline-offset: 2px;
-}
-
-.cf-radio-option:focus-within,
-.usa-checkbox__input:focus + [class*='__label'],
-.usa-radio__input:focus + [class*='__label'] {
-  @include u-border('blue-40v');
-  @include u-border('05');
-}
-
 /* By default, the USWDS checkbox input element is positioned off-screen and the label
  is styled to look like a checkbox.  This causes a problem with screen reader
  linear navigation because the screen reader navigation outline (different than focus outline)

--- a/server/app/assets/stylesheets/styles.css
+++ b/server/app/assets/stylesheets/styles.css
@@ -113,17 +113,6 @@
     }
   }
 
-  /* Rather than having a focus outline around the checkbox or radio button,
-  it is around the label */
-  input[type='radio']:focus,
-  input[type='checkbox']:focus {
-    @apply outline-none;
-  }
-  /* Mimics the focus outline styles from the checkbox or radio input on the label */
-  .cf-radio-option:focus-within {
-    @apply border-4;
-  }
-
   /* Overriding the style set by USWDS for this element */
   #name-search {
     @apply mt-0;

--- a/server/app/assets/stylesheets/uswds/_uswds-theme-custom-styles.scss
+++ b/server/app/assets/stylesheets/uswds/_uswds-theme-custom-styles.scss
@@ -20,10 +20,6 @@ See the radio-option below as an example.
 
 @use 'uswds-core' as *;
 
-.cf-radio-option:focus-within {
-  @include u-border('blue-40v');
-}
-
 // Put the focus outline around the chip instead of the underlying checkbox
 .filter-chip:focus-within {
   @include u-outline('05');


### PR DESCRIPTION
Remove custom focus styling that displayed focus outline around the label instead of the input control. This allows USWDS default focus styles to display on the checkbox/radio input itself, improving accessibility and consistency with USWDS design standards.

Tested in high-contrast mode to ensure accessibility compliance.

### Description

Please explain the changes you made here.

## Release notes

Remove this section if the feature is still under development or if title of the pull request can be used as the default release notes description. If more detail is needed to communicate to partners the scope of the PR's changes, use this release notes section (and remove this placeholder text).

When the Release engineer creates Release Notes, they will not look for this section for Under Development tagged PRs, and will use it if present for all other PRs included in the Release Notes.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [ ] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [ ] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

#### Database evolutions

Read the guidelines [here](https://github.com/civiform/civiform/wiki/Database#writing-database-evolutions)

- [ ] Assigned two reviewers
- [ ] Guarded against already existing resources using `IF NOT EXISTS` and `IF EXISTS`
- [ ] Downs created to undo changes in Ups
- [ ] Every comment in script should begin with -- and not # --- unless it denotes Ups or Downs. See [here](https://www.playframework.com/documentation/2.9.x/Evolutions) for details.
- [ ] Tested both the Downs and the Ups scripts manually (When testing, include all comments from the evolution in your test script to ensure any syntax errors in the comments are caught.)
- [ ] Data migrations aren't being done (please use a [Durable Job](https://github.com/civiform/civiform/wiki/Database#durable-jobs-for-data-updates) if doing a data migration)
- [ ] Update the model documentation in our [wiki](https://github.com/civiform/civiform/wiki/Database) if necessary

#### Durable jobs

Read the docs [here](https://github.com/civiform/civiform/wiki/Database#durable-jobs-for-data-updates)

- [ ] Assigned two reviewers
- [ ] Included a rollback plan and a job to undo the data changes if appropriate

#### User visible changes

- [ ] Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
  - [ ] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [ ] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order
- [ ] Performed manual accessibility tests for any applicant-facing changes or any new admin-facing features. See [manual-accessibility-testing](https://github.com/civiform/civiform/wiki/Accessibility#manual-accessibility-testing)
- [ ] Manually tested with a right-to-left language

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/helper/feature-flags.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://github.com/civiform/civiform/wiki/Feature-Flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Instructions for manual testing

If instructions are needed for manual testing by reviewers, include them here.

### Issue(s) this completes

Fixes #<issue_number>; Fixes #<issue_number>...
