### PR TITLE
Workflow to notify on slack if the messages file has changed

### DIFF
--- a/.github/workflows/translations_context_remider.yaml
+++ b/.github/workflows/translations_context_remider.yaml
@@ -51,7 +51,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "${{ steps.check_messages.outputs.mention }}: *Reminder to update translations in Transifex for this PR:*\n<${{ github.event.pull_request.html_url }}|${{ github.event.pull_request.title }}>\n\nThe base messages file was modified. Please:\n1. <https://app.transifex.com/civiform/|Add context> for any new or updated strings in Transifex (add the context string under 'String Instructions')\n2. If you don't want strings to be translated yet, mark them as locked by typing \"locked\" in the Tags field\n\nSee the <https://github.com/civiform/civiform/wiki/Internationalization-(i18n)#adding-new-strings|i18n wiki> for full instructions."
+                    "text": "${{ steps.check_messages.outputs.mention }}: *Reminder to update translations in Transifex for this PR:*\n<${{ github.event.pull_request.html_url }}|${{ github.event.pull_request.title }}>\n\nThe base messages file was modified. Please:\n1. Add context for any new or updated strings in <https://app.transifex.com/civiform/|Transifex> (add the context string under 'String Instructions')\n2. If you don't want strings to be translated yet, mark them as locked by typing \"locked\" in the Tags field\n\nSee the <https://github.com/civiform/civiform/wiki/Internationalization-(i18n)#adding-new-strings|wiki> for full instructions."
                   }
                 }
               ]


### PR DESCRIPTION
### Description

Slack notification for when a pr is merged with changes to messages file :)

This is what it will look like:
<img width="643" height="247" alt="Screenshot 2026-02-10 at 12 09 44 PM" src="https://github.com/user-attachments/assets/ad6bca7c-24c4-49a3-946c-b3897273c476" />

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.
