### PR TITLE
[Enumerators] Add an existing enumerator question to an enumerator block

### DIFF
--- a/browser-test/src/end_to_end_enumerators.test.ts
+++ b/browser-test/src/end_to_end_enumerators.test.ts
@@ -638,7 +638,7 @@ test.describe('End to end enumerator test with enumerators feature flag on', () 
       await loginAsAdmin(page)
       await adminPrograms.addProgram('Enumerator test program')
 
-      await test.step('Add questions to the program block', async () => {
+      await test.step('Create questions', async () => {
         await adminQuestions.addEnumeratorQuestion({
           questionName: 'enumerator-ete-householdmembers',
           description: 'desc',
@@ -805,6 +805,74 @@ test.describe('End to end enumerator test with enumerators feature flag on', () 
           page.getByRole('heading', {name: 'All questions'}),
         ).toBeVisible()
         await expect(page.getByText('Admin ID: pets enumerator')).toBeVisible()
+      })
+    })
+
+    test('can add an existing enumerator question to an enumerator block', async ({
+      page,
+    }) => {
+      const blockPanel = page.getByTestId('block-panel-edit')
+      const questionBankSidebar = page.getByRole('form', {
+        name: 'Add a question',
+      })
+
+      await test.step('Add a new repeated set', async () => {
+        await page.getByRole('button', {name: 'Add screen'}).first().click()
+        await page.getByRole('button', {name: 'Add repeated set'}).click()
+      })
+
+      await test.step('Select the repeated set block from the block order panel', async () => {
+        await page.getByRole('link', {name: 'Screen 2'}).click()
+      })
+
+      await test.step('Click the "Choose existing" radio button', async () => {
+        // Unfortunately, we have to click the label to select the radio button, because
+        // USWDS places the radio button itself outside the viewport.
+        await blockPanel.getByTestId('choose-existing-radio-label').click()
+      })
+
+      await test.step('Click the "Add question" button', async () => {
+        await blockPanel.getByRole('button', {name: 'Add question'}).click()
+      })
+
+      await test.step('Validate that the question bank sidebar only shows enumerator questions', async () => {
+        await expect(
+          questionBankSidebar.getByText('enumerator-ete-householdmembers'),
+        ).toBeVisible()
+        await expect(
+          questionBankSidebar.getByText('enumerator-ete-repeated-name'),
+        ).toBeHidden()
+      })
+
+      await test.step('Validate that the question bank sidebar does not show the "Create new question" button', async () => {
+        await expect(
+          questionBankSidebar.getByText(
+            "Not finding a question you're looking for in this list?",
+          ),
+        ).toBeHidden()
+        await expect(
+          questionBankSidebar.getByRole('button', {
+            name: 'Create new question',
+          }),
+        ).toBeHidden()
+      })
+
+      await test.step('Add a question to the block and validate question card is visible', async () => {
+        await questionBankSidebar.getByRole('button', {name: 'Add'}).click()
+
+        const enumeratorQuestionCard = blockPanel.getByTestId(
+          'question-admin-name-enumerator-ete-householdmembers',
+        )
+
+        await expect(enumeratorQuestionCard).toBeVisible()
+
+        await expect(questionBankSidebar).toBeHidden()
+      })
+
+      await test.step('Validate that focus is sent to the repeated set question section heading', async () => {
+        await expect(
+          blockPanel.getByText('Repeated set question'),
+        ).toBeFocused()
       })
     })
 

--- a/server/app/assets/javascripts/admin_programs.ts
+++ b/server/app/assets/javascripts/admin_programs.ts
@@ -404,6 +404,21 @@ class AdminPrograms {
     }
   }
 
+  /**
+   * After redirecting back to the block edit page from adding an existing enumerator question, the
+   * controller appends ?focusEnumeratorHeading=true so we know to move focus to the enumerator
+   * section heading. The param is then stripped so a refresh doesn't keep refocusing.
+   */
+  static focusOnEnumeratorQuestionSectionFromUrlParam() {
+    const url = new URL(window.location.href)
+    if (url.searchParams.get('focusEnumeratorHeading') !== 'true') {
+      return
+    }
+    this.focusOnEnumeratorQuestionSection()
+    url.searchParams.delete('focusEnumeratorHeading')
+    window.history.replaceState({}, '', url.toString())
+  }
+
   static focusOnFirstEnumeratorFormField() {
     const firstInputField = document.getElementById('listed-entity-input')
     if (firstInputField) {
@@ -505,4 +520,5 @@ export function init() {
   AdminPrograms.attachEventListenerToHtmxSwap()
   AdminPrograms.attachEventListenerToEnumeratorCreationMethod()
   AdminPrograms.attachEventListenerToRepeatedSetFieldAutofill()
+  AdminPrograms.focusOnEnumeratorQuestionSectionFromUrlParam()
 }

--- a/server/app/controllers/admin/AdminProgramBlockQuestionsController.java
+++ b/server/app/controllers/admin/AdminProgramBlockQuestionsController.java
@@ -126,11 +126,15 @@ public class AdminProgramBlockQuestionsController extends Controller {
 
     String editUrl =
         controllers.admin.routes.AdminProgramBlocksController.edit(programId, blockId).url();
-    // After adding an enumerator question via the "Choose existing" flow, the setup section is
-    // replaced by the question card, so leaving the bank open would be confusing. In all other
-    // cases, keep it open so the admin can add more questions.
+
+    // When the enumerator-improvements flag is on, adding an enumerator question via the
+    // "Choose existing" flow replaces the setup section with the question card, so leaving the
+    // bank open would be confusing. In all other cases, keep it open so the admin can add more
+    // questions.
+    boolean closeBankAndFocusEnumeratorHeading =
+        addedEnumeratorQuestion && settingsManifest.getEnumeratorImprovementsEnabled(request);
     return redirect(
-        addedEnumeratorQuestion
+        closeBankAndFocusEnumeratorHeading
             ? editUrl + "?focusEnumeratorHeading=true"
             : ProgramQuestionBank.addShowQuestionBankParam(editUrl));
   }

--- a/server/app/controllers/admin/AdminProgramBlockQuestionsController.java
+++ b/server/app/controllers/admin/AdminProgramBlockQuestionsController.java
@@ -92,12 +92,16 @@ public class AdminProgramBlockQuestionsController extends Controller {
 
     // The users' browser may be out of date. Find the last revision of each question.
     ImmutableList.Builder<Long> idBuilder = new ImmutableList.Builder<Long>();
+    boolean addedEnumeratorQuestion = false;
     for (Long qId : questionIds) {
       Optional<QuestionModel> latestQuestion = versionRepository.getLatestVersionOfQuestion(qId);
       if (latestQuestion.isEmpty()) {
         return notFound(String.format("Question ID %s not found", qId));
       }
       idBuilder.add(latestQuestion.get().id);
+      if (latestQuestion.get().getQuestionDefinition().isEnumerator()) {
+        addedEnumeratorQuestion = true;
+      }
     }
     ImmutableList<Long> latestQuestionIds = idBuilder.build();
 
@@ -120,9 +124,13 @@ public class AdminProgramBlockQuestionsController extends Controller {
       return notFound(e.externalMessage());
     }
 
+    String editUrl =
+        controllers.admin.routes.AdminProgramBlocksController.edit(programId, blockId).url();
+    // After adding an enumerator question via the "Choose existing" flow, the setup section is
+    // replaced by the question card, so leaving the bank open would be confusing. In all other
+    // cases, keep it open so the admin can add more questions.
     return redirect(
-        ProgramQuestionBank.addShowQuestionBankParam(
-            controllers.admin.routes.AdminProgramBlocksController.edit(programId, blockId).url()));
+        addedEnumeratorQuestion ? editUrl : ProgramQuestionBank.addShowQuestionBankParam(editUrl));
   }
 
   /** HTMX POST endpoint for creating a new enumerator question and adding it to a screen. */

--- a/server/app/controllers/admin/AdminProgramBlockQuestionsController.java
+++ b/server/app/controllers/admin/AdminProgramBlockQuestionsController.java
@@ -135,7 +135,7 @@ public class AdminProgramBlockQuestionsController extends Controller {
         addedEnumeratorQuestion && settingsManifest.getEnumeratorImprovementsEnabled(request);
     return redirect(
         closeBankAndFocusEnumeratorHeading
-            ? editUrl + "?focusEnumeratorHeading=true"
+            ? ProgramQuestionBank.addFocusEnumeratorHeadingParam(editUrl)
             : ProgramQuestionBank.addShowQuestionBankParam(editUrl));
   }
 

--- a/server/app/controllers/admin/AdminProgramBlockQuestionsController.java
+++ b/server/app/controllers/admin/AdminProgramBlockQuestionsController.java
@@ -130,7 +130,9 @@ public class AdminProgramBlockQuestionsController extends Controller {
     // replaced by the question card, so leaving the bank open would be confusing. In all other
     // cases, keep it open so the admin can add more questions.
     return redirect(
-        addedEnumeratorQuestion ? editUrl : ProgramQuestionBank.addShowQuestionBankParam(editUrl));
+        addedEnumeratorQuestion
+            ? editUrl + "?focusEnumeratorHeading=true"
+            : ProgramQuestionBank.addShowQuestionBankParam(editUrl));
   }
 
   /** HTMX POST endpoint for creating a new enumerator question and adding it to a screen. */

--- a/server/app/models/ApplicantModel.java
+++ b/server/app/models/ApplicantModel.java
@@ -227,7 +227,7 @@ public class ApplicantModel extends BaseModel {
         nameSuffix = Optional.of(listSplit.get(3));
         break;
       case 1:
-        // fallthrough
+      // fallthrough
       default:
         // Too many names - put them all in first name.
         firstName = displayName;

--- a/server/app/services/ProgramBlockValidation.java
+++ b/server/app/services/ProgramBlockValidation.java
@@ -54,11 +54,7 @@ public final class ProgramBlockValidation {
 
     // Cannot add question to the block because the question is an enumerator type, but the block is
     // not an enumerator block.
-    ENUMERATOR_ON_NON_ENUMERATOR_BLOCK,
-
-    // Cannot add question to the block because the question is not an enumerator type,
-    // and the block is an enumerator block.  Does not apply to initial questions.
-    NON_ENUMERATOR_ON_ENUMERATOR_BLOCK
+    ENUMERATOR_ON_NON_ENUMERATOR_BLOCK
   }
 
   /**
@@ -103,24 +99,6 @@ public final class ProgramBlockValidation {
           .QUESTION_NOT_IN_ACTIVE_OR_DRAFT_STATE;
     }
     return AddQuestionResult.ELIGIBLE;
-  }
-
-  public AddQuestionResult canAddQuestionToEnumeratorBlock(
-      ProgramDefinition program,
-      BlockDefinition block,
-      QuestionDefinition question,
-      boolean enumeratorImprovementsEnabled,
-      boolean fileUploadQuestionImprovementsEnabled) {
-    if (!question.isEnumerator()) {
-      return AddQuestionResult.NON_ENUMERATOR_ON_ENUMERATOR_BLOCK;
-    } else {
-      return canAddQuestion(
-          program,
-          block,
-          question,
-          enumeratorImprovementsEnabled,
-          fileUploadQuestionImprovementsEnabled);
-    }
   }
 
   private boolean isSingleBlockQuestion(

--- a/server/app/services/ProgramBlockValidation.java
+++ b/server/app/services/ProgramBlockValidation.java
@@ -54,7 +54,11 @@ public final class ProgramBlockValidation {
 
     // Cannot add question to the block because the question is an enumerator type, but the block is
     // not an enumerator block.
-    ENUMERATOR_ON_NON_ENUMERATOR_BLOCK
+    ENUMERATOR_ON_NON_ENUMERATOR_BLOCK,
+
+    // Cannot add question to the block because the question is not an enumerator type,
+    // and the block is an enumerator block.  Does not apply to initial questions.
+    NON_ENUMERATOR_ON_ENUMERATOR_BLOCK
   }
 
   /**
@@ -99,6 +103,24 @@ public final class ProgramBlockValidation {
           .QUESTION_NOT_IN_ACTIVE_OR_DRAFT_STATE;
     }
     return AddQuestionResult.ELIGIBLE;
+  }
+
+  public AddQuestionResult canAddQuestionToEnumeratorBlock(
+      ProgramDefinition program,
+      BlockDefinition block,
+      QuestionDefinition question,
+      boolean enumeratorImprovementsEnabled,
+      boolean fileUploadQuestionImprovementsEnabled) {
+    if (!question.isEnumerator()) {
+      return AddQuestionResult.NON_ENUMERATOR_ON_ENUMERATOR_BLOCK;
+    } else {
+      return canAddQuestion(
+          program,
+          block,
+          question,
+          enumeratorImprovementsEnabled,
+          fileUploadQuestionImprovementsEnabled);
+    }
   }
 
   private boolean isSingleBlockQuestion(

--- a/server/app/views/admin/programs/ProgramBlocksView.java
+++ b/server/app/views/admin/programs/ProgramBlocksView.java
@@ -7,6 +7,7 @@ import static j2html.TagCreator.div;
 import static j2html.TagCreator.fieldset;
 import static j2html.TagCreator.form;
 import static j2html.TagCreator.h1;
+import static j2html.TagCreator.h2;
 import static j2html.TagCreator.iff;
 import static j2html.TagCreator.input;
 import static j2html.TagCreator.join;
@@ -896,7 +897,7 @@ public final class ProgramBlocksView extends ProgramBaseView {
     DivTag questionCard = optionalQuestionCard.orElse(div());
     return div()
         .with(
-            p(messages.at(MessageKey.HEADING_REPEATED_SET_QUESTION.getKeyName()))
+            h2(messages.at(MessageKey.HEADING_REPEATED_SET_QUESTION.getKeyName()))
                 .withId("repeated-set-question-section-heading")
                 .withClasses("text-lg", "font-bold", "margin-bottom-05")
                 .withTabindex(-1),
@@ -972,7 +973,7 @@ public final class ProgramBlocksView extends ProgramBaseView {
 
   private DivTag renderChooseExistingQuestion(Messages messages) {
     return div(
-            p(messages.at(MessageKey.HEADING_REPEATED_SET_QUESTION.getKeyName()))
+            h2(messages.at(MessageKey.HEADING_REPEATED_SET_QUESTION.getKeyName()))
                 .withId("repeated-set-question-section-heading")
                 .withClasses("font-bold", "margin-bottom-05", "text-black-700")
                 .with(ViewUtils.requiredQuestionIndicator()),
@@ -983,7 +984,7 @@ public final class ProgramBlocksView extends ProgramBaseView {
                         messages.at(
                             MessageKey.TEXT_REPEATED_SET_ADD_QUESTION_DESCRIPTION.getKeyName()))),
             button("")
-                .withId("Add-question")
+                .withId("add-question")
                 .withClasses("usa-button", "usa-button--outline", "cf-open-question-bank-button")
                 .with(Icons.svg(Icons.ADD).withClasses("height-205", "width-205"))
                 .withText(messages.at(MessageKey.BUTTON_ADD_QUESTION.getKeyName())))

--- a/server/app/views/admin/programs/ProgramBlocksView.java
+++ b/server/app/views/admin/programs/ProgramBlocksView.java
@@ -984,7 +984,7 @@ public final class ProgramBlocksView extends ProgramBaseView {
                             MessageKey.TEXT_REPEATED_SET_ADD_QUESTION_DESCRIPTION.getKeyName()))),
             button("")
                 .withId("Add-question")
-                .withClasses("usa-button", "usa-button--outline")
+                .withClasses("usa-button", "usa-button--outline", "cf-open-question-bank-button")
                 .with(Icons.svg(Icons.ADD).withClasses("height-205", "width-205"))
                 .withText(messages.at(MessageKey.BUTTON_ADD_QUESTION.getKeyName())))
         .withId("add-question-section")

--- a/server/app/views/components/ProgramQuestionBank.java
+++ b/server/app/views/components/ProgramQuestionBank.java
@@ -49,6 +49,8 @@ public final class ProgramQuestionBank {
   // Url parameter used to force question bank open upon initial rendering
   // of program edit page.
   private static final String SHOW_QUESTION_BANK_PARAM = "sqb";
+  // Url parameter used to send focus to the enumerator question section heading
+  private static final String FOCUS_ENUMERATOR_HEADING_PARAM = "focusEnumeratorHeading";
   // Url parameter used to indicate a newly created question that should be auto-added to the block
   public static final String NEWLY_CREATED_QUESTION_ID_PARAM = "newQuestionId";
   // Data attribute used to store which text is relevant when filtering
@@ -380,22 +382,16 @@ public final class ProgramQuestionBank {
   }
 
   /**
-   * Used to filter questions in the question bank.
-   *
-   * <p>Questions that are filtered out:
-   *
-   * <ul>
-   *   <li>If there is at least one question in the current block, all single-block questions are
-   *       filtered.
-   *   <li>If there is a single block question in the current block, all questions are filtered.
-   *   <li>If this is a repeated block, only the appropriate repeated questions are shown.
-   *   <li>Questions already in the program are filtered.
-   * </ul>
+   * Used to filter questions in the question bank based on whether they are eligible to be added to
+   * the current block.
    */
   private Stream<QuestionDefinition> filterQuestions() {
     ProgramBlockValidation programBlockValidation = programBlockValidationFactory.create();
+    // If the enumerator feature flag is on, this is an enumerator block, and we're adding
+    // an existing question, only show enumerator questions.
+    boolean allowAllQuestions = !isChoosingExistingEnumeratorQuestion();
     return params.questions().stream()
-        .filter(q -> !isChoosingExistingEnumeratorQuestion() || q.isEnumerator())
+        .filter(q -> allowAllQuestions || q.isEnumerator())
         .filter(
             q ->
                 programBlockValidation.canAddQuestion(
@@ -416,6 +412,21 @@ public final class ProgramQuestionBank {
     try {
       return new URIBuilder(url)
           .setParameter(ProgramQuestionBank.SHOW_QUESTION_BANK_PARAM, "true")
+          .build()
+          .toString();
+    } catch (URISyntaxException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * When an admin has chosen an existing question as the enumerator question, we want focus to be
+   * sent to the section they were previously on after the page reloads.
+   */
+  public static String addFocusEnumeratorHeadingParam(String url) {
+    try {
+      return new URIBuilder(url)
+          .setParameter(ProgramQuestionBank.FOCUS_ENUMERATOR_HEADING_PARAM, "true")
           .build()
           .toString();
     } catch (URISyntaxException e) {

--- a/server/app/views/components/ProgramQuestionBank.java
+++ b/server/app/views/components/ProgramQuestionBank.java
@@ -112,10 +112,12 @@ public final class ProgramQuestionBank {
   }
 
   private FormTag questionBankPanel() {
+    String headingId = "question-bank-heading";
     FormTag questionForm =
         form()
             .withMethod(HttpVerbs.POST)
             .withAction(params.questionAction())
+            .attr("aria-labelledby", headingId)
             .with(params.csrfTag())
             .withClasses(
                 ReferenceClasses.QUESTION_BANK_PANEL,
@@ -136,7 +138,7 @@ public final class ProgramQuestionBank {
     DivTag contentDiv = div().withClasses("relative", "grid", "gap-6", "px-5", "pt-6", "pb-12");
     questionForm.with(contentDiv);
 
-    H1Tag headerDiv = h1("Add a question").withClasses("mx-2", "text-xl");
+    H1Tag headerDiv = h1("Add a question").withId(headingId).withClasses("mx-2", "text-xl");
     contentDiv.with(
         div()
             .withClasses("flex", "items-center")

--- a/server/app/views/components/ProgramQuestionBank.java
+++ b/server/app/views/components/ProgramQuestionBank.java
@@ -392,31 +392,17 @@ public final class ProgramQuestionBank {
    */
   private Stream<QuestionDefinition> filterQuestions() {
     ProgramBlockValidation programBlockValidation = programBlockValidationFactory.create();
-    boolean enumeratorImprovementsEnabled =
-        settingsManifest.getEnumeratorImprovementsEnabled(request);
-    boolean fileUploadQuestionImprovementsEnabled =
-        settingsManifest.getFileUploadQuestionImprovementsEnabled(request);
-    boolean isChoosingExistingEnumeratorQuestion = isChoosingExistingEnumeratorQuestion();
     return params.questions().stream()
+        .filter(q -> !isChoosingExistingEnumeratorQuestion() || q.isEnumerator())
         .filter(
-            q -> {
-              if (isChoosingExistingEnumeratorQuestion) {
-                return programBlockValidation.canAddQuestionToEnumeratorBlock(
+            q ->
+                programBlockValidation.canAddQuestion(
                         params.program(),
                         params.blockDefinition(),
                         q,
-                        enumeratorImprovementsEnabled,
-                        fileUploadQuestionImprovementsEnabled)
-                    == AddQuestionResult.ELIGIBLE;
-              }
-              return programBlockValidation.canAddQuestion(
-                      params.program(),
-                      params.blockDefinition(),
-                      q,
-                      enumeratorImprovementsEnabled,
-                      fileUploadQuestionImprovementsEnabled)
-                  == AddQuestionResult.ELIGIBLE;
-            });
+                        settingsManifest.getEnumeratorImprovementsEnabled(request),
+                        settingsManifest.getFileUploadQuestionImprovementsEnabled(request))
+                    == AddQuestionResult.ELIGIBLE);
   }
 
   /**

--- a/server/app/views/components/ProgramQuestionBank.java
+++ b/server/app/views/components/ProgramQuestionBank.java
@@ -150,28 +150,32 @@ public final class ProgramQuestionBank {
     contentDiv.with(
         QuestionBank.renderFilterAndSort(
             ImmutableList.of(QuestionSortOption.LAST_MODIFIED, QuestionSortOption.ADMIN_NAME)));
-    contentDiv.with(
-        div()
-            .with(
-                div()
-                    .withClasses("flex", "items-center", "justify-end")
-                    .with(
-                        p("Not finding a question you're looking for in this list?")
-                            .withClass("mr-2"),
-                        div()
-                            .withClass("flex")
-                            .with(
-                                div().withClass("flex-grow"),
-                                CreateQuestionButton.renderCreateQuestionButton(
-                                    params.questionCreateRedirectUrl(),
-                                    /* isPrimaryButton= */ false,
-                                    getParentEnumeratorId(),
-                                    params.blockDefinition().isRepeated(),
-                                    settingsManifest,
-                                    request,
-                                    /* isEmptyBlock= */ params.blockDefinition().getQuestionCount()
-                                        == 0,
-                                    /* isQuestionPage= */ false)))));
+    if (!isChoosingExistingEnumeratorQuestion()) {
+      contentDiv.with(
+          div()
+              .with(
+                  div()
+                      .withClasses("flex", "items-center", "justify-end")
+                      .with(
+                          p("Not finding a question you're looking for in this list?")
+                              .withClass("mr-2"),
+                          div()
+                              .withClass("flex")
+                              .with(
+                                  div().withClass("flex-grow"),
+                                  CreateQuestionButton.renderCreateQuestionButton(
+                                      params.questionCreateRedirectUrl(),
+                                      /* isPrimaryButton= */ false,
+                                      getParentEnumeratorId(),
+                                      params.blockDefinition().isRepeated(),
+                                      settingsManifest,
+                                      request,
+                                      /* isEmptyBlock= */ params
+                                              .blockDefinition()
+                                              .getQuestionCount()
+                                          == 0,
+                                      /* isQuestionPage= */ false)))));
+    }
 
     // Sort by last modified, since that's the default of the sort by dropdown
     ImmutableList<QuestionDefinition> allQuestions =
@@ -335,6 +339,23 @@ public final class ProgramQuestionBank {
   }
 
   /**
+   * True when this question bank instance is opened to pick an existing enumerator question for an
+   * empty enumerator block (the "Choose existing" path on the repeated-set creation UI). Future
+   * flows that open the bank against an enumerator block (e.g. picking an initial question) will
+   * use a different action URL, so they evaluate to false here.
+   */
+  private boolean isChoosingExistingEnumeratorQuestion() {
+    return settingsManifest.getEnumeratorImprovementsEnabled(request)
+        && params.blockDefinition().getIsEnumerator()
+        && params
+            .questionAction()
+            .equals(
+                controllers.admin.routes.AdminProgramBlockQuestionsController.create(
+                        params.program().id(), params.blockDefinition().id())
+                    .url());
+  }
+
+  /**
    * If this is a repeated question, return the id of the enumerator question for the parent block.
    */
   private Optional<String> getParentEnumeratorId() {
@@ -365,22 +386,37 @@ public final class ProgramQuestionBank {
    *   <li>If there is at least one question in the current block, all single-block questions are
    *       filtered.
    *   <li>If there is a single block question in the current block, all questions are filtered.
-   *   <li>If this is a repeated block, only the appropriate repeated questions are showed.
+   *   <li>If this is a repeated block, only the appropriate repeated questions are shown.
    *   <li>Questions already in the program are filtered.
    * </ul>
    */
   private Stream<QuestionDefinition> filterQuestions() {
     ProgramBlockValidation programBlockValidation = programBlockValidationFactory.create();
+    boolean enumeratorImprovementsEnabled =
+        settingsManifest.getEnumeratorImprovementsEnabled(request);
+    boolean fileUploadQuestionImprovementsEnabled =
+        settingsManifest.getFileUploadQuestionImprovementsEnabled(request);
+    boolean isChoosingExistingEnumeratorQuestion = isChoosingExistingEnumeratorQuestion();
     return params.questions().stream()
         .filter(
-            q ->
-                programBlockValidation.canAddQuestion(
+            q -> {
+              if (isChoosingExistingEnumeratorQuestion) {
+                return programBlockValidation.canAddQuestionToEnumeratorBlock(
                         params.program(),
                         params.blockDefinition(),
                         q,
-                        settingsManifest.getEnumeratorImprovementsEnabled(request),
-                        settingsManifest.getFileUploadQuestionImprovementsEnabled(request))
-                    == AddQuestionResult.ELIGIBLE);
+                        enumeratorImprovementsEnabled,
+                        fileUploadQuestionImprovementsEnabled)
+                    == AddQuestionResult.ELIGIBLE;
+              }
+              return programBlockValidation.canAddQuestion(
+                      params.program(),
+                      params.blockDefinition(),
+                      q,
+                      enumeratorImprovementsEnabled,
+                      fileUploadQuestionImprovementsEnabled)
+                  == AddQuestionResult.ELIGIBLE;
+            });
   }
 
   /**


### PR DESCRIPTION
### Description

On a new repeated set block, if the admin selects "Choose existing" in the 'Repeated set creation method' radio buttons, when they click "Add question", we want to open the question bank panel , show them all the existing enumerator questions, and allow them to select one of them to add to the block. The "Create a new question" button and "Not finding a question you're looking for in this list" text will be hidden.

Once an enumerator question is selected, the question bank sidebar closes, the enumerator question card replaces the radio buttons and the "Add question" button, and focus is sent to the "Repeated set question" heading.

Note:  Used Claude to bounce ideas off of.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [ ] Added an additional reviewer as required if changes potentially affect the security of the application.
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [x] Noted in the PR description which, if any, code in this PR was generated by AI.

#### User visible changes

- [ ] Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
  - [ ] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [ ] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [ ] Manually tested at 200% size
- [x] Manually evaluated tab order
- [x] Performed manual accessibility tests for any applicant-facing changes or any new admin-facing features. See [manual-accessibility-testing](https://github.com/civiform/civiform/wiki/Accessibility#manual-accessibility-testing)
- [ ] Manually tested with a right-to-left language

### Instructions for manual testing

1.  Log in as a CF admin.
2. Turn the ENUMERATOR_IMPROVEMENTS_ENABLED feature flag on.
3. Go to the admin program list page.
4. Click "Edit" on a program.
5. Click "Add screen", then "Add repeated set".
6. Click on the repeated set screen in the block order panel on the left.
7. Select the "Choose existing" radio button.
8. Click on "Add question".
9. When the question bank opens up, notice the absence of the "Create new question" button.
10. Notice that all the questions are enumerator questions.
11. Select one by clicking "Add".
12. Notice that focus is sent to the "Repeated set question" heading.
13. Notice the question card.
14. Notice that the question bank is closed.

### Issue(s) this completes

Fixes #12844
