### PR TITLE
Add generic form validation class

### DIFF
--- a/server/app/assets/javascripts/global/shared/form_validation.test.ts
+++ b/server/app/assets/javascripts/global/shared/form_validation.test.ts
@@ -1,0 +1,558 @@
+import {describe, it, expect, beforeEach, vi} from 'vitest'
+import {FormValidation} from '@/global/shared/form_validation'
+
+/**
+ * Initializes a FormValidation instance. This is not done in the beforeEach
+ * because it needs to happen after the form exists.
+ */
+function initFormValidation() {
+  const formValidation = new FormValidation()
+  formValidation.init()
+}
+
+/**
+ * Creates a form group formatted for the expected uswds structure
+ */
+function createFormGroup(
+  inputHtml: string,
+  options?: {helpTextId?: string},
+): string {
+  const helpText = options?.helpTextId
+    ? `<div class="usa-hint" id="${options.helpTextId}">Help text</div>`
+    : ''
+
+  return `
+    <div class="usa-form-group">
+      <label class="usa-label">Label</label>
+      ${helpText}
+      <span class="usa-error-message" id="error-${Math.random().toString(36).slice(2)}" style="display:none"></span>
+      ${inputHtml}
+    </div>
+  `
+}
+
+/**
+ * Creates a fieldset formatted for the expected uswds structure
+ */
+function createFieldsetGroup(
+  type: 'checkbox' | 'radio',
+  options: {required?: boolean; requiredMessage?: string; count?: number},
+): string {
+  const count = options.count ?? 3
+  const inputs = Array.from({length: count}, (_, i) => {
+    return `<input type="${type}" name="group" value="${i}" ${options.required ? 'required' : ''} />`
+  }).join('\n')
+
+  const dataAttr = options.requiredMessage
+    ? `data-required-message="${options.requiredMessage}"`
+    : ''
+
+  return `
+    <div class="usa-form-group">
+      <fieldset ${dataAttr}>
+        <legend>Pick one</legend>
+        <span class="usa-error-message" id="fieldset-error-${Math.random().toString(36).slice(2)}" style="display:none"></span>
+        ${inputs}
+      </fieldset>
+    </div>
+  `
+}
+
+/**
+ * Build a form
+ */
+function createForm(
+  innerHTML: string,
+  formType: 'static' | 'dynamic' = 'static',
+): HTMLFormElement {
+  const form = document.createElement('form')
+  form.setAttribute('data-form-type', formType)
+
+  form.innerHTML = innerHTML
+  document.body.appendChild(form)
+  return form
+}
+
+/** Triggers a blur event on an element. */
+function blur(el: HTMLElement) {
+  el.dispatchEvent(new Event('blur', {bubbles: true}))
+}
+
+/** Triggers a change event on an element. */
+function change(el: HTMLElement) {
+  el.dispatchEvent(new Event('change', {bubbles: true}))
+}
+
+/** Triggers a submit event on a form and returns the event. */
+function submit(form: HTMLFormElement): SubmitEvent {
+  const ev = new SubmitEvent('submit', {bubbles: true, cancelable: true})
+  form.dispatchEvent(ev)
+  return ev
+}
+
+/** Returns the form group and error element for a given control. */
+function getFormGroupElements(control: Element) {
+  const formGroup = control.closest('.usa-form-group')!
+  const errorEl =
+    formGroup.querySelector<HTMLSpanElement>('.usa-error-message')!
+  return {formGroup, errorEl}
+}
+
+describe('FormValidation', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  describe('initialization', () => {
+    it('sets noValidate on configured forms', () => {
+      const form = createForm(createFormGroup('<input type="text" />'))
+      initFormValidation()
+      expect(form.noValidate).toBe(true)
+    })
+
+    it('ignores forms without data-form-type', () => {
+      const form = document.createElement('form')
+      form.innerHTML = createFormGroup('<input type="text" required />')
+      document.body.appendChild(form)
+
+      initFormValidation()
+
+      // noValidate should not have been set
+      expect(form.noValidate).toBe(false)
+    })
+  })
+
+  describe('text input validation', () => {
+    it('shows error on blur when required field is empty', () => {
+      const form = createForm(createFormGroup('<input type="text" required />'))
+      initFormValidation()
+
+      const input = form.querySelector('input')!
+      blur(input)
+
+      const {formGroup, errorEl} = getFormGroupElements(input)
+      expect(formGroup.classList.contains('usa-form-group--error')).toBe(true)
+      expect(errorEl.textContent).toBe('This field is required')
+      expect(errorEl.style.display).toBe('block')
+    })
+
+    it('clears error on blur when required field has a value', () => {
+      const form = createForm(createFormGroup('<input type="text" required />'))
+      initFormValidation()
+
+      const input = form.querySelector('input')!
+
+      // First trigger error
+      blur(input)
+      expect(
+        input
+          .closest('.usa-form-group')!
+          .classList.contains('usa-form-group--error'),
+      ).toBe(true)
+
+      // Then fill in value and blur again
+      input.value = 'hello'
+      blur(input)
+
+      const {formGroup, errorEl} = getFormGroupElements(input)
+      expect(formGroup.classList.contains('usa-form-group--error')).toBe(false)
+      expect(errorEl.textContent).toBe('')
+      expect(errorEl.style.display).toBe('none')
+    })
+
+    it('does not validate inputs without constraints', () => {
+      const form = createForm(createFormGroup('<input type="text" />'))
+      initFormValidation()
+
+      const input = form.querySelector('input')!
+      blur(input)
+
+      const {formGroup} = getFormGroupElements(input)
+      expect(formGroup.classList.contains('usa-form-group--error')).toBe(false)
+    })
+  })
+
+  describe('custom error messages', () => {
+    it('uses data-required-message when set', () => {
+      const form = createForm(
+        createFormGroup(
+          '<input type="text" required data-required-message="Very required" />',
+        ),
+      )
+      initFormValidation()
+
+      const input = form.querySelector('input')!
+      blur(input)
+
+      const {errorEl} = getFormGroupElements(input)
+      expect(errorEl.textContent).toBe('Very required')
+    })
+
+    it('uses data-pattern-message for pattern mismatch', () => {
+      const form = createForm(
+        createFormGroup(
+          '<input type="text" pattern="[0-9]+" value="abc" data-pattern-message="Numbers only" />',
+        ),
+      )
+      initFormValidation()
+
+      const input = form.querySelector('input')!
+      blur(input)
+
+      const {errorEl} = getFormGroupElements(input)
+      expect(errorEl.textContent).toBe('Numbers only')
+    })
+
+    it('uses default message when no data attribute is set', () => {
+      const form = createForm(createFormGroup('<input type="text" required />'))
+      initFormValidation()
+
+      const input = form.querySelector('input')!
+      blur(input)
+
+      const {errorEl} = getFormGroupElements(input)
+      expect(errorEl.textContent).toBe('This field is required')
+    })
+  })
+
+  describe('select validation', () => {
+    it('validates required select on blur', () => {
+      const form = createForm(
+        createFormGroup(`
+          <select required>
+            <option value="">Choose</option>
+            <option value="a">A</option>
+          </select>
+        `),
+      )
+      initFormValidation()
+
+      const select = form.querySelector('select')!
+      blur(select)
+
+      const {formGroup} = getFormGroupElements(select)
+      expect(formGroup.classList.contains('usa-form-group--error')).toBe(true)
+    })
+  })
+
+  describe('textarea validation', () => {
+    it('validates required textarea on blur', () => {
+      const form = createForm(createFormGroup('<textarea required></textarea>'))
+      initFormValidation()
+
+      const textarea = form.querySelector('textarea')!
+      blur(textarea)
+
+      const {formGroup} = getFormGroupElements(textarea)
+      expect(formGroup.classList.contains('usa-form-group--error')).toBe(true)
+    })
+  })
+
+  describe('fieldset validation', () => {
+    it('shows error when no required checkbox is checked', () => {
+      const form = createForm(createFieldsetGroup('checkbox', {required: true}))
+      initFormValidation()
+
+      const input = form.querySelector('input')!
+      change(input)
+
+      const {formGroup} = getFormGroupElements(input)
+      expect(formGroup.classList.contains('usa-form-group--error')).toBe(true)
+    })
+
+    it('clears error when a required checkbox is checked', () => {
+      const form = createForm(createFieldsetGroup('checkbox', {required: true}))
+      initFormValidation()
+
+      const input = form.querySelector('input')!
+
+      // Trigger error
+      change(input)
+      expect(
+        input
+          .closest('.usa-form-group')!
+          .classList.contains('usa-form-group--error'),
+      ).toBe(true)
+
+      // Check and re-validate
+      input.checked = true
+      change(input)
+
+      const {formGroup} = getFormGroupElements(input)
+      expect(formGroup.classList.contains('usa-form-group--error')).toBe(false)
+    })
+
+    it('shows error when no required radio is selected', () => {
+      const form = createForm(createFieldsetGroup('radio', {required: true}))
+      initFormValidation()
+
+      const input = form.querySelector('input')!
+      change(input)
+
+      const {formGroup} = getFormGroupElements(input)
+      expect(formGroup.classList.contains('usa-form-group--error')).toBe(true)
+    })
+
+    it('clears error when a required radio is selected', () => {
+      const form = createForm(createFieldsetGroup('radio', {required: true}))
+      initFormValidation()
+
+      const input = form.querySelector('input')!
+
+      change(input)
+      expect(
+        input
+          .closest('.usa-form-group')!
+          .classList.contains('usa-form-group--error'),
+      ).toBe(true)
+
+      input.checked = true
+      change(input)
+
+      const {formGroup} = getFormGroupElements(input)
+      expect(formGroup.classList.contains('usa-form-group--error')).toBe(false)
+    })
+
+    it('uses custom data-required-message on fieldset', () => {
+      const form = createForm(
+        createFieldsetGroup('checkbox', {
+          required: true,
+          requiredMessage: 'Pick at least one',
+        }),
+      )
+      initFormValidation()
+
+      const input = form.querySelector('input')!
+      change(input)
+
+      const {errorEl} = getFormGroupElements(input)
+      expect(errorEl.textContent).toBe('Pick at least one')
+    })
+
+    it('does not show error for non-required fieldsets', () => {
+      const form = createForm(
+        createFieldsetGroup('checkbox', {required: false}),
+      )
+      initFormValidation()
+
+      const input = form.querySelector('input')!
+      change(input)
+
+      const {formGroup} = getFormGroupElements(input)
+      expect(formGroup.classList.contains('usa-form-group--error')).toBe(false)
+    })
+  })
+
+  describe('aria attributes', () => {
+    it('sets aria-invalid on invalid control', () => {
+      const form = createForm(createFormGroup('<input type="text" required />'))
+      initFormValidation()
+
+      const input = form.querySelector('input')!
+      blur(input)
+
+      expect(input.getAttribute('aria-invalid')).toBe('true')
+    })
+
+    it('removes aria-invalid when control becomes valid', () => {
+      const form = createForm(createFormGroup('<input type="text" required />'))
+      initFormValidation()
+
+      const input = form.querySelector('input')!
+      blur(input)
+      expect(input.getAttribute('aria-invalid')).toBe('true')
+
+      input.value = 'hello'
+      blur(input)
+      expect(input.hasAttribute('aria-invalid')).toBe(false)
+    })
+
+    it('sets aria-describedby referencing error and help text', () => {
+      const form = createForm(
+        createFormGroup('<input type="text" required />', {
+          helpTextId: 'hint-1',
+        }),
+      )
+      initFormValidation()
+
+      const input = form.querySelector('input')!
+      blur(input)
+
+      const {errorEl} = getFormGroupElements(input)
+      expect(input.getAttribute('aria-describedby')).toBe(
+        `${errorEl.id} hint-1`,
+      )
+    })
+
+    it('sets aria-describedby to only help text when valid', () => {
+      const form = createForm(
+        createFormGroup('<input type="text" required />', {
+          helpTextId: 'hint-1',
+        }),
+      )
+      initFormValidation()
+
+      const input = form.querySelector('input')!
+      input.value = 'hello'
+      blur(input)
+
+      expect(input.getAttribute('aria-describedby')).toBe('hint-1')
+    })
+
+    it('removes aria-describedby when valid and no help text', () => {
+      const form = createForm(createFormGroup('<input type="text" required />'))
+      initFormValidation()
+
+      const input = form.querySelector('input')!
+      input.value = 'hello'
+      blur(input)
+
+      expect(input.hasAttribute('aria-describedby')).toBe(false)
+    })
+
+    it('sets aria-invalid on all inputs in an invalid fieldset', () => {
+      const form = createForm(
+        createFieldsetGroup('checkbox', {required: true, count: 3}),
+      )
+      initFormValidation()
+
+      const inputs = form.querySelectorAll('input')
+      change(inputs[0])
+
+      inputs.forEach((input) => {
+        expect(input.getAttribute('aria-invalid')).toBe('true')
+      })
+    })
+
+    it('removes aria-invalid from all inputs when fieldset becomes valid', () => {
+      const form = createForm(
+        createFieldsetGroup('checkbox', {required: true, count: 3}),
+      )
+      initFormValidation()
+
+      const inputs = form.querySelectorAll('input')
+
+      // Trigger error
+      change(inputs[0])
+      inputs.forEach((input) => {
+        expect(input.getAttribute('aria-invalid')).toBe('true')
+      })
+
+      // Fix
+      inputs[1].checked = true
+      change(inputs[1])
+      inputs.forEach((input) => {
+        expect(input.hasAttribute('aria-invalid')).toBe(false)
+      })
+    })
+  })
+
+  describe('submit validation', () => {
+    it('prevents submission when a required field is empty', () => {
+      const form = createForm(createFormGroup('<input type="text" required />'))
+      initFormValidation()
+
+      const ev = submit(form)
+      expect(ev.defaultPrevented).toBe(true)
+    })
+
+    it('allows submission when all fields are valid', () => {
+      const form = createForm(
+        createFormGroup('<input type="text" required value="hello" />'),
+      )
+      initFormValidation()
+
+      const ev = submit(form)
+      expect(ev.defaultPrevented).toBe(false)
+    })
+
+    it('prevents submission when required checkbox group has none checked', () => {
+      const form = createForm(createFieldsetGroup('checkbox', {required: true}))
+      initFormValidation()
+
+      const ev = submit(form)
+      expect(ev.defaultPrevented).toBe(true)
+    })
+
+    it('allows submission when required checkbox group has one checked', () => {
+      const form = createForm(createFieldsetGroup('checkbox', {required: true}))
+      initFormValidation()
+
+      form.querySelector('input')!.checked = true
+
+      const ev = submit(form)
+      expect(ev.defaultPrevented).toBe(false)
+    })
+
+    it('shows errors on all invalid fields on submit', () => {
+      const html =
+        createFormGroup('<input type="text" required />') +
+        createFormGroup('<input type="email" required />')
+
+      const form = createForm(html)
+      initFormValidation()
+
+      submit(form)
+
+      form.querySelectorAll('.usa-form-group').forEach((fg) => {
+        expect(fg.classList.contains('usa-form-group--error')).toBe(true)
+      })
+    })
+
+    it('focuses the first invalid control on submit', () => {
+      const html =
+        createFormGroup('<input id="first" type="text" required />') +
+        createFormGroup('<input id="second" type="text" required />')
+
+      const form = createForm(html)
+      initFormValidation()
+
+      const focusSpy = vi.spyOn(
+        form.querySelector<HTMLInputElement>('#first')!,
+        'focus',
+      )
+
+      submit(form)
+
+      expect(focusSpy).toHaveBeenCalled()
+    })
+  })
+
+  describe('dynamic forms', () => {
+    it('configures controls added after initialization', async () => {
+      const form = createForm('', 'dynamic')
+      initFormValidation()
+
+      const div = document.createElement('div')
+      div.innerHTML = createFormGroup('<input type="text" required />')
+      form.appendChild(div)
+
+      // Wait for MutationObserver to fire. Yes, the `0` here looks weird, but
+      // it is enough to allow the MutationObserver to trigger. For more details
+      // look into Javascript Microtasks vs Macrotasks.
+      await new Promise((r) => setTimeout(r, 0))
+
+      const input = form.querySelector('input')!
+      blur(input)
+
+      const {formGroup} = getFormGroupElements(input)
+      expect(formGroup.classList.contains('usa-form-group--error')).toBe(true)
+    })
+
+    it('does not observe static forms for mutations', () => {
+      const form = createForm('', 'static')
+      initFormValidation()
+
+      const div = document.createElement('div')
+      div.innerHTML = createFormGroup('<input type="text" required />')
+      form.appendChild(div)
+
+      const input = form.querySelector('input')!
+      blur(input)
+
+      // Should not have been configured, so no error class added
+      const {formGroup} = getFormGroupElements(input)
+      expect(formGroup.classList.contains('usa-form-group--error')).toBe(false)
+    })
+  })
+})

