### PR TITLE
Stab at claude adding enum support

### DIFF
--- a/env-var-docs/parser-package/src/env_var_docs/parser.py
+++ b/env-var-docs/parser-package/src/env_var_docs/parser.py
@@ -56,6 +56,7 @@ class Variable:
     values: Union[List[str], None]
     regex: Union[str, None]
     regex_tests: Union[List[RegexTest], None]
+    enum_class: Union[str, None]
     mode: Mode
 
 
@@ -358,12 +359,21 @@ def _try_parse_variable(
         extract_fn=convert_regex_tests)
     errors.extend(errs)
 
+    # Parse the 'enum_class' field.
+    enum_class, errs = _parse_field(
+        parent_path=parent_path,
+        key="enum_class",
+        json_type=str,
+        required=False,
+        obj=obj)
+    errors.extend(errs)
+
     # Check that no other fields are defined.
     errors.extend(
         _ensure_no_extra_fields(
             parent_path, obj, [
                 "description", "type", "required", "values", "regex",
-                "regex_tests", "mode"
+                "regex_tests", "enum_class", "mode"
             ]))
 
     if len(errors) != 0:
@@ -375,7 +385,8 @@ def _try_parse_variable(
         assert required is not None
         assert mode is not None
         return Variable(
-            description, type, required, values, regex, regex_tests, mode), []
+            description, type, required, values, regex, regex_tests, enum_class,
+            mode), []
 
 
 CheckFn = typing.Callable[[str, UnparsedJSON], ParseErrors]

--- a/env-var-docs/parser-package/src/env_var_docs/settings_manifest.py
+++ b/env-var-docs/parser-package/src/env_var_docs/settings_manifest.py
@@ -165,6 +165,8 @@ class GetterMethodSpec:
         # yapf cannot handle match/case statements so we use if/else instead
         # https://github.com/google/yapf/issues/1045
         if self.variable.type == "string":
+            if self.variable.enum_class:
+                return "getEnum"
             return "getString"
         elif self.variable.type == "bool":
             return "getBool"
@@ -177,6 +179,9 @@ class GetterMethodSpec:
         # yapf cannot handle match/case statements so we use if/else instead
         # https://github.com/google/yapf/issues/1045
         if self.variable.type == "string":
+            if self.variable.enum_class:
+                simple_name = self.variable.enum_class.rsplit(".", 1)[-1]
+                return f"Optional<{simple_name}>"
             return "Optional<String>"
         elif self.variable.type == "bool":
             return "boolean"
@@ -184,6 +189,23 @@ class GetterMethodSpec:
             return "Optional<Integer>"
         elif self.variable.type == "index-list":
             return "Optional<ImmutableList<String>>"
+
+    def enum_class_arg(self):
+        if self.variable.enum_class:
+            simple_name = self.variable.enum_class.rsplit(".", 1)[-1]
+            return f", {simple_name}.class"
+        return ""
+
+
+def enum_imports(getter_method_specs: List[GetterMethodSpec]) -> List[str]:
+    """Collects unique enum class imports from all getter specs."""
+    seen = set()
+    imports = []
+    for spec in getter_method_specs:
+        if spec.variable.enum_class and spec.variable.enum_class not in seen:
+            seen.add(spec.variable.enum_class)
+            imports.append(spec.variable.enum_class)
+    return imports
 
 
 def generate_manifest(
@@ -224,6 +246,7 @@ def generate_manifest(
             sections=sections,
             getter_method_specs=getter_method_specs,
             writeable_mode=Mode.ADMIN_WRITEABLE,
+            enum_imports=enum_imports(getter_method_specs),
         ),
         [],
     )

--- a/env-var-docs/parser-package/src/env_var_docs/templates/SettingsManifest.java.jinja
+++ b/env-var-docs/parser-package/src/env_var_docs/templates/SettingsManifest.java.jinja
@@ -18,6 +18,9 @@ import java.util.Optional;
 import java.util.regex.Pattern;
 import javax.inject.Inject;
 import play.mvc.Http.RequestHeader;
