### PR TITLE
Remove the note from issue_within_epic.md template

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue_within_epic.md
+++ b/.github/ISSUE_TEMPLATE/issue_within_epic.md
@@ -8,8 +8,6 @@ epic: ''
 status: ''
 ---
 
-> **NOTE:** This template should only be used when creating an issue for an epic contained in the `CiviForm Project Roadmap & Tracker` project.
-
 ### Checklist (remove this section after completion):
 
 - [ ] Add the correct epic label to the 'epic' category


### PR DESCRIPTION
### Description

Removed the note saying that you should only use this template for issues in the CiviForm `CiviForm Project Roadmap & Tracker` project since it's a very handy template when you're creating an issue on an epic board.
