### PR TITLE
[Account Merge] Prevent guests from merging into TI accounts

### DIFF
--- a/server/app/auth/oidc/CiviformOidcProfileCreator.java
+++ b/server/app/auth/oidc/CiviformOidcProfileCreator.java
@@ -217,8 +217,7 @@ public abstract class CiviformOidcProfileCreator extends OidcProfileCreator {
     // If the civiform user is a TI, do not merge it with a guest.
     // The guest will be left a guest account as if they never logged in.
     // TIs should not have applicant data, and should not be using guest
-    // accounts to apply for clients, so this is a place where we could try to
-    // communicate the situation to the TI directly if we desired too.
+    // accounts to apply for clients.
     boolean isTi =
         existingApplicant.filter(app -> isTrustedIntermediary(app.getAccount())).isPresent();
     if (isTi) {

--- a/server/test/auth/oidc/CiviformOidcProfileCreatorTest.java
+++ b/server/test/auth/oidc/CiviformOidcProfileCreatorTest.java
@@ -509,8 +509,8 @@ public class CiviformOidcProfileCreatorTest extends ResetPostgres {
     CiviFormProfileData guestProfileData = profileFactory.createNewApplicant();
     CiviFormProfile guestProfile = profileFactory.wrapProfileData(guestProfileData);
 
+    ApplicantModel guestApplicant = guestProfile.getApplicant().join();
     if (guestHasApplications) {
-      ApplicantModel guestApplicant = guestProfile.getApplicant().join();
       resourceCreator.insertActiveApplication(
           guestApplicant, resourceCreator.insertActiveProgram("test-program"));
     }
@@ -526,9 +526,13 @@ public class CiviformOidcProfileCreatorTest extends ResetPostgres {
     assertThat(Long.parseLong(profileData.getId())).isEqualTo(tiAccount.id);
     // The TI should not have the guest applicant merged into it.
     tiAccount.refresh();
-    assertThat(tiAccount.getApplicants()).hasSize(1);
+    var tiApplicants = tiAccount.getApplicants();
+    assertThat(tiApplicants).hasSize(1);
+    assertThat(tiApplicants.get(0).getApplications()).hasSize(0);
     // Guest profile's account should remain separate (not merged).
     assertThat(guestProfileData.getId()).isNotEqualTo(profileData.getId());
+    guestApplicant.refresh();
+    assertThat(guestApplicant.getApplications()).hasSize(guestHasApplications ? 1 : 0);
   }
 
   /**


### PR DESCRIPTION
### Description

Detect when a guest is logging in as a TI and prevent the guest data from being merged into the TI.

TIs should not have applicant data as they can not apply for programs themself.  However currently when a guest logs in as a TI we merge their data in the default manner.

These changes simply drop the guest account as if the guest user had cleared their session.

AI: Claude wrote the base of the unit test.

#### Manual verification

1. Submit an application as a guest
2. Log in as a TI
3. Check the database

<ins>Before this PR</ins>

Guest is originally 8229, TI is 8226.  We can see that the Guest (8229) Applicant was reassociated with the TI Account 8229.  The guest account is abandoned.

```
 account | applicant |    email_address    |  id  | preferred_locale |                                                                      object                                                                       | account_id |      when_created       | first_name | middle_name | last_name | email_address | country_code | phone_number | date_of_birth | suffix | applications | application_ids 
---------+-----------+---------------------+------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------+------------+-------------------------+------------+-------------+-----------+---------------+--------------+--------------+---------------+--------+--------------+-----------------
    8226 |      8226 | shaneTI@example.com | 8226 | en-US            | {"applicant": {}}                                                                                                                                 |       8226 | 2026-02-11 21:14:54.524 |            |             |           |               |              |              |               |        |            0 | 
    8226 |      8229 | shaneTI@example.com | 8229 | en-US            | {"applicant": {"sample_name_question": {"last_name": "GuestLN", "first_name": "GuestFN", "updated_at": 1770844578791, "program_updated_in": 20}}} |       8226 | 2026-02-11 21:16:10.262 | GuestFN    |             | GuestLN   |               |              |              |               |        |            1 | 831
    8229 |           |                     |      |                  |                                                                                                                                                   |            |                         |            |             |           |               |              |              |               |        |            0 | 
```

<ins>After this PR</ins>

TI (8231) and Guest (8233) remain separate.

```
 account | applicant |    email_address     |  id  | preferred_locale |                                                                       object                                                                        | account_id |      when_created       | first_name | middle_name | last_name | email_address | country_code | phone_number | date_of_birth | suffix | applications | application_ids 
---------+-----------+----------------------+------+------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------+------------+-------------------------+------------+-------------+-----------+---------------+--------------+--------------+---------------+--------+--------------+-----------------
    8231 |      8231 | shaneTI2@example.com | 8231 | en-US            | {"applicant": {}}                                                                                                                                   |       8231 | 2026-02-11 21:42:32.325 |            |             |           |               |              |              |               |        |            0 | 
    8233 |      8233 |                      | 8233 | en-US            | {"applicant": {"sample_name_question": {"last_name": "Guest2LN", "first_name": "Guest2FN", "updated_at": 1770846202740, "program_updated_in": 20}}} |       8233 | 2026-02-11 21:43:13.554 | Guest2FN   |             | Guest2LN  |               |              |              |               |        |            1 | 832
```

## Release notes

Prevent guest accounts from being merged into TI accounts when a TI logs in after applying for a client as a guest.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [x] Noted in the PR description which, if any, code in this PR was generated by AI.


### Instructions for manual testing


1. Create a TI account
2. As a guest apply for a program
3. For devs: Look at the database state for the two users: Account, Applicant
4. As the guest log in to the TI account
Notice: The TI is logged in as expected, there are no issues.

For a dev:
Notice: In the database the guest and TI accounts/applicants, etc are completely separate with no changes.

### Issue(s) this completes

Addresses: #11776