+{% for enum_import in enum_imports %}
+import {{enum_import}};
+{% endfor %}
 
 /** Data class providing access to server settings. */
 public final class SettingsManifest extends AbstractSettingsManifest {
@@ -46,12 +49,12 @@ public final class SettingsManifest extends AbstractSettingsManifest {
   {% if method_spec.variable.mode == writeable_mode %}
   /** {{method_spec.doc()}} */
   public {{method_spec.return_type()}} get{{method_spec.method_name()}}(RequestHeader request) {
-    return {{method_spec.internal_getter()}}("{{method_spec.variable_name()}}", request);
+    return {{method_spec.internal_getter()}}("{{method_spec.variable_name()}}"{{method_spec.enum_class_arg()}}, request);
   }
   {% else %}
   /** {{method_spec.doc()}} */
   public {{method_spec.return_type()}} get{{method_spec.method_name()}}() {
-    return {{method_spec.internal_getter()}}("{{method_spec.variable_name()}}");
+    return {{method_spec.internal_getter()}}("{{method_spec.variable_name()}}"{{method_spec.enum_class_arg()}});
   }
   {% endif %}
   {% endfor %}

--- a/env-var-docs/parser-package/tests/parser_test.py
+++ b/env-var-docs/parser-package/tests/parser_test.py
@@ -121,6 +121,7 @@ class TestVisit(unittest.TestCase):
                     values=None,
                     regex=None,
                     regex_tests=None,
+                    enum_class=None,
                     mode=Mode.HIDDEN)),
             Node(
                 level=2,
@@ -138,6 +139,7 @@ class TestVisit(unittest.TestCase):
                     values=None,
                     regex=None,
                     regex_tests=None,
+                    enum_class=None,
                     mode=Mode.HIDDEN)),
             Node(
                 level=2,
@@ -150,6 +152,7 @@ class TestVisit(unittest.TestCase):
                     values=None,
                     regex=None,
                     regex_tests=None,
+                    enum_class=None,
                     mode=Mode.HIDDEN)),
             Node(
                 level=1,
@@ -162,6 +165,7 @@ class TestVisit(unittest.TestCase):
                     values=None,
                     regex=None,
                     regex_tests=None,
+                    enum_class=None,
                     mode=Mode.HIDDEN)),
         ]
 
@@ -396,6 +400,7 @@ class TestParseVariable(unittest.TestCase):
                         values=None,
                         regex=None,
                         regex_tests=None,
+                        enum_class=None,
                         mode=Mode.HIDDEN))
 
     def test_unrequired_fields_not_set(self):
@@ -410,6 +415,7 @@ class TestParseVariable(unittest.TestCase):
                 values=None,
                 regex=None,
                 regex_tests=None,
+                enum_class=None,
                 mode=Mode.HIDDEN))
 
     def test_required_wrong_type(self):
@@ -432,6 +438,7 @@ class TestParseVariable(unittest.TestCase):
                 values=None,
                 regex=None,
                 regex_tests=None,
+                enum_class=None,
                 mode=Mode.HIDDEN))
 
     def test_required_true(self):
@@ -447,6 +454,7 @@ class TestParseVariable(unittest.TestCase):
                 values=None,
                 regex=None,
                 regex_tests=None,
+                enum_class=None,
                 mode=Mode.HIDDEN))
 
     def test_values_wrong_type(self):
@@ -483,6 +491,27 @@ class TestParseVariable(unittest.TestCase):
                 values=["one", "two"],
                 regex=None,
                 regex_tests=None,
+                enum_class=None,
+                mode=Mode.HIDDEN))
+
+    def test_enum_class_valid(self):
+        v = dict(
+            self.basevar, **{
+                "values": ["A", "B"],
+                "enum_class": "some.EnumType"
+            })
+        got, gotErrors = _try_parse_variable("root", v)
+        self.assertEqual(gotErrors, [])
+        self.assertEqual(
+            got,
+            Variable(
+                description="Var",
+                type="string",
+                required=False,
+                values=["A", "B"],
+                regex=None,
+                regex_tests=None,
+                enum_class="some.EnumType",
                 mode=Mode.HIDDEN))
 
     def test_regex_wrong_type(self):
