### PR TITLE
[File Upload] move file name uniqueness method to server

### DIFF
--- a/server/app/assets/javascripts/file_upload.ts
+++ b/server/app/assets/javascripts/file_upload.ts
@@ -1,13 +1,7 @@
-import {
-  getUniqueName,
-  hideError,
-  isFileTooLarge,
-  showError,
-} from '@/file_upload_util'
+import {hideError, isFileTooLarge, showError} from '@/file_upload_util'
 import {default as uswdsFileInput} from '@uswds/uswds/js/usa-file-input'
 import {HtmxAfterRequestEvent} from '@/types/htmx'
 
-const UPLOADED_FILE_ATTR = 'data-uploaded-files'
 const CF_FILE_UPLOADING_CLASS = 'cf-file-uploading'
 const CF_FILE_UPLOAD_CONTAINER_SELECTOR = '[data-cf-file-upload-container]'
 const FILE_UPLOAD_HTMX_FAILURE = '[data-fileupload-error="request-failed"]'
@@ -90,36 +84,6 @@ export const init = () => {
         ),
         event.detail.elt,
       )
-    }
-  })
-
-  document.body.addEventListener('htmx:configRequest', (event) => {
-    const triggerElt = event.detail.elt
-    if (!isCfFileUploadInput(triggerElt)) {
-      return
-    }
-
-    const fileUploadContainer = triggerElt.closest(
-      CF_FILE_UPLOAD_CONTAINER_SELECTOR,
-    )
-    if (!fileUploadContainer) return
-
-    const uploadedFilesAttribute = fileUploadContainer
-      .querySelector(`[${UPLOADED_FILE_ATTR}]`)
-      ?.getAttribute(UPLOADED_FILE_ATTR)
-
-    if (!uploadedFilesAttribute) return
-    const uploadedFilesArray = JSON.parse(uploadedFilesAttribute) as string[]
-
-    const formData = event.detail.formData
-    const file = formData.get('file')
-    if (!(file instanceof File)) return
-
-    const newName = getUniqueName(file.name, uploadedFilesArray)
-
-    if (file.name !== newName) {
-      formData.delete('file')
-      formData.append('file', file, newName)
     }
   })
 

--- a/server/app/controllers/applicant/FileUploadController.java
+++ b/server/app/controllers/applicant/FileUploadController.java
@@ -5,6 +5,7 @@ import static java.util.concurrent.CompletableFuture.completedFuture;
 import static java.util.concurrent.CompletableFuture.failedFuture;
 
 import auth.ProfileUtils;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import controllers.CiviFormController;
 import java.util.Optional;
@@ -146,8 +147,13 @@ public final class FileUploadController extends CiviFormController {
                             applicantId)));
               }
 
+              ImmutableList<String> existingFileNames =
+                  fileUploadQuestion.getOriginalFileNameListValue().orElse(ImmutableList.of());
+              String deduplicatedFileName =
+                  FileUploadQuestion.getUniqueName(originalFileName, existingFileNames);
+
               ImmutableMap<String, String> formData =
