### PR TITLE
[Account Merge & Main] Update Account -> Applicant lookup from max to min creation time.

### DIFF
--- a/server/app/repository/AccountRepository.java
+++ b/server/app/repository/AccountRepository.java
@@ -161,7 +161,7 @@ public final class AccountRepository {
         () -> {
           Optional<ApplicantModel> applicantOpt =
               account.getApplicants().stream()
-                  .max(Comparator.comparing(ApplicantModel::getWhenCreated));
+                  .min(Comparator.comparing(ApplicantModel::getWhenCreated));
           return applicantOpt.orElseGet(
               () -> new ApplicantModel().setAccount(account).saveAndReturn());
         });

--- a/server/app/repository/AccountRepository.java
+++ b/server/app/repository/AccountRepository.java
@@ -151,7 +151,7 @@ public final class AccountRepository {
   }
 
   /**
-   * Returns the most recent Applicant identified by Account, creating one if necessary.
+   * Returns the oldest Applicant identified by Account, creating one if necessary.
    *
    * <p>If no applicant exists, this is probably an account waiting for a trusted intermediary, so
    * we create one.

--- a/server/test/auth/oidc/CiviformOidcProfileCreatorTest.java
+++ b/server/test/auth/oidc/CiviformOidcProfileCreatorTest.java
@@ -174,6 +174,35 @@ public class CiviformOidcProfileCreatorTest extends ResetPostgres {
   }
 
   @Test
+  public void getExistingApplicant_multipleApplicants_returnsOldest() {
+    // Setup.
+    // Existing account with multiple Applicants.
+    var oldestApplicant = resourceCreator.insertApplicant();
+    var newestApplicant = resourceCreator.insertApplicant();
+    var account =
+        resourceCreator
+            .insertAccount()
+            .setEmailAddress(EMAIL)
+            .setAuthorityId(AUTHORITY_ID)
+            // Put in the opposite creation-time order to help ensure it's not
+            // just selecting the first.
+            .setApplicants(ImmutableList.of(newestApplicant, oldestApplicant));
+    account.save();
+    oldestApplicant.setAccount(account);
+    newestApplicant.setAccount(account);
+    oldestApplicant.save();
+    newestApplicant.save();
+    CiviformOidcProfileCreator oidcProfileCreator = getOidcProfileCreator();
+
+    // Execute.
+    Optional<ApplicantModel> applicant = oidcProfileCreator.getExistingApplicant(oidcProfile);
+
+    // Verify.
+    assertThat(applicant).isPresent();
+    assertThat(applicant.get().id).isEqualTo(oldestApplicant.id);
+  }
+
+  @Test
   public void mergeCiviFormProfile_succeeds_new_user() {
     CiviformOidcProfileCreator oidcProfileCreator = getOidcProfileCreator();
     // Execute.


### PR DESCRIPTION
### Description

For account merging, when we find the CiviForm account's applicant to use in the merge we currently find the newest, and this PR changes that to be the oldest.  The oldest is now selected because it will be the first applicant that existed for the account when there happen to be multiples, and therefor the most logical one to use for continuity.  Note there are only multiples for users that have gone through the current guest merge flow.

For the **existing merge logic**, which is broken, the applicant selected doesn't really matter because we merge question answers into the newest applicant (`mergeApplicantsOlderIntoNewer`), usually the guests, then never select the newest applicant as the user's applicant to use. We actually use the oldest by way of which deciding which of the account's applicant ids we store in the profile (`getOldestApplicantForAccount`). The existing logic being broken is somewhat reflected in that there are no existing tests that care about this change.

[mergeApplicantAndGuestProfile](https://github.com/civiform/civiform/blob/bc729f9560e1d1a58c08ea789a5515c308b3c1a6/server/app/auth/CiviFormProfileMerger.java#L141)
```
->  ApplicantRepository::mergeApplicantsOlderIntoNewer
->  profileFactory.wrap
  ->  CiviFormProfile::storeApplicantIdInProfile
    -> getOldestApplicantForAccount()
```

For the **new merge logic** it is necessary that we always select the oldest applicant as the singular applicant for the account as that will be the one guests are merged into, and as indicated above, is the one selected for the user when they login.

This PR changes the applicant selection for the existing and new flow. It does so as the new flow requires it and also to support the DRY_RUN of the new flow while the current flow is active. The DRY_RUN needs the correct/oldest applicant to be selected and we can't do that selection different from the existing merge flow; at least not without complication.

Making this update is fine given the stated issues in the existing merge as well as the following:

AccountRepository::[`getOrCreateApplicant`](https://github.com/civiform/civiform/blob/bc729f9560e1d1a58c08ea789a5515c308b3c1a6/server/app/repository/AccountRepository.java#L159) is the method updated in this PR, it is only used to select the applicant to use for merging. 

It is used only through [`CiviformOidcProfileCreator.java::innerCreate()`](https://github.com/civiform/civiform/blob/main/server/app/auth/oidc/CiviformOidcProfileCreator.java#L205) call to `getExistingApplicant`

```
CiviformOidcProfileCreator::getExistingApplicant (CiviformOidcProfileCreator.java:294)                                                                                                                        
    -> AccountRepository::lookupApplicantByAuthorityId (AccountRepository.java:170)                                                                                                                             
      -> AccountRepository::lookupAccountByAuthorityId (AccountRepository.java:173)                                                                                                                             
      -> AccountRepository::getOrCreateApplicant (AccountRepository.java:173)                                            
  CiviformOidcProfileCreator::getExistingApplicant (CiviformOidcProfileCreator.java:320)                                                                                                                        
    -> AccountRepository::lookupApplicantByEmail (AccountRepository.java:~179)                                                                                                                                  
      -> AccountRepository::lookupAccountByEmail  (AccountRepository.java:109, called at :179)                                                
      -> AccountRepository::getOrCreateApplicant (AccountRepository.java:159, called at :179) 
```

However at the end of the merge, `profileFactory.wrap` ignores the applicant in the profile and looks up the oldest as outlined with `mergeApplicantAndGuestProfile` above.

```
CiviformOidcProfileCreator::innerCreate (CiviformOidcProfileCreator.java:205)                                                                                                                                 
    -> CiviFormProfileMerger::mergeProfiles (CiviFormProfileMerger.java:53, called at :247)
      -> CiviFormProfileMerger::mergeApplicantAndGuestProfile(Optional, Optional, Stage) (CiviFormProfileMerger.java:76, called at :64)                                                                         
        -> CiviFormProfileMerger::mergeApplicantAndGuestProfile(ApplicantModel, CiviFormProfile, Stage) (CiviFormProfileMerger.java:110, called at :106)                                                        
          -> ProfileFactory::wrap (called at :141)     
```

## Release notes

Updates which applicant is used in the guest log-in merge flow.  This will have no user visible effect.

### Checklist

Remove any sections below that do not apply to your PR. For sections that do apply, complete all of the appropriate checklist items and check them off. If a checklist item doesn't apply to your PR, leave it unchecked but do not delete it.

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [x] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

### Instructions for manual testing

Manual testing this with the current incorrect merge logic requires a complicated set of steps and inspecting the database, so it's unlikely to be fruitful or worth it the effort.

Basic regression testing is otherwise sufficient by running through the standard merge flow and ensuring nothing is more broken than currently.

1. Log in as a user
2. As A guest apply to a program
3. Log in as the user in #1
4. Notice: you can't see your application.
5. Notice: If you apply for the same program you do not see the guests question answers.

### Issue(s) this completes

Fixes #13174
