### PR TITLE
fix oidc bug

### DIFF
--- a/server/app/auth/ProfileFactory.java
+++ b/server/app/auth/ProfileFactory.java
@@ -142,7 +142,15 @@ public final class ProfileFactory {
   public CiviFormProfile wrap(ApplicantModel applicant) {
     CiviFormProfileData profileData = new CiviFormProfileData(applicant.getAccount().id, clock);
     CiviFormProfile profile = wrapProfileData(profileData);
-    profile.getAccount().thenAccept(account -> profile.storeApplicantIdInProfile(account)).join();
+    profile
+        .getAccount()
+        .thenAccept(
+            account -> {
+              profile.storeApplicantIdInProfile(account);
+              addActiveSession(account, profileData);
+              account.save();
+            })
+        .join();
     return profile;
   }
 


### PR DESCRIPTION
### Description

I'm running into a bug with dev-oidc where I end up in a redirect loop if `session_replay_protection_enabled=true`

To recreate: 

1. In `application.dev.conf`, add `session_replay_protection_enabled=true`
2. Start the app locally
3. Log in as an applicant
4. Log out
5. Log in again as an applicant - you are logged out immediately after

(Claude helped me figure this one out) I think this is the fix because I think it's logging you out in the route filters (maybe ValidAccountFilter - it's hard to tell) due to not finding an active session for the fake user created.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [x] Noted in the PR description which, if any, code in this PR was generated by AI.