### PR TITLE
[Expanded logic] Enable expanded form logic in dev environments

### DIFF
--- a/browser-test/src/admin/admin_application_statuses.test.ts
+++ b/browser-test/src/admin/admin_application_statuses.test.ts
@@ -8,6 +8,7 @@ import {
   loginAsProgramAdmin,
   loginAsTestUser,
   logout,
+  disableFeatureFlag,
   supportsEmailInspection,
   testUserDisplayName,
   extractEmailsForRecipient,
@@ -698,6 +699,7 @@ test.describe('view program statuses', () => {
         adminPrograms,
       }) => {
         await loginAsAdmin(page)
+        await disableFeatureFlag(page, 'expanded_form_logic_enabled')
 
         // Create a program without eligibility
         await adminQuestions.addNameQuestion({

--- a/browser-test/src/admin/admin_program_translation.test.ts
+++ b/browser-test/src/admin/admin_program_translation.test.ts
@@ -3,6 +3,7 @@ import {
   loginAsAdmin,
   logout,
   loginAsTestUser,
+  disableFeatureFlag,
   selectApplicantLanguage,
   validateScreenshot,
   validateToastMessage,
@@ -414,6 +415,7 @@ test.describe('Admin can manage program translations', () => {
     applicantQuestions,
   }) => {
     await loginAsAdmin(page)
+    await disableFeatureFlag(page, 'expanded_form_logic_enabled')
 
     const questionName = 'eligibility-question-q'
     const eligibilityMsg = 'Cutomized eligibility mesage'

--- a/browser-test/src/applicant/application_version_fast_forward.test.ts
+++ b/browser-test/src/applicant/application_version_fast_forward.test.ts
@@ -7,6 +7,7 @@ import {
   loginAsProgramAdmin,
   loginAsTestUser,
   logout,
+  disableFeatureFlag,
   closeWarningMessage,
   AdminPredicates,
   testUserDisplayName,
@@ -39,6 +40,10 @@ test.describe('Application Version Fast-Forward Flow', () => {
     const programAdminActor = await FastForwardProgramAdminActor.create(
       programName,
       browser,
+    )
+    await disableFeatureFlag(
+      civiformAdminActor.getPage(),
+      'expanded_form_logic_enabled',
     )
 
     /*
@@ -495,6 +500,10 @@ test.describe('Application Version Fast-Forward Flow', () => {
     const applicantActor = await FastForwardApplicantActor.create(
       programName,
       browser,
+    )
+    await disableFeatureFlag(
+      civiformAdminActor.getPage(),
+      'expanded_form_logic_enabled',
     )
 
     /*

--- a/browser-test/src/applicant/ineligible.test.ts
+++ b/browser-test/src/applicant/ineligible.test.ts
@@ -3,6 +3,7 @@ import {
   loginAsAdmin,
   loginAsTestUser,
   logout,
+  disableFeatureFlag,
   validateScreenshot,
   validateAccessibility,
   loginAsTrustedIntermediary,
@@ -17,6 +18,8 @@ test.describe('Ineligible Page Tests', () => {
 
   test.beforeEach(
     async ({page, adminQuestions, adminPrograms, adminPredicates}) => {
+      await disableFeatureFlag(page, 'expanded_form_logic_enabled')
+
       await test.step('Setup: Create program with eligibility condition', async () => {
         await loginAsAdmin(page)
 

--- a/browser-test/src/applicant/navigation/application_navigation_address_visibility_eligibility.test.ts
+++ b/browser-test/src/applicant/navigation/application_navigation_address_visibility_eligibility.test.ts
@@ -1,5 +1,6 @@
 import {test, expect} from '../../support/civiform_fixtures'
 import {
+  disableFeatureFlag,
   enableFeatureFlag,
   isLocalDevEnvironment,
   loginAsAdmin,
@@ -26,6 +27,7 @@ test.describe('Applicant navigation flow', () => {
             page,
             'esri_address_service_area_validation_enabled',
           )
+          await disableFeatureFlag(page, 'expanded_form_logic_enabled')
 
           // Create Questions
           await adminQuestions.addAddressQuestion({

--- a/browser-test/src/applicant/navigation/application_navigation_pre_screener.test.ts
+++ b/browser-test/src/applicant/navigation/application_navigation_pre_screener.test.ts
@@ -5,6 +5,7 @@ import {
   loginAsAdmin,
   loginAsTestUser,
   loginAsTrustedIntermediary,
+  disableFeatureFlag,
   logout,
   selectApplicantLanguage,
   validateAccessibility,
@@ -25,6 +26,7 @@ test.describe('Applicant navigation flow', () => {
     test.beforeEach(
       async ({page, adminQuestions, adminPredicates, adminPrograms}) => {
         await loginAsAdmin(page)
+        await disableFeatureFlag(page, 'expanded_form_logic_enabled')
 
         // Add questions
         await adminQuestions.addNumberQuestion({

--- a/browser-test/src/applicant/navigation/application_navigation_with_eligibility_conditions.test.ts
+++ b/browser-test/src/applicant/navigation/application_navigation_with_eligibility_conditions.test.ts
@@ -3,6 +3,7 @@ import {
   AdminQuestions,
   loginAsAdmin,
   logout,
+  disableFeatureFlag,
   validateAccessibility,
   validateScreenshot,
 } from '../../support'
@@ -18,6 +19,7 @@ test.describe('Applicant navigation flow', () => {
     test.beforeEach(
       async ({page, adminQuestions, adminPredicates, adminPrograms}) => {
         await loginAsAdmin(page)
+        await disableFeatureFlag(page, 'expanded_form_logic_enabled')
 
         await adminQuestions.addNumberQuestion({
           questionName: eligibilityQuestionId,

--- a/browser-test/src/applicant/navigation/navigation_address_visibility_condition.test.ts
+++ b/browser-test/src/applicant/navigation/navigation_address_visibility_condition.test.ts
@@ -1,5 +1,6 @@
 import {test, expect} from '../../support/civiform_fixtures'
 import {
+  disableFeatureFlag,
   enableFeatureFlag,
   isLocalDevEnvironment,
   loginAsAdmin,
@@ -25,6 +26,7 @@ test.describe('Applicant navigation flow', () => {
             page,
             'esri_address_service_area_validation_enabled',
           )
+          await disableFeatureFlag(page, 'expanded_form_logic_enabled')
 
           await loginAsAdmin(page)
 

--- a/browser-test/src/applicant/program_overview.test.ts
+++ b/browser-test/src/applicant/program_overview.test.ts
@@ -1,6 +1,7 @@
 import {expect, test} from '../support/civiform_fixtures'
 import {
   ClientInformation,
+  disableFeatureFlag,
   loginAsAdmin,
   loginAsTrustedIntermediary,
   loginAsTestUser,
@@ -19,6 +20,7 @@ test.describe('Applicant program overview', () => {
   test.beforeEach(async ({page, adminPrograms, adminQuestions}) => {
     await test.step('create a new program with one text question', async () => {
       await loginAsAdmin(page)
+      await disableFeatureFlag(page, 'expanded_form_logic_enabled')
       await adminQuestions.addTextQuestion({
         questionName: 'text question',
         questionText: questionText,

--- a/server/conf/application.dev.conf
+++ b/server/conf/application.dev.conf
@@ -94,3 +94,4 @@ program_filtering_enabled = true
 name_suffix_dropdown_enabled = true
 session_timeout_enabled = false
 custom_theme_colors_enabled = true
+expanded_form_logic_enabled = true


### PR DESCRIPTION
### Description

Enable the expanded form logic flag by default in "dev".

For browser tests that still assume the old predicate edit flow, disable the new flag. Tests will be fixed as part of #11883.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

### Issue(s) this completes

Related to #12650 
