### PR TITLE
Making cf:button compatible with link and updating admin reporting button

### DIFF
--- a/server/app/views/admin/reporting/AdminReportingPage.html
+++ b/server/app/views/admin/reporting/AdminReportingPage.html
@@ -42,12 +42,12 @@
       </th:block>
     </tbody>
   </table>
-  <a
-    class="usa-button"
+  <cf:button
+    th:type="link"
     th:href="${model.getDownloadCsvUrl('APPLICATION_COUNTS_BY_PROGRAM')}"
     th:text="#{button.downloadCsv}"
-  >
-  </a>
+    class="usa-button"
+  />
 
   <table class="usa-table">
     <caption th:text="#{caption.submissionsByMonth}"></caption>
@@ -87,10 +87,10 @@
       </th:block>
     </tbody>
   </table>
-  <a
-    class="usa-button"
+  <cf:button
+    th:type="link"
     th:href="${model.getDownloadCsvUrl('APPLICATION_COUNTS_BY_MONTH')}"
     th:text="#{button.downloadCsv}"
-  >
-  </a>
+    class="usa-button"
+  />
 </th:block>

--- a/server/app/views/tags/settings/ButtonFormSettings.java
+++ b/server/app/views/tags/settings/ButtonFormSettings.java
@@ -16,7 +16,7 @@ import views.tags.AbstractElementModelProcessor.AttributeInfo;
 @Accessors(fluent = true)
 public final class ButtonFormSettings {
   private static final ImmutableList<String> ALLOWED_TYPES =
-      ImmutableList.of("button", "reset", "submit");
+      ImmutableList.of("button", "reset", "submit", "link");
   private static final ImmutableList<String> ALLOWED_SIZES = ImmutableList.of("big");
   private static final ImmutableList<String> ALLOWED_VARIANTS =
       ImmutableList.of("secondary", "outline", "accent-cool", "accent-warm", "base", "unstyled");

--- a/server/test/views/tags/ButtonElementTagModelProcessorTest.java
+++ b/server/test/views/tags/ButtonElementTagModelProcessorTest.java
@@ -49,7 +49,7 @@ public class ButtonElementTagModelProcessorTest extends BaseElementTagModelProce
             th:inverse="${model.inverse()}" />
         """,
         """
-<button type="submit" class="usa-button usa-button--secondary usa-button--big usa-button--inverse" id="actionBtn" name="action" value="submit">Submit Form</button>
+<button class="usa-button usa-button--secondary usa-button--big usa-button--inverse" type="submit" id="actionBtn" name="action" value="submit">Submit Form</button>
 """);
 
     // With plain attributes
@@ -66,7 +66,7 @@ public class ButtonElementTagModelProcessorTest extends BaseElementTagModelProce
             inverse="true" />
         """,
         """
-<button type="submit" class="usa-button usa-button--secondary usa-button--big usa-button--inverse" id="actionBtn" name="action" value="submit">Submit Form</button>
+<button class="usa-button usa-button--secondary usa-button--big usa-button--inverse" type="submit" id="actionBtn" name="action" value="submit">Submit Form</button>
 """);
   }
 
@@ -79,7 +79,7 @@ public class ButtonElementTagModelProcessorTest extends BaseElementTagModelProce
         <cf:button th:type="${model.type()}" th:text="${model.text()}" />
         """,
         """
-        <button type="submit" class="usa-button">Submit Form</button>
+        <button class="usa-button" type="submit">Submit Form</button>
         """);
 
     // With plain attributes
@@ -88,7 +88,7 @@ public class ButtonElementTagModelProcessorTest extends BaseElementTagModelProce
         <cf:button type="submit" text="Submit Form" />
         """,
         """
-        <button type="submit" class="usa-button">Submit Form</button>
+        <button class="usa-button" type="submit">Submit Form</button>
         """);
   }
 
@@ -101,7 +101,7 @@ public class ButtonElementTagModelProcessorTest extends BaseElementTagModelProce
         <cf:button th:variant="${model.variant()}" th:text="${model.text()}" />
         """,
         """
-        <button type="button" class="usa-button usa-button--secondary">Secondary</button>
+        <button class="usa-button usa-button--secondary" type="button">Secondary</button>
         """);
 
     // With plain attributes
@@ -110,7 +110,7 @@ public class ButtonElementTagModelProcessorTest extends BaseElementTagModelProce
         <cf:button variant="secondary" text="Secondary" />
         """,
         """
-        <button type="button" class="usa-button usa-button--secondary">Secondary</button>
+        <button class="usa-button usa-button--secondary" type="button">Secondary</button>
         """);
   }
 
@@ -123,7 +123,7 @@ public class ButtonElementTagModelProcessorTest extends BaseElementTagModelProce
         <cf:button th:size="${model.size()}" th:text="${model.text()}" />
         """,
         """
-        <button type="button" class="usa-button usa-button--big">Big Button</button>
+        <button class="usa-button usa-button--big" type="button">Big Button</button>
         """);
 
     // With plain attributes
@@ -132,7 +132,7 @@ public class ButtonElementTagModelProcessorTest extends BaseElementTagModelProce
         <cf:button size="big" text="Big Button" />
         """,
         """
-        <button type="button" class="usa-button usa-button--big">Big Button</button>
+        <button class="usa-button usa-button--big" type="button">Big Button</button>
         """);
   }
 
