### PR TITLE
hxFilter: Check the applicant ID ownership of the request

### DIFF
--- a/server/app/controllers/applicant/ApplicantProgramsController.java
+++ b/server/app/controllers/applicant/ApplicantProgramsController.java
@@ -397,8 +397,7 @@ public final class ApplicantProgramsController extends CiviFormController {
                     .as("text/html"))
         .exceptionally(
             ex -> {
-              if (ex instanceof CompletionException
-                  && ex.getCause() instanceof SecurityException) {
+              if (ex instanceof CompletionException && ex.getCause() instanceof SecurityException) {
                 return Results.unauthorized();
               }
               logger.error(

--- a/server/app/controllers/applicant/ApplicantProgramsController.java
+++ b/server/app/controllers/applicant/ApplicantProgramsController.java
@@ -398,7 +398,7 @@ public final class ApplicantProgramsController extends CiviFormController {
         .exceptionally(
             ex -> {
               if (ex instanceof CompletionException && ex.getCause() instanceof SecurityException) {
-                return Results.unauthorized();
+                return Results.forbidden();
               }
               logger.error(
                   "There was an error in rendering the filtered programs"

--- a/server/app/controllers/applicant/ApplicantProgramsController.java
+++ b/server/app/controllers/applicant/ApplicantProgramsController.java
@@ -374,8 +374,12 @@ public final class ApplicantProgramsController extends CiviFormController {
           applicantService.relevantProgramsWithoutApplicant(request).toCompletableFuture();
     } else {
       programsFuture =
-          applicantService
-              .relevantProgramsForApplicant(maybeApplicantId.get(), requesterProfile, request)
+          checkApplicantAuthorization(request, maybeApplicantId.get())
+              .thenComposeAsync(
+                  _ ->
+                      applicantService.relevantProgramsForApplicant(
+                          maybeApplicantId.get(), requesterProfile, request),
+                  classLoaderExecutionContext.current())
               .toCompletableFuture();
     }
 
@@ -393,6 +397,10 @@ public final class ApplicantProgramsController extends CiviFormController {
                     .as("text/html"))
         .exceptionally(
             ex -> {
+              if (ex instanceof CompletionException
+                  && ex.getCause() instanceof SecurityException) {
+                return Results.unauthorized();
+              }
               logger.error(
                   "There was an error in rendering the filtered programs"
                       + " partial view with these categories: "

--- a/server/test/controllers/applicant/ApplicantProgramsControllerTest.java
+++ b/server/test/controllers/applicant/ApplicantProgramsControllerTest.java
@@ -676,7 +676,7 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
   }
 
   @Test
-  public void hxFilter_noId_isOk() {
+  public void hxFilter_currentApplicant_noId_isOk() {
     Result result =
         controller
             .hxFilter(fakeRequest(), ImmutableList.of(), /* applicantId= */ "")
@@ -687,7 +687,7 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
   }
 
   @Test
-  public void hxFilter_currentApplicant_isOk() {
+  public void hxFilter_currentApplicant_specifyId_isOk() {
     Result result =
         controller
             .hxFilter(fakeRequest(), ImmutableList.of(), String.valueOf(currentApplicant.id))

--- a/server/test/controllers/applicant/ApplicantProgramsControllerTest.java
+++ b/server/test/controllers/applicant/ApplicantProgramsControllerTest.java
@@ -57,7 +57,6 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
   private ApplicantModel currentApplicant;
   private ApplicantModel applicantWithoutProfile;
   private ApplicantProgramsController controller;
-  private VersionRepository versionRepository;
   private SettingsManifest settingsManifest;
 
   @Before
@@ -184,7 +183,7 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
 
   @Test
   public void test_deduplicate_inProgressProgram() {
-    versionRepository = instanceOf(VersionRepository.class);
+    VersionRepository versionRepository = instanceOf(VersionRepository.class);
     String programName = "In Progress Program";
     ProgramModel program = resourceCreator().insertActiveProgram(programName);
 
@@ -192,7 +191,7 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
     app.save();
 
     resourceCreator().insertDraftProgram(programName);
-    this.versionRepository.publishNewSynchronizedVersion();
+    versionRepository.publishNewSynchronizedVersion();
 
     Result result =
         controller
@@ -677,21 +676,58 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
   }
 
   @Test
-  public void hxFilter_isOk() {
+  public void hxFilter_noId_isOk() {
     Result result =
-        controller.hxFilter(fakeRequest(), ImmutableList.of(), "").toCompletableFuture().join();
+        controller
+            .hxFilter(fakeRequest(), ImmutableList.of(), /* applicantId= */ "")
+            .toCompletableFuture()
+            .join();
 
     assertThat(result.status()).isEqualTo(OK);
+  }
+
+  @Test
+  public void hxFilter_currentApplicant_isOk() {
+    Result result =
+        controller
+            .hxFilter(fakeRequest(), ImmutableList.of(), String.valueOf(currentApplicant.id))
+            .toCompletableFuture()
+            .join();
+
+    assertThat(result.status()).isEqualTo(OK);
+  }
+
+  @Test
+  public void hxFilter_tiWithManagedApplicant_isOk() {
+    ApplicantModel managedApplicant = createApplicant();
+    AccountModel ti = createTIWithMockedProfile(managedApplicant);
+
+    // Since these tests just verify the HTTP result, verify the profile
+    // being used is not accidentally the managedApplicant by requesting both
+    // its data and the TI's own data.
+    Result managedResult =
+        controller
+            .hxFilter(fakeRequest(), ImmutableList.of(), String.valueOf(managedApplicant.id))
+            .toCompletableFuture()
+            .join();
+
+    assertThat(managedResult.status()).isEqualTo(OK);
+
+    Result tiResult =
+        controller
+            .hxFilter(
+                fakeRequest(), ImmutableList.of(), String.valueOf(ti.getApplicants().getFirst().id))
+            .toCompletableFuture()
+            .join();
+
+    assertThat(tiResult.status()).isEqualTo(OK);
   }
 
   @Test
   public void hxFilter_differentApplicant_returnsUnauthorizedResult() {
     Result result =
         controller
-            .hxFilter(
-                fakeRequest(),
-                ImmutableList.of(),
-                String.valueOf(currentApplicant.id + 1))
+            .hxFilter(fakeRequest(), ImmutableList.of(), String.valueOf(currentApplicant.id + 1))
             .toCompletableFuture()
             .join();
 

--- a/server/test/controllers/applicant/ApplicantProgramsControllerTest.java
+++ b/server/test/controllers/applicant/ApplicantProgramsControllerTest.java
@@ -7,11 +7,11 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 import static play.inject.Bindings.bind;
 import static play.mvc.Http.Status.BAD_REQUEST;
+import static play.mvc.Http.Status.FORBIDDEN;
 import static play.mvc.Http.Status.FOUND;
 import static play.mvc.Http.Status.NOT_FOUND;
 import static play.mvc.Http.Status.OK;
 import static play.mvc.Http.Status.SEE_OTHER;
-import static play.mvc.Http.Status.UNAUTHORIZED;
 import static play.test.Helpers.contentAsString;
 import static play.test.Helpers.stubMessagesApi;
 import static support.FakeRequestBuilder.fakeRequest;
@@ -731,7 +731,7 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
             .toCompletableFuture()
             .join();
 
-    assertThat(result.status()).isEqualTo(UNAUTHORIZED);
+    assertThat(result.status()).isEqualTo(FORBIDDEN);
   }
 
   @Test

--- a/server/test/controllers/applicant/ApplicantProgramsControllerTest.java
+++ b/server/test/controllers/applicant/ApplicantProgramsControllerTest.java
@@ -11,6 +11,7 @@ import static play.mvc.Http.Status.FOUND;
 import static play.mvc.Http.Status.NOT_FOUND;
 import static play.mvc.Http.Status.OK;
 import static play.mvc.Http.Status.SEE_OTHER;
+import static play.mvc.Http.Status.UNAUTHORIZED;
 import static play.test.Helpers.contentAsString;
 import static play.test.Helpers.stubMessagesApi;
 import static support.FakeRequestBuilder.fakeRequest;
@@ -681,6 +682,20 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
         controller.hxFilter(fakeRequest(), ImmutableList.of(), "").toCompletableFuture().join();
 
     assertThat(result.status()).isEqualTo(OK);
+  }
+
+  @Test
+  public void hxFilter_differentApplicant_returnsUnauthorizedResult() {
+    Result result =
+        controller
+            .hxFilter(
+                fakeRequest(),
+                ImmutableList.of(),
+                String.valueOf(currentApplicant.id + 1))
+            .toCompletableFuture()
+            .join();
+
+    assertThat(result.status()).isEqualTo(UNAUTHORIZED);
   }
 
   @Test


### PR DESCRIPTION
### Description

The request specifies an applicantId but doesn't ensure the requester has access to it.

This route is used when an applicant/TI selects different program filters in the program page.

### Checklist

Remove any sections below that do not apply to your PR. For sections that do apply, complete all of the appropriate checklist items and check them off. If a checklist item doesn't apply to your PR, leave it unchecked but do not delete it.

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [ ] Added an additional reviewer as required if changes potentially affect the security of the application.
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.


### Instructions for manual testing

Filtering the program list should work as expected, for Applicants and TIs applying on behalf of a client.

1. Load a program list where the programs have filterable options.
2. Select one and apply it
3. Notice the correct program shows.
4. Begin applying for the program.

Repeat as a TI with a client.