### PR TITLE
Remove defunct storeApplicantIdInProfile in profile merging

### DIFF
--- a/server/app/auth/CiviFormProfileMerger.java
+++ b/server/app/auth/CiviFormProfileMerger.java
@@ -70,21 +70,14 @@ public final class CiviFormProfileMerger {
 
   private CiviFormProfile mergeApplicantAndGuestProfile(
       ApplicantModel applicantInDatabase, Optional<CiviFormProfile> optionalGuestProfile) {
-    final CiviFormProfile guestProfile;
     if (optionalGuestProfile.isEmpty()
         || optionalGuestProfile.get().getApplicant().join().getApplications().isEmpty()) {
       // Easy merge case - we have an existing applicant, but no guest profile (or a guest profile
       // with no applications). This will be the most common.
-      guestProfile = profileFactory.wrap(applicantInDatabase);
-    } else {
-      // Merge the two applicants and prefer the newer one.
-      guestProfile = mergeApplicantAndGuestProfile(applicantInDatabase, optionalGuestProfile.get());
+      return profileFactory.wrap(applicantInDatabase);
     }
-    // Ideally, the applicant id would already be populated in `guestProfile`. However, there
-    // could be profiles in user sessions that were created before we started populating this
-    // info.
-    guestProfile.storeApplicantIdInProfile(applicantInDatabase.id);
-    return guestProfile;
+    // Merge the two applicants and prefer the newer one.
+    return mergeApplicantAndGuestProfile(applicantInDatabase, optionalGuestProfile.get());
   }
 
   private CiviFormProfile mergeApplicantAndGuestProfile(


### PR DESCRIPTION
### Description

In [Dec 2023 we added ](https://github.com/civiform/civiform/commit/e89fa42440f9ee2d455ed2be0d1f93028e84452b#diff-e10a726ff1970f8f2e815de53f68e8e5d912ea4e2a1b44a82b221373c4b44003) setting Applicant ids in the session.  To bridge the gap for that launch the profile merge code [updated existing sessions](https://github.com/civiform/civiform/blob/3cc52cb1cfb1c562c9845b9477d16dd16fd71a27/server/app/auth/CiviFormProfileMerger.java#L83) to ensure the ID was set.

2 years later this bridging is no longer necessary, and this removes it.


## Release notes

Removes setting applicant IDs in the profile merge flow as it is no longer necessary.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [ ] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.
