### PR TITLE
[Enumerators] Handle validation errors on the enumerator question form

### DIFF
--- a/server/app/assets/javascripts/admin_programs.ts
+++ b/server/app/assets/javascripts/admin_programs.ts
@@ -351,7 +351,11 @@ class AdminPrograms {
         return
       }
       if (targetElement.id === 'enumerator-setup') {
-        this.focusOnEnumeratorQuestionSection()
+        if (document.getElementById('new-enumerator-question-form-errors')) {
+          this.focusOnFirstEnumeratorFormField()
+        } else {
+          this.focusOnEnumeratorQuestionSection()
+        }
       }
     })
   }
@@ -362,6 +366,13 @@ class AdminPrograms {
     )
     if (enumeratorSectionHeading) {
       enumeratorSectionHeading.focus()
+    }
+  }
+
+  static focusOnFirstEnumeratorFormField() {
+    const firstInputField = document.getElementById('listed-entity-input')
+    if (firstInputField) {
+      firstInputField.focus()
     }
   }
 }

--- a/server/test/controllers/admin/AdminProgramBlockQuestionsControllerTest.java
+++ b/server/test/controllers/admin/AdminProgramBlockQuestionsControllerTest.java
@@ -97,7 +97,7 @@ public class AdminProgramBlockQuestionsControllerTest extends ResetPostgres {
   }
 
   @Test
-  public void hxCreateEnumerator_withIncompleteForm_returnsQuestionEditFormWithToastError()
+  public void hxCreateEnumerator_withIncompleteForm_returnsEnumeratorFormWithErrorMessage()
       throws ProgramBlockDefinitionNotFoundException {
 
     ProgramBuilder programBuilder = ProgramBuilder.newDraftProgram();
@@ -115,6 +115,7 @@ public class AdminProgramBlockQuestionsControllerTest extends ResetPostgres {
     Result result = controller.hxCreateEnumerator(request, program.id, 1);
 
     assertThat(result.status()).isEqualTo(OK);
+    assertThat(contentAsString(result)).contains("<div id=\"enumerator-setup\">");
     assertThat(contentAsString(result)).contains("Error: Question text cannot be blank.");
   }
 


### PR DESCRIPTION
### Description

When there are errors in the new enumerator question form, we show an alert with the error messages and focus on the first form field.  This is a temporary solution until we implement inline error validation for admin question creation, as part of the admin UI migration.  I didn't provide translations for the error messages because these are the same error messages that we use on the general question edit form and they will likely all be re-written in a more wholistic way.  

Also, I opted to show a USWDS alert rather than a toast message since there weren't any error toast messages set up on this page yet and since the alert seems more clear.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

#### User visible changes

- [ ] Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
  - [ ] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [ ] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [ ] Manually tested at 200% size
- [x] Manually evaluated tab order
- [x] Performed manual accessibility tests for any applicant-facing changes or any new admin-facing features. See [manual-accessibility-testing](https://github.com/civiform/civiform/wiki/Accessibility#manual-accessibility-testing)
- [ ] Manually tested with a right-to-left language

### Instructions for manual testing

1. Turn the ENUMERATOR_IMPROVEMENTS_ENABLED feature flag on.
2. Log in as a CF admin and go to the Programs list page.
3. Select a program and click "Edit".
4. Click "Add screen" and then "Add repeated set".
5. In the block order panel on the left, click on the repeated set.
6. Fill out only one field of the new enumerator question form.
7. Click the "Create repeated set" button on the form.
8. Focus should go to the first form field.
9. An error alert should be displayed explaining which fields are missing.
10. The input you entered should still be there.

### Issue(s) this completes

Fixes #12004
