### PR TITLE
Remove redundant String::isEmpty use with isBlank

### DIFF
--- a/server/app/models/ApplicantModel.java
+++ b/server/app/models/ApplicantModel.java
@@ -309,10 +309,7 @@ public class ApplicantModel extends BaseModel {
 
   /** Save in a similar way to {@link CfJsonDocumentContext#putPhoneNumber} */
   public ApplicantModel setPhoneNumber(String phoneNumber) {
-    this.phoneNumber =
-        phoneNumber.isBlank()
-            ? null
-            : phoneNumber.replaceAll("[^0-9]", "");
+    this.phoneNumber = phoneNumber.isBlank() ? null : phoneNumber.replaceAll("[^0-9]", "");
     setCountryCodeFromPhoneNumber();
     return this;
   }


### PR DESCRIPTION
### Description

`String::isBlank` covers `String::isEmpty` so calling `isEmpty` is redundant.

https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/String.html#isBlank()
```public boolean isBlank()
Returns true if the string is empty or contains only white space codepoints, otherwise false.
```
### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [ ] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.