@@ -623,6 +652,7 @@ class TestParseVariable(unittest.TestCase):
                 values=None,
                 regex=".*",
                 regex_tests=self.basetests_parsed,
+                enum_class=None,
                 mode=Mode.HIDDEN))
 
     def test_has_only_extra_fields(self):
@@ -638,11 +668,11 @@ class TestParseVariable(unittest.TestCase):
                 ParseError("root", "'mode' is a required field"),
                 ParseError(
                     "root",
-                    "'extra' is an invalid key, valid keys are ['description', 'type', 'required', 'values', 'regex', 'regex_tests', 'mode']"
+                    "'extra' is an invalid key, valid keys are ['description', 'type', 'required', 'values', 'regex', 'regex_tests', 'enum_class', 'mode']"
                 ),
                 ParseError(
                     "root",
-                    "'field' is an invalid key, valid keys are ['description', 'type', 'required', 'values', 'regex', 'regex_tests', 'mode']"
+                    "'field' is an invalid key, valid keys are ['description', 'type', 'required', 'values', 'regex', 'regex_tests', 'enum_class', 'mode']"
                 )
             ])
         self.assertEqual(got, None)

--- a/env-var-docs/parser-package/tests/settings_manifest_test.py
+++ b/env-var-docs/parser-package/tests/settings_manifest_test.py
@@ -3,7 +3,7 @@ import os
 import unittest
 
 from env_var_docs.parser import Mode, Variable
-from env_var_docs.settings_manifest import ParsedGroup, render_sections
+from env_var_docs.settings_manifest import GetterMethodSpec, ParsedGroup, enum_imports, render_sections
 
 
 class TestGenerateSettingsManifest(unittest.TestCase):
@@ -30,6 +30,7 @@ class TestGenerateSettingsManifest(unittest.TestCase):
                                     values=None,
                                     regex=None,
                                     regex_tests=None,
+                                    enum_class=None,
                                     mode=Mode.HIDDEN,
                                 )
                         },
@@ -50,6 +51,7 @@ class TestGenerateSettingsManifest(unittest.TestCase):
                         values=None,
                         regex=None,
                         regex_tests=None,
+                        enum_class=None,
                         mode=Mode.ADMIN_READABLE,
                     ),
                 "ENUM_VARIABLE":
@@ -60,6 +62,7 @@ class TestGenerateSettingsManifest(unittest.TestCase):
                         values=["one", "two"],
                         regex=None,
                         regex_tests=None,
+                        enum_class=None,
                         mode=Mode.ADMIN_READABLE,
                     ),
                 "REGEX_VARIABLE":
@@ -70,6 +73,7 @@ class TestGenerateSettingsManifest(unittest.TestCase):
                         values=None,
                         regex="^regex$",
                         regex_tests=None,
+                        enum_class=None,
                         mode=Mode.ADMIN_READABLE,
                     ),
             },
