### PR TITLE
generate release docs on publish [merge after 4/7, to test while on call]

### DIFF
--- a/.github/workflows/generate_env_var_docs_markdown_for_release.yaml
+++ b/.github/workflows/generate_env_var_docs_markdown_for_release.yaml
@@ -1,25 +1,20 @@
 name: Env Variable Docs - Generate
 
 on:
-  # Need to declare separate inputs for getting manually called (workflow_dispatch) and called by the release.yaml workflow (workflow_call).
+  release:
+    types: [published]
   workflow_dispatch:
     inputs:
       release_number:
         description: 'The release number to generate/update env var docs markdown for, v1.2.3 for example. IMPORTANT: the release number must already be a tag in this repo.'
         required: true
         type: string
-  workflow_call:
-    inputs:
-      release_number:
-        description: 'The release number to generate/update env var docs markdown for, v1.2.3 for example. IMPORTANT: the release number must already be a tag in this repo.'
-        required: true
-        type: string
-    secrets:
-      CIVIFORM_GITHUB_AUTOMATION_PERSONAL_ACCESS_TOKEN:
-        required: true
 
 permissions:
   contents: read
+
+env:
+  RELEASE_NUMBER: ${{ github.event.release.tag_name || inputs.release_number }}
 
 jobs:
   generate_markdown:
@@ -30,17 +25,17 @@ jobs:
         with:
           path: civiform-main
 
-      - name: Checkout civiform/civiform@${{ inputs.release_number }}
+      - name: Checkout civiform/civiform@${{ env.RELEASE_NUMBER }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          ref: ${{ inputs.release_number }}
+          ref: ${{ env.RELEASE_NUMBER }}
           path: civiform-main/civiform-release
 
       - name: Run bin/env-var-docs-generate-markdown
         env:
           LOCAL_OUTPUT: false
           ENV_VAR_DOCS_PATH: ./civiform-release/server/conf/env-var-docs.json
-          RELEASE_VERSION: ${{ inputs.release_number }}
+          RELEASE_VERSION: ${{ env.RELEASE_NUMBER }}
           GITHUB_ACCESS_TOKEN: ${{ secrets.CIVIFORM_GITHUB_AUTOMATION_PERSONAL_ACCESS_TOKEN }}
           TARGET_REPO: civiform/docs
           TARGET_PATH: docs/it-manual/sre-playbook/server-environment-variables

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,12 +47,3 @@ jobs:
           https://api.github.com/repos/civiform/cloud-deploy-infra/actions/workflows/tag.yaml/dispatches \
           -d '{"ref":"main","inputs":{"commit_sha":"${{ github.event.inputs.cloud_deploy_infra_sha }}","version":"${{ github.event.inputs.release_number }}"}'
         if: ${{ success() }}
-  update_environment_variable_documentation_markdown:
-    permissions:
-      contents: read
-    needs: create_release # The generate markdown job relies on the release tag being added, so wait for bin/create-release to complete.
-    uses: ./.github/workflows/generate_env_var_docs_markdown_for_release.yaml
-    with:
-      release_number: ${{ github.event.inputs.release_number }}
-    secrets:
-      CIVIFORM_GITHUB_AUTOMATION_PERSONAL_ACCESS_TOKEN: ${{ secrets.CIVIFORM_GITHUB_AUTOMATION_PERSONAL_ACCESS_TOKEN }}


### PR DESCRIPTION
### Description

Env var docs get automatically generated in the docs site. Ex: https://docs.civiform.us/it-manual/sre-playbook/upgrading-to-a-new-release/server-environment-variables/v3.25.0

They get generated upon draft of the release. This PR changes it to being on release because I think it makes more sense.