### PR TITLE
Store address suggestion json in hidden form field

### DIFF
--- a/server/app/controllers/applicant/ApplicantProgramBlocksController.java
+++ b/server/app/controllers/applicant/ApplicantProgramBlocksController.java
@@ -13,7 +13,6 @@ import static views.questiontypes.ApplicantQuestionRendererParams.ErrorDisplayMo
 import auth.Authorizers;
 import auth.CiviFormProfile;
 import auth.ProfileUtils;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -78,7 +77,6 @@ import views.trustedintermediary.ApplicationBaseViewParams;
  */
 public final class ApplicantProgramBlocksController extends CiviFormController {
   private static final ImmutableSet<String> STRIPPED_FORM_FIELDS = ImmutableSet.of("csrfToken");
-  @VisibleForTesting static final String ADDRESS_JSON_SESSION_KEY = "addressJson";
 
   private final ApplicantService applicantService;
   private final MessagesApi messagesApi;
@@ -334,7 +332,8 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
     DynamicForm form = formFactory.form().bindFromRequest(request);
     Optional<String> selectedAddress =
         Optional.ofNullable(form.get(AddressCorrectionBlockView.SELECTED_ADDRESS_NAME));
-    Optional<String> maybeAddressJson = request.session().get(ADDRESS_JSON_SESSION_KEY);
+    Optional<String> maybeAddressJson =
+        Optional.ofNullable(form.get(AddressCorrectionBlockView.ADDRESS_JSON_FIELD_NAME));
 
     ImmutableList<AddressSuggestion> suggestions =
         addressSuggestionJsonSerializer.deserialize(
@@ -407,7 +406,6 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
             classLoaderExecutionContext.current())
         .thenComposeAsync(
             roApplicantProgramService -> {
-              removeAddressJsonFromSession(request);
               CiviFormProfile profile = profileUtils.currentUserProfile(request);
               return renderErrorOrRedirectToRequestedPage(
                   request,
@@ -421,19 +419,7 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
                   roApplicantProgramService);
             },
             classLoaderExecutionContext.current())
-        .exceptionally(
-            throwable -> {
-              removeAddressJsonFromSession(request);
-              return handleUpdateExceptions(throwable);
-            });
-  }
-
-  /**
-   * Clean up the address suggestions json from the session. Remove this to prevent the chance of
-   * the old session value being used on subsequent address corrections.
-   */
-  private void removeAddressJsonFromSession(Request request) {
-    request.session().removing(ADDRESS_JSON_SESSION_KEY);
+        .exceptionally(throwable -> handleUpdateExceptions(throwable));
   }
 
   /**
@@ -1636,9 +1622,9 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
                   applicationParams,
                   addressSuggestionGroup,
                   applicantRequestedAction,
-                  isEligibilityEnabledOnThisBlock))
-              .as(Http.MimeTypes.HTML)
-              .addingToSession(request, ADDRESS_JSON_SESSION_KEY, json));
+                  isEligibilityEnabledOnThisBlock,
+                  json))
+              .as(Http.MimeTypes.HTML));
     }
   }
 

--- a/server/app/views/applicant/addresscorrection/AddressCorrectionBlockTemplate.html
+++ b/server/app/views/applicant/addresscorrection/AddressCorrectionBlockTemplate.html
@@ -45,6 +45,11 @@
               th:with="suggestions=${addressSuggestionGroup.getAddressSuggestions()}"
             >
               <input hidden th:value="${csrfToken}" name="csrfToken" />
+              <input
+                type="hidden"
+                name="addressJson"
+                th:value="${addressJson}"
+              />
               <fieldset class="cf-no-margin-padding border-0">
                 <!--/* If this question is used for eligibility, we must use the corrected address */-->
                 <div th:if="${!isEligibilityEnabled}" class="usa-prose">