@@ -147,7 +147,7 @@ public class ButtonElementTagModelProcessorTest extends BaseElementTagModelProce
             data-analytics="track-click" />
         """,
         """
-<button type="button" class="usa-button" data-testid="submit-button" data-analytics="track-click">Track Me</button>
+<button class="usa-button" type="button" data-testid="submit-button" data-analytics="track-click">Track Me</button>
 """);
 
     // Thymeleaf data attributes
@@ -161,7 +161,7 @@ public class ButtonElementTagModelProcessorTest extends BaseElementTagModelProce
             th:data-target="'#' + ${model.id()}" />
         """,
         """
-<button type="button" class="usa-button" id="myButton" data-testid="myButton" data-target="#myButton">Button</button>
+<button class="usa-button" type="button" id="myButton" data-testid="myButton" data-target="#myButton">Button</button>
 """);
   }
 
@@ -176,7 +176,7 @@ public class ButtonElementTagModelProcessorTest extends BaseElementTagModelProce
             aria-label="Close dialog" />
         """,
         """
-        <button type="button" class="usa-button" aria-label="Close dialog">Close</button>
+        <button class="usa-button" type="button" aria-label="Close dialog">Close</button>
         """);
 
     // Thymeleaf aria attributes
@@ -188,7 +188,7 @@ public class ButtonElementTagModelProcessorTest extends BaseElementTagModelProce
             th:aria-label="${model.text()}" />
         """,
         """
-        <button type="button" class="usa-button" aria-label="Close">Close</button>
+        <button class="usa-button" type="button" aria-label="Close">Close</button>
         """);
   }
 
@@ -203,29 +203,28 @@ public class ButtonElementTagModelProcessorTest extends BaseElementTagModelProce
             th:text="${model.text()}" />
         """,
         """
-<button type="button" class="usa-button usa-button--outline usa-button--big">Large Outline Button</button>
+<button class="usa-button usa-button--outline usa-button--big" type="button">Large Outline Button</button>
 """);
   }
 
   @Test
   public void button_submit_with_disabled() {
     // With Thymeleaf
+
     assertHtml(
         Model.builder().disabled("true").text("Disabled").build(),
         """
         <cf:button th:disabled="${model.disabled()}" th:text="${model.text()}" />
         """,
         """
-        <button type="button" class="usa-button" disabled="disabled">Disabled</button>
+        <button class="usa-button" type="button" disabled="disabled">Disabled</button>
         """);
-
-    // With plain attributes
     assertHtml(
         """
         <cf:button disabled="true" text="Disabled" />
         """,
         """
-        <button type="button" class="usa-button" disabled="disabled">Disabled</button>
+        <button class="usa-button" type="button" disabled="disabled">Disabled</button>
         """);
   }
 
@@ -240,8 +239,9 @@ public class ButtonElementTagModelProcessorTest extends BaseElementTagModelProce
             th:text="${model.text()}" />
         """,
         """
-<button type="button" class="usa-button usa-button--outline usa-button--inverse">Inverse Outline</button>
+<button class="usa-button usa-button--outline usa-button--inverse" type="button">Inverse Outline</button>
 """);
+    // Duplicate test removed, already covered above
   }
 
   @Test
@@ -253,8 +253,8 @@ public class ButtonElementTagModelProcessorTest extends BaseElementTagModelProce
         </cf:button>
         """,
         """
-        <button type="button" class="usa-button usa-button--outline">
-          <svg class="usa-icon" aria-hidden="true"><use href="#close"></use></svg>Close
+        <button class="usa-button usa-button--outline" type="button">
+            <svg class="usa-icon" aria-hidden="true"><use href="#close"></use></svg>Close
         </button>
         """);
   }
@@ -266,7 +266,7 @@ public class ButtonElementTagModelProcessorTest extends BaseElementTagModelProce
         <cf:button />
         """,
         """
-        <button type="button" class="usa-button"></button>
+        <button class="usa-button" type="button"></button>
         """);
   }
 


### PR DESCRIPTION
### Description

Make cf:button compatible with a link tag (using <a> behind the scenes in cases where there is a link). Update the button in the admin reporting page. 

UI changes partially aided by Claude. 

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [x] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [x] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [x] Noted in the PR description which, if any, code in this PR was generated by AI.

#### User visible changes

- [ ] Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
  - [ ] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [ ] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [x] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [x] Manually tested at 200% size
- [x] Manually evaluated tab order
- [ ] Performed manual accessibility tests for any applicant-facing changes or any new admin-facing features. See [manual-accessibility-testing](https://github.com/civiform/civiform/wiki/Accessibility#manual-accessibility-testing)
- [ ] Manually tested with a right-to-left language

### Instructions for manual testing

1. Go to the admin/reporting page
2. Click on both "Download CSV" buttons and make sure a CSV is downloaded. 

### Issue(s) this completes
Improves #12445