### PR TITLE
Fix incorrect HTTP status handling caused by finally block

### DIFF
--- a/server/app/services/email/aws/SimpleEmail.java
+++ b/server/app/services/email/aws/SimpleEmail.java
@@ -116,14 +116,15 @@ public final class SimpleEmail implements EmailSendClient {
       SendEmailRequest emailRequest =
           SendEmailRequest.builder().destination(destination).message(msg).source(sender).build();
       client.get().sendEmail(emailRequest);
+      // Increase the count of emails sent.
+      emailSendMetrics.getEmailSendCount().labels(String.valueOf(HttpStatusCode.OK)).inc();
     } catch (SesException e) {
       logger.error(e.toString());
       e.printStackTrace();
       emailSendMetrics.getEmailFailCount().inc();
       emailSendMetrics.getEmailSendCount().labels(String.valueOf(e.statusCode())).inc();
     } finally {
-      // Increase the count of emails sent.
-      emailSendMetrics.getEmailSendCount().labels(String.valueOf(HttpStatusCode.OK)).inc();
+      
       // Record the execution time of the email sending process.
       timer.observeDuration();
     }

--- a/server/app/services/email/graph/GraphApiEmailClient.java
+++ b/server/app/services/email/graph/GraphApiEmailClient.java
@@ -128,14 +128,15 @@ public class GraphApiEmailClient implements EmailSendClient {
             .sendMail()
             .post(sendMailPostRequestBody);
       }
+      // Increase the count of emails sent.
+      emailSendMetrics.getEmailSendCount().labels(String.valueOf(HttpStatusCode.OK)).inc();
     } catch (ApiException e) {
       logger.error(e.toString());
       e.printStackTrace();
       emailSendMetrics.getEmailFailCount().inc();
       emailSendMetrics.getEmailSendCount().labels(String.valueOf(e.getResponseStatusCode())).inc();
     } finally {
-      // Increase the count of emails sent.
-      emailSendMetrics.getEmailSendCount().labels(String.valueOf(HttpStatusCode.OK)).inc();
+      
       // Record the execution time of the email sending process.
       timer.observeDuration();
     }


### PR DESCRIPTION
This PR fixes incorrect HTTP status handling where the response status code was being set inside a finally block.

Setting the status code in finally causes it to execute regardless of whether an exception occurred, which may override error responses and result in misleading success status codes being returned to clients.

This change ensures that:
- Success status codes are only set when the operation completes successfully.
- Error status codes are preserved when exceptions occur.
- Response behavior accurately reflects execution outcome.