### PR TITLE
[File Upload] remove support for xlxs mime types

### DIFF
--- a/server/app/parsers/FileTypeValidation.java
+++ b/server/app/parsers/FileTypeValidation.java
@@ -45,9 +45,6 @@ public final class FileTypeValidation {
           .put(".bmp", "image/bmp")
           .put(".webp", "image/webp")
           .put(".tiff", "image/tiff")
-          // xlsx is a ZIP container, and Tika's byte-prefix detection reports it as
-          // application/zip. Accepted risk: a plain .zip renamed to .xlsx passes as xlsx.
-          .put(".xlsx", "application/zip")
           .build();
 
   /** Parses a comma-separated list of MIME types, wildcards, and extensions. */

--- a/server/test/app/parsers/FileTypeValidationTest.java
+++ b/server/test/app/parsers/FileTypeValidationTest.java
@@ -13,11 +13,10 @@ import repository.ResetPostgres;
 
 public class FileTypeValidationTest extends ResetPostgres {
   private static final ImmutableList<String> ALLOWED =
-      FileTypeValidation.parseSpecifiers("image/*,.pdf,.xlsx");
+      FileTypeValidation.parseSpecifiers("image/*,.pdf");
 
   private static final byte[] PNG_MAGIC = {(byte) 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A};
   private static final byte[] PDF_MAGIC = {0x25, 0x50, 0x44, 0x46, 0x2D, 0x31, 0x2E, 0x34};
-  private static final byte[] ZIP_MAGIC = {0x50, 0x4B, 0x03, 0x04};
   private static final byte[] UNKNOWN = {0x00, 0x01, 0x02, 0x03};
   private FileTypeValidation validator;
 
@@ -28,7 +27,7 @@ public class FileTypeValidationTest extends ResetPostgres {
 
   @Test
   public void parseSpecifiers_translatesExtensionsAndPreservesWildcards() {
-    assertThat(ALLOWED).containsExactly("image/*", "application/pdf", "application/zip");
+    assertThat(ALLOWED).containsExactly("image/*", "application/pdf");
   }
 
   @Test
@@ -40,11 +39,6 @@ public class FileTypeValidationTest extends ResetPostgres {
   @Test
   public void validateHeaderBytes_realPng_passes() {
     validator.validateHeaderBytes(ByteString.fromArray(PNG_MAGIC), "photo.png", ALLOWED);
-  }
-
-  @Test
-  public void validateHeaderBytes_realXlsx_passes() {
-    validator.validateHeaderBytes(ByteString.fromArray(ZIP_MAGIC), "budget.xlsx", ALLOWED);
   }
 
   @Test


### PR DESCRIPTION
### Description

Seattle said they no longer need xlsx uploads for applicants, so I'm going to remove that mime type until someone asks for it.

### Checklist

Remove any sections below that do not apply to your PR. For sections that do apply, complete all of the appropriate checklist items and check them off. If a checklist item doesn't apply to your PR, leave it unchecked but do not delete it.

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [ ] Added an additional reviewer as required if changes potentially affect the security of the application.
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.