--- a/server/app/assets/javascripts/global/shared/form_validation.ts
+++ b/server/app/assets/javascripts/global/shared/form_validation.ts
@@ -1,0 +1,296 @@
+import {assertNotNull} from '@/util'
+
+type FormControl = HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement
+
+type CheckableInput = HTMLInputElement & {type: 'checkbox' | 'radio'}
+
+enum FormType {
+  STATIC = 'static',
+  DYNAMIC = 'dynamic',
+}
+
+/**
+ * Provides client-side form validation using the Constraint Validation API
+ *
+ * Forms opt in via the `data-form-type` attribute, which can be "static"
+ * or "dynamic". Dynamic forms use a MutationObserver to configure
+ * controls added to the DOM after initial page load.
+ */
+export class FormValidation {
+  private observers: Map<HTMLFormElement, MutationObserver> = new Map()
+
+  /**
+   * Discovers all forms with the `data-form-type` attribute and configures
+   * validation for each.
+   */
+  init() {
+    document
+      .querySelectorAll<HTMLFormElement>('form[data-form-type]')
+      .forEach((el) => this.configureForm(el))
+  }
+
+  /**
+   * Configures a form by disabling native browser validation, attaching
+   * event listeners to existing controls, setting up submit handling,
+   * and optionally observing the DOM for dynamically added controls.
+   */
+  private configureForm(form: HTMLFormElement) {
+    // Disable native browser validation UI
+    form.noValidate = true
+
+    // Configure existing controls
+    form
+      .querySelectorAll<FormControl>('input,textarea,select')
+      .forEach((el) => this.configureControl(el))
+
+    // Validate all controls on submit
+    form.addEventListener('submit', this.onSubmit)
+
+    // Set up MutationObserver for dynamic forms
+    if (form.dataset.formType === FormType.DYNAMIC) {
+      const observer = new MutationObserver((mutations) => {
+        mutations.forEach((mutation) => {
+          mutation.addedNodes.forEach((node) => {
+            if (this.isFormControl(node)) {
+              this.configureControl(node)
+            }
+
+            if (node instanceof HTMLElement) {
+              node
+                .querySelectorAll<FormControl>('input,textarea,select')
+                .forEach((el) => this.configureControl(el))
+            }
+          })
+        })
+      })
+
+      observer.observe(form, {
+        childList: true,
+        subtree: true,
+      })
+
+      this.observers.set(form, observer)
+    }
+  }
+
+  /**
+   * Validate the form on submit, if invalid focuses on the first invalid control
+   */
+  private onSubmit = (ev: SubmitEvent) => {
+    const form = ev.target as HTMLFormElement
+    let isValid = true
+
+    form
+      .querySelectorAll<FormControl>('input,textarea,select')
+      .forEach((el) => {
+        if (this.isCheckableInput(el) && !this.validateFieldset(el)) {
+          isValid = false
+        } else if (!this.isCheckableInput(el) && !this.validateControl(el)) {
+          isValid = false
+        }
+      })
+
+    if (!isValid) {
+      ev.preventDefault()
+      form
+        .querySelector('.usa-form-group--error')
+        ?.querySelector<FormControl>('input,textarea,select')
+        ?.focus()
+    }
+  }
+
+  /**
+   * Check that the element is an expected type
+   */
+  private isFormControl(node: Node): node is FormControl {
+    return (
+      node instanceof HTMLInputElement ||
+      node instanceof HTMLSelectElement ||
+      node instanceof HTMLTextAreaElement
+    )
+  }
+
+  /**
+   * Check that the element is either a checkbox or radio button.
+   */
+  private isCheckableInput(
+    formControl: FormControl,
+  ): formControl is CheckableInput {
+    return (
+      formControl instanceof HTMLInputElement &&
+      ['checkbox', 'radio'].includes(formControl.type)
+    )
+  }
+
+  /**
+   * Bind the control to the type appropriate change event
+   */
+  private configureControl(formControl: FormControl) {
+    const eventType = this.isCheckableInput(formControl) ? 'change' : 'blur'
+    formControl.addEventListener(eventType, this.validate)
+  }
+
+  /**
+   * Callback trigger by a change in the control
+   */
+  private validate = (ev: Event) => {
+    const target = ev.target as FormControl
+
+    if (this.isCheckableInput(target)) {
+      this.validateFieldset(target)
+    } else {
+      this.validateControl(target)
+    }
+  }
+
+  /**
+   * Validates a control (excluding checkbox/radio buttons) and configures
+   * appropriately for if there is an error or not.
+   *
+   * @returns true if the control is valid, false otherwise.
+   */
+  private validateControl(formControl: FormControl): boolean {
+    if (!formControl.willValidate) {
+      return true
+    }
+
+    const formGroup = assertNotNull(formControl.closest('.usa-form-group'))
+    const errorElement = assertNotNull(
+      formGroup.querySelector<HTMLSpanElement>('.usa-error-message'),
+    )
+    const helpTextId =
+      formGroup.querySelector<HTMLDivElement>('.usa-hint')?.id ?? ''
+
+    if (formControl.validity.valid) {
+      formGroup.classList.remove('usa-form-group--error')
+      errorElement.textContent = ''
+      errorElement.style.display = 'none'
+      this.setAriaValid(formControl, helpTextId)
+      return true
+    } else {
+      formGroup.classList.add('usa-form-group--error')
+      errorElement.textContent = this.getErrorMessage(formControl)
+      errorElement.style.display = 'block'
+      this.setAriaInvalid(formControl, errorElement.id, helpTextId)
+      return false
+    }
+  }
+
+  /**
+   * Validates a checkbox/radio button group and configures
+   * appropriately for if there is an error or not.
+   *
+   * @returns true if the fieldset is valid, false otherwise.
+   */
+  private validateFieldset(triggerElement: HTMLInputElement): boolean {
+    if (!triggerElement.willValidate) {
+      return true
+    }
+
+    const fieldset = assertNotNull(triggerElement.closest('fieldset'))
+    const inputs = fieldset.querySelectorAll<HTMLInputElement>(
+      'input[type="checkbox"], input[type="radio"]',
+    )
+    const formGroup = assertNotNull(fieldset.closest('.usa-form-group'))
+
+    const hasRequired = Array.from(inputs).some((input) => input.required)
+
+    if (!hasRequired) {
+      return true
+    }
+
+    const errorElement = assertNotNull(
+      formGroup.querySelector<HTMLSpanElement>('.usa-error-message'),
+    )
+    const helpTextId =
+      formGroup.querySelector<HTMLDivElement>('.usa-hint')?.id ?? ''
+    const hasChecked = Array.from(inputs).some((input) => input.checked)
+
+    if (hasChecked) {
+      formGroup.classList.remove('usa-form-group--error')
+      errorElement.textContent = ''
+      errorElement.style.display = 'none'
+      inputs.forEach((input) => this.setAriaValid(input, helpTextId))
+      return true
+    } else {
+      formGroup.classList.add('usa-form-group--error')
+      errorElement.textContent =
+        fieldset.dataset.requiredMessage || 'This field is required'
+      errorElement.style.display = 'block'
+      inputs.forEach((input) =>
+        this.setAriaInvalid(input, errorElement.id, helpTextId),
+      )
+      return false
+    }
+  }
+
+  /**
+   * Sets aria attributes on a form control to indicate a valid state.
+   * Removes `aria-invalid` and restores `aria-describedby` to reference
+   * only the help text, if present.
+   */
+  private setAriaValid(element: FormControl, helpTextId: string) {
+    element.removeAttribute('aria-invalid')
+    if (helpTextId === '') {
+      element.removeAttribute('aria-describedby')
+    } else {
+      element.setAttribute('aria-describedby', helpTextId)
+    }
+  }
+
+  /**
+   * Sets aria attributes on a form control to indicate an invalid state.
+   * Adds `aria-invalid` and sets `aria-describedby` to reference both the
+   * error message and help text elements.
+   */
+  private setAriaInvalid(
+    element: FormControl,
+    errorElementId: string,
+    helpTextId: string,
+  ) {
+    element.setAttribute('aria-invalid', 'true')
+    element.setAttribute(
+      'aria-describedby',
+      `${errorElementId} ${helpTextId}`.trim(),
+    )
+  }
+
+  /**
+   * Returns the custom error message for a form control based on its validity state. If
+   * the data-* attribute isn't found falls back to a context specific default, followed
+   * by the browser default text.
+   *
+   * The data-* attributes should be typically be present as they will contain
+   * our custom localized strings.
+   */
+  private getErrorMessage(field: FormControl): string {
+    const validity = field.validity
+
+    if (validity.valueMissing) {
+      return field.dataset.requiredMessage || 'This field is required'
+    } else if (validity.patternMismatch) {
+      return field.dataset.patternMessage || 'Invalid format'
+    } else if (validity.typeMismatch && field.type === 'email') {
+      return field.dataset.emailMessage || 'Please enter a valid email'
+    } else if (validity.typeMismatch && field.type === 'url') {
+      return field.dataset.urlMessage || 'Please enter a valid url'
+    } else if (validity.tooLong && 'maxLength' in field) {
+      return (
+        field.dataset.maxlengthMessage ||
+        `Maximum ${field.maxLength} characters allowed`
+      )
+    } else if (validity.tooShort && 'minLength' in field) {
+      return (
+        field.dataset.minlengthMessage ||
+        `Minimum ${field.minLength} characters required`
+      )
+    } else if (validity.rangeOverflow && 'max' in field) {
+      return field.dataset.maxMessage || `Value must be ${field.max} or less`
+    } else if (validity.rangeUnderflow && 'min' in field) {
+      return field.dataset.minMessage || `Value must be ${field.min} or more`
+    }
+
+    // Final fallback to browser default text
+    return field.validationMessage
+  }
+}

