### PR TITLE
Renovate min package age

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -9,6 +9,8 @@
   schedule: ["after 4am", "before 10am"],
   // Github label(s) applied to the generated pull request, unless overridden below
   labels: ["dependencies"],
+  // Amount of time to wait after a release before opening a PR, to avoid chasing yanked or broken releases.
+  minimumReleaseAge: "3 days",
   // These files deviate from standard compose naming convention. 
   // This makes sure renovate finds them.
   "docker-compose": {


### PR DESCRIPTION
Set min package age of three days before renovate opens a PR for an updated dependency. This will give a little bit of time to determine if the releases have issues while still saying updated for security issues.
