### PR TITLE
Fix toast message overflow for long status names

### DIFF
--- a/server/app/assets/stylesheets/northstar/_uswds-theme-custom-styles.scss
+++ b/server/app/assets/stylesheets/northstar/_uswds-theme-custom-styles.scss
@@ -850,6 +850,8 @@ main {
     0 4px 6px -4px rgba(0, 0, 0, 0.1); // tailwind shadow-lg
   color: color('gray-cool-70');
   transition: opacity 300ms cubic-bezier(0.4, 0, 0.2, 1);
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .bg-cf-toast-alert {

--- a/server/app/assets/stylesheets/uswds/_uswds-theme-custom-styles.scss
+++ b/server/app/assets/stylesheets/uswds/_uswds-theme-custom-styles.scss
@@ -406,6 +406,8 @@ button.usa-button.usa-button--unstyled.htmx-request {
     0 4px 6px -4px rgba(0, 0, 0, 0.1); // tailwind shadow-lg
   color: color('gray-cool-70');
   transition: opacity 300ms cubic-bezier(0.4, 0, 0.2, 1);
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .bg-cf-toast-alert {


### PR DESCRIPTION
## Summary
- allow toast messages to wrap long, unbroken status names instead of overflowing
- apply the same wrapping rules to both USWDS and Northstar toast styles

## Related Issues
- fixes #5000

## Testing
- not run (style-only change)