@@ -87,3 +91,67 @@ ImmutableList.of(SettingDescription.create("STRING_VARIABLE", "Fake string varia
 SettingDescription.create("ENUM_VARIABLE", "Fake string variable for testing", /* isRequired= */ true, SettingType.ENUM, SettingMode.ADMIN_READABLE, ImmutableList.of("one", "two")), \
 SettingDescription.create("REGEX_VARIABLE", "Fake string variable for testing", /* isRequired= */ false, SettingType.STRING, SettingMode.ADMIN_READABLE, Pattern.compile("^regex$"))))).build()""",
         )
+
+
+class TestGetterMethodSpec(unittest.TestCase):
+
+    def test_string_getter(self):
+        var = Variable(
+            description="A string var",
+            type="string",
+            required=False,
+            values=None,
+            regex=None,
+            regex_tests=None,
+            enum_class=None,
+            mode=Mode.HIDDEN,
+        )
+        spec = GetterMethodSpec("MY_STRING_VAR", var)
+        self.assertEqual(spec.internal_getter(), "getString")
+        self.assertEqual(spec.return_type(), "Optional<String>")
+        self.assertEqual(spec.enum_class_arg(), "")
+
+    def test_enum_getter(self):
+        var = Variable(
+            description="An enum var",
+            type="string",
+            required=False,
+            values=["A", "B"],
+            regex=None,
+            regex_tests=None,
+            enum_class="some.EnumType",
+            mode=Mode.HIDDEN,
+        )
+        spec = GetterMethodSpec("MY_ENUM_VAR", var)
+        self.assertEqual(spec.internal_getter(), "getEnum")
+        self.assertEqual(spec.return_type(), "Optional<EnumType>")
+        self.assertEqual(spec.enum_class_arg(), ", EnumType.class")
+
+    def test_enum_imports(self):
+        var_with_enum = Variable(
+            description="An enum var",
+            type="string",
+            required=False,
+            values=["A", "B"],
+            regex=None,
+            regex_tests=None,
+            enum_class="auth.ClientIpType",
+            mode=Mode.HIDDEN,
+        )
+        var_without_enum = Variable(
+            description="A string var",
+            type="string",
+            required=False,
+            values=None,
+            regex=None,
+            regex_tests=None,
+            enum_class=None,
+            mode=Mode.HIDDEN,
+        )
+        specs = [
+            GetterMethodSpec("VAR_A", var_with_enum),
+            GetterMethodSpec("VAR_B", var_without_enum),
+            GetterMethodSpec("VAR_C", var_with_enum),
+        ]
+        result = enum_imports(specs)
+        self.assertEqual(result, ["auth.ClientIpType"])

--- a/server/app/auth/ClientIpResolver.java
+++ b/server/app/auth/ClientIpResolver.java
@@ -33,7 +33,7 @@ public final class ClientIpResolver {
     if (settingsManifest.getClientIpType().isEmpty()) {
       throw new ConfigurationException("CLIENT_IP_TYPE is not configured");
     }
-    this.clientIpType = ClientIpType.valueOf(settingsManifest.getClientIpType().orElseThrow());
+    this.clientIpType = settingsManifest.getClientIpType().orElseThrow();
   }
 
   /**

--- a/server/app/services/settings/AbstractSettingsManifest.java
+++ b/server/app/services/settings/AbstractSettingsManifest.java
@@ -168,6 +168,15 @@ public abstract class AbstractSettingsManifest {
     return getConfigVal(config::getString, getHoconName(variableName));
   }
 
+  protected <E extends Enum<E>> Optional<E> getEnum(String variableName, Class<E> enumClass) {
+    return getString(variableName).map(value -> Enum.valueOf(enumClass, value));
+  }
+
+  protected <E extends Enum<E>> Optional<E> getEnum(
+      String variableName, Class<E> enumClass, Http.RequestHeader request) {
+    return getString(variableName, request).map(value -> Enum.valueOf(enumClass, value));
+  }
+
   protected Optional<Integer> getInt(
       SettingDescription settingDescription, Http.RequestHeader request) {
     return getInt(settingDescription.variableName(), request);

--- a/server/app/services/settings/SettingsManifest.java
+++ b/server/app/services/settings/SettingsManifest.java
@@ -9,6 +9,7 @@ package services.settings;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import auth.ClientIpType;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -856,8 +857,8 @@ public final class SettingsManifest extends AbstractSettingsManifest {
    * the request is the originating IP address. If "FORWARDED" then request has been reverse proxied
    * and the originating IP address is stored in the X-Forwarded-For header.
    */
-  public Optional<String> getClientIpType() {
-    return getString("CLIENT_IP_TYPE");
+  public Optional<ClientIpType> getClientIpType() {
+    return getEnum("CLIENT_IP_TYPE", ClientIpType.class);
   }
 
   /**

--- a/server/conf/env-var-docs.json
+++ b/server/conf/env-var-docs.json
@@ -752,7 +752,8 @@
     "mode": "ADMIN_READABLE",
     "description": "Where to find the IP address for incoming requests. Default is \"DIRECT\" where the IP address of the request is the originating IP address. If \"FORWARDED\" then request has been reverse proxied and the originating IP address is stored in the X-Forwarded-For header.",
     "type": "string",
-    "values": ["DIRECT", "FORWARDED"]
+    "values": ["DIRECT", "FORWARDED"],
+    "enum_class": "auth.ClientIpType"
   },
   "NUM_TRUSTED_PROXIES": {
     "mode": "ADMIN_READABLE",

--- a/server/test/auth/ApiAuthenticatorTest.java
+++ b/server/test/auth/ApiAuthenticatorTest.java
@@ -122,7 +122,7 @@ public class ApiAuthenticatorTest {
   @Test
   public void validate_success_forwarded() {
     when(MOCK_SETTINGS_MANIFEST.getNumTrustedProxies()).thenReturn(Optional.of(1));
-    when(MOCK_SETTINGS_MANIFEST.getClientIpType()).thenReturn(Optional.of("FORWARDED"));
+    when(MOCK_SETTINGS_MANIFEST.getClientIpType()).thenReturn(Optional.of(ClientIpType.FORWARDED));
 
     var authenticator =
         new ApiAuthenticator(
@@ -192,7 +192,7 @@ public class ApiAuthenticatorTest {
   @Test
   public void validate_ipNotInSubnet_forwarded() {
     when(MOCK_SETTINGS_MANIFEST.getNumTrustedProxies()).thenReturn(Optional.of(1));
-    when(MOCK_SETTINGS_MANIFEST.getClientIpType()).thenReturn(Optional.of("FORWARDED"));
+    when(MOCK_SETTINGS_MANIFEST.getClientIpType()).thenReturn(Optional.of(ClientIpType.FORWARDED));
 
     var authenticator =
         new ApiAuthenticator(
@@ -221,7 +221,7 @@ public class ApiAuthenticatorTest {
     logger.addAppender(listAppender);
 
     when(MOCK_SETTINGS_MANIFEST.getNumTrustedProxies()).thenReturn(Optional.of(1));
-    when(MOCK_SETTINGS_MANIFEST.getClientIpType()).thenReturn(Optional.of("FORWARDED"));
+    when(MOCK_SETTINGS_MANIFEST.getClientIpType()).thenReturn(Optional.of(ClientIpType.FORWARDED));
 
     var authenticator =
         new ApiAuthenticator(

--- a/server/test/auth/ClientIpResolverTest.java
+++ b/server/test/auth/ClientIpResolverTest.java
@@ -19,7 +19,7 @@ public class ClientIpResolverTest {
 
   @Test
   public void resolveClientIp_direct() {
-    when(MOCK_SETTINGS_MANIFEST.getClientIpType()).thenReturn(Optional.of("DIRECT"));
+    when(MOCK_SETTINGS_MANIFEST.getClientIpType()).thenReturn(Optional.of(ClientIpType.DIRECT));
     var clientIpResolver = new ClientIpResolver(MOCK_SETTINGS_MANIFEST);
 
     Request request =
@@ -31,7 +31,7 @@ public class ClientIpResolverTest {
   @Test
   public void resolveClientIp_forwarded() {
     when(MOCK_SETTINGS_MANIFEST.getNumTrustedProxies()).thenReturn(Optional.of(1));
-    when(MOCK_SETTINGS_MANIFEST.getClientIpType()).thenReturn(Optional.of("FORWARDED"));
+    when(MOCK_SETTINGS_MANIFEST.getClientIpType()).thenReturn(Optional.of(ClientIpType.FORWARDED));
     var clientIpResolver = new ClientIpResolver(MOCK_SETTINGS_MANIFEST);
 
     Request request = fakeRequestBuilder().addXForwardedFor("3.3.3.3, 2.2.2.2").build();
@@ -42,7 +42,7 @@ public class ClientIpResolverTest {
   @Test
   public void resolveClientIp_forwarded_no_header() {
     when(MOCK_SETTINGS_MANIFEST.getNumTrustedProxies()).thenReturn(Optional.of(1));
-    when(MOCK_SETTINGS_MANIFEST.getClientIpType()).thenReturn(Optional.of("FORWARDED"));
+    when(MOCK_SETTINGS_MANIFEST.getClientIpType()).thenReturn(Optional.of(ClientIpType.FORWARDED));
     var clientIpResolver = new ClientIpResolver(MOCK_SETTINGS_MANIFEST);
 
     Request request = fakeRequestBuilder().remoteAddress("3.3.3.3").build();
@@ -55,7 +55,7 @@ public class ClientIpResolverTest {
   @Test
   public void resolveClientIp_overload_singleProxy() {
     when(MOCK_SETTINGS_MANIFEST.getNumTrustedProxies()).thenReturn(Optional.of(1));
-    when(MOCK_SETTINGS_MANIFEST.getClientIpType()).thenReturn(Optional.of("FORWARDED"));
+    when(MOCK_SETTINGS_MANIFEST.getClientIpType()).thenReturn(Optional.of(ClientIpType.FORWARDED));
     var clientIpResolver = new ClientIpResolver(MOCK_SETTINGS_MANIFEST);
 
     Request request = fakeRequestBuilder().addXForwardedFor("3.3.3.3, 2.2.2.2").build();
@@ -66,7 +66,7 @@ public class ClientIpResolverTest {
   @Test
   public void resolveClientIp_overload_multipleProxies_singleHeader() {
     when(MOCK_SETTINGS_MANIFEST.getNumTrustedProxies()).thenReturn(Optional.of(2));
-    when(MOCK_SETTINGS_MANIFEST.getClientIpType()).thenReturn(Optional.of("FORWARDED"));
+    when(MOCK_SETTINGS_MANIFEST.getClientIpType()).thenReturn(Optional.of(ClientIpType.FORWARDED));
     var clientIpResolver = new ClientIpResolver(MOCK_SETTINGS_MANIFEST);
 
     Request request = fakeRequestBuilder().addXForwardedFor("3.3.3.3, 2.2.2.2, 1.1.1.1").build();
@@ -77,7 +77,7 @@ public class ClientIpResolverTest {
   @Test
   public void resolveClientIp_overload_multipleProxies_multipleHeaders() {
     when(MOCK_SETTINGS_MANIFEST.getNumTrustedProxies()).thenReturn(Optional.of(2));
-    when(MOCK_SETTINGS_MANIFEST.getClientIpType()).thenReturn(Optional.of("FORWARDED"));
+    when(MOCK_SETTINGS_MANIFEST.getClientIpType()).thenReturn(Optional.of(ClientIpType.FORWARDED));
     var clientIpResolver = new ClientIpResolver(MOCK_SETTINGS_MANIFEST);
 
     Request request =
@@ -92,7 +92,7 @@ public class ClientIpResolverTest {
   @Test
   public void resolveClientIp_overload_proxyConfigurationError() {
     when(MOCK_SETTINGS_MANIFEST.getNumTrustedProxies()).thenReturn(Optional.of(2));
-    when(MOCK_SETTINGS_MANIFEST.getClientIpType()).thenReturn(Optional.of("FORWARDED"));
+    when(MOCK_SETTINGS_MANIFEST.getClientIpType()).thenReturn(Optional.of(ClientIpType.FORWARDED));
     var clientIpResolver = new ClientIpResolver(MOCK_SETTINGS_MANIFEST);
 
     Request request = fakeRequestBuilder().addXForwardedFor("1.1.1.1").build();
@@ -107,7 +107,7 @@ public class ClientIpResolverTest {
   @Test
   public void getClientIpType_forwarded() {
     when(MOCK_SETTINGS_MANIFEST.getNumTrustedProxies()).thenReturn(Optional.of(1));
-    when(MOCK_SETTINGS_MANIFEST.getClientIpType()).thenReturn(Optional.of("FORWARDED"));
+    when(MOCK_SETTINGS_MANIFEST.getClientIpType()).thenReturn(Optional.of(ClientIpType.FORWARDED));
     var clientIpResolver = new ClientIpResolver(MOCK_SETTINGS_MANIFEST);
 
     assertThat(clientIpResolver.getClientIpType()).isEqualTo(ClientIpType.FORWARDED);
@@ -116,7 +116,7 @@ public class ClientIpResolverTest {
   @Test
   public void getClientIpType_direct() {
     when(MOCK_SETTINGS_MANIFEST.getNumTrustedProxies()).thenReturn(Optional.of(1));
-    when(MOCK_SETTINGS_MANIFEST.getClientIpType()).thenReturn(Optional.of("DIRECT"));
+    when(MOCK_SETTINGS_MANIFEST.getClientIpType()).thenReturn(Optional.of(ClientIpType.DIRECT));
     var clientIpResolver = new ClientIpResolver(MOCK_SETTINGS_MANIFEST);
 
     assertThat(clientIpResolver.getClientIpType()).isEqualTo(ClientIpType.DIRECT);

--- a/server/test/controllers/FileControllerTest.java
+++ b/server/test/controllers/FileControllerTest.java
@@ -8,6 +8,7 @@ import static play.mvc.Http.Status.SEE_OTHER;
 import static play.mvc.Http.Status.UNAUTHORIZED;
 import static support.FakeRequestBuilder.fakeRequest;
 
+import auth.ClientIpType;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
@@ -32,7 +33,7 @@ public class FileControllerTest extends WithMockedProfiles {
   public void setUp() {
     resetDatabase();
     mockSettingsManifest = Mockito.mock(SettingsManifest.class);
-    when(mockSettingsManifest.getClientIpType()).thenReturn(Optional.of("FORWARDED"));
+    when(mockSettingsManifest.getClientIpType()).thenReturn(Optional.of(ClientIpType.FORWARDED));
     when(mockSettingsManifest.getAllowCiviformAdminAccessPrograms(request)).thenReturn(false);
     setupInjectorWithExtraBinding(bind(SettingsManifest.class).toInstance(mockSettingsManifest));
     controller = instanceOf(FileController.class);


### PR DESCRIPTION
### Description

Add formal support for java enum backed configuration value in our env-var/Feature-flag configurations.

## Release notes

Remove this section if the feature is still under development or if title of the pull request can be used as the default release notes description. If more detail is needed to communicate to partners the scope of the PR's changes, use this release notes section (and remove this placeholder text).

When the Release engineer creates Release Notes, they will not look for this section for Under Development tagged PRs, and will use it if present for all other PRs included in the Release Notes.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [ ] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [ ] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

#### Database evolutions

Read the guidelines [here](https://github.com/civiform/civiform/wiki/Database#writing-database-evolutions)

- [ ] Assigned two reviewers
- [ ] Guarded against already existing resources using `IF NOT EXISTS` and `IF EXISTS`
- [ ] Downs created to undo changes in Ups
- [ ] Every comment in script should begin with -- and not # --- unless it denotes Ups or Downs. See [here](https://www.playframework.com/documentation/2.9.x/Evolutions) for details.
- [ ] Tested both the Downs and the Ups scripts manually (When testing, include all comments from the evolution in your test script to ensure any syntax errors in the comments are caught.)
- [ ] Data migrations aren't being done (please use a [Durable Job](https://github.com/civiform/civiform/wiki/Database#durable-jobs-for-data-updates) if doing a data migration)
- [ ] Update the model documentation in our [wiki](https://github.com/civiform/civiform/wiki/Database) if necessary

#### Durable jobs

Read the docs [here](https://github.com/civiform/civiform/wiki/Database#durable-jobs-for-data-updates)

- [ ] Assigned two reviewers
- [ ] Included a rollback plan and a job to undo the data changes if appropriate

#### User visible changes

- [ ] Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
  - [ ] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [ ] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order
- [ ] Performed manual accessibility tests for any applicant-facing changes or any new admin-facing features. See [manual-accessibility-testing](https://github.com/civiform/civiform/wiki/Accessibility#manual-accessibility-testing)
- [ ] Manually tested with a right-to-left language

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/helper/feature-flags.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://github.com/civiform/civiform/wiki/Feature-Flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Instructions for manual testing

If instructions are needed for manual testing by reviewers, include them here.

### Issue(s) this completes

Fixes #<issue_number>; Fixes #<issue_number>...
