### PR TITLE
Prevent users from adding questions to repeated sets until questions exist

### DIFF
--- a/browser-test/src/end_to_end_enumerators.test.ts
+++ b/browser-test/src/end_to_end_enumerators.test.ts
@@ -959,7 +959,7 @@ test.describe('End to end enumerator test with enumerators feature flag on', () 
       })
       const repeatedSetAlert = blockPanel.getByRole('alert').filter({
         hasText:
-          'To add questions to this repeated screen, first select or create and save a repeated set question on the parent repeated set screen.',
+          'A repeated set question must first be added before repeated questions can be. Please navigate to the parent screen to add a repeated set question.',
       })
 
       await test.step('Add a new repeated set and verify repeated screen is selected', async () => {

--- a/server/app/views/admin/programs/ProgramBlocksView.java
+++ b/server/app/views/admin/programs/ProgramBlocksView.java
@@ -598,7 +598,7 @@ public final class ProgramBlocksView extends ProgramBaseView {
     if (enumeratorImprovementsEnabled && blockDefinition.isRepeated()) {
       optionalParentEnumeratorBlock = optionallyGetParentEnumeratorBlock(program, blockDefinition);
       isEnumeratorBlockComplete =
-          optionalParentEnumeratorBlock.map(block -> block.getQuestionCount() > 0).orElse(false);
+          optionalParentEnumeratorBlock.map(block -> block.hasEnumeratorQuestion()).orElse(false);
     }
 
     DivTag blockInfoDisplay =

--- a/server/conf/i18n/messages
+++ b/server/conf/i18n/messages
@@ -1176,7 +1176,7 @@ input.repeatedSet.minEntities=Minimum entity count
 # A form field where admins set the maximum number of entities that applicants can list
 input.repeatedSet.maxEntities=Maximum entity count
 # Alert shown to notify admins that repeated-screen questions are blocked until an enumerator question is saved.
-alert.repeatedSet.addQuestionDisabled=To add questions to this repeated screen, first select or create and save a repeated set question on the parent repeated set screen.
+alert.repeatedSet.addQuestionDisabled=A repeated set question must first be added before repeated questions can be. Please navigate to the parent screen to add a repeated set question.
 # Alert shown to notify admin that creating a new repeated set will add a new question to the question bank
 alert.repeatedSet.newQuestion=Creating a repeated set will add a new question to the question bank.
 # Submission button for creating a new repeated set

--- a/server/test/controllers/admin/AdminProgramBlocksControllerTest.java
+++ b/server/test/controllers/admin/AdminProgramBlocksControllerTest.java
@@ -247,39 +247,6 @@ public class AdminProgramBlocksControllerTest extends ResetPostgres {
   }
 
   @Test
-  public void edit_repeatedBlockWithoutSavedEnumeratorQuestion_disablesAddQuestionWithAlert()
-      throws Exception {
-    ProgramModel program = ProgramBuilder.newDraftProgram().build();
-
-    Request createRequest =
-        fakeRequestBuilder()
-            .addCiviFormSetting("ENUMERATOR_IMPROVEMENTS_ENABLED", "true")
-            .bodyForm(ImmutableMap.of("blockType", "ENUMERATOR"))
-            .build();
-    Result createResult = controller.create(createRequest, program.id);
-
-    assertThat(createResult.status()).isEqualTo(SEE_OTHER);
-    assertThat(createResult.redirectLocation())
-        .hasValue(
-            routes.AdminProgramBlocksController.edit(program.id, /* blockDefinitionId= */ 3L)
-                .url());
-
-    Request editRequest =
-        fakeRequestBuilder().addCiviFormSetting("ENUMERATOR_IMPROVEMENTS_ENABLED", "true").build();
-    Result editResult = controller.edit(editRequest, program.id, /* blockId= */ 3L);
-
-    assertThat(editResult.status()).isEqualTo(OK);
-    String html = contentAsString(editResult);
-    assertThat(html)
-        .contains(
-            "To add questions to this repeated screen, first select or create and save a"
-                + " repeated set question on the parent repeated set screen.")
-        .contains("cf-open-question-bank-button")
-        .contains("Add a question")
-        .contains("disabled");
-  }
-
-  @Test
   public void edit_withNewlyCreatedQuestionId_autoAddsQuestionAndRedirects() {
     ProgramModel program = ProgramBuilder.newDraftProgram().build();
     QuestionModel question = testQuestionBank.nameApplicantName();


### PR DESCRIPTION
### Description

Prevent users from adding questions to repeated set screens until the parent screen has a saved question.

Parent screen does not have a saved question:
<img width="906" height="343" alt="Screenshot 2026-02-26 at 7 09 07 PM" src="https://github.com/user-attachments/assets/b054816f-5999-4a11-bafd-d789a0c6940c" />

Parent screen does have a saved question:
<img width="888" height="305" alt="Screenshot 2026-02-26 at 7 09 15 PM" src="https://github.com/user-attachments/assets/5a394354-33ad-4ff5-962e-0ea4efa211ad" />

Unit and browser tests assisted by Claude.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [x] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [x] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [x] Noted in the PR description which, if any, code in this PR was generated by AI.

### Instructions for manual testing

1. Log in as a Civiform admin
2. Create a program and create a repeated screen
3. Go to the child screen and affirm that adding a question is disabled.
4. Now, go back to the parent repeated screen and create and save a question.
5. Go back to the child screen and affirm that adding a question is enabled.

### Issue(s) this completes

Fixes #12060
