### PR TITLE
[Account Merge & Main] Update Account -> Applicant lookup from max to min creation time.

### DIFF
--- a/server/app/repository/AccountRepository.java
+++ b/server/app/repository/AccountRepository.java
@@ -161,7 +161,7 @@ public final class AccountRepository {
         () -> {
           Optional<ApplicantModel> applicantOpt =
               account.getApplicants().stream()
-                  .max(Comparator.comparing(ApplicantModel::getWhenCreated));
+                  .min(Comparator.comparing(ApplicantModel::getWhenCreated));
           return applicantOpt.orElseGet(
               () -> new ApplicantModel().setAccount(account).saveAndReturn());
         });

--- a/server/app/repository/AccountRepository.java
+++ b/server/app/repository/AccountRepository.java
@@ -161,7 +161,8 @@ public final class AccountRepository {
         () -> {
           Optional<ApplicantModel> applicantOpt =
               account.getApplicants().stream()
-                  .max(Comparator.comparing(ApplicantModel::getWhenCreated));
+                  // DO NOT SUBMIT
+                  .min(Comparator.comparing(ApplicantModel::getWhenCreated));
           return applicantOpt.orElseGet(
               () -> new ApplicantModel().setAccount(account).saveAndReturn());
         });

--- a/server/app/repository/AccountRepository.java
+++ b/server/app/repository/AccountRepository.java
@@ -161,8 +161,7 @@ public final class AccountRepository {
         () -> {
           Optional<ApplicantModel> applicantOpt =
               account.getApplicants().stream()
-                  // DO NOT SUBMIT
-                  .min(Comparator.comparing(ApplicantModel::getWhenCreated));
+                  .max(Comparator.comparing(ApplicantModel::getWhenCreated));
           return applicantOpt.orElseGet(
               () -> new ApplicantModel().setAccount(account).saveAndReturn());
         });

--- a/server/app/repository/CiviFormAccountMerger.java
+++ b/server/app/repository/CiviFormAccountMerger.java
@@ -619,8 +619,29 @@ public final class CiviFormAccountMerger {
         .formatted(fileIds);
   }
 
