### PR TITLE
[Session Replay] default session replay protection to true

### DIFF
--- a/server/conf/helper/feature-flags.conf
+++ b/server/conf/helper/feature-flags.conf
@@ -46,7 +46,7 @@ name_suffix_dropdown_enabled = false
 name_suffix_dropdown_enabled = ${?NAME_SUFFIX_DROPDOWN_ENABLED}
 
 # Session replay protection
-session_replay_protection_enabled = false
+session_replay_protection_enabled = true
 session_replay_protection_enabled = ${?SESSION_REPLAY_PROTECTION_ENABLED}
 
 # Custom eligibility message


### PR DESCRIPTION
### Description

Defaults session replay protection to enabled.

## Release notes

With this release, session replay protection is enabled as a security measure to prevent session hijacking and replay attacks. This means any user with an active session will be automatically logged out after a configured length of time. The default is 600 minutes (10 hours), but this can be customized by setting maximum_session_duration_minutes to the desired session duration in minutes in your deployment configuration file. To disable this feature, set session_replay_protection_enabled=false in the deployment configuration file.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.
