### PR TITLE
Clean up Settings code and add tests

### DIFF
--- a/server/app/services/settings/AbstractSettingsManifest.java
+++ b/server/app/services/settings/AbstractSettingsManifest.java
@@ -57,7 +57,7 @@ public abstract class AbstractSettingsManifest {
   }
 
   private ImmutableList<SettingDescription> getAllFeatureFlagsSettingDescriptions() {
-    return Optional.ofNullable(getSections())
+    return Optional.of(getSections())
         .map(m -> m.get(FEATURE_FLAG_SETTING_SECTION_NAME))
         .map(this::getSettingDescriptions)
         .orElseGet(ImmutableList::of);

--- a/server/test/services/settings/SettingsManifestTest.java
+++ b/server/test/services/settings/SettingsManifestTest.java
@@ -262,7 +262,7 @@ public class SettingsManifestTest {
                 "TEST_SECTION",
                 SettingsSection.create(
                     "Test Section",
-                    "Fake section.",
+                    "Fake section",
                     ImmutableList.of(),
                     ImmutableList.of(BOOL_VARIABLE))),
             CONFIG);


### PR DESCRIPTION
### Description

Clean up Settings code by:
1.  Reducing containsKey/getKey style  to getOptional()/isPresent(), as well are duplication of them.
2. Handling null values better through Optional chaining.
3. Reducing duplication in the "default" return value computation.

Additionally this PR adds testing as generated by Claude.  The tests were added before the tested-code changes.

### Checklist

Remove any sections below that do not apply to your PR. For sections that do apply, complete all of the appropriate checklist items and check them off. If a checklist item doesn't apply to your PR, leave it unchecked but do not delete it.

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [ ] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [x] Noted in the PR description which, if any, code in this PR was generated by AI.

