### PR TITLE
Update on-call checklist to reflect new tech debt practices

### DIFF
--- a/.github/ISSUE_TEMPLATE/oncall-rotation.md
+++ b/.github/ISSUE_TEMPLATE/oncall-rotation.md
@@ -37,9 +37,8 @@ Resources:
 - [ ] Create an Oncall issue for the next rotation, and assign to the next oncall
 - [ ] Check Security lists daily
 - [ ] Check #eng-ci Slack channel daily to monitor failed pushes and e2e test runs
-- [ ] Check [needs triage bugs](https://github.com/orgs/civiform/projects/1/views/50) daily to ensure there aren't any P0s
 - [ ] Once per shift, check Transifex to see if strings are ready to be sent for translation. See [Managing Translations](https://github.com/civiform/civiform/wiki/Exygy-Admin-Info#managing-translations) for detailed instructions.
-- [ ] Make some progress (< 2 days) on an issue from the [On Call board](https://github.com/orgs/civiform/projects/1/views/95) or a broken dependency update (see below)
+- [ ] Make a weeks worth of progress (4 days) on an issue from the [On Call board](https://github.com/orgs/civiform/projects/1/views/95), a broken dependency update (see below), or a more urgent issue if one was assigned to you from the EM or PM.
 - [ ] Check for dependency updates
   - Resolve mergeable dependency updates a few times per shift in batches of 3-5.
   - If there are broken dependency updates, pick one to look into during your shift. If it's a small fix that you can do in < 2 days, fix it and merge it.


### PR DESCRIPTION
### Description

We're trying out a new process for on-call where on-callers are no longer responsible for triage, but are asked to do a full week (4 days) on a tech debt item or urgent issue.

Also updated our wiki on-call docs [here](https://github.com/civiform/civiform/wiki/On-Call-Guide/_compare/8e1380884625ac449ba37f0c381170b2cbfac67d...3fe8e6466be8ffef81a915094b182c2e625cb022)

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [ ] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [ ] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.
