### PR TITLE
Fix bulk status update when no applications are selected

### DIFF
--- a/server/app/controllers/admin/AdminApplicationController.java
+++ b/server/app/controllers/admin/AdminApplicationController.java
@@ -574,6 +574,21 @@ public final class AdminApplicationController extends CiviFormController {
     var applicationIdList =
         form.get().getApplicationsIds().stream().collect(ImmutableList.toImmutableList());
 
+    if (applicationIdList.isEmpty()) {
+      return redirect(
+          routes.AdminApplicationController.index(
+                  programId,
+                  /* search= */ Optional.empty(),
+                  /* page= */ Optional.empty(),
+                  /* fromDate= */ Optional.empty(),
+                  /* untilDate= */ Optional.empty(),
+                  /* applicationStatus= */ Optional.empty(),
+                  Optional.empty(),
+                  /* showDownloadModal= */ Optional.empty(),
+                  /* message= */ Optional.of(
+                      "Select at least one application before changing status"))
+              .url());
+    }
     boolean sendEmail = form.get().getShouldSendEmail();
     programAdminApplicationService.setStatuses(
         applicationIdList,

--- a/server/test/controllers/admin/AdminApplicationControllerTest.java
+++ b/server/test/controllers/admin/AdminApplicationControllerTest.java
@@ -690,6 +690,36 @@ public class AdminApplicationControllerTest extends ResetPostgres {
   }
 
   @Test
+  public void updateStatuses_noApplicationsSelected_redirectsWithMessage() throws Exception {
+    AccountModel adminAccount = resourceCreator.insertAccount();
+    controller = makeNoOpProfileController(Optional.of(adminAccount));
+    ProgramModel program = ProgramBuilder.newActiveProgram("test name", "test description").build();
+    repo.createOrUpdateStatusDefinitions(
+        program.getProgramDefinition().adminName(), new StatusDefinitions(ORIGINAL_STATUSES));
+    ApplicantModel applicant =
+        resourceCreator.insertApplicantWithAccount(Optional.of("user@example.com"));
+    ApplicationModel application =
+        ApplicationModel.create(applicant, program, LifecycleStage.ACTIVE).setSubmitTimeToNow();
+
+    Request request =
+        fakeRequestBuilder()
+            .bodyForm(
+                ImmutableMap.of(
+                    "statusText", APPROVED_STATUS.statusText(),
+                    "shouldSendEmail", "false"))
+            .build();
+
+    Result result = controller.updateStatuses(request, program.id);
+
+    assertThat(result.status()).isEqualTo(SEE_OTHER);
+    assertThat(result.redirectLocation()).isPresent();
+    assertThat(result.redirectLocation().get())
+        .contains("message=Select+at+least+one+application+before+changing+status");
+    application.refresh();
+    assertThat(application.getApplicationEvents()).isEmpty();
+  }
+
+  @Test
   public void updateStatus_emptySendEmail_succeeds() throws Exception {
     // Setup
     AccountModel adminAccount = resourceCreator.insertAccount();


### PR DESCRIPTION
## Summary
- add a guard in updateStatuses to handle empty application selection
- redirect back to the applications page with an inline error message instead of triggering a server error
- add a controller test that verifies redirect behavior and ensures no events are created

Closes #12152