### PR TITLE
Move text on admin reporting program page to messages to support i18n

### DIFF
--- a/server/app/views/admin/reporting/AdminReportingProgramPage.html
+++ b/server/app/views/admin/reporting/AdminReportingProgramPage.html
@@ -1,23 +1,28 @@
 <!--/*@thymesVar id="templateGlobals" type="views.admin.shared.TemplateGlobals"*/-->
 <!--/*@thymesVar id="model" type="views.admin.reporting.AdminReportingProgramPageViewModel"*/-->
 <th:block th:fragment="content">
-  <h1 th:text="${model.enUSLocalizedProgramName} + ' reporting'"></h1>
+  <h1
+    th:text="${#messages.msg('reportingProgram.heading', model.enUSLocalizedProgramName)}"
+  ></h1>
   <div class="my-8">
-    <p>Data may be up to an hour delayed.</p>
+    <p th:text="#{reportingProgram.dataDelay}"></p>
   </div>
   <div class="grid-container section usa-prose">
     <table class="usa-table">
-      <caption>
-        Submissions by month
-      </caption>
+      <caption
+        th:text="#{reportingProgram.caption.submissionsByMonth}"
+      ></caption>
       <thead>
         <tr>
-          <th scope="col">Month</th>
-          <th scope="col">Submissions</th>
-          <th scope="col">Time to complete (p25)</th>
-          <th scope="col">Median time to complete</th>
-          <th scope="col">Time to complete (p75)</th>
-          <th scope="col">Time to complete (p99)</th>
+          <th scope="col" th:text="#{reportingProgram.month}"></th>
+          <th scope="col" th:text="#{reportingProgram.submissions}"></th>
+          <th scope="col" th:text="#{reportingProgram.timeToCompleteP25}"></th>
+          <th
+            scope="col"
+            th:text="#{reportingProgram.medianTimeToComplete}"
+          ></th>
+          <th scope="col" th:text="#{reportingProgram.timeToCompleteP75}"></th>
+          <th scope="col" th:text="#{reportingProgram.timeToCompleteP99}"></th>
         </tr>
       </thead>
       <tbody>
@@ -47,8 +52,8 @@
     <a
       class="usa-button"
       th:href="${model.getDownloadProgramCsvUrl(model.programSlug)}"
+      th:text="#{reportingProgram.downloadCsv}"
     >
-      Download CSV
     </a>
   </div>
 </th:block>

--- a/server/conf/i18n/messages
+++ b/server/conf/i18n/messages
@@ -1191,3 +1191,29 @@ button.downloadCsv=Download CSV
 caption.submissionsByMonth=Submissions by month (all programs)
 # Column header for month
 content.month=Month
+
+#------------------------------------------------------------------------------#
+#  ADMIN REPORTING PROGRAM                                                     #
+#------------------------------------------------------------------------------#
+
+# Heading for the program reporting page
+reportingProgram.heading={0} reporting
+# Info text about data delay
+reportingProgram.dataDelay=Data may be up to an hour delayed.
+# Caption for the table showing submissions by month for a program
+reportingProgram.caption.submissionsByMonth=Submissions by month
+# Column header for month
+reportingProgram.month=Month
+# Column header for submissions
+reportingProgram.submissions=Submissions
+# Column header for 25th percentile time to complete
+reportingProgram.timeToCompleteP25=Time to complete (p25)
+# Column header for median (50th percentile) time to complete
+reportingProgram.medianTimeToComplete=Median time to complete
+# Column header for 75th percentile time to complete
+reportingProgram.timeToCompleteP75=Time to complete (p75)
+# Column header for 99th percentile time to complete
+reportingProgram.timeToCompleteP99=Time to complete (p99)
+# Text on button to download CSV file
+reportingProgram.downloadCsv=Download CSV
+


### PR DESCRIPTION
### Description

Moved text in the admin/reporting/program page to messages to support internationalization. 

I have chosen to create new entries for messages even when they are also used on the admin/reporting page so that text can be changed independently. I've used the page name to differentiate the messages, but have not changed the reporting page's messages. Please let me know what you think of this system and I can either change the reporting change to match, or do something different for the admin/reporting/program page. 

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

#### User visible changes

- [x] Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
  - [x] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [ ] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order
- [ ] Performed manual accessibility tests for any applicant-facing changes or any new admin-facing features. See [manual-accessibility-testing](https://github.com/civiform/civiform/wiki/Accessibility#manual-accessibility-testing)
- [ ] Manually tested with a right-to-left language

### Issue(s) this completes

Advances #12446