### PR TITLE
Ignore local claude settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,6 @@ server/dependencies-compile.graphml
 
 # Output of bin/renovate-test
 renovate-debug-output.txt
+
+# AI
+.claude/settings.local.json


### PR DESCRIPTION
Prevent the `.claude/settings.local.json` file from being added to git. It isn't supposed to be checked in. Shared settings should be in `.claude/settings.json`, but we should avoid them, at least for now because it affects everyone.
