### PR TITLE
Improve readability of mergeProfiles

### DIFF
--- a/server/app/auth/CiviFormProfileMerger.java
+++ b/server/app/auth/CiviFormProfileMerger.java
@@ -71,17 +71,21 @@ public final class CiviFormProfileMerger {
 
     boolean useApplicantModel = optionalApplicantInDatabase.isPresent();
     // If there's no applicant, retain whatever guest data there is, if any.
+    // This represents the user logging in for the first time.
     if (!useApplicantModel) {
       return optionalGuestProfile;
     }
 
     // If there is an applicant, only retain guest information if it has
     // applications. We won't retain question answers, etc if there are none.
+    // This represents a guest logging in to an existing civiform user, and
+    // we only want to retain their data if they took an affirmative action
+    // as the guest to submit data.
     boolean useGuestProfile =
         optionalGuestProfile.isPresent()
             && !optionalGuestProfile.get().getApplicant().join().getApplications().isEmpty();
-    final CiviFormProfile profile;
 
+    final CiviFormProfile profile;
     if (!useGuestProfile) {
       // Easy merge case - we have an existing applicant, but no guest profile (or a guest profile
       // with no applications). This will be the most common.


### PR DESCRIPTION
### Description

Improve the readability of mergeProfiles by pushing all the `mergeApplicantAndGuestProfile` associated logic into that method, and using explicit exhaustive if/else-if/else

This code is functionally equivalent to the previous, and hopefully clearer in the overall logic with the two Optionals.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

