### PR TITLE
[Maps] enable map question by default

### DIFF
--- a/server/app/services/settings/SettingsManifest.java
+++ b/server/app/services/settings/SettingsManifest.java
@@ -1073,8 +1073,8 @@ public final class SettingsManifest extends AbstractSettingsManifest {
   }
 
   /** Enable allowing CiviForm admins to add a map question to their programs. */
-  public boolean getMapQuestionEnabled(RequestHeader request) {
-    return getBool("MAP_QUESTION_ENABLED", request);
+  public boolean getMapQuestionEnabled() {
+    return getBool("MAP_QUESTION_ENABLED");
   }
 
   /** Enables being able to add a new yes/no question. */
@@ -2347,7 +2347,7 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                               + " programs.",
                           /* isRequired= */ false,
                           SettingType.BOOLEAN,
-                          SettingMode.ADMIN_WRITEABLE),
+                          SettingMode.ADMIN_READABLE),
                       SettingDescription.create(
                           "YES_NO_QUESTION_ENABLED",
                           "Enables being able to add a new yes/no question.",

--- a/server/app/views/BaseHtmlLayout.java
+++ b/server/app/views/BaseHtmlLayout.java
@@ -141,7 +141,7 @@ public class BaseHtmlLayout {
         link().withHref(bundledAssetsFinder.getUswdsStylesheet()).withRel("stylesheet"));
     bundle.addStylesheets(
         link().withHref(bundledAssetsFinder.getTailwindStylesheet()).withRel("stylesheet"));
-    if (settingsManifest.getMapQuestionEnabled(bundle.getRequest())) {
+    if (settingsManifest.getMapQuestionEnabled()) {
       bundle.addStylesheets(
           link().withHref(bundledAssetsFinder.getMapLibreGLStylesheet()).withRel("stylesheet"));
     }

--- a/server/app/views/applicant/ApplicantBaseView.java
+++ b/server/app/views/applicant/ApplicantBaseView.java
@@ -67,7 +67,7 @@ public abstract class ApplicantBaseView {
     context.setVariable("civiformImageTag", settingsManifest.getCiviformImageTag().get());
     context.setVariable("addNoIndexMetaTag", settingsManifest.getStagingAddNoindexMetaTag());
     context.setVariable("favicon", settingsManifest.getFaviconUrl().orElse(""));
-    context.setVariable("mapQuestionEnabled", settingsManifest.getMapQuestionEnabled(request));
+    context.setVariable("mapQuestionEnabled", settingsManifest.getMapQuestionEnabled());
 
     context.setVariable("useBundlerDevServer", bundledAssetsFinder.useBundlerDevServer());
     context.setVariable("viteClientUrl", bundledAssetsFinder.viteClientUrl());

--- a/server/app/views/components/CreateQuestionButton.java
+++ b/server/app/views/components/CreateQuestionButton.java
@@ -58,7 +58,7 @@ public final class CreateQuestionButton {
       if (type == QuestionType.YES_NO && !settingsManifest.getYesNoQuestionEnabled()) {
         continue;
       }
-      if (type == QuestionType.MAP && !settingsManifest.getMapQuestionEnabled(request)) {
+      if (type == QuestionType.MAP && !settingsManifest.getMapQuestionEnabled()) {
         continue;
       }
 

--- a/server/conf/env-var-docs.json
+++ b/server/conf/env-var-docs.json
@@ -930,7 +930,7 @@
         "required": false
       },
       "MAP_QUESTION_ENABLED": {
-        "mode": "ADMIN_WRITEABLE",
+        "mode": "ADMIN_READABLE",
         "description": "Enable allowing CiviForm admins to add a map question to their programs.",
         "type": "bool",
         "required": false

--- a/server/conf/helper/feature-flags.conf
+++ b/server/conf/helper/feature-flags.conf
@@ -70,7 +70,7 @@ yes_no_question_enabled = true
 yes_no_question_enabled = ${?YES_NO_QUESTION_ENABLED}
 
 # Allow admins to add a map question to their programs
-map_question_enabled = false
+map_question_enabled = true
 map_question_enabled = ${?MAP_QUESTION_ENABLED}
 
 # Enables translation management improvement phase one


### PR DESCRIPTION
### Description

Enables map question by default.

## Release notes

With this release, the map question is enabled by default.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.