### PR TITLE
[Session Timeout] rename last activity time used for the session

### DIFF
--- a/server/app/auth/CiviFormProfileData.java
+++ b/server/app/auth/CiviFormProfileData.java
@@ -25,12 +25,7 @@ import repository.DatabaseExecutionContext;
 public class CiviFormProfileData extends CommonProfile {
   public static final String SESSION_ID = "sessionId";
 
-  /**
-   * TODO: There are two "last activity time" implementations: this session-level attribute (used
-   * for session timeout) and {@link models.AccountModel#getLastActivityTime()} (DB column, updated
-   * on every save). Reconcile into one or rename to clarify their distinct purposes.
-   */
-  public static final String LAST_ACTIVITY_TIME = "lastActivityTime";
+  public static final String LAST_SESSION_ACTIVITY_TIME = "lastSessionActivityTime";
 
   // It is crucial that serialization of this class does not change, so that user profiles continue
   // to be honored and in-progress applications are not lost.
@@ -51,7 +46,7 @@ public class CiviFormProfileData extends CommonProfile {
   public CiviFormProfileData(Long accountId, Clock clock) {
     this();
     this.setId(accountId.toString());
-    addAttribute(LAST_ACTIVITY_TIME, clock.instant().toEpochMilli());
+    addAttribute(LAST_SESSION_ACTIVITY_TIME, clock.instant().toEpochMilli());
   }
 
   /**
@@ -79,8 +74,8 @@ public class CiviFormProfileData extends CommonProfile {
     return getAttributeAsString(SESSION_ID);
   }
 
-  public void updateLastActivityTime(Clock clock) {
-    addAttribute(LAST_ACTIVITY_TIME, clock.instant().toEpochMilli());
+  public void updateLastSessionActivityTime(Clock clock) {
+    addAttribute(LAST_SESSION_ACTIVITY_TIME, clock.instant().toEpochMilli());
   }
 
   /**
@@ -89,8 +84,9 @@ public class CiviFormProfileData extends CommonProfile {
    * is not present. This effectively gives legacy sessions a fresh activity timestamp when the
    * timeout feature is first enabled.
    */
-  public long getLastActivityTime(Clock clock) {
-    return (Long) getAttributes().getOrDefault(LAST_ACTIVITY_TIME, clock.instant().toEpochMilli());
+  public long getLastSessionActivityTime(Clock clock) {
+    return (Long)
+        getAttributes().getOrDefault(LAST_SESSION_ACTIVITY_TIME, clock.instant().toEpochMilli());
   }
 
   /**

--- a/server/app/controllers/SessionController.java
+++ b/server/app/controllers/SessionController.java
@@ -40,7 +40,7 @@ public class SessionController extends Controller {
         .optionalCurrentUserProfile(request)
         .map(
             profile -> {
-              profile.getProfileData().updateLastActivityTime(clock);
+              profile.getProfileData().updateLastSessionActivityTime(clock);
               return ok();
             })
         .orElse(unauthorized());

--- a/server/app/filters/CiviFormSessionFilter.java
+++ b/server/app/filters/CiviFormSessionFilter.java
@@ -69,7 +69,8 @@ public class CiviFormSessionFilter extends EssentialFilter {
             request
                 .attrs()
                 .getOptional(ProfileUtils.CURRENT_USER_PROFILE)
-                .ifPresent(profile -> profile.getProfileData().updateLastActivityTime(clock));
+                .ifPresent(
+                    profile -> profile.getProfileData().updateLastSessionActivityTime(clock));
             return next.apply(request);
           }
 
@@ -134,7 +135,7 @@ public class CiviFormSessionFilter extends EssentialFilter {
                           }
 
                           // Update last activity time
-                          profile.getProfileData().updateLastActivityTime(clock);
+                          profile.getProfileData().updateLastSessionActivityTime(clock);
 
                           return next.apply(request)
                               .map(

--- a/server/app/models/AccountModel.java
+++ b/server/app/models/AccountModel.java
@@ -65,11 +65,7 @@ public class AccountModel extends BaseModel {
   @DbJsonB(name = "active_sessions")
   private Map<String, SessionDetails> activeSessions = new HashMap<>();
 
-  /**
-   * TODO: There are two "last activity time" implementations: this DB column (updated on every
-   * save) and {@link auth.CiviFormProfileData#LAST_ACTIVITY_TIME} (session-level, used for session
-   * timeout). Reconcile into one or rename to clarify their distinct purposes.
-   */
+  /** Updated automatically on every save via {@code @WhenModified}. */
   @WhenModified private Instant lastActivityTime;
 
   public Instant getLastActivityTime() {

--- a/server/app/services/session/SessionTimeoutService.java
+++ b/server/app/services/session/SessionTimeoutService.java
@@ -41,11 +41,12 @@ public final class SessionTimeoutService {
 
   private boolean isSessionTimedOutDueToInactivity(CiviFormProfile profile) {
     long currentTimeInMillis = clock.millis();
-    long lastActivityTimeInMillis = profile.getProfileData().getLastActivityTime(clock);
+    long lastSessionActivityTimeInMillis =
+        profile.getProfileData().getLastSessionActivityTime(clock);
 
     long inactivityTimeoutInMillis = getInactivityTimeoutMillis();
 
-    return (currentTimeInMillis - lastActivityTimeInMillis) > inactivityTimeoutInMillis;
+    return (currentTimeInMillis - lastSessionActivityTimeInMillis) > inactivityTimeoutInMillis;
   }
 
   /**
@@ -66,12 +67,13 @@ public final class SessionTimeoutService {
     int durationWarningMinutes =
         settingsManifest.get().getSessionDurationWarningThresholdMinutes().orElseThrow();
 
-    long lastActivityTimeInSeconds = profile.getProfileData().getLastActivityTime(clock) / 1000;
+    long lastSessionActivityTimeInSeconds =
+        profile.getProfileData().getLastSessionActivityTime(clock) / 1000;
     return new TimeoutData(
-        calculateTimeoutLimit(lastActivityTimeInSeconds, inactivityMinutes),
+        calculateTimeoutLimit(lastSessionActivityTimeInSeconds, inactivityMinutes),
         calculateTimeoutLimit(sessionStartTimeInSeconds, totalLengthMinutes),
         calculateWarningTime(
-            lastActivityTimeInSeconds, inactivityMinutes, inactivityWarningMinutes),
+            lastSessionActivityTimeInSeconds, inactivityMinutes, inactivityWarningMinutes),
         calculateWarningTime(sessionStartTimeInSeconds, totalLengthMinutes, durationWarningMinutes),
         currentTime);
   }

--- a/server/test/controllers/SessionControllerTest.java
+++ b/server/test/controllers/SessionControllerTest.java
@@ -48,7 +48,7 @@ public class SessionControllerTest {
     Result result = controller.extendSession(request);
 
     assertThat(result.status()).isEqualTo(Http.Status.OK);
-    verify(mockProfileData).updateLastActivityTime(clock);
+    verify(mockProfileData).updateLastSessionActivityTime(clock);
   }
 
   @Test
@@ -59,7 +59,7 @@ public class SessionControllerTest {
     Result result = controller.extendSession(request);
 
     assertThat(result.status()).isEqualTo(Http.Status.BAD_REQUEST);
-    verify(mockProfileData, never()).updateLastActivityTime(any());
+    verify(mockProfileData, never()).updateLastSessionActivityTime(any());
   }
 
   @Test
@@ -74,6 +74,6 @@ public class SessionControllerTest {
     Result result = controller.extendSession(request);
 
     assertThat(result.status()).isEqualTo(Http.Status.UNAUTHORIZED);
-    verify(mockProfileData, never()).updateLastActivityTime(any());
+    verify(mockProfileData, never()).updateLastSessionActivityTime(any());
   }
 }

--- a/server/test/filters/CiviFormSessionFilterTest.java
+++ b/server/test/filters/CiviFormSessionFilterTest.java
@@ -131,7 +131,7 @@ public class CiviFormSessionFilterTest extends WithApplication {
     Result result = executeFilter(request);
 
     assertThat(result.status()).isEqualTo(200);
-    verify(mockProfileData, never()).updateLastActivityTime(clock);
+    verify(mockProfileData, never()).updateLastSessionActivityTime(clock);
   }
 
   @Test
@@ -235,7 +235,7 @@ public class CiviFormSessionFilterTest extends WithApplication {
     Result result = executeFilter(request);
 
     verify(sessionTimeoutService).calculateTimeoutData(eq(mockProfile), anyLong());
-    verify(mockProfileData).updateLastActivityTime(clock);
+    verify(mockProfileData).updateLastSessionActivityTime(clock);
 
     Optional<Http.Cookie> cookie = result.cookies().get(TIMEOUT_COOKIE_NAME);
     assertThat(cookie).isPresent();

--- a/server/test/services/session/SessionTimeoutServiceTest.java
+++ b/server/test/services/session/SessionTimeoutServiceTest.java
@@ -57,20 +57,20 @@ public class SessionTimeoutServiceTest {
 
   @Test
   public void isSessionTimedOut_noTimeout() {
-    long lastActivityTime = getTimeMinutesAgo(10);
-    when(profileData.getLastActivityTime(clock)).thenReturn(lastActivityTime);
+    long lastSessionActivityTime = getTimeMinutesAgo(10);
+    when(profileData.getLastSessionActivityTime(clock)).thenReturn(lastSessionActivityTime);
 
-    boolean result = sessionTimeoutService.isSessionTimedOut(profile, lastActivityTime);
+    boolean result = sessionTimeoutService.isSessionTimedOut(profile, lastSessionActivityTime);
 
     assertThat(result).isFalse();
   }
 
   @Test
   public void isSessionTimedOut_inactivityTimeout() {
-    long lastActivityTime = getTimeMinutesAgo(INACTIVITY_TIMEOUT_MINUTES + 1);
-    when(profileData.getLastActivityTime(clock)).thenReturn(lastActivityTime);
+    long lastSessionActivityTime = getTimeMinutesAgo(INACTIVITY_TIMEOUT_MINUTES + 1);
+    when(profileData.getLastSessionActivityTime(clock)).thenReturn(lastSessionActivityTime);
 
-    boolean result = sessionTimeoutService.isSessionTimedOut(profile, lastActivityTime);
+    boolean result = sessionTimeoutService.isSessionTimedOut(profile, lastSessionActivityTime);
 
     assertThat(result).isTrue();
   }
@@ -78,7 +78,7 @@ public class SessionTimeoutServiceTest {
   @Test
   public void isSessionTimedOut_totalDurationTimeout() {
     long sessionStartTime = getTimeMinutesAgo(MAX_SESSION_DURATION_MINUTES + 1);
-    when(profileData.getLastActivityTime(clock))
+    when(profileData.getLastSessionActivityTime(clock))
         .thenReturn(CURRENT_TIME * 1000 - 10 * 60 * 1000); // Recent activity
 
     boolean result = sessionTimeoutService.isSessionTimedOut(profile, sessionStartTime);
@@ -89,19 +89,19 @@ public class SessionTimeoutServiceTest {
   @Test
   public void calculateTimeoutData_allValuesPresent() {
     long sessionStartTime = getTimeMinutesAgo(30);
-    long lastActivityTime = getTimeMinutesAgo(10);
-    when(profileData.getLastActivityTime(clock)).thenReturn(lastActivityTime);
+    long lastSessionActivityTime = getTimeMinutesAgo(10);
+    when(profileData.getLastSessionActivityTime(clock)).thenReturn(lastSessionActivityTime);
 
     SessionTimeoutService.TimeoutData timeoutData =
         sessionTimeoutService.calculateTimeoutData(profile, sessionStartTime);
 
     assertThat(timeoutData.inactivityTimeout())
-        .isEqualTo(lastActivityTime / 1000 + INACTIVITY_TIMEOUT_MINUTES * 60);
+        .isEqualTo(lastSessionActivityTime / 1000 + INACTIVITY_TIMEOUT_MINUTES * 60);
     assertThat(timeoutData.totalTimeout())
         .isEqualTo(sessionStartTime / 1000 + MAX_SESSION_DURATION_MINUTES * 60);
     assertThat(timeoutData.inactivityWarning())
         .isEqualTo(
-            lastActivityTime / 1000
+            lastSessionActivityTime / 1000
                 + (INACTIVITY_TIMEOUT_MINUTES - INACTIVITY_WARNING_MINUTES) * 60);
     assertThat(timeoutData.totalWarning())
         .isEqualTo(
@@ -122,7 +122,7 @@ public class SessionTimeoutServiceTest {
   @Test
   public void missingMaxSessionDuration_throwsException() {
     when(settings.getMaximumSessionDurationMinutes()).thenReturn(Optional.empty());
-    when(profileData.getLastActivityTime(clock)).thenReturn(getTimeMinutesAgo(10));
+    when(profileData.getLastSessionActivityTime(clock)).thenReturn(getTimeMinutesAgo(10));
 
     assertThatThrownBy(
             () -> sessionTimeoutService.isSessionTimedOut(profile, getTimeMinutesAgo(10)))
@@ -132,20 +132,22 @@ public class SessionTimeoutServiceTest {
   @Test
   public void missingSessionDurationWarningThreshold_throwsException() {
     when(settings.getSessionDurationWarningThresholdMinutes()).thenReturn(Optional.empty());
-    long lastActivityTime = getTimeMinutesAgo(10);
-    when(profileData.getLastActivityTime(clock)).thenReturn(lastActivityTime);
+    long lastSessionActivityTime = getTimeMinutesAgo(10);
+    when(profileData.getLastSessionActivityTime(clock)).thenReturn(lastSessionActivityTime);
 
-    assertThatThrownBy(() -> sessionTimeoutService.calculateTimeoutData(profile, lastActivityTime))
+    assertThatThrownBy(
+            () -> sessionTimeoutService.calculateTimeoutData(profile, lastSessionActivityTime))
         .isInstanceOf(NoSuchElementException.class);
   }
 
   @Test
   public void missingSessionInactivityWarningThreshold_throwsException() {
     when(settings.getSessionInactivityWarningThresholdMinutes()).thenReturn(Optional.empty());
-    long lastActivityTime = getTimeMinutesAgo(10);
-    when(profileData.getLastActivityTime(clock)).thenReturn(lastActivityTime);
+    long lastSessionActivityTime = getTimeMinutesAgo(10);
+    when(profileData.getLastSessionActivityTime(clock)).thenReturn(lastSessionActivityTime);
 
-    assertThatThrownBy(() -> sessionTimeoutService.calculateTimeoutData(profile, lastActivityTime))
+    assertThatThrownBy(
+            () -> sessionTimeoutService.calculateTimeoutData(profile, lastSessionActivityTime))
         .isInstanceOf(NoSuchElementException.class);
   }
 }


### PR DESCRIPTION
### Description

Renaming last activity time used for the session to last session activity time to minimize confusion with the account last activity time.