### PR TITLE
Internationalize text in Dev Tools page

### DIFF
--- a/server/app/views/dev/DevToolsPage.html
+++ b/server/app/views/dev/DevToolsPage.html
@@ -6,7 +6,7 @@
     <div class="grid-row grid-gap">
       <div class="grid-col-12">
         <a class="usa-button usa-button--outline" th:href="${model.homeUrl}"
-          >🏠 Home page</a
+          >🏠 [[#{devtools.homepage}]]</a
         >
       </div>
     </div>
@@ -14,21 +14,21 @@
     <!-- Seed Section -->
     <div class="grid-row grid-gap">
       <div class="grid-col-12 border border-base-lighter">
-        <h2>Seed</h2>
-        <p>Populate or clear sample data</p>
+        <h2>[[#{devtools.seed.title}]]</h2>
+        <p>[[#{devtools.seed.description}]]</p>
         <form th:action="${model.seedProgramsUrl}" method="post">
           <button class="usa-button" type="submit">
-            Seed sample programs and categories
+            [[#{devtools.seed.programs}]]
           </button>
         </form>
         <form th:action="${model.seedQuestionsUrl}" method="post">
           <button class="usa-button" type="submit">
-            Seed sample questions
+            [[#{devtools.seed.questions}]]
           </button>
         </form>
         <form th:action="${model.clearUrl}" method="post">
           <button class="usa-button usa-button--secondary" type="submit">
-            Clear entire database (irreversible!)
+            [[#{devtools.seed.clear}]]
           </button>
         </form>
       </div>
@@ -37,15 +37,17 @@
     <!-- Caching Section -->
     <div class="grid-row grid-gap">
       <div class="grid-col-12 border border-base-lighter">
-        <h2>Caching</h2>
-        <p>Manage or clear cache</p>
+        <h2>[[#{devtools.cache.title}]]</h2>
+        <p>[[#{devtools.cache.description}]]</p>
         <form th:action="${model.clearCacheUrl}" method="post">
           <input
             type="hidden"
             name="csrfToken"
             th:value="${templateGlobals.csrfToken()}"
           />
-          <button class="usa-button" type="submit">💵 Clear cache</button>
+          <button class="usa-button" type="submit">
+            💵 [[#{devtools.cache.clear}]]
+          </button>
         </form>
       </div>
     </div>
@@ -53,15 +55,15 @@
     <!-- Durable Jobs Section -->
     <div class="grid-row grid-gap">
       <div class="grid-col-12 border border-base-lighter">
-        <h2>Durable Jobs</h2>
-        <p>Manually run the selected job</p>
+        <h2>[[#{devtools.jobs.title}]]</h2>
+        <p>[[#{devtools.jobs.description}]]</p>
         <form th:action="${model.runDurableJobUrl}" method="post">
           <input
             type="hidden"
             name="csrfToken"
             th:value="${templateGlobals.csrfToken()}"
           />
-          <label for="durable-job-select">Choose job to run once</label>
+          <label for="durable-job-select">[[#{devtools.jobs.select}]]</label>
           <select
             id="durable-job-select"
             name="durableJobSelect"
@@ -73,7 +75,9 @@
               th:text="${option}"
             ></option>
           </select>
-          <button class="usa-button" type="submit">Run job</button>
+          <button class="usa-button" type="submit">
+            [[#{devtools.jobs.run}]]
+          </button>
         </form>
       </div>
     </div>
@@ -81,10 +85,10 @@
     <!-- Icons Section -->
     <div class="grid-row grid-gap">
       <div class="grid-col-12 border border-base-lighter">
-        <h2>Icons</h2>
-        <p>See all the svg icons in CiviForm</p>
+        <h2>[[#{devtools.icons.title}]]</h2>
+        <p>[[#{devtools.icons.description}]]</p>
         <a class="usa-button usa-button--outline" th:href="${model.iconsUrl}"
-          >View All SVG Icons</a
+          >[[#{devtools.icons.view}]]</a
         >
       </div>
     </div>
@@ -92,25 +96,25 @@
     <!-- Email/Localstack Section (Dev only) -->
     <div th:if="${model.isDev}" class="grid-row grid-gap">
       <div class="grid-col-12 border border-base-lighter">
-        <h2>Localstack</h2>
-        <p>Open S3 or SES endpoints on localstack</p>
+        <h2>[[#{devtools.localstack.title}]]</h2>
+        <p>[[#{devtools.localstack.description}]]</p>
         <a
           class="usa-button usa-button--outline"
           href="http://localhost.localstack.cloud:4566/_aws/ses/"
           target="_blank"
-          >✉️ View SES Emails</a
+          >✉️ [[#{devtools.localstack.ses}]]</a
         >
         <a
           class="usa-button usa-button--outline"
           href="http://civiform-local-s3.localhost.localstack.cloud:4566/civiform-local-s3"
           target="_blank"
-          >📁 S3 Private Bucket</a
+          >📁 [[#{devtools.localstack.private}]]</a
         >
         <a
           class="usa-button usa-button--outline"
           href="http://civiform-local-s3.localhost.localstack.cloud:4566/civiform-local-s3-public"
           target="_blank"
-          >📁 S3 Public Bucket</a
+          >📁 [[#{devtools.localstack.public}]]</a
         >
       </div>
     </div>
@@ -118,12 +122,12 @@
     <!-- Address Tools Section -->
     <div class="grid-row grid-gap">
       <div class="grid-col-12 border border-base-lighter">
-        <h2>Address Tools</h2>
-        <p>View address lookup and eligibility results</p>
+        <h2>[[#{devtools.address.title}]]</h2>
+        <p>[[#{devtools.address.description}]]</p>
         <a
           class="usa-button usa-button--outline"
           th:href="${model.addressToolsUrl}"
-          >🗺️ Go to address tools</a
+          >🗺️ [[#{devtools.address.go}]]</a
         >
       </div>
     </div>
@@ -131,17 +135,17 @@
     <!-- Session Tools Section -->
     <div class="grid-row grid-gap">
       <div class="grid-col-12 border border-base-lighter">
-        <h2>Session Tools</h2>
-        <p>Inspect the current session</p>
+        <h2>[[#{devtools.session.title}]]</h2>
+        <p>[[#{devtools.session.description}]]</p>
         <a
           class="usa-button usa-button--outline"
           th:href="${model.sessionProfileUrl}"
-          >👤 View current pac4j profile</a
+          >👤 [[#{devtools.session.pac4j}]]</a
         >
         <a
           class="usa-button usa-button--outline"
           th:href="${model.sessionDisplayUrl}"
-          >📜 View current Play session</a
+          >📜 [[#{devtools.session.play}]]</a
         >
       </div>
     </div>

--- a/server/conf/i18n/messages
+++ b/server/conf/i18n/messages
@@ -1232,3 +1232,70 @@ reportingProgram.timeToCompleteP75=Time to complete (p75)
 reportingProgram.timeToCompleteP99=Time to complete (p99)
 # Text on button to download CSV file
 reportingProgram.downloadCsv=Download CSV
+
+#------------------------------------------------------------------------------#
+#  DEV TOOLS - text for the developer tools page                               #
+#------------------------------------------------------------------------------#
+# The text on the button to go to the home page from the dev tools page.
+devtools.homepage=Home page
+
+# Heading for the seed section of the dev tools page.
+devtools.seed.title=Seed
+# Description for the seed section of the dev tools page.
+devtools.seed.description=Populate or clear sample data
+# Button text to seed sample programs and categories.
+devtools.seed.programs=Seed sample programs and categories
+# Button text to seed sample questions.
+devtools.seed.questions=Seed sample questions
+# Button text to clear the entire database (irreversible action).
+devtools.seed.clear=Clear entire database (irreversible!)
+
+# Heading for the caching section of the dev tools page.
+devtools.cache.title=Caching
+# Description for the caching section of the dev tools page.
+devtools.cache.description=Manage or clear cache
+# Button text to clear the cache.
+devtools.cache.clear=Clear cache
+
+# Heading for the durable jobs section of the dev tools page.
+devtools.jobs.title=Durable Jobs
+# Description for the durable jobs section of the dev tools page.
+devtools.jobs.description=Manually run the selected job
+# Label for the dropdown to select a durable job to run.
+devtools.jobs.select=Choose job to run once
+# Button text to run the selected durable job.
+devtools.jobs.run=Run job
+
+# Heading for the icons section of the dev tools page.
+devtools.icons.title=Icons
+# Description for the icons section of the dev tools page.
+devtools.icons.description=See all the svg icons in CiviForm
+# Button text to view all SVG icons.
+devtools.icons.view=View All SVG Icons
+
+# Heading for the Localstack section of the dev tools page.
+devtools.localstack.title=Localstack
+# Description for the Localstack section of the dev tools page.
+devtools.localstack.description=Open S3 or SES endpoints on localstack
+# Button text to view SES emails in Localstack.
+devtools.localstack.ses=View SES Emails
+# Button text to view the S3 private bucket in Localstack.
+devtools.localstack.private=S3 Private Bucket
+# Button text to view the S3 public bucket in Localstack.
+devtools.localstack.public=S3 Public Bucket
+
+# Heading for the address tools section of the dev tools page.
+devtools.address.title=Address Tools
+# Description for the address tools section of the dev tools page.
+devtools.address.description=View address lookup and eligibility results
+# Button text to go to the address tools page.
+devtools.address.go=Go to address tools
+
+# Heading for the session tools section of the dev tools page.
+devtools.session.title=Session Tools
+# Description for the session tools section of the dev tools page.
+devtools.session.description=Inspect the current session
+# Button text to view the current pac4j profile.
+devtools.session.pac4j=View current pac4j profile
+# Button text to view the current Play session.
+devtools.session.play=View current Play session


### PR DESCRIPTION
### Description

Move text from dev tools page to messages to prepare for internationalization.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ x Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [x] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [x] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [x] Noted in the PR description which, if any, code in this PR was generated by AI.

#### User visible changes

- [x] Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
  - [x] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [x] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [x] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [x] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [x] Manually tested at 200% size
- [x] Manually evaluated tab order
- [x] Performed manual accessibility tests for any applicant-facing changes or any new admin-facing features. See [manual-accessibility-testing](https://github.com/civiform/civiform/wiki/Accessibility#manual-accessibility-testing)
- [ ] Manually tested with a right-to-left language

### Issue(s) this completes

Advances #12450