### PR TITLE
Set maximum sizes for caches

### DIFF
--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -326,6 +326,28 @@ play.cache {
   # The civiform-settings cache is managed by the SettingsCacheMaintainer and
   # should not expire.
   caffeine.civiform-settings.expire-after-write = "infinite"
+
+  # Set maximum sizes for caches to enable LRU eviction of older entries.
+  #
+  # WARNING: Memory estimates are unreliable for Ebean model caches.
+  # These caches store Ebean models (ProgramModel, QuestionModel, VersionModel)
+  # which contain BeanCollections that may be lazy-loaded after caching. Since
+  # Caffeine caches by reference, any code that reads from cache and triggers
+  # lazy-loading mutates the cached object, potentially inflating its size.
+  #
+  # Only full-program-definition is predictable as it stores immutable
+  # ProgramDefinition value objects.
+  #
+  # These entry limits are guesses. LRU eviction provides a safety
+  # valve but actual memory usage may vary significantly. A very rough
+  # estimate puts the worst-case memory usage of 100 entries for all
+  # caches with full objects at around 2.6GB, but this is unlikely to actually
+  # materialize in practice.
+  caffeine.version-programs.maximum-size = 100
+  caffeine.version-questions.maximum-size = 100
+  caffeine.full-program-definition.maximum-size = 100
+  caffeine.program.maximum-size = 100
+  caffeine.program-versions.maximum-size = 100
 }
 
 ## Security rules for play-pac4j SecurityFilter


### PR DESCRIPTION
When we don't set size limits for our NamedCaches, they default to unlimited. This means that if we ever end uploading a bunch of different programs/questions, like we do in the CalculateEligibilityDetermination DurableJob or in the API, we run the risk of the caches filling up the heap and causing the server to crash with out of memory errors.

The maximum amount of memory that could be used by 100 completely hydrated objects in the caches is hard to estimate, but some back-of-the-hand math puts it at perhaps 2.6GB or so in a roughly worst case. So we'll also be looking to bump up the heap size as well in a different commit.

### Checklist

Remove any sections below that do not apply to your PR. For sections that do apply, complete all of the appropriate checklist items and check them off. If a checklist item doesn't apply to your PR, leave it unchecked but do not delete it.

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [x] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

### Instructions for manual testing

Should be transparent to all testing and workflows, but ensure nothing weird is seen.

### Issue(s) this completes

Does not complete a specific issue, but is likely one fix for [the CalculateEligibilityDetermination job causing the system to go down in Seattle.](https://github.com/civiform/civiform/issues/12749)
