### PR TITLE
move session timeout filter to application.dev.conf from browser test conf

### DIFF
--- a/server/conf/application.dev-browser-tests.conf
+++ b/server/conf/application.dev-browser-tests.conf
@@ -10,12 +10,6 @@ db {
   default.url = "jdbc:postgresql://db:5432/browsertests"
 }
 
-# Enable SessionTimeoutFilter for browser tests
-# This filter must run after ValidAccountFilter in the filter chain
-play.filters {
-  enabled += filters.SessionTimeoutFilter
-}
-
 # Bundler dev tooling
 bundler.useDevServer = false
 

--- a/server/conf/application.dev.conf
+++ b/server/conf/application.dev.conf
@@ -37,6 +37,7 @@ play.filters {
     directives.connect-src = "*"
     directives.frame-ancestors = 'self'
   }
+  enabled += filters.SessionTimeoutFilter
 }
 
 # Disable timeouts so that debugging the app doesn't retry requests


### PR DESCRIPTION
Probers tests needs the addition of SessionTimeoutFilter in application.dev.conf rather than just the browser test conf.