### PR TITLE
Add allowed versions for OWASP Java HTML Sanitizer

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -27,6 +27,10 @@
       matchPackageNames: ["com.google.auto.value:{/,}**"],
     },
     {
+      matchPackageNames: ["com.googlecode.owasp-java-html-sanitizer:owasp-java-html-sanitizer"],
+      allowedVersions: "/^[0-9]{8}\\.[0-9]+$/",
+    },
+    {
       groupName: "awssdk",
       matchPackageNames: ["software.amazon.awssdk:{/,}**"],
       prHeader: "Release Notes: https://github.com/aws/aws-sdk-java-v2/blob/master/CHANGELOG.md"


### PR DESCRIPTION
Renovate is getting confused because in the [Maven repository](https://mvnrepository.com/artifact/com.googlecode.owasp-java-html-sanitizer/owasp-java-html-sanitizer), the metadata and versions are rather screwy. Old versions that look like `r239` are treated like `239.x`, version `20251202.2` looks like `2.x`, and the latest version `20260102.1` looks like `1.x`.  This tells Renovate to only look at the version string for how the versions are defined recently, and ignore all the other weird ones.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [x] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [x] Noted in the PR description which, if any, code in this PR was generated by AI.