--- a/server/app/views/applicant/addresscorrection/AddressCorrectionBlockView.java
+++ b/server/app/views/applicant/addresscorrection/AddressCorrectionBlockView.java
@@ -25,6 +25,7 @@ public class AddressCorrectionBlockView extends ApplicantBaseView {
   // to process address correction form submissions
   public static final String USER_KEEPING_ADDRESS_VALUE = "USER_KEEPING_ADDRESS_VALUE";
   public static final String SELECTED_ADDRESS_NAME = "selectedAddress";
+  public static final String ADDRESS_JSON_FIELD_NAME = "addressJson";
 
   @Inject
   AddressCorrectionBlockView(
@@ -50,7 +51,8 @@ public class AddressCorrectionBlockView extends ApplicantBaseView {
       ApplicationBaseViewParams params,
       AddressSuggestionGroup addressSuggestionGroup,
       ApplicantRequestedAction applicantRequestedAction,
-      Boolean isEligibilityEnabled) {
+      Boolean isEligibilityEnabled,
+      String addressJson) {
     ThymeleafModule.PlayThymeleafContext context =
         createThymeleafContext(
             request,
@@ -74,6 +76,7 @@ public class AddressCorrectionBlockView extends ApplicantBaseView {
     context.setVariable("addressSuggestionGroup", addressSuggestionGroup);
     context.setVariable("isEligibilityEnabled", isEligibilityEnabled);
     context.setVariable("applicationParams", params);
+    context.setVariable("addressJson", addressJson);
 
     // Progress bar
     ProgressBar progressBar =

--- a/server/test/controllers/applicant/ApplicantProgramBlocksControllerTest.java
+++ b/server/test/controllers/applicant/ApplicantProgramBlocksControllerTest.java
@@ -1,6 +1,5 @@
 package controllers.applicant;
 
-import static controllers.applicant.ApplicantProgramBlocksController.ADDRESS_JSON_SESSION_KEY;
 import static controllers.applicant.ApplicantRequestedAction.NEXT_BLOCK;
 import static controllers.applicant.ApplicantRequestedAction.PREVIOUS_BLOCK;
 import static controllers.applicant.ApplicantRequestedAction.REVIEW_PAGE;
@@ -2887,7 +2886,10 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
 
     Request request =
         fakeRequestBuilder()
-            .session(ADDRESS_JSON_SESSION_KEY, createAddressSuggestionsJson())
+            .bodyForm(
+                ImmutableMap.of(
+                    AddressCorrectionBlockView.ADDRESS_JSON_FIELD_NAME,
+                    createAddressSuggestionsJson()))
             .build();
 
     Result result =
@@ -2915,7 +2917,10 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
 
     Request request =
         fakeRequestBuilder()
-            .session(ADDRESS_JSON_SESSION_KEY, createAddressSuggestionsJson())
+            .bodyForm(
+                ImmutableMap.of(
+                    AddressCorrectionBlockView.ADDRESS_JSON_FIELD_NAME,
+                    createAddressSuggestionsJson()))
             .build();
     Result result =
         subject
@@ -2944,7 +2949,10 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
 
     Request request =
         fakeRequestBuilder()
-            .session(ADDRESS_JSON_SESSION_KEY, createAddressSuggestionsJson())
+            .bodyForm(
+                ImmutableMap.of(
+                    AddressCorrectionBlockView.ADDRESS_JSON_FIELD_NAME,
+                    createAddressSuggestionsJson()))
             .build();
     Result result =
         subject
@@ -2971,7 +2979,10 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
 
     Request request =
         fakeRequestBuilder()
-            .session(ADDRESS_JSON_SESSION_KEY, createAddressSuggestionsJson())
+            .bodyForm(
+                ImmutableMap.of(
+                    AddressCorrectionBlockView.ADDRESS_JSON_FIELD_NAME,
+                    createAddressSuggestionsJson()))
             .build();
     Result result =
         subject
@@ -2994,7 +3005,10 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
 
     Request request =
         fakeRequestBuilder()
-            .session(ADDRESS_JSON_SESSION_KEY, createAddressSuggestionsJson())
+            .bodyForm(
+                ImmutableMap.of(
+                    AddressCorrectionBlockView.ADDRESS_JSON_FIELD_NAME,
+                    createAddressSuggestionsJson()))
             .build();
 
     Result result =
@@ -3016,7 +3030,7 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
   public void confirmAddress_noAddressJson_throws() {
     Request request =
         fakeRequestBuilder()
-            // Don't set the ADDRESS_JSON_SESSION_KEY on the session
+            // Don't set ADDRESS_JSON_FIELD_NAME in the form body
             .bodyForm(
                 ImmutableMap.of(
                     AddressCorrectionBlockView.SELECTED_ADDRESS_NAME,
@@ -3078,12 +3092,13 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
             .join();
     // Check that we're taken to the address correction screen with some suggestions
     assertThat(result.status()).isEqualTo(OK);
-    assertThat(result.session().get(ADDRESS_JSON_SESSION_KEY)).isPresent();
-
     // Then, send a confirmAddress request but don't fill in SELECTED_ADDRESS_NAME in the form body
     Request request =
         fakeRequestBuilder()
-            .session(ADDRESS_JSON_SESSION_KEY, createAddressSuggestionsJson())
+            .bodyForm(
+                ImmutableMap.of(
+                    AddressCorrectionBlockView.ADDRESS_JSON_FIELD_NAME,
+                    createAddressSuggestionsJson()))
             .build();
 
     Result confirmAddressResult =
@@ -3156,12 +3171,15 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
         addressSuggestionJsonSerializer.serialize(ImmutableList.of(addressSuggestion));
 
     // The selected address (set in the body form with the key SELECTED_ADDRESS_NAME) should match
-    // one of the address
-    // suggestions (set in the session with the key ADDRESS_JSON_SESSION_KEY).
+    // one of the address suggestions (set in the form with the key ADDRESS_JSON_FIELD_NAME).
     Request request =
         fakeRequestBuilder()
-            .session(ADDRESS_JSON_SESSION_KEY, addressSuggestionString)
-            .bodyForm(ImmutableMap.of(AddressCorrectionBlockView.SELECTED_ADDRESS_NAME, address))
+            .bodyForm(
+                ImmutableMap.of(
+                    AddressCorrectionBlockView.SELECTED_ADDRESS_NAME,
+                    address,
+                    AddressCorrectionBlockView.ADDRESS_JSON_FIELD_NAME,
+                    addressSuggestionString))
             .build();
     Result result =
         subject
@@ -3210,10 +3228,12 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
 
     Request request =
         fakeRequestBuilder()
-            .session(ADDRESS_JSON_SESSION_KEY, createAddressSuggestionsJson())
             .bodyForm(
                 ImmutableMap.of(
-                    AddressCorrectionBlockView.SELECTED_ADDRESS_NAME, SUGGESTED_ADDRESS))
+                    AddressCorrectionBlockView.SELECTED_ADDRESS_NAME,
+                    SUGGESTED_ADDRESS,
+                    AddressCorrectionBlockView.ADDRESS_JSON_FIELD_NAME,
+                    createAddressSuggestionsJson()))
             .build();
     Result result =
         subject
@@ -3257,10 +3277,12 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
 
     Request request =
         fakeRequestBuilder()
-            .session(ADDRESS_JSON_SESSION_KEY, createAddressSuggestionsJson())
             .bodyForm(
                 ImmutableMap.of(
-                    AddressCorrectionBlockView.SELECTED_ADDRESS_NAME, SUGGESTED_ADDRESS))
+                    AddressCorrectionBlockView.SELECTED_ADDRESS_NAME,
+                    SUGGESTED_ADDRESS,
+                    AddressCorrectionBlockView.ADDRESS_JSON_FIELD_NAME,
+                    createAddressSuggestionsJson()))
             .build();
     Result result =
         subject
@@ -3334,11 +3356,12 @@ public class ApplicantProgramBlocksControllerTest extends WithMockedProfiles {
     // Then, choose the original address during address correction
     Request confirmAddressRequest =
         fakeRequestBuilder()
-            .session(ADDRESS_JSON_SESSION_KEY, createAddressSuggestionsJson())
             .bodyForm(
                 ImmutableMap.of(
                     AddressCorrectionBlockView.SELECTED_ADDRESS_NAME,
-                    AddressCorrectionBlockView.USER_KEEPING_ADDRESS_VALUE))
+                    AddressCorrectionBlockView.USER_KEEPING_ADDRESS_VALUE,
+                    AddressCorrectionBlockView.ADDRESS_JSON_FIELD_NAME,
+                    createAddressSuggestionsJson()))
             .build();
 
     Result confirmAddressResult =


### PR DESCRIPTION
### Description

Moving the address suggestion json from the session to a hidden form input field. The json string has always had an HMAC signature to prevent tampering so this is safe to store here the same as it was in the session cookie.


Related to #12806

Fixes: #12813