### PR TITLE
Stream CSV export to HTTP response to prevent memory buffering and OO…

### DIFF
--- a/server/app/controllers/admin/AdminApplicationController.java
+++ b/server/app/controllers/admin/AdminApplicationController.java
@@ -17,22 +17,33 @@ import controllers.BadRequestException;
 import controllers.CiviFormController;
 import controllers.FlashKey;
 import forms.admin.BulkStatusUpdateForm;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeParseException;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import javax.inject.Inject;
 import models.ApplicationModel;
 import models.LifecycleStage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.pac4j.play.java.Secure;
 import play.data.Form;
 import play.data.FormFactory;
 import play.i18n.Messages;
 import play.i18n.MessagesApi;
 import play.mvc.Http;
+import play.mvc.HttpExecutionContext;
 import play.mvc.Result;
 import repository.SubmittedApplicationFilter;
 import repository.TimeFilter;
@@ -69,6 +80,8 @@ import views.admin.programs.ProgramApplicationView;
 /** Controller for admins viewing applications to programs. */
 public final class AdminApplicationController extends CiviFormController {
   private static final int PAGE_SIZE_BULK_STATUS = 100;
+  private static final Logger logger = LoggerFactory.getLogger(AdminApplicationController.class);
+  private static final long CSV_WRITE_TIMEOUT_SECONDS = 120;
 
   private static final String REDIRECT_URI_KEY = "redirectUri";
 
@@ -86,6 +99,7 @@ public final class AdminApplicationController extends CiviFormController {
   private final StatusService statusService;
   private final ProgramApplicationTableView tableView;
   private final SettingsManifest settingsManifest;
+  private final HttpExecutionContext httpExecutionContext;
 
   public enum RelativeTimeOfDay {
     UNKNOWN,
@@ -112,7 +126,8 @@ public final class AdminApplicationController extends CiviFormController {
       VersionRepository versionRepository,
       StatusService statusService,
       ProgramApplicationTableView tableView,
-      SettingsManifest settingsManifest) {
+      SettingsManifest settingsManifest,
+      HttpExecutionContext httpExecutionContext) {
     super(profileUtils, versionRepository);
     this.programService = checkNotNull(programService);
     this.applicantService = checkNotNull(applicantService);
@@ -128,6 +143,7 @@ public final class AdminApplicationController extends CiviFormController {
     this.statusService = checkNotNull(statusService);
     this.tableView = checkNotNull(tableView);
     this.settingsManifest = checkNotNull(settingsManifest);
+    this.httpExecutionContext = checkNotNull(httpExecutionContext);
   }
 
   /** Download a JSON file containing all applications to all versions of the specified program. */
@@ -199,36 +215,84 @@ public final class AdminApplicationController extends CiviFormController {
       return unauthorized();
     }
     boolean shouldApplyFilters = ignoreFilters.orElse("").isEmpty();
+    SubmittedApplicationFilter filters = SubmittedApplicationFilter.EMPTY;
+    if (shouldApplyFilters) {
+      filters =
+          SubmittedApplicationFilter.builder()
+              .setSearchNameFragment(search)
+              .setSubmitTimeFilter(
+                  TimeFilter.builder()
+                      .setFromTime(
+                          parseDateTimeFromQuery(dateConverter, fromDate, RelativeTimeOfDay.START))
+                      .setUntilTime(
+                          parseDateTimeFromQuery(dateConverter, untilDate, RelativeTimeOfDay.END))
+                      .build())
+              .setApplicationStatus(applicationStatus)
+              .setLifecycleStages(ImmutableList.of(LifecycleStage.ACTIVE, LifecycleStage.OBSOLETE))
+              .build();
+    }
+
+    ProgramDefinition program = programService.getFullProgramDefinition(programId);
     try {
-      SubmittedApplicationFilter filters = SubmittedApplicationFilter.EMPTY;
-      if (shouldApplyFilters) {
-        filters =
-            SubmittedApplicationFilter.builder()
-                .setSearchNameFragment(search)
-                .setSubmitTimeFilter(
-                    TimeFilter.builder()
-                        .setFromTime(
-                            parseDateTimeFromQuery(
-                                dateConverter, fromDate, RelativeTimeOfDay.START))
-                        .setUntilTime(
-                            parseDateTimeFromQuery(dateConverter, untilDate, RelativeTimeOfDay.END))
-                        .build())
-                .setApplicationStatus(applicationStatus)
-                .setLifecycleStages(
-                    ImmutableList.of(LifecycleStage.ACTIVE, LifecycleStage.OBSOLETE))
-                .build();
-      }
-      ProgramDefinition program = programService.getFullProgramDefinition(programId);
       checkProgramAdminAuthorization(request, program.adminName()).join();
-      String filename = String.format("%s-%s.csv", program.adminName(), nowProvider.get());
-      String csv = exporterService.getProgramAllVersionsCsv(programId, filters);
-      return ok(csv)
-          .as(Http.MimeTypes.BINARY)
-          .withHeader(
-              "Content-Disposition", String.format("attachment; filename=\"%s\"", filename));
     } catch (CompletionException | MissingOptionalException e) {
       return unauthorized();
     }
+
+    String filename = String.format("%s-%s.csv", program.adminName(), nowProvider.get());
+
+    PipedInputStream inputStream = new PipedInputStream(256 * 1024);
+    PipedOutputStream outputStream;
+    try {
+      outputStream = new PipedOutputStream(inputStream);
+    } catch (IOException e) {
+      logger.error("Failed to create piped stream for CSV export: {}", e.getMessage());
+      return internalServerError("Unable to create download stream");
+    }
+
+    CompletableFuture.runAsync(
+            () -> {
+              try (OutputStream safeStream = outputStream) {
+                logger.debug("Starting CSV export for program {}", programId);
+                exporterService.writeProgramAllVersionsCsv(programId, filters, safeStream);
+                logger.debug("CSV export completed successfully for program {}", programId);
+              } catch (IOException e) {
+                logger.warn(
+                    "Client disconnected during CSV download for program {}: {}",
+                    programId,
+                    e.getMessage());
+              } catch (ProgramNotFoundException e) {
+                logger.error("Program not found during CSV export: {}", programId);
+                closeStreamWithError(inputStream);
+              } catch (Exception e) {
+                logger.error(
+                    "Unexpected error during CSV export for program {}: {}",
+                    programId,
+                    e.getMessage(),
+                    e);
+                closeStreamWithError(inputStream);
+              }
+            },
+            httpExecutionContext.current())
+        .orTimeout(CSV_WRITE_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        .exceptionally(
+            ex -> {
+              if (ex instanceof TimeoutException || ex.getCause() instanceof TimeoutException) {
+                logger.error(
+                    "CSV export timeout exceeded ({} sec) for program {}",
+                    CSV_WRITE_TIMEOUT_SECONDS,
+                    programId);
+              } else {
+                logger.error("CSV export task failed for program {}: {}", programId, ex.getMessage(), ex);
+              }
+              closeStreamWithError(inputStream);
+              return null;
+            });
+
+    return ok()
+        .sendInputStream(() -> inputStream)
+        .as("text/csv; charset=utf-8")
+        .withHeader("Content-Disposition", String.format("attachment; filename=\"%s\"", filename));
   }
 
   /**
@@ -269,10 +333,55 @@ public final class AdminApplicationController extends CiviFormController {
             .setUntilTime(parseDateTimeFromQuery(dateConverter, untilDate, RelativeTimeOfDay.END))
             .build();
     String filename = String.format("demographics-%s.csv", nowProvider.get());
-    String csv = exporterService.getDemographicsCsv(submitTimeFilter);
-    return ok(csv)
-        .as(Http.MimeTypes.BINARY)
+
+    PipedInputStream inputStream = new PipedInputStream(256 * 1024);
+    PipedOutputStream outputStream;
+    try {
+      outputStream = new PipedOutputStream(inputStream);
+    } catch (IOException e) {
+      logger.error("Failed to create piped stream for demographics export: {}", e.getMessage());
+      return internalServerError("Unable to create download stream");
+    }
+
+    CompletableFuture.runAsync(
+            () -> {
+              try (OutputStream safeStream = outputStream) {
+                logger.debug("Starting demographics CSV export");
+                exporterService.writeDemographicsCsv(submitTimeFilter, safeStream);
+                logger.debug("Demographics CSV export completed successfully");
+              } catch (IOException e) {
+                logger.warn("Client disconnected during demographics download: {}", e.getMessage());
+              } catch (Exception e) {
+                logger.error("Unexpected error during demographics export: {}", e.getMessage(), e);
+                closeStreamWithError(inputStream);
+              }
+            },
+            httpExecutionContext.current())
+        .orTimeout(CSV_WRITE_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        .exceptionally(
+            ex -> {
+              if (ex instanceof TimeoutException || ex.getCause() instanceof TimeoutException) {
+                logger.error(
+                    "Demographics export timeout exceeded ({} sec)", CSV_WRITE_TIMEOUT_SECONDS);
+              } else {
+                logger.error("Demographics export task failed: {}", ex.getMessage(), ex);
+              }
+              closeStreamWithError(inputStream);
+              return null;
+            });
+
+    return ok()
+        .sendInputStream(() -> inputStream)
+        .as("text/csv; charset=utf-8")
         .withHeader("Content-Disposition", String.format("attachment; filename=\"%s\"", filename));
+  }
+
+  private void closeStreamWithError(InputStream stream) {
+    try {
+      stream.close();
+    } catch (IOException e) {
+      logger.debug("Error closing stream after export failure: {}", e.getMessage());
+    }
   }
 
   /** Download a PDF file of the application to the program. */

--- a/server/app/services/export/CsvExporterService.java
+++ b/server/app/services/export/CsvExporterService.java
@@ -72,6 +72,14 @@ public final class CsvExporterService {
 
   /** Return a string containing a CSV of all applications at all versions of particular program. */
   public String getProgramAllVersionsCsv(long programId, SubmittedApplicationFilter filters)
+       throws ProgramNotFoundException {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    writeProgramAllVersionsCsv(programId, filters, baos);
+    return baos.toString(StandardCharsets.UTF_8);
+  }
+
+  public void writeProgramAllVersionsCsv(
+      long programId, SubmittedApplicationFilter filters, OutputStream outputStream)
       throws ProgramNotFoundException {
     ImmutableMap<Long, ProgramDefinition> programDefinitionsForAllVersions =
         programService.getAllVersionsFullProgramDefinition(programId).stream()
@@ -90,13 +98,14 @@ public final class CsvExporterService {
         generateCsvConfig(
             applications, programDefinitionsForAllVersions, currentProgram.hasEligibilityEnabled());
 
-    return exportCsv(
+    exportCsvToStream(
         exportConfig,
         applications,
         // Use our local program definition cache when exporting applications,
         // it's faster then the cache in the ProgramRepository.
         programDefinitionsForAllVersions::get,
-        Optional.of(currentProgram));
+        Optional.of(currentProgram),
+        outputStream);
   }
 
   private CsvExportConfig generateCsvConfig(
@@ -135,45 +144,40 @@ public final class CsvExporterService {
    * @param getProgramDefinition a function used to retrieve the ProgramDefinition by ID
    * @param currentProgram the current program definition
    */
-  private String exportCsv(
+  private void exportCsvToStream(
       CsvExportConfig exportConfig,
       ImmutableList<ApplicationModel> applications,
       Function<Long, ProgramDefinition> getProgramDefinition,
-      Optional<ProgramDefinition> currentProgram) {
-    OutputStream inMemoryBytes = new ByteArrayOutputStream();
-    try (Writer writer = new OutputStreamWriter(inMemoryBytes, StandardCharsets.UTF_8)) {
-      try (CsvExporter csvExporter =
-          new CsvExporter(
-              exportConfig.columns(),
-              config.getString("play.http.secret.key"),
-              writer,
-              dateConverter)) {
-        boolean shouldCheckEligibility =
-            currentProgram.isPresent() && currentProgram.get().hasEligibilityEnabled();
+      Optional<ProgramDefinition> currentProgram,
+      OutputStream outputStream) {
+    try (Writer writer = new OutputStreamWriter(outputStream, StandardCharsets.UTF_8);
+        CsvExporter csvExporter =
+            new CsvExporter(
+                exportConfig.columns(),
+                config.getString("play.http.secret.key"),
+                writer,
+                dateConverter)) {
+      boolean shouldCheckEligibility =
+          currentProgram.isPresent() && currentProgram.get().hasEligibilityEnabled();
 
-        for (ApplicationModel application : applications) {
-          ProgramDefinition programDefForApplication =
-              getProgramDefinition.apply(application.getProgram().id);
-          ReadOnlyApplicantProgramService roApplicantService =
-              applicantService.getReadOnlyApplicantProgramService(
-                  application, programDefForApplication);
+      for (ApplicationModel application : applications) {
+        ProgramDefinition programDefForApplication = getProgramDefinition.apply(application.getProgram().id);
+        ReadOnlyApplicantProgramService roApplicantService =
+            applicantService.getReadOnlyApplicantProgramService(application, programDefForApplication);
 
-          Optional<Boolean> optionalEligibilityStatus =
-              shouldCheckEligibility
-                  ? applicantService.getApplicationEligibilityStatus(
-                      application, programDefForApplication)
-                  : Optional.empty();
+        Optional<Boolean> optionalEligibilityStatus =
+            shouldCheckEligibility
+                ? applicantService.getApplicationEligibilityStatus(application, programDefForApplication)
+                : Optional.empty();
 
-          csvExporter.exportRecord(
-              application, roApplicantService, optionalEligibilityStatus, programDefForApplication);
-        }
+        csvExporter.exportRecord(
+            application, roApplicantService, optionalEligibilityStatus, programDefForApplication);
       }
+
+      writer.flush();
     } catch (IOException e) {
-      // Since it's an in-memory writer, this shouldn't happen.  Catch so that callers don't
-      // have to deal with it.
       throw new RuntimeException(e);
     }
-    return inMemoryBytes.toString();
   }
 
   /**
@@ -242,6 +246,12 @@ public final class CsvExporterService {
    * TODO(#6746): Include repeated questions in the demographic export
    */
   public String getDemographicsCsv(TimeFilter filter) {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        writeDemographicsCsv(filter, baos);
+        return baos.toString(StandardCharsets.UTF_8);
+    }
+
+    public void writeDemographicsCsv(TimeFilter filter, OutputStream outputStream) {
     // Use the ProgramDefinition cache in the ProgramRepository, since we don't already have a local
     // cache of ProgramDefinitions. This will cause a database call for program definitions that
     // aren't yet in the cache.
@@ -257,11 +267,12 @@ public final class CsvExporterService {
             throw new RuntimeException(e);
           }
         };
-    return exportCsv(
+    exportCsvToStream(
         getDemographicsExporterConfig(),
         applicantService.getApplications(filter),
         getProgramDefinition,
-        /* currentProgram= */ Optional.empty());
+        /* currentProgram= */ Optional.empty(),
+        outputStream);
   }
 
   private CsvExportConfig getDemographicsExporterConfig() {


### PR DESCRIPTION
What This Patch Does:

This patch converts CSV export from in-memory buffering to true HTTP streaming.

Previously, CSV data could be accumulated in memory using a ByteArrayOutputStream, which poses a memory risk when exporting large datasets.

This patch ensures:

->CSV data is written directly to the HTTP response stream
->No full-file buffering occurs in application memory
->Export runs asynchronously using CompletableFuture
->Export is protected with a timeout
->Client disconnects are handled gracefully

How It Works:

->A PipedInputStream and PipedOutputStream pair is created.
->The CSV exporter writes directly to the PipedOutputStream.
->Play reads from the PipedInputStream and streams data to the client.
->Writing occurs in a background thread using CompletableFuture.
->Timeout protection ensures long-running exports are terminated safely.
->This design allows data to flow incrementally without accumulating the full CSV in memory.