### PR TITLE
[Session Timeout] enable session timeout by default in dev and clean up old feature flags

### DIFF
--- a/server/conf/application.dev.conf
+++ b/server/conf/application.dev.conf
@@ -83,8 +83,10 @@ esri_address_service_area_validation_attributes = ["CITYNAME"]
 # Allow any IP for local development
 api_keys_ban_global_subnet = false
 
-# Allow dev sessions to last 5 days
+# Allow dev sessions to last 5 days total
 maximum_session_duration_minutes = 7200
+# Allow dev sessions to last 4 days without activity
+session_inactivity_timeout_minutes= 5760
 
 # Feature flags
 program_filtering_enabled = true


### PR DESCRIPTION
### Description

- Enabled session timeout by default in dev
  - session inactivity timeout is 4 days
  - session length timeout is 5 days

- Removed deprecated feature flags
  - map_question_enabled (entirely removed already)
  - session_replay_protection_enabled (enabled by default)