+  /**
+   * Merges the question answers in the two users and stores them on {@code civiformUser}, {@code
+   * guestUser} is not modified.
+   *
+   * <p>The user's question answers in {@code Applicant.object} and the PAI answers are both merged.
+   * For both, the guest's data is preferred, and the civiform user's data is only used if the guest
+   * does not have the data item.
+   *
+   * <p>Merging is done at the question level and not at the level of each individual field present
+   * in a question's answer data. This means for the `object` question answer data, the entire
+   * question answer is used from either user in whole and not its sub data items individually. EG:
+   * if one has a middle name but the other doesn't we will not use just that middle name separate
+   * from the other name parts in that user's data.
+   *
+   * <p>The same policy above also applies to the PAI data stored directly on the applicant.
+   *
+   * @param applyChanges if database changes should be applied. If false the return will log what
+   *     would have occurred.
+   * @return a log message indicating what changes occurred.
+   */
   private static String mergeQuestionAnswers(
       ApplicantModel civiformUser, ApplicantModel guestUser, boolean applyChanges) {
+
     // Merge question answers in the Applicant object data.
     // Use the guest's as the base, and supplement with the CiviForm users
     // for any questions that are missing.
@@ -631,15 +652,16 @@ public final class CiviFormAccountMerger {
       civiformUser.setApplicantData(mergeData);
     }
 
-    // Collect the CiviForm user answers that effectively supplement the
-    // guest's.  Determining this is a little backwards because as a
-    // narrative, we are supplementing the guest's data with the cf users,
+    // Merge question answers in the PAIs.  As above, prefer the guest's answers when present.
+
+    // For logging, collect the CiviForm user answers that effectively
+    // supplement the guest's.  Determining this is a little backwards because as a
+    // narrative we are supplementing the guest's data with the cf users,
     // however programmatically we are copying guest data into the cf user.
-    // So to determine which cf user data is retained we track which of its
+    // So to determine which cf user data is retained/used we track which of its
     // pais exist but weren't overwritten.
     StringJoiner cfPaisNotOverwritten = new StringJoiner(",");
 
-    // Merge question answers in the PAIs.  As above, prefer the guest's answers when present.
     // Name.  First/Last are required in forms, the others are not.
     if (guestUser.getFirstName().isPresent() && guestUser.getLastName().isPresent()) {
       if (applyChanges) {
@@ -663,7 +685,8 @@ public final class CiviFormAccountMerger {
       cfPaisNotOverwritten.add("email");
     }
 
-    // Phone number.
+    // Phone number.   Country code is set as a side effect of setting
+    // the phone number, so we don't manage it separately.
     if (guestUser.getPhoneNumber().isPresent()) {
       if (applyChanges) {
         civiformUser.setPhoneNumber(guestUser.getPhoneNumber().get());
@@ -684,6 +707,7 @@ public final class CiviFormAccountMerger {
     if (applyChanges) {
       civiformUser.save();
     }
+
     return """
     Using guest applicant data and supplementing with CiviForm user data:
     * CiviForm question answers: %d copied %d not copied.

--- a/server/app/repository/CiviFormAccountMerger.java
+++ b/server/app/repository/CiviFormAccountMerger.java
@@ -619,29 +619,8 @@ public final class CiviFormAccountMerger {
         .formatted(fileIds);
   }
 
-  /**
-   * Merges the question answers in the two users and stores them on {@code civiformUser}, {@code
-   * guestUser} is not modified.
-   *
-   * <p>The user's question answers in {@code Applicant.object} and the PAI answers are both merged.
-   * For both, the guest's data is preferred because it is more recent, and the civiform user's data
-   * is only used if the guest does not have the data item.
-   *
-   * <p>Merging is done at the question level and not at the level of each individual field present
-   * in a question's answer data. This means for the `object` question answer data, the entire
-   * question answer is used from either user in whole and not its sub data items individually. EG:
-   * if one has a middle name but the other doesn't we will not use just that middle name separate
-   * from the other name parts in that user's data.
-   *
-   * <p>The same policy above also applies to the PAI data stored directly on the applicant.
-   *
-   * @param applyChanges if database changes should be applied. If false the return will log what
-   *     would have occurred.
-   * @return a log message indicating what changes occurred.
-   */
   private static String mergeQuestionAnswers(
       ApplicantModel civiformUser, ApplicantModel guestUser, boolean applyChanges) {
-
     // Merge question answers in the Applicant object data.
     // Use the guest's as the base, and supplement with the CiviForm users
     // for any questions that are missing.
@@ -652,16 +631,16 @@ public final class CiviFormAccountMerger {
       civiformUser.setApplicantData(mergeData);
     }
 
-    // Merge the applicant's Primary Applicant Info (PAI).  As above, prefer the guest's answers
-    // when present.
-    // Track the status of each PAI for logging.
-    StringJoiner cfPaiOverwritten = new StringJoiner(",");
-    StringJoiner cfPaiSupplemented = new StringJoiner(",");
-    StringJoiner cfPaiMaintained = new StringJoiner(",");
+    // Collect the CiviForm user answers that effectively supplement the
+    // guest's.  Determining this is a little backwards because as a
+    // narrative, we are supplementing the guest's data with the cf users,
+    // however programmatically we are copying guest data into the cf user.
+    // So to determine which cf user data is retained we track which of its
+    // pais exist but weren't overwritten.
+    StringJoiner cfPaisNotOverwritten = new StringJoiner(",");
 
+    // Merge question answers in the PAIs.  As above, prefer the guest's answers when present.
     // Name.  First/Last are required in forms, the others are not.
-    boolean cfUserHasName =
-        civiformUser.getFirstName().isPresent() && civiformUser.getLastName().isPresent();
     if (guestUser.getFirstName().isPresent() && guestUser.getLastName().isPresent()) {
       if (applyChanges) {
         civiformUser.setUserName(
@@ -670,79 +649,49 @@ public final class CiviFormAccountMerger {
             /* lastName= */ guestUser.getLastName(),
             /* nameSuffix= */ guestUser.getSuffix());
       }
-      if (cfUserHasName) {
-        cfPaiOverwritten.add("name");
-      } else {
-        cfPaiSupplemented.add("name");
-      }
-    } else if (cfUserHasName) {
-      cfPaiMaintained.add("name");
+
+    } else if (civiformUser.getFirstName().isPresent() && civiformUser.getLastName().isPresent()) {
+      cfPaisNotOverwritten.add("name");
     }
 
     // Email.
-    boolean cfUserHasEmail = civiformUser.getEmailAddress().isPresent();
     if (guestUser.getEmailAddress().isPresent()) {
       if (applyChanges) {
         civiformUser.setEmailAddress(guestUser.getEmailAddress().get());
       }
-      if (cfUserHasEmail) {
-        cfPaiOverwritten.add("email");
-      } else {
-        cfPaiSupplemented.add("email");
-      }
-
-    } else if (cfUserHasEmail) {
-      cfPaiMaintained.add("email");
+    } else if (civiformUser.getEmailAddress().isPresent()) {
+      cfPaisNotOverwritten.add("email");
     }
 
-    // Phone number.   Country code is set as a side effect of setting
-    // the phone number, so we don't manage it separately.
-    boolean cfUserHasPhone = civiformUser.getPhoneNumber().isPresent();
+    // Phone number.
     if (guestUser.getPhoneNumber().isPresent()) {
       if (applyChanges) {
         civiformUser.setPhoneNumber(guestUser.getPhoneNumber().get());
       }
-      if (cfUserHasPhone) {
-        cfPaiOverwritten.add("phone-number");
-      } else {
-        cfPaiSupplemented.add("phone-number");
-      }
-    } else if (cfUserHasPhone) {
-      cfPaiMaintained.add("phone-number");
+    } else if (civiformUser.getPhoneNumber().isPresent()) {
+      cfPaisNotOverwritten.add("phone-number");
     }
 
     // Date of birth.
-    boolean cfUserHasDob = civiformUser.getDateOfBirth().isPresent();
     if (guestUser.getDateOfBirth().isPresent()) {
       if (applyChanges) {
         civiformUser.setDateOfBirth(guestUser.getDateOfBirth().get());
       }
-      if (cfUserHasDob) {
-        cfPaiOverwritten.add("dob");
-      } else {
-        cfPaiSupplemented.add("dob");
-      }
-    } else if (cfUserHasDob) {
-      cfPaiMaintained.add("dob");
+    } else if (civiformUser.getDateOfBirth().isPresent()) {
+      cfPaisNotOverwritten.add("dob");
     }
 
     if (applyChanges) {
       civiformUser.save();
     }
-
     return """
-    Updating CiviForm user data with guest data:
+    Using guest applicant data and supplementing with CiviForm user data:
     * CiviForm question answers: %d copied %d not copied.
-    * CiviForm PAIs:
-      * Guest overwrote CiviForm user: %s
-      * Guest supplemented CiviForm user: %s
-      * CiviForm user data maintained: %s
+    * CiviForm PAIs copied: %s
     """
         .formatted(
             qaMergeSummary.mergedPaths().size(),
             qaMergeSummary.droppedPaths().size(),
-            cfPaiOverwritten,
-            cfPaiSupplemented,
-            cfPaiMaintained);
+            cfPaisNotOverwritten);
   }
 }


### PR DESCRIPTION
### Description

For account merging, when we find the CiviForm account's applicant to use in the merge we currently find the newest, and this PR changes that to be the oldest.  The oldest is now selected because it will be the first applicant the existed when there are multiples and therefor the most logical one to use for continuity.

For the **existing merge logic**, which is broken, the applicant selected doesn't really matter because we merge question answers into the newest applicant (`mergeApplicantsOlderIntoNewer`) then never select the newest applicant as the user's applicant to use; we actually select the oldest by way of which of the account's applicant ids we store in the profile (`getOldestApplicantForAccount`)

[mergeApplicantAndGuestProfile](https://github.com/civiform/civiform/blob/bc729f9560e1d1a58c08ea789a5515c308b3c1a6/server/app/auth/CiviFormProfileMerger.java#L141)
```
->  ApplicantRepository::mergeApplicantsOlderIntoNewer
->  profileFactory.wrap
  ->  CiviFormProfile::storeApplicantIdInProfile
    -> getOldestApplicantForAccount()
```

For the **new merge logic** it is necessary that we always select the oldest applicant as the singular applicant for the account.

This PR changes the applicant selection for the existing and new flow. It does so as the new flow requires it and also to support the DRY_RUN for the new flow. The DRY_RUN needs the correct/oldest applicant to be selected and we can't do that selection different from the core flow of the existing merge flow; at least not without complication.

Making this update is fine given the stated issues in the existing merge as well as:

AccountRepository::[`getOrCreateApplicant`](https://github.com/civiform/civiform/blob/bc729f9560e1d1a58c08ea789a5515c308b3c1a6/server/app/repository/AccountRepository.java#L159) is the updated method, it is effectively only used to select the applicant to use for merging. 

It is used only through [`CiviformOidcProfileCreator.java::innerCreate()`](https://github.com/civiform/civiform/blob/main/server/app/auth/oidc/CiviformOidcProfileCreator.java#L205) call to `getExistingApplicant`

```
CiviformOidcProfileCreator::getExistingApplicant (CiviformOidcProfileCreator.java:294)                                                                                                                        
    -> AccountRepository::lookupApplicantByAuthorityId (AccountRepository.java:170)                                                                                                                             
      -> AccountRepository::lookupAccountByAuthorityId (AccountRepository.java:173)                                                                                                                             
      -> AccountRepository::getOrCreateApplicant (AccountRepository.java:173)                                            
  CiviformOidcProfileCreator::getExistingApplicant (CiviformOidcProfileCreator.java:320)                                                                                                                        
    -> AccountRepository::lookupApplicantByEmail (AccountRepository.java:~179)                                                                                                                                  
      -> AccountRepository::lookupAccountByEmail  (AccountRepository.java:109, called at :179)                                                
      -> AccountRepository::getOrCreateApplicant (AccountRepository.java:159, called at :179) 
```

However at the end of the merge, `profileFactory.wrap` ignores the applicant in the profile and looks up the oldest as outlined with `mergeApplicantAndGuestProfile` above.

```
CiviformOidcProfileCreator::innerCreate (CiviformOidcProfileCreator.java:205)                                                                                                                                 
    -> CiviFormProfileMerger::mergeProfiles (CiviFormProfileMerger.java:53, called at :247)
      -> CiviFormProfileMerger::mergeApplicantAndGuestProfile(Optional, Optional, Stage) (CiviFormProfileMerger.java:76, called at :64)                                                                         
        -> CiviFormProfileMerger::mergeApplicantAndGuestProfile(ApplicantModel, CiviFormProfile, Stage) (CiviFormProfileMerger.java:110, called at :106)                                                        
          -> ProfileFactory::wrap (called at :141)     
```

## Release notes

Updates which applicant is used in the guest log-in merge flow.  This will have no user visible effect.

### Checklist

Remove any sections below that do not apply to your PR. For sections that do apply, complete all of the appropriate checklist items and check them off. If a checklist item doesn't apply to your PR, leave it unchecked but do not delete it.

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [ ] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [ ] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

### Instructions for manual testing

If instructions are needed for manual testing by reviewers, include them here.

### Issue(s) this completes

Fixes #13174