-                  fileUploadQuestion.buildFormDataForAdd(fileKey, originalFileName);
+                  fileUploadQuestion.buildFormDataForAdd(fileKey, deduplicatedFileName);
 
               return getOrMakeFileRecord(fileKey, Optional.of(originalFileName), applicantId)
                   .thenComposeAsync(

--- a/server/app/services/applicant/question/FileUploadQuestion.java
+++ b/server/app/services/applicant/question/FileUploadQuestion.java
@@ -7,6 +7,8 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import java.util.Optional;
 import java.util.concurrent.CompletionStage;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.IntStream;
 import models.StoredFileModel;
 import play.api.libs.json.JsArray;
@@ -275,6 +277,35 @@ public final class FileUploadQuestion extends AbstractQuestion {
   public static String getFileName(String fileKey) {
     String[] parts = fileKey.split("/", 4);
     return parts[parts.length - 1];
+  }
+
+  // Matches a filename that already ends with "-<number>" before an optional extension.
+  private static final Pattern FILE_NAME_DIGIT_SUFFIX_REGEX =
+      Pattern.compile("(.*?)(-\\d+)(\\.[^.]+)?$");
+  // Matches a filename with an extension.
+  private static final Pattern FILE_NAME_REGEX = Pattern.compile("(.*)(\\.[^.]+)$");
+
+  /**
+   * Returns a name derived from {@code name} that does not appear in {@code existingNames},
+   * appending or incrementing a "-N" numeric suffix as needed.
+   */
+  public static String getUniqueName(String name, ImmutableList<String> existingNames) {
+    while (existingNames.contains(name)) {
+      Matcher digitSuffixMatcher = FILE_NAME_DIGIT_SUFFIX_REGEX.matcher(name);
+      if (digitSuffixMatcher.matches()) {
+        int nextNumber = Integer.parseInt(digitSuffixMatcher.group(2).substring(1)) + 1;
+        String ext = digitSuffixMatcher.group(3) != null ? digitSuffixMatcher.group(3) : "";
+        name = digitSuffixMatcher.group(1) + "-" + nextNumber + ext;
+      } else {
+        Matcher extMatcher = FILE_NAME_REGEX.matcher(name);
+        if (extMatcher.matches()) {
+          name = extMatcher.group(1) + "-2" + extMatcher.group(2);
+        } else {
+          name = name + "-2";
+        }
+      }
+    }
+    return name;
   }
 
   @Override

--- a/server/test/services/applicant/question/FileUploadQuestionTest.java
+++ b/server/test/services/applicant/question/FileUploadQuestionTest.java
@@ -278,4 +278,18 @@ public class FileUploadQuestionTest extends ResetPostgres {
 
     assertThat(result).isEmpty();
   }
+
+  @Test
+  public void getUniqueName_appendsAndIncrementsSuffix() {
+    assertThat(FileUploadQuestion.getUniqueName("file.txt", ImmutableList.of()))
+        .isEqualTo("file.txt");
+    assertThat(FileUploadQuestion.getUniqueName("file.txt", ImmutableList.of("file.txt")))
+        .isEqualTo("file-2.txt");
+    assertThat(
+            FileUploadQuestion.getUniqueName(
+                "file.txt", ImmutableList.of("file.txt", "file-2.txt")))
+        .isEqualTo("file-3.txt");
+    assertThat(FileUploadQuestion.getUniqueName("file", ImmutableList.of("file")))
+        .isEqualTo("file-2");
+  }
 }


### PR DESCRIPTION
### Description

Please explain the changes you made here.

## Release notes

Remove this section if the feature is still under development or if title of the pull request can be used as the default release notes description. If more detail is needed to communicate to partners the scope of the PR's changes, use this release notes section (and remove this placeholder text).

When the Release engineer creates Release Notes, they will not look for this section for Under Development tagged PRs, and will use it if present for all other PRs included in the Release Notes.

### Checklist

Remove any sections below that do not apply to your PR. For sections that do apply, complete all of the appropriate checklist items and check them off. If a checklist item doesn't apply to your PR, leave it unchecked but do not delete it.

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [ ] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [ ] Added an additional reviewer as required if changes potentially affect the security of the application.
- [ ] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

#### Database evolutions

Read the guidelines [here](https://github.com/civiform/civiform/wiki/Database#writing-database-evolutions)

- [ ] Assigned two reviewers
- [ ] Guarded against already existing resources using `IF NOT EXISTS` and `IF EXISTS`
- [ ] Downs created to undo changes in Ups
- [ ] Every comment in script should begin with -- and not # --- unless it denotes Ups or Downs. See [here](https://www.playframework.com/documentation/2.9.x/Evolutions) for details.
- [ ] Tested both the Downs and the Ups scripts manually (When testing, include all comments from the evolution in your test script to ensure any syntax errors in the comments are caught.)
- [ ] Data migrations aren't being done (please use a [Durable Job](https://github.com/civiform/civiform/wiki/Database#durable-jobs-for-data-updates) if doing a data migration)
- [ ] Update the model documentation in our [wiki](https://github.com/civiform/civiform/wiki/Database) if necessary

#### Durable jobs

Read the docs [here](https://github.com/civiform/civiform/wiki/Database#durable-jobs-for-data-updates)

- [ ] Assigned two reviewers
- [ ] Included a rollback plan and a job to undo the data changes if appropriate

#### User visible changes

- [ ] Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
  - [ ] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [ ] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order
- [ ] Performed manual accessibility tests for any applicant-facing changes or any new admin-facing features. See [manual-accessibility-testing](https://github.com/civiform/civiform/wiki/Accessibility#manual-accessibility-testing)
- [ ] Manually tested with a right-to-left language

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/helper/feature-flags.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://github.com/civiform/civiform/wiki/Feature-Flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Instructions for manual testing

If instructions are needed for manual testing by reviewers, include them here.

### Issue(s) this completes

Fixes #<issue_number>; Fixes #<issue_number>...
