### PR TITLE
Speed up application_navigation_buttons test and de-flake ally test

### DIFF
--- a/browser-test/src/applicant/navigation/application_navigation_buttons.test.ts
+++ b/browser-test/src/applicant/navigation/application_navigation_buttons.test.ts
@@ -237,6 +237,7 @@ test.describe('Applicant navigation flow', () => {
         // The date question is required, so expect the error modal.
         await applicantQuestions.expectErrorOnPreviousModal()
 
+        await waitForPageJsLoad(page)
         await validateAccessibility(page)
         await validateScreenshot(page, 'error-on-previous-modal', {
           fullPage: false,


### PR DESCRIPTION
### Description

Changes beforeEach to beforeAll reducing run time locally from 6.5m to 1m

Claude did everything related to that.  I manually fixed the ally test for flakeyness with the wait.

### Checklist

Remove any sections below that do not apply to your PR. For sections that do apply, complete all of the appropriate checklist items and check them off. If a checklist item doesn't apply to your PR, leave it unchecked but do not delete it.

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [ ] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [ ] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.
