### PR TITLE
[Session Timeout] add redirectTo param to log back in call

### DIFF
--- a/server/app/assets/javascripts/session.test.ts
+++ b/server/app/assets/javascripts/session.test.ts
@@ -460,7 +460,9 @@ describe('SessionTimeoutHandler', () => {
         ) as HTMLButtonElement
         loginButton?.click()
 
-        expect(window.location.href).toBe('/logBackIn')
+        expect(window.location.href).toBe(
+          `/logBackIn?redirectTo=${encodeURIComponent(window.location.pathname + window.location.search)}`,
+        )
       })
 
       it('handles inactivity cancel button click', () => {

--- a/server/app/assets/javascripts/session.ts
+++ b/server/app/assets/javascripts/session.ts
@@ -368,6 +368,9 @@ export class SessionTimeoutHandler {
    * Initiates login.
    */
   private static login() {
-    window.location.href = '/logBackIn'
+    const redirectTo = encodeURIComponent(
+      window.location.pathname + window.location.search,
+    )
+    window.location.href = `/logBackIn?redirectTo=${redirectTo}`
   }
 }


### PR DESCRIPTION
### Description

Redirects back to the previous page the user was on when logging in from the session length modal.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [x] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [x] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [x] Noted in the PR description which, if any, code in this PR was generated by AI.

### Instructions for manual testing

1. Update `application.dev.conf` with session timeout variables.
(We are intentionally making inactivity long so we hit the session duration one first, for easier testing)
```
session_inactivity_timeout_minutes = 7
session_inactivity_warning_threshold_minutes = 1
session_duration_warning_threshold_minutes = 1
maximum_session_duration_minutes = 2
```
2. Start the application locally
3. In the admin settings panel, set SESSION_TIMEOUT_ENABLED to true
> 1. Log in
> 2. Start an application (note which page you are on)
> 3. Wait ~1 mins
> 4. Confirm the session length warning modal has popped up
> 5. Click `Log in` on the modal
> 6. Confirm you are back at the page from step 2

### Issue(s) this completes

Fixes #12644