--- a/server/eslint.config.mjs
+++ b/server/eslint.config.mjs
@@ -24,6 +24,7 @@ export default [
   },
   js.configs.recommended,
 
+  // Rules for all files
   {
     files: ["app/assets/javascripts/**/*.ts"],
 
@@ -67,6 +68,16 @@ export default [
           methods: ["DOMPurify.sanitize"],
         },
       }],
+    },
+  },
+
+  // Rule overrides for unit test files
+  {
+    files: ["app/assets/javascripts/**/*.test.ts"],
+    rules: {
+      // It is common to need to set the innerHTML in typescript unit tests to
+      // build html to test against. It is safe to ignore this rule in our sandbox test code.
+      "no-unsanitized/property": "off",
     },
   },
 ];


### PR DESCRIPTION
This adds a typescript class that provides client-side form validation using the Constraint Validation API.

Forms opt in via the `data-form-type` attribute, which can be of type "static" or "dynamic". Dynamic forms use a MutationObserver to configure controls added to the DOM after initial page load.

While this is intrinsically aligned with the html generated by the custom Thymeleaf components, anything can use this as long as they are structured correctly. Primary validation messages come from data-* attributes which are set on the server with Thymeleaf. This is where localized strings should get set.

Accessibility built in. Quick checks look good, but we will do more in depth checks when we get to building real forms.

I'm still trying to get a good feel for writing these unit tests. As such I've had Claude provide assistance.