### PR TITLE
add delay

### DIFF
--- a/browser-test/src/support/applicant_questions.ts
+++ b/browser-test/src/support/applicant_questions.ts
@@ -159,11 +159,13 @@ export class ApplicantQuestions {
       buffer: bufferForApplicantFileUpload(text, fileName),
     })
     await waitForHtmxReady(this.page)
+    await this.page.waitForTimeout(1000)
   }
 
   async answerFileUploadQuestionFromAssets(fileName: string) {
     await this.page.setInputFiles('input[type=file]', 'src/assets/' + fileName)
     await waitForHtmxReady(this.page)
+    await this.page.waitForTimeout(1000)
   }
 
   /** Creates a file with the given size in MB and uploads it to the file upload question. */


### PR DESCRIPTION
This is just to test the theory that the file upload questions were failing in probers because the two files were getting uploaded in too short of a succession for AWS. If probers passes with this, that's correct. Otherwise, revert and back to the drawing board.