### PR TITLE
Make sure the page is loaded before attempting to open question bank

### DIFF
--- a/browser-test/src/support/admin_programs.ts
+++ b/browser-test/src/support/admin_programs.ts
@@ -1369,6 +1369,7 @@ export class AdminPrograms {
   }
 
   async openQuestionBank() {
+    await waitForPageJsLoad(this.page)
     await this.page.getByRole('button', {name: /^Add( a)? question$/}).click()
     await this.waitForQuestionBankAnimationToFinish()
   }


### PR DESCRIPTION
Make sure the page is loaded before attempting to open question bank. It was not and on slow connections the button click attempts to run before the javascript is done loading.