### PR TITLE
[Account Merge] Give CiviForm user read access to guest's files

### DIFF
--- a/server/app/auth/CiviFormProfileMerger.java
+++ b/server/app/auth/CiviFormProfileMerger.java
@@ -11,6 +11,7 @@ import org.pac4j.core.profile.UserProfile;
 import repository.AccountRepository;
 import repository.CiviFormAccountMerger;
 import repository.DatabaseExecutionContext;
+import repository.StoredFileRepository;
 import repository.TransactionManager;
 
 /** Helper class for common {@code UserProfile} merging logic. */
@@ -25,10 +26,11 @@ public final class CiviFormProfileMerger {
   public CiviFormProfileMerger(
       ProfileFactory profileFactory,
       Provider<AccountRepository> applicantRepositoryProvider,
+      Provider<StoredFileRepository> storedFileRepositoryProvider,
       DatabaseExecutionContext dbExecutionContext) {
     this.profileFactory = profileFactory;
     this.applicantRepositoryProvider = applicantRepositoryProvider;
-    this.accountMerger = new CiviFormAccountMerger();
+    this.accountMerger = new CiviFormAccountMerger(storedFileRepositoryProvider);
     this.dbExecutionContext = dbExecutionContext;
     this.transactionManager = new TransactionManager();
   }

--- a/server/app/auth/oidc/CiviformOidcProfileCreator.java
+++ b/server/app/auth/oidc/CiviformOidcProfileCreator.java
@@ -54,7 +54,11 @@ public abstract class CiviformOidcProfileCreator extends OidcProfileCreator {
     this.profileFactory = Preconditions.checkNotNull(params.profileFactory());
     this.accountRepositoryProvider = Preconditions.checkNotNull(params.accountRepositoryProvider());
     this.civiFormProfileMerger =
-        new CiviFormProfileMerger(profileFactory, accountRepositoryProvider, dbExecutionContext);
+        new CiviFormProfileMerger(
+            profileFactory,
+            accountRepositoryProvider,
+            Preconditions.checkNotNull(params.storedFileRepositoryProvider()),
+            dbExecutionContext);
     this.settingsManifest =
         new SettingsManifest(Preconditions.checkNotNull(params.configuration()));
   }

--- a/server/app/auth/oidc/OidcClientProviderParams.java
+++ b/server/app/auth/oidc/OidcClientProviderParams.java
@@ -7,6 +7,7 @@ import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import javax.inject.Provider;
 import repository.AccountRepository;
+import repository.StoredFileRepository;
 
 /** Class that holds parameters required by OidcClientProvider and its subclasses. */
 @AutoValue
@@ -14,17 +15,24 @@ public abstract class OidcClientProviderParams {
   public static OidcClientProviderParams create(
       Config configuration,
       ProfileFactory profileFactory,
-      Provider<AccountRepository> accountRepositoryProvider) {
+      Provider<AccountRepository> accountRepositoryProvider,
+      Provider<StoredFileRepository> storedFileRepositoryProvider) {
     return new AutoValue_OidcClientProviderParams(
-        configuration, profileFactory, accountRepositoryProvider);
+        configuration, profileFactory, accountRepositoryProvider, storedFileRepositoryProvider);
   }
 
   // Our tests have paths like:
   //   /usr/src/server/test/auth/ProfileMergeTest.java
   @RestrictedApi(explanation = "Only allow for tests", allowedOnPath = ".*/test/.*")
   public static OidcClientProviderParams create(
-      ProfileFactory profileFactory, Provider<AccountRepository> accountRepositoryProvider) {
-    return create(ConfigFactory.empty(), profileFactory, accountRepositoryProvider);
+      ProfileFactory profileFactory,
+      Provider<AccountRepository> accountRepositoryProvider,
+      Provider<StoredFileRepository> storedFileRepositoryProvider) {
+    return create(
+        ConfigFactory.empty(),
+        profileFactory,
+        accountRepositoryProvider,
+        storedFileRepositoryProvider);
   }
 
   public abstract Config configuration();
@@ -32,4 +40,6 @@ public abstract class OidcClientProviderParams {
   abstract ProfileFactory profileFactory();
 
   abstract Provider<AccountRepository> accountRepositoryProvider();
+
+  abstract Provider<StoredFileRepository> storedFileRepositoryProvider();
 }

--- a/server/app/auth/oidc/admin/AdfsClientProvider.java
+++ b/server/app/auth/oidc/admin/AdfsClientProvider.java
@@ -14,6 +14,7 @@ import org.pac4j.oidc.client.OidcClient;
 import org.pac4j.oidc.config.OidcConfiguration;
 import repository.AccountRepository;
 import repository.DatabaseExecutionContext;
+import repository.StoredFileRepository;
 
 /** Provider class for the AD OIDC Client. */
 public class AdfsClientProvider implements Provider<OidcClient> {
@@ -22,6 +23,7 @@ public class AdfsClientProvider implements Provider<OidcClient> {
   private final String baseUrl;
   private final ProfileFactory profileFactory;
   private final Provider<AccountRepository> accountRepositoryProvider;
+  private final Provider<StoredFileRepository> storedFileRepositoryProvider;
   private final DatabaseExecutionContext dbExecutionContext;
 
   @Inject
@@ -29,10 +31,12 @@ public class AdfsClientProvider implements Provider<OidcClient> {
       Config configuration,
       ProfileFactory profileFactory,
       Provider<AccountRepository> accountRepositoryProvider,
+      Provider<StoredFileRepository> storedFileRepositoryProvider,
       DatabaseExecutionContext dbExecutionContext) {
     this.configuration = checkNotNull(configuration);
     this.profileFactory = checkNotNull(profileFactory);
     this.accountRepositoryProvider = checkNotNull(accountRepositoryProvider);
+    this.storedFileRepositoryProvider = storedFileRepositoryProvider;
     this.dbExecutionContext = dbExecutionContext;
     this.baseUrl = configuration.getString("base_url");
   }
@@ -91,7 +95,10 @@ public class AdfsClientProvider implements Provider<OidcClient> {
             config,
             client,
             OidcClientProviderParams.create(
-                configuration, profileFactory, accountRepositoryProvider),
+                configuration,
+                profileFactory,
+                accountRepositoryProvider,
+                storedFileRepositoryProvider),
             dbExecutionContext));
 
     client.setCallbackUrlResolver(new PathParameterCallbackUrlResolver());

--- a/server/app/auth/saml/LoginRadiusClientProvider.java
+++ b/server/app/auth/saml/LoginRadiusClientProvider.java
@@ -16,6 +16,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import repository.AccountRepository;
 import repository.DatabaseExecutionContext;
+import repository.StoredFileRepository;
 
 // TODO(#3856): Update with a non deprecated saml impl.
 @SuppressWarnings("deprecation")
@@ -26,6 +27,7 @@ public class LoginRadiusClientProvider implements Provider<SAML2Client> {
   private final Config configuration;
   private final ProfileFactory profileFactory;
   private final Provider<AccountRepository> applicantRepositoryProvider;
+  private final Provider<StoredFileRepository> storedFileRepositoryProvider;
   private final DatabaseExecutionContext dbExecutionContext;
   private final String baseUrl;
 
@@ -34,10 +36,12 @@ public class LoginRadiusClientProvider implements Provider<SAML2Client> {
       Config configuration,
       ProfileFactory profileFactory,
       Provider<AccountRepository> applicantRepositoryProvider,
+      Provider<StoredFileRepository> storedFileRepositoryProvider,
       DatabaseExecutionContext dbExecutionContext) {
     this.configuration = checkNotNull(configuration);
     this.profileFactory = checkNotNull(profileFactory);
     this.applicantRepositoryProvider = checkNotNull(applicantRepositoryProvider);
+    this.storedFileRepositoryProvider = storedFileRepositoryProvider;
     this.dbExecutionContext = dbExecutionContext;
     this.baseUrl = configuration.getString("base_url");
   }
@@ -67,7 +71,12 @@ public class LoginRadiusClientProvider implements Provider<SAML2Client> {
 
     client.setProfileCreator(
         new SamlProfileCreator(
-            config, client, profileFactory, applicantRepositoryProvider, dbExecutionContext));
+            config,
+            client,
+            profileFactory,
+            applicantRepositoryProvider,
+            storedFileRepositoryProvider,
+            dbExecutionContext));
 
     client.setCallbackUrlResolver(new PathParameterCallbackUrlResolver());
     client.setCallbackUrl(baseUrl + "/callback");

--- a/server/app/auth/saml/SamlProfileCreator.java
+++ b/server/app/auth/saml/SamlProfileCreator.java
@@ -30,6 +30,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import repository.AccountRepository;
 import repository.DatabaseExecutionContext;
+import repository.StoredFileRepository;
 
 public class SamlProfileCreator extends AuthenticatorProfileCreator {
 
@@ -50,12 +51,17 @@ public class SamlProfileCreator extends AuthenticatorProfileCreator {
       SAML2Client client,
       ProfileFactory profileFactory,
       Provider<AccountRepository> applicantRepositoryProvider,
+      Provider<StoredFileRepository> storedFileRepositoryProvider,
       DatabaseExecutionContext dbExecutionContext) {
     super();
     this.profileFactory = Preconditions.checkNotNull(profileFactory);
     this.applicantRepositoryProvider = Preconditions.checkNotNull(applicantRepositoryProvider);
     this.civiFormProfileMerger =
-        new CiviFormProfileMerger(profileFactory, applicantRepositoryProvider, dbExecutionContext);
+        new CiviFormProfileMerger(
+            profileFactory,
+            applicantRepositoryProvider,
+            storedFileRepositoryProvider,
+            dbExecutionContext);
     this.saml2Client = client;
     this.saml2Configuration = configuration;
     // TODO(#12696): Handle enhanced logout.

--- a/server/app/modules/MainModule.java
+++ b/server/app/modules/MainModule.java
@@ -19,6 +19,7 @@ import play.i18n.Lang;
 import play.i18n.Messages;
 import play.i18n.MessagesApi;
 import repository.AccountRepository;
+import repository.StoredFileRepository;
 
 /**
  * This class is a Guice module that tells Guice how to bind several different types. This Guice
@@ -59,7 +60,9 @@ public class MainModule extends AbstractModule {
   public OidcClientProviderParams provideOidcClientProviderParams(
       Config config,
       ProfileFactory profileFactory,
-      Provider<AccountRepository> accountRepositoryProvider) {
-    return OidcClientProviderParams.create(config, profileFactory, accountRepositoryProvider);
+      Provider<AccountRepository> accountRepositoryProvider,
+      Provider<StoredFileRepository> storedFileRepositoryProvider) {
+    return OidcClientProviderParams.create(
+        config, profileFactory, accountRepositoryProvider, storedFileRepositoryProvider);
   }
 }

--- a/server/app/repository/CiviFormAccountMerger.java
+++ b/server/app/repository/CiviFormAccountMerger.java
@@ -55,12 +55,13 @@ public final class CiviFormAccountMerger {
         };
     StringBuilder finalLogMessage = new StringBuilder();
     // 1. Merge Applications.
-    String mergeLog = mergeGuestApplicationsIntoCfUser(civiformUser, guestUser, applyChanges);
-    finalLogMessage.append(mergeLog);
+    String applicationLog = mergeGuestApplicationsIntoCfUser(civiformUser,
+      guestUser, applyChanges);
+    finalLogMessage.append(applicationLog);
     // 2. Update the guest's file references to permit the CF users to read
     // them.
-    String fileMergeLog = mergeGuestFilesIntoCfUser(civiformUser.id, guestUser.id, applyChanges);
-    finalLogMessage.append("\n").append(fileMergeLog);
+    String fileLog = mergeGuestFilesIntoCfUser(civiformUser.id, guestUser.id, applyChanges);
+    finalLogMessage.append("\n").append(fileLog);
     // 3. Merge CFApp question answers and PAI into guest data and store in CF App
     // TODO(#11389): Step 3 is not yet implemented.
     logger.info("{}", finalLogMessage);

--- a/server/app/repository/CiviFormAccountMerger.java
+++ b/server/app/repository/CiviFormAccountMerger.java
@@ -55,8 +55,7 @@ public final class CiviFormAccountMerger {
         };
     StringBuilder finalLogMessage = new StringBuilder();
     // 1. Merge Applications.
-    String applicationLog = mergeGuestApplicationsIntoCfUser(civiformUser,
-      guestUser, applyChanges);
+    String applicationLog = mergeGuestApplicationsIntoCfUser(civiformUser, guestUser, applyChanges);
     finalLogMessage.append(applicationLog);
     // 2. Update the guest's file references to permit the CF users to read
     // them.

--- a/server/app/repository/CiviFormAccountMerger.java
+++ b/server/app/repository/CiviFormAccountMerger.java
@@ -62,7 +62,7 @@ public final class CiviFormAccountMerger {
     // TODO(#11389): Step 3 is not yet implemented.
     logger.info("{}\n{}", log, fileMergeLog);
   }
-  
+
   /**
    * A container for the CiviForm user's applications. We don't need obsolete records for the CF
    * user as compared to the Guest.
@@ -71,32 +71,31 @@ public final class CiviFormAccountMerger {
 
   /** A container for the Guest user's applications. */
   private record GuestUserApps(
-    List<ApplicationModel> obsolete,
-    Optional<ApplicationModel> active,
-    Optional<ApplicationModel> draft) {}
+      List<ApplicationModel> obsolete,
+      Optional<ApplicationModel> active,
+      Optional<ApplicationModel> draft) {}
 
   // Collect the applications into the nicer structure.
   private GuestUserApps categorizeGuestApps(List<ApplicationModel> apps) {
     List<ApplicationModel> obsolete =
-      apps.stream()
-          .filter(a -> a.getLifecycleStage() == LifecycleStage.OBSOLETE)
-          .collect(Collectors.toList());
+        apps.stream()
+            .filter(a -> a.getLifecycleStage() == LifecycleStage.OBSOLETE)
+            .collect(Collectors.toList());
     Optional<ApplicationModel> active =
-      apps.stream().filter(a -> a.getLifecycleStage() == LifecycleStage.ACTIVE).findFirst();
+        apps.stream().filter(a -> a.getLifecycleStage() == LifecycleStage.ACTIVE).findFirst();
     Optional<ApplicationModel> draft =
-      apps.stream().filter(a -> a.getLifecycleStage() == LifecycleStage.DRAFT).findFirst();
+        apps.stream().filter(a -> a.getLifecycleStage() == LifecycleStage.DRAFT).findFirst();
     return new GuestUserApps(obsolete, active, draft);
   }
 
   // Collect the applications into the nicer structure.
   private CfUserApps categorizeCfApps(List<ApplicationModel> apps) {
     Optional<ApplicationModel> active =
-      apps.stream().filter(a -> a.getLifecycleStage() == LifecycleStage.ACTIVE).findFirst();
+        apps.stream().filter(a -> a.getLifecycleStage() == LifecycleStage.ACTIVE).findFirst();
     Optional<ApplicationModel> draft =
-      apps.stream().filter(a -> a.getLifecycleStage() == LifecycleStage.DRAFT).findFirst();
+        apps.stream().filter(a -> a.getLifecycleStage() == LifecycleStage.DRAFT).findFirst();
     return new CfUserApps(active, draft);
   }
-
 
   /// Merge logic:
   /// 1. For programs only present in the guest user, move their applications

--- a/server/app/repository/CiviFormAccountMerger.java
+++ b/server/app/repository/CiviFormAccountMerger.java
@@ -37,7 +37,7 @@ public final class CiviFormAccountMerger {
    *
    * <p>When a Guest Active application is moved it will have originalApplicantId set to the Guest
    * applicant to allow for matching across api data pulls. Draft applications will not have it set
-   * because Draft applications are not pulled by the api. and it serves no purpose then.
+   * because Draft applications are not pulled by the api and it serves no purpose then.
    *
    * @param newMergeStage what launch stage the new merge feature is at. Must be DRY_RUN OR ENABLED.
    */
@@ -53,14 +53,17 @@ public final class CiviFormAccountMerger {
               throw new IllegalArgumentException(
                   "New merge launch stage is not supported: " + newMergeStage);
         };
+    StringBuilder finalLogMessage = new StringBuilder();
     // 1. Merge Applications.
-    String log = mergeGuestApplicationsIntoCfUser(civiformUser, guestUser, applyChanges);
+    String mergeLog = mergeGuestApplicationsIntoCfUser(civiformUser, guestUser, applyChanges);
+    finalLogMessage.append(mergeLog);
     // 2. Update the guest's file references to permit the CF users to read
     // them.
     String fileMergeLog = mergeGuestFilesIntoCfUser(civiformUser.id, guestUser.id, applyChanges);
+    finalLogMessage.append("\n").append(fileMergeLog);
     // 3. Merge CFApp question answers and PAI into guest data and store in CF App
     // TODO(#11389): Step 3 is not yet implemented.
-    logger.info("{}\n{}", log, fileMergeLog);
+    logger.info("{}", finalLogMessage);
   }
 
   /**
@@ -579,8 +582,14 @@ public final class CiviFormAccountMerger {
         .formatted(cfDraft.id, guestDraft.id, cfUser.id);
   }
 
-  private String mergeGuestFilesIntoCfUser(
-      Long civiformUserId, Long guestUserId, boolean applyChanges) {
+  /**
+   * Add {@code cfUserId} to the read ACL for all files {@code guestUserId} created.
+   *
+   * @param applyChanges if database changes should be applied. If false the return will log what
+   *     would have occurred.
+   * @return a log message indicating what changes occurred.
+   */
+  private String mergeGuestFilesIntoCfUser(Long cfUserId, Long guestUserId, boolean applyChanges) {
     var guestFiles =
         storedFileRepositoryProvider
             .get()
@@ -591,14 +600,14 @@ public final class CiviFormAccountMerger {
     for (StoredFileModel file : guestFiles) {
       fileIds.add(file.id.toString());
       if (applyChanges) {
-        file.getAcls().addApplicantToReaders(civiformUserId);
+        file.getAcls().addApplicantToReaders(cfUserId);
         file.save();
       }
     }
 
     var logMessage = fileIds.toString();
     if (logMessage.isBlank()) {
-      return "Guest user has no files to merge with CiviForm user.";
+      return "Guest user has no files to merge.";
     }
 
     return """

--- a/server/app/repository/CiviFormAccountMerger.java
+++ b/server/app/repository/CiviFormAccountMerger.java
@@ -57,7 +57,7 @@ public final class CiviFormAccountMerger {
     // 1. Merge Applications.
     String applicationLog = mergeGuestApplicationsIntoCfUser(civiformUser, guestUser, applyChanges);
     finalLogMessage.append(applicationLog);
-    // 2. Update the guest's file references to permit the CF users to read
+    // 2. Update the guest's file references to permit the CF user to read
     // them.
     String fileLog = mergeGuestFilesIntoCfUser(civiformUser.id, guestUser.id, applyChanges);
     finalLogMessage.append("\n").append(fileLog);

--- a/server/app/repository/CiviFormAccountMerger.java
+++ b/server/app/repository/CiviFormAccountMerger.java
@@ -11,6 +11,7 @@ import javax.inject.Provider;
 import models.ApplicantModel;
 import models.ApplicationModel;
 import models.LifecycleStage;
+import models.StoredFileModel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,12 +55,12 @@ public final class CiviFormAccountMerger {
         };
     // 1. Merge Applications.
     String log = mergeGuestApplicationsIntoCfUser(civiformUser, guestUser, applyChanges);
-    String fileMergeLog = mergeGuestFilesIntoCfUser(civiformUser, guestUser, applyChanges);
-    // 2. Update File references for guest to allow CF App
-    //    * Set CFApp in ApplicantReadAcls
+    // 2. Update the guest's file references to permit the CF users to read
+    // them.
+    String fileMergeLog = mergeGuestFilesIntoCfUser(civiformUser.id, guestUser.id, applyChanges);
     // 3. Merge CFApp question answers and PAI into guest data and store in CF App
     // TODO(#11389): Step 3 is not yet implemented.
-    logger.info("{}{}", log, fileMergeLog);
+    logger.info("{}\n{}", log, fileMergeLog);
   }
   
   /**
@@ -580,8 +581,30 @@ public final class CiviFormAccountMerger {
   }
 
   private String mergeGuestFilesIntoCfUser(
-      ApplicantModel civiformUser, ApplicantModel guestUser, boolean applyChanges) {
+      Long civiformUserId, Long guestUserId, boolean applyChanges) {
+    var guestFiles =
+        storedFileRepositoryProvider
+            .get()
+            .lookupFilesByApplicant(guestUserId)
+            .toCompletableFuture()
+            .join();
+    StringJoiner fileIds = new StringJoiner(", ");
+    for (StoredFileModel file : guestFiles) {
+      fileIds.add(file.id.toString());
+      if (applyChanges) {
+        file.getAcls().addApplicantToReaders(civiformUserId);
+        file.save();
+      }
+    }
 
-    return "";
+    var logMessage = fileIds.toString();
+    if (logMessage.isBlank()) {
+      return "Guest user has no files to merge with CiviForm user.";
+    }
+
+    return """
+    Giving the CiviForm user read permissions to the guest's file IDs: %s
+    """
+        .formatted(fileIds);
   }
 }

--- a/server/app/repository/CiviFormAccountMerger.java
+++ b/server/app/repository/CiviFormAccountMerger.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.StringJoiner;
 import java.util.stream.Collectors;
+import javax.inject.Provider;
 import models.ApplicantModel;
 import models.ApplicationModel;
 import models.LifecycleStage;
@@ -15,6 +16,11 @@ import org.slf4j.LoggerFactory;
 
 public final class CiviFormAccountMerger {
   private static final Logger logger = LoggerFactory.getLogger(CiviFormAccountMerger.class);
+  private final Provider<StoredFileRepository> storedFileRepositoryProvider;
+
+  public CiviFormAccountMerger(Provider<StoredFileRepository> storedFileRepositoryProvider) {
+    this.storedFileRepositoryProvider = storedFileRepositoryProvider;
+  }
 
   /**
    * Merge data from the two applicants.
@@ -30,7 +36,7 @@ public final class CiviFormAccountMerger {
    *
    * <p>When a Guest Active application is moved it will have originalApplicantId set to the Guest
    * applicant to allow for matching across api data pulls. Draft applications will not have it set
-   * because Draft applications are not pulled by the api and it serves no purpose then.
+   * because Draft applications are not pulled by the api. and it serves no purpose then.
    *
    * @param newMergeStage what launch stage the new merge feature is at. Must be DRY_RUN OR ENABLED.
    */
@@ -48,13 +54,14 @@ public final class CiviFormAccountMerger {
         };
     // 1. Merge Applications.
     String log = mergeGuestApplicationsIntoCfUser(civiformUser, guestUser, applyChanges);
-    // TODO(#11389): Steps 2 and 3 are not yet implemented.
+    String fileMergeLog = mergeGuestFilesIntoCfUser(civiformUser, guestUser, applyChanges);
     // 2. Update File references for guest to allow CF App
     //    * Set CFApp in ApplicantReadAcls
     // 3. Merge CFApp question answers and PAI into guest data and store in CF App
-    logger.info(log);
+    // TODO(#11389): Step 3 is not yet implemented.
+    logger.info("{}{}", log, fileMergeLog);
   }
-
+  
   /**
    * A container for the CiviForm user's applications. We don't need obsolete records for the CF
    * user as compared to the Guest.
@@ -63,31 +70,32 @@ public final class CiviFormAccountMerger {
 
   /** A container for the Guest user's applications. */
   private record GuestUserApps(
-      List<ApplicationModel> obsolete,
-      Optional<ApplicationModel> active,
-      Optional<ApplicationModel> draft) {}
+    List<ApplicationModel> obsolete,
+    Optional<ApplicationModel> active,
+    Optional<ApplicationModel> draft) {}
 
   // Collect the applications into the nicer structure.
   private GuestUserApps categorizeGuestApps(List<ApplicationModel> apps) {
     List<ApplicationModel> obsolete =
-        apps.stream()
-            .filter(a -> a.getLifecycleStage() == LifecycleStage.OBSOLETE)
-            .collect(Collectors.toList());
+      apps.stream()
+          .filter(a -> a.getLifecycleStage() == LifecycleStage.OBSOLETE)
+          .collect(Collectors.toList());
     Optional<ApplicationModel> active =
-        apps.stream().filter(a -> a.getLifecycleStage() == LifecycleStage.ACTIVE).findFirst();
+      apps.stream().filter(a -> a.getLifecycleStage() == LifecycleStage.ACTIVE).findFirst();
     Optional<ApplicationModel> draft =
-        apps.stream().filter(a -> a.getLifecycleStage() == LifecycleStage.DRAFT).findFirst();
+      apps.stream().filter(a -> a.getLifecycleStage() == LifecycleStage.DRAFT).findFirst();
     return new GuestUserApps(obsolete, active, draft);
   }
 
   // Collect the applications into the nicer structure.
   private CfUserApps categorizeCfApps(List<ApplicationModel> apps) {
     Optional<ApplicationModel> active =
-        apps.stream().filter(a -> a.getLifecycleStage() == LifecycleStage.ACTIVE).findFirst();
+      apps.stream().filter(a -> a.getLifecycleStage() == LifecycleStage.ACTIVE).findFirst();
     Optional<ApplicationModel> draft =
-        apps.stream().filter(a -> a.getLifecycleStage() == LifecycleStage.DRAFT).findFirst();
+      apps.stream().filter(a -> a.getLifecycleStage() == LifecycleStage.DRAFT).findFirst();
     return new CfUserApps(active, draft);
   }
+
 
   /// Merge logic:
   /// 1. For programs only present in the guest user, move their applications
@@ -569,5 +577,11 @@ public final class CiviFormAccountMerger {
       * Moving Guest Draft application id %d to CiviForm applicant id %d
     """
         .formatted(cfDraft.id, guestDraft.id, cfUser.id);
+  }
+
+  private String mergeGuestFilesIntoCfUser(
+      ApplicantModel civiformUser, ApplicantModel guestUser, boolean applyChanges) {
+
+    return "";
   }
 }

--- a/server/app/repository/StoredFileRepository.java
+++ b/server/app/repository/StoredFileRepository.java
@@ -12,6 +12,7 @@ import java.util.Set;
 import java.util.concurrent.CompletionStage;
 import javax.inject.Inject;
 import models.StoredFileModel;
+import services.cloud.ApplicantFileNameFormatter;
 
 /**
  * StoredFileRepository performs complicated operations on {@link StoredFileModel} that involve
@@ -51,6 +52,24 @@ public final class StoredFileRepository {
                 .setProfileLocation(queryProfileLocationBuilder.create("lookupFiles"))
                 .where()
                 .in("name", keyNames)
+                .findList(),
+        dbExecutionContext);
+  }
+
+  public CompletionStage<List<StoredFileModel>> lookupFilesByApplicant(Long applicantId) {
+    // The strict prefix of the file name from the start of the name pattern.
+    String fileNamePrefix =
+        ApplicantFileNameFormatter.formatFilenameApplicantLookupPrefixString(applicantId);
+    return supplyAsync(
+        () ->
+            database
+                .find(StoredFileModel.class)
+                .setLabel("StoredFile.findListByApplicant")
+                .setProfileLocation(queryProfileLocationBuilder.create("lookupFilesByApplicant"))
+                .where()
+                // Note: The indexes only support exact and prefix pattern
+                // matches as this is doing.
+                .like("name", fileNamePrefix + "%")
                 .findList(),
         dbExecutionContext);
   }

--- a/server/app/services/cloud/ApplicantFileNameFormatter.java
+++ b/server/app/services/cloud/ApplicantFileNameFormatter.java
@@ -30,6 +30,16 @@ public final class ApplicantFileNameFormatter {
   }
 
   /**
+   * Returns the filename prefix string to identify this applicant's file in a filename.
+   *
+   * <p>The result will have a trailing / to ensure it does not match entries in which it otherwise
+   * would be a substring of other applicant data.
+   */
+  public static String formatFilenameApplicantLookupPrefixString(long applicantId) {
+    return String.format("applicant-%d/", applicantId);
+  }
+
+  /**
    * Generates a file key with a random UUID as the filename, preserving the original file's
    * extension. Used in the new HTMX file upload flow where the server generates the storage name.
    */

--- a/server/app/services/cloud/ApplicantFileNameFormatter.java
+++ b/server/app/services/cloud/ApplicantFileNameFormatter.java
@@ -33,7 +33,7 @@ public final class ApplicantFileNameFormatter {
    * Returns the filename prefix string to identify this applicant's file in a filename.
    *
    * <p>The result will have a trailing / to ensure it does not match entries in which it otherwise
-   * would be a substring of other applicant data.
+   * would be a substring of other applicant's files.
    */
   public static String formatFilenameApplicantLookupPrefixString(long applicantId) {
     return String.format("applicant-%d/", applicantId);

--- a/server/conf/evolutions/default/95.sql
+++ b/server/conf/evolutions/default/95.sql
@@ -1,5 +1,6 @@
-# --- Add unique index on files.name with varchar_pattern_ops to support prefix queries
-# --- https://www.postgresql.org/docs/8.4/indexes-opclass.html
+-- Add unique index on files.name with varchar_pattern_ops to support prefix queries
+-- https://www.postgresql.org/docs/8.4/indexes-opclass.html
+
 # --- !Ups
 CREATE UNIQUE INDEX IF NOT EXISTS index_file_name_prefix_pattern ON files (name varchar_pattern_ops);
 

--- a/server/conf/evolutions/default/95.sql
+++ b/server/conf/evolutions/default/95.sql
@@ -1,6 +1,7 @@
 # --- Add unique index on files.name with varchar_pattern_ops to support prefix queries
+# --- https://www.postgresql.org/docs/8.4/indexes-opclass.html
 # --- !Ups
-CREATE UNIQUE INDEX IF NOT EXISTS index_file_name_pattern ON files (name varchar_pattern_ops);
+CREATE UNIQUE INDEX IF NOT EXISTS index_file_name_prefix_pattern ON files (name varchar_pattern_ops);
 
 # --- !Downs
-DROP INDEX IF EXISTS index_file_name_pattern;
+DROP INDEX IF EXISTS index_file_name_prefix_pattern;

--- a/server/conf/evolutions/default/95.sql
+++ b/server/conf/evolutions/default/95.sql
@@ -2,6 +2,9 @@
 -- https://www.postgresql.org/docs/8.4/indexes-opclass.html
 # --- !Ups
 CREATE UNIQUE INDEX IF NOT EXISTS index_file_name_prefix_pattern ON files (name varchar_pattern_ops);
+DROP INDEX IF EXISTS index_file_names
 
 # --- !Downs
+-- From evolution 39, added IF NOT EXISTS.
+CREATE UNIQUE INDEX IF NOT EXISTS index_file_names ON files (name);
 DROP INDEX IF EXISTS index_file_name_prefix_pattern;

--- a/server/conf/evolutions/default/95.sql
+++ b/server/conf/evolutions/default/95.sql
@@ -2,9 +2,11 @@
 -- https://www.postgresql.org/docs/8.4/indexes-opclass.html
 # --- !Ups
 CREATE UNIQUE INDEX IF NOT EXISTS index_file_name_prefix_pattern ON files (name varchar_pattern_ops);
-DROP INDEX IF EXISTS index_file_names
+
+DROP INDEX IF EXISTS index_file_names;
 
 # --- !Downs
 -- From evolution 39, added IF NOT EXISTS.
 CREATE UNIQUE INDEX IF NOT EXISTS index_file_names ON files (name);
+
 DROP INDEX IF EXISTS index_file_name_prefix_pattern;

--- a/server/conf/evolutions/default/95.sql
+++ b/server/conf/evolutions/default/95.sql
@@ -1,0 +1,6 @@
+# --- Add unique index on files.name with varchar_pattern_ops to support prefix queries
+# --- !Ups
+CREATE UNIQUE INDEX IF NOT EXISTS index_file_name_pattern ON files (name varchar_pattern_ops);
+
+# --- !Downs
+DROP INDEX IF EXISTS index_file_name_pattern;

--- a/server/conf/evolutions/default/95.sql
+++ b/server/conf/evolutions/default/95.sql
@@ -1,6 +1,5 @@
 -- Add unique index on files.name with varchar_pattern_ops to support prefix queries
 -- https://www.postgresql.org/docs/8.4/indexes-opclass.html
-
 # --- !Ups
 CREATE UNIQUE INDEX IF NOT EXISTS index_file_name_prefix_pattern ON files (name varchar_pattern_ops);
 

--- a/server/test/auth/CiviFormProfileMergerTest.java
+++ b/server/test/auth/CiviFormProfileMergerTest.java
@@ -16,6 +16,7 @@ import org.pac4j.core.profile.UserProfile;
 import repository.AccountRepository;
 import repository.DatabaseExecutionContext;
 import repository.ResetPostgres;
+import repository.StoredFileRepository;
 import services.program.ProgramDefinition;
 import support.ProgramBuilder;
 
@@ -25,18 +26,21 @@ public class CiviFormProfileMergerTest extends ResetPostgres {
   private static final String EMAIL_ATTR = "user_emailid";
   private static final String EMAIL = "bar@foo.com";
 
-  private AccountRepository repository;
   private ProfileFactory profileFactory;
   private CiviFormProfileMerger civiFormProfileMerger;
   private UserProfile userProfile;
 
   @Before
   public void setup() {
-    repository = instanceOf(AccountRepository.class);
+    var repository = instanceOf(AccountRepository.class);
+    var storedFileRepository = instanceOf(StoredFileRepository.class);
     profileFactory = instanceOf(ProfileFactory.class);
     civiFormProfileMerger =
         new CiviFormProfileMerger(
-            profileFactory, () -> repository, instanceOf(DatabaseExecutionContext.class));
+            profileFactory,
+            () -> repository,
+            () -> storedFileRepository,
+            instanceOf(DatabaseExecutionContext.class));
     userProfile = new CommonProfile();
   }
 

--- a/server/test/auth/ProfileMergeTest.java
+++ b/server/test/auth/ProfileMergeTest.java
@@ -74,7 +74,7 @@ public class ProfileMergeTest extends ResetPostgres {
             /* client= */ null,
             profileFactory,
             CfTestHelpers.userRepositoryProvider(accountRepository),
-            CfTestHelpers.storedFileRepositoryProvider(storedFileRepository),
+            () -> storedFileRepository,
             instanceOf(DatabaseExecutionContext.class));
   }
 

--- a/server/test/auth/ProfileMergeTest.java
+++ b/server/test/auth/ProfileMergeTest.java
@@ -26,6 +26,7 @@ import org.pac4j.saml.profile.SAML2Profile;
 import repository.AccountRepository;
 import repository.DatabaseExecutionContext;
 import repository.ResetPostgres;
+import repository.StoredFileRepository;
 import support.CfTestHelpers;
 
 public class ProfileMergeTest extends ResetPostgres {
@@ -33,7 +34,6 @@ public class ProfileMergeTest extends ResetPostgres {
   private IdcsApplicantProfileCreator idcsApplicantProfileCreator;
   private SamlProfileCreator samlProfileCreator;
   private ProfileFactory profileFactory;
-  private static AccountRepository accountRepository;
   private Database database;
 
   @Before
@@ -44,7 +44,8 @@ public class ProfileMergeTest extends ResetPostgres {
   @Before
   public void setupFactory() {
     profileFactory = instanceOf(ProfileFactory.class);
-    accountRepository = instanceOf(AccountRepository.class);
+    var accountRepository = instanceOf(AccountRepository.class);
+    var storedFileRepository = instanceOf(StoredFileRepository.class);
     OidcClient client = CfTestHelpers.getOidcClient("dev-oidc", 3390);
     OidcConfiguration client_config = CfTestHelpers.getOidcConfiguration("dev-oidc", 3390);
 
@@ -62,7 +63,9 @@ public class ProfileMergeTest extends ResetPostgres {
             client_config,
             client,
             OidcClientProviderParams.create(
-                profileFactory, CfTestHelpers.userRepositoryProvider(accountRepository)),
+                profileFactory,
+                CfTestHelpers.userRepositoryProvider(accountRepository),
+                () -> storedFileRepository),
             standardClaimsAttributeNames,
             instanceOf(DatabaseExecutionContext.class));
     samlProfileCreator =
@@ -71,6 +74,7 @@ public class ProfileMergeTest extends ResetPostgres {
             /* client= */ null,
             profileFactory,
             CfTestHelpers.userRepositoryProvider(accountRepository),
+            CfTestHelpers.storedFileRepositoryProvider(storedFileRepository),
             instanceOf(DatabaseExecutionContext.class));
   }
 

--- a/server/test/auth/StoredFileAclsTest.java
+++ b/server/test/auth/StoredFileAclsTest.java
@@ -69,6 +69,17 @@ public class StoredFileAclsTest extends ResetPostgres {
     assertThat(acl.hasProgramReadPermission(account)).isEqualTo(hasAccess);
   }
 
+  @Test
+  public void addApplicantToReaders() {
+    var acls = new StoredFileAcls();
+
+    acls.addApplicantToReaders(1L);
+    assertThat(acls.getApplicantReadAcls()).containsExactly(1L);
+
+    acls.addApplicantToReaders(2L);
+    assertThat(acls.getApplicantReadAcls()).containsExactly(1L, 2L);
+  }
+
   // NamedParameters is necessary in Junit4 because the json contains commas
   // which is also @Parameters argument delimiter.
   /** Test data for an account that administers 'program-one'. */

--- a/server/test/auth/oidc/CiviformOidcLogoutActionBuilderTest.java
+++ b/server/test/auth/oidc/CiviformOidcLogoutActionBuilderTest.java
@@ -41,6 +41,7 @@ import org.pac4j.oidc.config.OidcConfiguration;
 import org.pac4j.play.PlayWebContext;
 import repository.AccountRepository;
 import repository.ResetPostgres;
+import repository.StoredFileRepository;
 import support.CfTestHelpers;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -57,9 +58,12 @@ public class CiviformOidcLogoutActionBuilderTest extends ResetPostgres {
   @Mock private AccountRepository accountRepository;
   @Mock private ProfileFactory profileFactory;
   @Mock private SessionStore sessionStore;
+  private Provider<StoredFileRepository> storedFileRepositoryProvider;
 
   @Before
   public void setup() {
+    var storedFileRepository = instanceOf(StoredFileRepository.class);
+    storedFileRepositoryProvider = () -> storedFileRepository;
     oidcConfig = CfTestHelpers.getOidcClient(oidcHost, oidcPort).getConfiguration();
     Clock clock = Clock.fixed(Instant.ofEpochSecond(10), ZoneOffset.UTC);
     civiFormProfileData = new CiviFormProfileData(accountId, clock);
@@ -95,7 +99,11 @@ public class CiviformOidcLogoutActionBuilderTest extends ResetPostgres {
     Provider<AccountRepository> accountRepositoryProvider = () -> accountRepository;
 
     OidcClientProviderParams params =
-        OidcClientProviderParams.create(civiformConfig, profileFactory, accountRepositoryProvider);
+        OidcClientProviderParams.create(
+            civiformConfig,
+            profileFactory,
+            accountRepositoryProvider,
+            storedFileRepositoryProvider);
     CiviformOidcLogoutActionBuilder builder =
         new CiviformOidcLogoutActionBuilder(
             oidcConfig, clientId, params, IdentityProviderType.APPLICANT_IDENTITY_PROVIDER);
@@ -133,7 +141,11 @@ public class CiviformOidcLogoutActionBuilderTest extends ResetPostgres {
     Provider<AccountRepository> accountRepositoryProvider = () -> accountRepository;
 
     OidcClientProviderParams params =
-        OidcClientProviderParams.create(civiformConfig, profileFactory, accountRepositoryProvider);
+        OidcClientProviderParams.create(
+            civiformConfig,
+            profileFactory,
+            accountRepositoryProvider,
+            storedFileRepositoryProvider);
     CiviformOidcLogoutActionBuilder builder =
         new CiviformOidcLogoutActionBuilder(
             oidcConfig, clientId, params, IdentityProviderType.ADMIN_IDENTITY_PROVIDER);
@@ -175,7 +187,11 @@ public class CiviformOidcLogoutActionBuilderTest extends ResetPostgres {
     Provider<AccountRepository> accountRepositoryProvider = () -> accountRepository;
 
     OidcClientProviderParams params =
-        OidcClientProviderParams.create(civiformConfig, profileFactory, accountRepositoryProvider);
+        OidcClientProviderParams.create(
+            civiformConfig,
+            profileFactory,
+            accountRepositoryProvider,
+            storedFileRepositoryProvider);
     CiviformOidcLogoutActionBuilder builder =
         new CiviformOidcLogoutActionBuilder(
             oidcConfig, clientId, params, IdentityProviderType.APPLICANT_IDENTITY_PROVIDER);
@@ -216,7 +232,11 @@ public class CiviformOidcLogoutActionBuilderTest extends ResetPostgres {
     Provider<AccountRepository> accountRepositoryProvider = () -> accountRepository;
 
     OidcClientProviderParams params =
-        OidcClientProviderParams.create(civiformConfig, profileFactory, accountRepositoryProvider);
+        OidcClientProviderParams.create(
+            civiformConfig,
+            profileFactory,
+            accountRepositoryProvider,
+            storedFileRepositoryProvider);
     CiviformOidcLogoutActionBuilder builder =
         new CiviformOidcLogoutActionBuilder(
             oidcConfig, clientId, params, IdentityProviderType.ADMIN_IDENTITY_PROVIDER);
@@ -259,7 +279,11 @@ public class CiviformOidcLogoutActionBuilderTest extends ResetPostgres {
     Provider<AccountRepository> accountRepositoryProvider = () -> accountRepository;
 
     OidcClientProviderParams params =
-        OidcClientProviderParams.create(civiformConfig, profileFactory, accountRepositoryProvider);
+        OidcClientProviderParams.create(
+            civiformConfig,
+            profileFactory,
+            accountRepositoryProvider,
+            storedFileRepositoryProvider);
     CiviformOidcLogoutActionBuilder builder =
         new CiviformOidcLogoutActionBuilder(
             oidcConfig, clientId, params, IdentityProviderType.ADMIN_IDENTITY_PROVIDER);
@@ -297,7 +321,11 @@ public class CiviformOidcLogoutActionBuilderTest extends ResetPostgres {
     Provider<AccountRepository> accountRepositoryProvider = () -> accountRepository;
 
     OidcClientProviderParams params =
-        OidcClientProviderParams.create(civiformConfig, profileFactory, accountRepositoryProvider);
+        OidcClientProviderParams.create(
+            civiformConfig,
+            profileFactory,
+            accountRepositoryProvider,
+            storedFileRepositoryProvider);
     CiviformOidcLogoutActionBuilder builder =
         new CiviformOidcLogoutActionBuilder(
             oidcConfig, clientId, params, IdentityProviderType.ADMIN_IDENTITY_PROVIDER);

--- a/server/test/auth/oidc/CiviformOidcProfileCreatorTest.java
+++ b/server/test/auth/oidc/CiviformOidcProfileCreatorTest.java
@@ -28,6 +28,7 @@ import org.pac4j.oidc.profile.OidcProfile;
 import repository.AccountRepository;
 import repository.DatabaseExecutionContext;
 import repository.ResetPostgres;
+import repository.StoredFileRepository;
 import support.CfTestHelpers;
 
 @RunWith(JUnitParamsRunner.class)
@@ -91,13 +92,15 @@ public class CiviformOidcProfileCreatorTest extends ResetPostgres {
             .setPhoneNumber(phoneNumberAttribute)
             .build();
 
+    var storedFileRepository = instanceOf(StoredFileRepository.class);
     return new IdcsApplicantProfileCreator(
         oidcConfig,
         client,
         OidcClientProviderParams.create(
             civiformConfig,
             profileFactory,
-            CfTestHelpers.userRepositoryProvider(accountRepository)),
+            CfTestHelpers.userRepositoryProvider(accountRepository),
+            () -> storedFileRepository),
         standardClaimsAttributeNames,
         instanceOf(DatabaseExecutionContext.class));
   }

--- a/server/test/auth/oidc/OidcClientProviderTest.java
+++ b/server/test/auth/oidc/OidcClientProviderTest.java
@@ -23,6 +23,7 @@ import play.api.test.Helpers;
 import repository.AccountRepository;
 import repository.DatabaseExecutionContext;
 import repository.ResetPostgres;
+import repository.StoredFileRepository;
 import support.CfTestHelpers;
 
 @RunWith(JUnitParamsRunner.class)
@@ -30,6 +31,7 @@ public class OidcClientProviderTest extends ResetPostgres {
   private OidcClientProvider oidcClientProvider;
   private ProfileFactory profileFactory;
   private static AccountRepository accountRepository;
+  private static StoredFileRepository storedFileRepository;
   private static final String DISCOVERY_URI =
       "http://dev-oidc:3390/.well-known/openid-configuration";
   private static final String BASE_URL =
@@ -38,6 +40,7 @@ public class OidcClientProviderTest extends ResetPostgres {
   @Before
   public void setup() {
     accountRepository = instanceOf(AccountRepository.class);
+    storedFileRepository = instanceOf(StoredFileRepository.class);
     profileFactory = instanceOf(ProfileFactory.class);
     Config config =
         ConfigFactory.parseMap(
@@ -55,7 +58,10 @@ public class OidcClientProviderTest extends ResetPostgres {
     oidcClientProvider =
         new IdcsClientProvider(
             OidcClientProviderParams.create(
-                config, profileFactory, CfTestHelpers.userRepositoryProvider(accountRepository)),
+                config,
+                profileFactory,
+                CfTestHelpers.userRepositoryProvider(accountRepository),
+                () -> storedFileRepository),
             instanceOf(DatabaseExecutionContext.class));
   }
 
@@ -113,7 +119,10 @@ public class OidcClientProviderTest extends ResetPostgres {
     OidcClientProvider oidcClientProvider =
         new IdcsClientProvider(
             OidcClientProviderParams.create(
-                config, profileFactory, CfTestHelpers.userRepositoryProvider(accountRepository)),
+                config,
+                profileFactory,
+                CfTestHelpers.userRepositoryProvider(accountRepository),
+                () -> storedFileRepository),
             instanceOf(DatabaseExecutionContext.class));
 
     OidcClient client = oidcClientProvider.get();
@@ -189,7 +198,8 @@ public class OidcClientProviderTest extends ResetPostgres {
                       OidcClientProviderParams.create(
                           bad_secret_config,
                           profileFactory,
-                          CfTestHelpers.userRepositoryProvider(accountRepository)),
+                          CfTestHelpers.userRepositoryProvider(accountRepository),
+                          () -> storedFileRepository),
                       instanceOf(DatabaseExecutionContext.class));
               badOidcClientProvider.get();
             })

--- a/server/test/auth/oidc/admin/GenericOidcClientProviderTest.java
+++ b/server/test/auth/oidc/admin/GenericOidcClientProviderTest.java
@@ -18,6 +18,7 @@ import play.api.test.Helpers;
 import repository.AccountRepository;
 import repository.DatabaseExecutionContext;
 import repository.ResetPostgres;
+import repository.StoredFileRepository;
 import support.CfTestHelpers;
 
 @RunWith(JUnitParamsRunner.class)
@@ -31,6 +32,7 @@ public class GenericOidcClientProviderTest extends ResetPostgres {
   @Before
   public void setup() {
     AccountRepository accountProvider = instanceOf(AccountRepository.class);
+    var storedFileRepository = instanceOf(StoredFileRepository.class);
     ProfileFactory profileFactory = instanceOf(ProfileFactory.class);
     Config config =
         ConfigFactory.parseMap(
@@ -52,7 +54,10 @@ public class GenericOidcClientProviderTest extends ResetPostgres {
     genericOidcProvider =
         new GenericOidcClientProvider(
             OidcClientProviderParams.create(
-                config, profileFactory, CfTestHelpers.userRepositoryProvider(accountProvider)),
+                config,
+                profileFactory,
+                CfTestHelpers.userRepositoryProvider(accountProvider),
+                () -> storedFileRepository),
             instanceOf(DatabaseExecutionContext.class));
   }
 

--- a/server/test/auth/oidc/admin/GenericOidcProfileCreatorTest.java
+++ b/server/test/auth/oidc/admin/GenericOidcProfileCreatorTest.java
@@ -19,6 +19,7 @@ import org.pac4j.oidc.profile.OidcProfile;
 import repository.AccountRepository;
 import repository.DatabaseExecutionContext;
 import repository.ResetPostgres;
+import repository.StoredFileRepository;
 import support.CfTestHelpers;
 
 public class GenericOidcProfileCreatorTest extends ResetPostgres {
@@ -28,6 +29,7 @@ public class GenericOidcProfileCreatorTest extends ResetPostgres {
   public void setup() {
     AccountRepository accountRepository = instanceOf(AccountRepository.class);
     ProfileFactory profileFactory = instanceOf(ProfileFactory.class);
+    var storedFileRepository = instanceOf(StoredFileRepository.class);
     OidcClient client = CfTestHelpers.getOidcClient("dev-oidc", 3390);
     OidcConfiguration client_config = CfTestHelpers.getOidcConfiguration("dev-oidc", 3390);
     Config serverConfig =
@@ -43,7 +45,8 @@ public class GenericOidcProfileCreatorTest extends ResetPostgres {
             OidcClientProviderParams.create(
                 serverConfig,
                 profileFactory,
-                CfTestHelpers.userRepositoryProvider(accountRepository)),
+                CfTestHelpers.userRepositoryProvider(accountRepository),
+                () -> storedFileRepository),
             instanceOf(DatabaseExecutionContext.class));
   }
 

--- a/server/test/auth/oidc/applicant/Auth0ProviderTest.java
+++ b/server/test/auth/oidc/applicant/Auth0ProviderTest.java
@@ -27,6 +27,7 @@ import play.mvc.Http.Request;
 import repository.AccountRepository;
 import repository.DatabaseExecutionContext;
 import repository.ResetPostgres;
+import repository.StoredFileRepository;
 import support.CfTestHelpers;
 
 @RunWith(JUnitParamsRunner.class)
@@ -46,6 +47,7 @@ public class Auth0ProviderTest extends ResetPostgres {
   public void setup() {
     AccountRepository accountRepository = instanceOf(AccountRepository.class);
     ProfileFactory profileFactory = instanceOf(ProfileFactory.class);
+    var storedFileRepository = instanceOf(StoredFileRepository.class);
     Config config =
         ConfigFactory.parseMap(
             ImmutableMap.<String, String>builder()
@@ -62,7 +64,10 @@ public class Auth0ProviderTest extends ResetPostgres {
     auth0Provider =
         new Auth0ClientProvider(
             OidcClientProviderParams.create(
-                config, profileFactory, CfTestHelpers.userRepositoryProvider(accountRepository)),
+                config,
+                profileFactory,
+                CfTestHelpers.userRepositoryProvider(accountRepository),
+                () -> storedFileRepository),
             instanceOf(DatabaseExecutionContext.class));
   }
 

--- a/server/test/auth/oidc/applicant/GenericApplicantProfileCreatorTest.java
+++ b/server/test/auth/oidc/applicant/GenericApplicantProfileCreatorTest.java
@@ -19,6 +19,7 @@ import org.pac4j.oidc.profile.OidcProfile;
 import repository.AccountRepository;
 import repository.DatabaseExecutionContext;
 import repository.ResetPostgres;
+import repository.StoredFileRepository;
 import support.CfTestHelpers;
 
 public class GenericApplicantProfileCreatorTest extends ResetPostgres {
@@ -36,11 +37,13 @@ public class GenericApplicantProfileCreatorTest extends ResetPostgres {
   private GenericApplicantProfileCreator oidcProfileAdapter;
   private ProfileFactory profileFactory;
   private static AccountRepository accountRepository;
+  private static StoredFileRepository storedFileRepository;
 
   @Before
   public void setup() {
     accountRepository = instanceOf(AccountRepository.class);
     profileFactory = instanceOf(ProfileFactory.class);
+    storedFileRepository = instanceOf(StoredFileRepository.class);
     OidcClient client = CfTestHelpers.getOidcClient("dev-oidc", 3390);
     OidcConfiguration client_config = CfTestHelpers.getOidcConfiguration("dev-oidc", 3390);
     // Just need some complete adaptor to access methods.
@@ -49,7 +52,9 @@ public class GenericApplicantProfileCreatorTest extends ResetPostgres {
             client_config,
             client,
             OidcClientProviderParams.create(
-                profileFactory, CfTestHelpers.userRepositoryProvider(accountRepository)),
+                profileFactory,
+                CfTestHelpers.userRepositoryProvider(accountRepository),
+                () -> storedFileRepository),
             StandardClaimsAttributeNames.builder()
                 .setEmail(EMAIL_ATTRIBUTE_NAME)
                 .setLocale(Optional.of(LOCALE_ATTRIBUTE_NAME))
@@ -72,7 +77,9 @@ public class GenericApplicantProfileCreatorTest extends ResetPostgres {
             client_config,
             client,
             OidcClientProviderParams.create(
-                profileFactory, CfTestHelpers.userRepositoryProvider(accountRepository)),
+                profileFactory,
+                CfTestHelpers.userRepositoryProvider(accountRepository),
+                () -> storedFileRepository),
             StandardClaimsAttributeNames.builder()
                 .setEmail(EMAIL_ATTRIBUTE_NAME)
                 .setLocale(Optional.of(LOCALE_ATTRIBUTE_NAME))

--- a/server/test/auth/oidc/applicant/GenericOidcClientProviderTest.java
+++ b/server/test/auth/oidc/applicant/GenericOidcClientProviderTest.java
@@ -20,6 +20,7 @@ import play.api.test.Helpers;
 import repository.AccountRepository;
 import repository.DatabaseExecutionContext;
 import repository.ResetPostgres;
+import repository.StoredFileRepository;
 import support.CfTestHelpers;
 
 @RunWith(JUnitParamsRunner.class)
@@ -36,6 +37,7 @@ public class GenericOidcClientProviderTest extends ResetPostgres {
   public void setup() {
     accountRepository = instanceOf(AccountRepository.class);
     profileFactory = instanceOf(ProfileFactory.class);
+    var storedFileRepository = instanceOf(StoredFileRepository.class);
     Config config =
         ConfigFactory.parseMap(
             ImmutableMap.<String, String>builder()
@@ -59,7 +61,10 @@ public class GenericOidcClientProviderTest extends ResetPostgres {
     genericOidcProvider =
         new GenericOidcClientProvider(
             OidcClientProviderParams.create(
-                config, profileFactory, CfTestHelpers.userRepositoryProvider(accountRepository)),
+                config,
+                profileFactory,
+                CfTestHelpers.userRepositoryProvider(accountRepository),
+                () -> storedFileRepository),
             instanceOf(DatabaseExecutionContext.class));
   }
 

--- a/server/test/auth/oidc/applicant/IdcsClientProviderTest.java
+++ b/server/test/auth/oidc/applicant/IdcsClientProviderTest.java
@@ -18,6 +18,7 @@ import play.api.test.Helpers;
 import repository.AccountRepository;
 import repository.DatabaseExecutionContext;
 import repository.ResetPostgres;
+import repository.StoredFileRepository;
 import support.CfTestHelpers;
 
 @RunWith(JUnitParamsRunner.class)
@@ -34,6 +35,7 @@ public class IdcsClientProviderTest extends ResetPostgres {
   public void setup() {
     accountRepository = instanceOf(AccountRepository.class);
     profileFactory = instanceOf(ProfileFactory.class);
+    var storedFileRepository = instanceOf(StoredFileRepository.class);
     Config config =
         ConfigFactory.parseMap(
             ImmutableMap.of(
@@ -50,7 +52,10 @@ public class IdcsClientProviderTest extends ResetPostgres {
     idcsProvider =
         new IdcsClientProvider(
             OidcClientProviderParams.create(
-                config, profileFactory, CfTestHelpers.userRepositoryProvider(accountRepository)),
+                config,
+                profileFactory,
+                CfTestHelpers.userRepositoryProvider(accountRepository),
+                () -> storedFileRepository),
             instanceOf(DatabaseExecutionContext.class));
   }
 

--- a/server/test/auth/oidc/applicant/LoginGovClientProviderTest.java
+++ b/server/test/auth/oidc/applicant/LoginGovClientProviderTest.java
@@ -30,6 +30,7 @@ import play.mvc.Http.Request;
 import repository.AccountRepository;
 import repository.DatabaseExecutionContext;
 import repository.ResetPostgres;
+import repository.StoredFileRepository;
 import support.CfTestHelpers;
 
 @RunWith(JUnitParamsRunner.class)
@@ -49,6 +50,7 @@ public class LoginGovClientProviderTest extends ResetPostgres {
   public void setup() {
     AccountRepository accountRepository = instanceOf(AccountRepository.class);
     ProfileFactory profileFactory = instanceOf(ProfileFactory.class);
+    var storedFileRepository = instanceOf(StoredFileRepository.class);
     Config config =
         ConfigFactory.parseMap(
             ImmutableMap.<String, String>builder()
@@ -62,7 +64,10 @@ public class LoginGovClientProviderTest extends ResetPostgres {
     loginGovProvider =
         new LoginGovClientProvider(
             OidcClientProviderParams.create(
-                config, profileFactory, CfTestHelpers.userRepositoryProvider(accountRepository)),
+                config,
+                profileFactory,
+                CfTestHelpers.userRepositoryProvider(accountRepository),
+                () -> storedFileRepository),
             instanceOf(DatabaseExecutionContext.class));
   }
 

--- a/server/test/repository/CiviFormAccountMergerTest.java
+++ b/server/test/repository/CiviFormAccountMergerTest.java
@@ -10,6 +10,7 @@ import auth.NewGuestMergeLaunchStage;
 import com.google.common.collect.ImmutableMap;
 import java.time.Clock;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import junitparams.JUnitParamsRunner;
@@ -17,9 +18,11 @@ import junitparams.Parameters;
 import models.ApplicantModel;
 import models.ApplicationModel;
 import models.LifecycleStage;
+import models.StoredFileModel;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import services.cloud.ApplicantFileNameFormatter;
 import services.settings.SettingsManifest;
 
 @RunWith(JUnitParamsRunner.class)
@@ -27,11 +30,13 @@ public class CiviFormAccountMergerTest extends ResetPostgres {
   private CiviFormAccountMerger merger;
   private AccountRepository acctRepo;
   private ApplicationRepository applRepo;
+  private StoredFileRepository storedFileRepository;
 
   @Before
   public void setupApplicantRepository() {
     SettingsManifest mockSettingsManifest = mock(SettingsManifest.class);
-    merger = new CiviFormAccountMerger(() -> instanceOf(StoredFileRepository.class));
+    storedFileRepository = instanceOf(StoredFileRepository.class);
+    merger = new CiviFormAccountMerger(() -> storedFileRepository);
     acctRepo =
         new AccountRepository(
             instanceOf(DatabaseExecutionContext.class),
@@ -484,5 +489,93 @@ public class CiviFormAccountMergerTest extends ResetPostgres {
     assertThat(idToApplication.get(guestActive.id).getOriginalApplicantId()).hasValue(guestUser.id);
     // CF's draft is deleted.
     assertThat(applRepo.getApplication(cfDraft.id).toCompletableFuture().join()).isEmpty();
+  }
+
+  @Test
+  public void mergeGuestFilesIntoCfUser_dryRun_doesNotAddCfUserToAcl() {
+    ApplicantModel cfUser =
+        resourceCreator.insertApplicantWithAccount(Optional.of("cf@example.com"));
+    ApplicantModel guestUser = resourceCreator.insertApplicantWithAccount();
+    cfUser.refresh();
+    guestUser.refresh();
+
+    StoredFileModel guestFile = insertFileForApplicant(guestUser.id);
+
+    merger.mergeApplicants(cfUser, guestUser, NewGuestMergeLaunchStage.DRY_RUN);
+
+    StoredFileModel fileAfterMerge = lookupFile(guestFile.id);
+    assertThat(fileAfterMerge.getAcls().getApplicantReadAcls()).doesNotContain(cfUser.id);
+  }
+
+  @Test
+  @Parameters({"0", "1", "2"})
+  public void mergeGuestFilesIntoCfUser_enabled_addsCfUserToAcl(int numFiles) {
+    ApplicantModel cfUser =
+        resourceCreator.insertApplicantWithAccount(Optional.of("cf@example.com"));
+    ApplicantModel guestUser = resourceCreator.insertApplicantWithAccount();
+    cfUser.refresh();
+    guestUser.refresh();
+    List<Long> fileIds = new ArrayList<>();
+    for (int i = 0; i < numFiles; i++) {
+      fileIds.add(insertFileForApplicant(guestUser.id, /* programId= */ i).id);
+    }
+
+    merger.mergeApplicants(cfUser, guestUser, NewGuestMergeLaunchStage.ENABLED);
+
+    for (Long fileId : fileIds) {
+      StoredFileModel fileAfterMerge = lookupFile(fileId);
+      assertThat(fileAfterMerge.getAcls().getApplicantReadAcls()).containsExactly(cfUser.id);
+    }
+
+    assertThat(lookupUserFiles(cfUser.id)).isEmpty();
+    assertThat(lookupUserFiles(guestUser.id)).containsExactlyElementsOf(fileIds);
+  }
+
+  @Test
+  public void mergeGuestFilesIntoCfUser_enabled_cfUserFilesNotAffected() {
+    ApplicantModel cfUser =
+        resourceCreator.insertApplicantWithAccount(Optional.of("cf@example.com"));
+    ApplicantModel guestUser = resourceCreator.insertApplicantWithAccount();
+    cfUser.refresh();
+    guestUser.refresh();
+
+    StoredFileModel cfFile = insertFileForApplicant(cfUser.id);
+    StoredFileModel guestFile = insertFileForApplicant(guestUser.id);
+
+    merger.mergeApplicants(cfUser, guestUser, NewGuestMergeLaunchStage.ENABLED);
+
+    // CF user's own file ACLs are not modified.
+    assertThat(lookupFile(cfFile.id).getAcls().getApplicantReadAcls())
+        .doesNotContain(cfUser.id, guestUser.id);
+    // Guest file gets cfUser added.
+    assertThat(lookupFile(guestFile.id).getAcls().getApplicantReadAcls())
+        .containsExactly(cfUser.id);
+  }
+
+  private StoredFileModel insertFileForApplicant(long applicantId) {
+    return insertFileForApplicant(applicantId, /* programId= */ 1L);
+  }
+
+  private StoredFileModel insertFileForApplicant(long applicantId, long programId) {
+    StoredFileModel file = new StoredFileModel();
+    file.setName(
+        ApplicantFileNameFormatter.formatFileUploadQuestionFilename(
+            applicantId, programId, /* blockId= */ "1"));
+    file.save();
+    return file;
+  }
+
+  private StoredFileModel lookupFile(long fileId) {
+    return storedFileRepository.lookupFile(fileId).toCompletableFuture().join().orElseThrow();
+  }
+
+  private List<Long> lookupUserFiles(long applicantId) {
+    return storedFileRepository
+        .lookupFilesByApplicant(applicantId)
+        .toCompletableFuture()
+        .join()
+        .stream()
+        .map(f -> f.id)
+        .toList();
   }
 }

--- a/server/test/repository/CiviFormAccountMergerTest.java
+++ b/server/test/repository/CiviFormAccountMergerTest.java
@@ -524,7 +524,9 @@ public class CiviFormAccountMergerTest extends ResetPostgres {
 
     for (Long fileId : fileIds) {
       StoredFileModel fileAfterMerge = lookupFile(fileId);
-      assertThat(fileAfterMerge.getAcls().getApplicantReadAcls()).containsExactly(cfUser.id);
+      assertThat(fileAfterMerge.getAcls().getApplicantReadAcls())
+          .withFailMessage(() -> "File id %d".formatted(fileId))
+          .containsExactly(cfUser.id);
     }
 
     assertThat(lookupUserFiles(cfUser.id)).isEmpty();

--- a/server/test/repository/CiviFormAccountMergerTest.java
+++ b/server/test/repository/CiviFormAccountMergerTest.java
@@ -31,7 +31,7 @@ public class CiviFormAccountMergerTest extends ResetPostgres {
   @Before
   public void setupApplicantRepository() {
     SettingsManifest mockSettingsManifest = mock(SettingsManifest.class);
-    merger = new CiviFormAccountMerger();
+    merger = new CiviFormAccountMerger(() -> instanceOf(StoredFileRepository.class));
     acctRepo =
         new AccountRepository(
             instanceOf(DatabaseExecutionContext.class),

--- a/server/test/repository/StoredFileRepositoryTest.java
+++ b/server/test/repository/StoredFileRepositoryTest.java
@@ -10,6 +10,7 @@ import java.util.List;
 import models.StoredFileModel;
 import org.junit.Before;
 import org.junit.Test;
+import services.cloud.ApplicantFileNameFormatter;
 import support.ProgramBuilder;
 
 public class StoredFileRepositoryTest extends ResetPostgres {
@@ -66,6 +67,47 @@ public class StoredFileRepositoryTest extends ResetPostgres {
     StoredFileModel result = repo.lookupFile(file.getName()).toCompletableFuture().join().get();
 
     assertThat(result).isEqualTo(file);
+  }
+
+  @Test
+  public void lookupFilesByApplicant() {
+    // Verify only Applicant 1 is returned and does not substring match on 10.
+    long applicantId = 1L;
+    long supersetApplicantId = 10L;
+
+    StoredFileModel applicantFile1 =
+        new StoredFileModel()
+            .setName(
+                ApplicantFileNameFormatter.formatFileUploadQuestionFilename(
+                    applicantId, /* programId= */ 20L, /* blockId= */ "5"));
+    applicantFile1.save();
+
+    StoredFileModel applicantFile2 =
+        new StoredFileModel()
+            .setName(
+                ApplicantFileNameFormatter.formatFileUploadQuestionFilename(
+                    applicantId, /* programId= */ 30L, /* blockId= */ "6"));
+    applicantFile2.save();
+
+    StoredFileModel supersetApplicantFile =
+        new StoredFileModel()
+            .setName(
+                ApplicantFileNameFormatter.formatFileUploadQuestionFilename(
+                    supersetApplicantId, /* programId= */ 20L, /* blockId= */ "5"));
+    supersetApplicantFile.save();
+
+    List<StoredFileModel> result =
+        repo.lookupFilesByApplicant(applicantId).toCompletableFuture().join();
+
+    assertThat(result).containsExactlyInAnyOrder(applicantFile1, applicantFile2);
+  }
+
+  @Test
+  public void lookupFilesByApplicant_noFiles_returnsEmpty() {
+    List<StoredFileModel> result =
+        repo.lookupFilesByApplicant(/* applicantId= */ 99L).toCompletableFuture().join();
+
+    assertThat(result).isEmpty();
   }
 
   /**

--- a/server/test/services/cloud/ApplicantFileNameFormatterTest.java
+++ b/server/test/services/cloud/ApplicantFileNameFormatterTest.java
@@ -64,6 +64,13 @@ public class ApplicantFileNameFormatterTest {
   }
 
   @Test
+  public void formatFilenameApplicantLookupPrefixString() {
+    String prefix =
+        ApplicantFileNameFormatter.formatFilenameApplicantLookupPrefixString(/* applicantId= */ 1L);
+    assertThat(FILE_NAME).startsWith(prefix);
+  }
+
+  @Test
   public void formatFileUploadQuestionFilenameWithUuid() {
     String result =
         ApplicantFileNameFormatter.formatFileUploadQuestionFilenameWithUuid(


### PR DESCRIPTION
### Description

When merging a guest into a CiviForm user, we can't change the filename based ACL from the guest to the CF user, so we instead add the CF user to the guest's file's ACL list.

The key changes are in `CiviFormAccountMerger.java`

This PR adds a new index on the file names so that we can do an index based prefix lookup to find all of the guest's files.  This is managed through `StoredFileRepository`

Note: this acl was added specifically for this purpose and uses of the ACL are already in place (#12564)

Most of the touched files are just to pass a `StoredFileRepository` from constructs that have `@Inject` down to `CiviFormAccountMerger`, and their tests.

**Logging**:

New logging example as the last line here:

```
CiviForm user and Guest both only have a Draft application.
  * Deleting CiviForm Draft application id 14
  * Moving Guest Draft application id 15 to CiviForm applicant id 16

Giving the CiviForm user read permissions to the guest's file IDs: 10019, 20019, 30020, 1030021, 2030021, 3030005
```

**AI**: Claude wrote the initial versions of the tests.

### Checklist

Remove any sections below that do not apply to your PR. For sections that do apply, complete all of the appropriate checklist items and check them off. If a checklist item doesn't apply to your PR, leave it unchecked but do not delete it.

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [x] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [x] Noted in the PR description which, if any, code in this PR was generated by AI.

#### Database evolutions

Read the guidelines [here](https://github.com/civiform/civiform/wiki/Database#writing-database-evolutions)

- [x] Assigned two reviewers
- [x] Guarded against already existing resources using `IF NOT EXISTS` and `IF EXISTS`
- [x] Downs created to undo changes in Ups
- [x] Every comment in script should begin with -- and not # --- unless it denotes Ups or Downs. See [here](https://www.playframework.com/documentation/2.9.x/Evolutions) for details.
- [x] Tested both the Downs and the Ups scripts manually (When testing, include all comments from the evolution in your test script to ensure any syntax errors in the comments are caught.)
- [x] Data migrations aren't being done (please use a [Durable Job](https://github.com/civiform/civiform/wiki/Database#durable-jobs-for-data-updates) if doing a data migration)
- [x] Update the model documentation in our [wiki](https://github.com/civiform/civiform/wiki/Database) if necessary

### Instructions for manual testing

It is unnecessary to test this PR in isolation as it is behind a feature flag, however if one wanted to:

1. Enable the `new_applicant_guest_merging_strategy_enabled` flag.
1. Create a CF account.
1. As a guest upload a file to any program. You don't need to submit.
1. Login as the CF account.
1. Check the `files` table and see that the CF user id is in the ACL for the guest's file.

### Issue(s) this completes

Fixes #13123