### PR TITLE
Test for null questions

### DIFF
--- a/server/test/repository/ProgramRepositoryTest.java
+++ b/server/test/repository/ProgramRepositoryTest.java
@@ -407,50 +407,44 @@ public class ProgramRepositoryTest extends ResetPostgres {
   public void createOrUpdateDraft_programModelWithNullQuestion_doesNotSaveNullQuestionToDraft() {
     // This test demonstrates the bug: createOrUpdateDraft(ProgramModel) calls
     // getShallowProgramDefinition which, on a cache miss, falls back to
-    // program.getProgramDefinition(). That definition can contain null-question sentinels
-    // (e.g. when a ProgramModel is constructed in memory with unresolved question
-    // references). On the update-existing-draft path there is no null-question guard,
-    // so the incomplete definition is persisted directly to the DB.
+    // program.getProgramDefinition(). That definition can contain null-question sentinels.
+    // On the update-existing-draft path there is no null-question guard, so the incomplete
+    // definition is persisted directly to the DB.
 
-    // Build an active program with a real question so a draft can be created.
-    QuestionModel realQuestion = resourceCreator.insertQuestion("realQuestion");
-    ProgramModel activeProgram =
-        ProgramBuilder.newActiveProgram("nullQuestionProg")
-            .withBlock("Screen 1")
-            .withRequiredQuestion(realQuestion)
-            .build();
-
-    // Create an initial draft — the next call to createOrUpdateDraft will take
-    // the update-existing-draft branch (lines 250-267) rather than creating a new one.
+    // Create an active program (no questions) and an initial draft so that the second
+    // createOrUpdateDraft call takes the update-existing-draft path (lines 250-267).
+    ProgramModel activeProgram = resourceCreator.insertActiveProgram("nullQuestionProg");
     repo.createOrUpdateDraft(activeProgram);
 
-    // Build a ProgramModel whose getProgramDefinition() returns a definition that
-    // contains a null-question sentinel. This mirrors the state that arises when
-    // the question-definition cache misses and the program was built with unresolved
-    // question references (e.g. via ProgramBuilder.withRequiredQuestion(nullQuestion)).
+    // Build a ProgramModel whose getProgramDefinition() contains a null-question sentinel.
+    // toProgram() sets this.programDefinition directly (no DB round-trip), so
+    // getProgramDefinition() on this model returns the null-question definition.
     QuestionDefinition nullQuestionDef =
         new TestQuestionBank(false).nullQuestion().getQuestionDefinition();
     BlockDefinition blockWithNullQuestion =
-        activeProgram.getProgramDefinition().blockDefinitions().get(0).toBuilder()
+        BlockDefinition.builder()
+            .setId(1L)
+            .setName("Screen 1")
+            .setDescription("Screen 1")
+            .setLocalizedName(LocalizedStrings.withDefaultValue("Screen 1"))
+            .setLocalizedDescription(LocalizedStrings.withDefaultValue("Screen 1"))
             .setProgramQuestionDefinitions(
                 ImmutableList.of(
                     ProgramQuestionDefinition.create(
                         nullQuestionDef, Optional.of(activeProgram.getProgramDefinition().id()))))
             .build();
-    // toProgram() sets this.programDefinition = definition directly (no DB round-trip),
-    // so getProgramDefinition() on this model returns the null-question definition.
     ProgramModel programWithNullQuestion =
         activeProgram.getProgramDefinition().toBuilder()
             .setBlockDefinitions(ImmutableList.of(blockWithNullQuestion))
             .build()
             .toProgram();
 
-    // getShallowProgramDefinition falls back to getProgramDefinition() (cache is disabled),
-    // returning the null-question definition. The update-existing-draft path then saves
-    // it straight to the DB without checking for null questions.
+    // getShallowProgramDefinition falls back to getProgramDefinition() (cache is disabled for
+    // null-question definitions). The update-existing-draft path saves it without a guard.
     ProgramModel updatedDraft = repo.createOrUpdateDraft(programWithNullQuestion);
 
-    // The saved draft must not contain null-question sentinels, but it does.
+    // The saved draft must not contain null-question sentinels, but it does — demonstrating
+    // the bug.
     assertThat(
             updatedDraft.getProgramDefinition().blockDefinitions().stream()
                 .noneMatch(BlockDefinition::hasNullQuestion))


### PR DESCRIPTION
### Description

Test exhibiting how a null question can arise.


## Release notes

Remove this section if the feature is still under development or if title of the pull request can be used as the default release notes description. If more detail is needed to communicate to partners the scope of the PR's changes, use this release notes section (and remove this placeholder text).

When the Release engineer creates Release Notes, they will not look for this section for Under Development tagged PRs, and will use it if present for all other PRs included in the Release Notes.

### Checklist

Remove any sections below that do not apply to your PR. For sections that do apply, complete all of the appropriate checklist items and check them off. If a checklist item doesn't apply to your PR, leave it unchecked but do not delete it.

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [ ] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [ ] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

#### Database evolutions

Read the guidelines [here](https://github.com/civiform/civiform/wiki/Database#writing-database-evolutions)

- [ ] Assigned two reviewers
- [ ] Guarded against already existing resources using `IF NOT EXISTS` and `IF EXISTS`
- [ ] Downs created to undo changes in Ups
- [ ] Every comment in script should begin with -- and not # --- unless it denotes Ups or Downs. See [here](https://www.playframework.com/documentation/2.9.x/Evolutions) for details.
- [ ] Tested both the Downs and the Ups scripts manually (When testing, include all comments from the evolution in your test script to ensure any syntax errors in the comments are caught.)
- [ ] Data migrations aren't being done (please use a [Durable Job](https://github.com/civiform/civiform/wiki/Database#durable-jobs-for-data-updates) if doing a data migration)
- [ ] Update the model documentation in our [wiki](https://github.com/civiform/civiform/wiki/Database) if necessary

#### Durable jobs

Read the docs [here](https://github.com/civiform/civiform/wiki/Database#durable-jobs-for-data-updates)

- [ ] Assigned two reviewers
- [ ] Included a rollback plan and a job to undo the data changes if appropriate

#### User visible changes

- [ ] Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
  - [ ] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [ ] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order
- [ ] Performed manual accessibility tests for any applicant-facing changes or any new admin-facing features. See [manual-accessibility-testing](https://github.com/civiform/civiform/wiki/Accessibility#manual-accessibility-testing)
- [ ] Manually tested with a right-to-left language

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/helper/feature-flags.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://github.com/civiform/civiform/wiki/Feature-Flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Instructions for manual testing

If instructions are needed for manual testing by reviewers, include them here.

### Issue(s) this completes

Fixes #<issue_number>; Fixes #<issue_number>...
