### PR TITLE
considerRegister: Deprecate applicantId, and use the application's owner instead.

### DIFF
--- a/server/app/controllers/applicant/ApplicantProgramReviewController.java
+++ b/server/app/controllers/applicant/ApplicantProgramReviewController.java
@@ -332,7 +332,7 @@ public class ApplicantProgramReviewController extends CiviFormController {
 
               Call endOfProgramSubmission =
                   routes.UpsellController.considerRegister(
-                      applicantId,
+                      Optional.of(applicantId),
                       programParam,
                       applicationId,
                       applicantRoutes.index(submittingProfile, applicantId).url(),

--- a/server/app/controllers/applicant/UpsellController.java
+++ b/server/app/controllers/applicant/UpsellController.java
@@ -20,6 +20,8 @@ import models.AccountModel;
 import models.ApplicationModel;
 import org.apache.commons.lang3.StringUtils;
 import org.pac4j.play.java.Secure;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import play.i18n.MessagesApi;
 import play.libs.concurrent.ClassLoaderExecutionContext;
 import play.mvc.Http;
@@ -43,6 +45,7 @@ import views.applicant.upsell.UpsellParams;
 
 /** Controller for handling methods for upselling applicants. */
 public final class UpsellController extends CiviFormController {
+  private static final Logger logger = LoggerFactory.getLogger(UpsellController.class);
 
   private final ClassLoaderExecutionContext classLoaderExecutionContext;
   private final ApplicantService applicantService;
@@ -88,7 +91,6 @@ public final class UpsellController extends CiviFormController {
   @Secure
   public CompletionStage<Result> considerRegister(
       Http.Request request,
-      long applicantId,
       String programParam,
       long applicationId,
       String redirectTo,
@@ -103,9 +105,23 @@ public final class UpsellController extends CiviFormController {
       return CompletableFuture.completedFuture(redirectToHome());
     }
 
+    // Derive the applicant ID from the application.
+    Optional<ApplicationModel> maybeApplication =
+      applicationService.getApplicationAsync(applicationId).toCompletableFuture().join();
+    if (maybeApplication.isEmpty()) {
+      return CompletableFuture.completedFuture(notFound());
+    }
+    long verifiedApplicantId = maybeApplication.get().getApplicant().id;
+
+    if(profileUtils.currentUserProfile(request).isTrustedIntermediary()) {
+      //if(applicantId != verifiedApplicantId) {
+      //  logger.warn("Request supplied applicantId");
+      //}
+    }
+
     long programId =
         programSlugHandler
-            .resolveProgramParam(programParam, applicantId, programSlugUrlsEnabled)
+            .resolveProgramParam(programParam, verifiedApplicantId, programSlugUrlsEnabled)
             .toCompletableFuture()
             .join();
 
@@ -116,24 +132,24 @@ public final class UpsellController extends CiviFormController {
             .toCompletableFuture();
 
     CompletableFuture<ApplicantPersonalInfo> applicantPersonalInfo =
-        applicantService.getPersonalInfo(applicantId).toCompletableFuture();
+        applicantService.getPersonalInfo(verifiedApplicantId).toCompletableFuture();
 
     CompletableFuture<AccountModel> account =
         applicantPersonalInfo
             .thenComposeAsync(
-                v -> checkApplicantAuthorization(request, applicantId),
+                v -> checkApplicantAuthorization(request, verifiedApplicantId),
                 classLoaderExecutionContext.current())
             .thenComposeAsync(v -> profile.getAccount(), classLoaderExecutionContext.current())
             .toCompletableFuture();
 
     CompletableFuture<ReadOnlyApplicantProgramService> roApplicantProgramService =
         applicantService
-            .getReadOnlyApplicantProgramService(applicantId, programId)
+            .getReadOnlyApplicantProgramService(verifiedApplicantId, programId)
             .toCompletableFuture();
 
     CompletableFuture<ApplicantService.ApplicationPrograms> relevantProgramsFuture =
         applicantService
-            .relevantProgramsForApplicant(applicantId, profile, request)
+            .relevantProgramsForApplicant(verifiedApplicantId, profile, request)
             .toCompletableFuture();
 
     return CompletableFuture.allOf(
@@ -148,12 +164,12 @@ public final class UpsellController extends CiviFormController {
               }
 
               return applicantPersonalInfo
-                  .thenComposeAsync(v -> checkApplicantAuthorization(request, applicantId))
+                  .thenComposeAsync(v -> checkApplicantAuthorization(request, verifiedApplicantId))
                   .thenComposeAsync(
                       // We are already checking if profile is empty
                       _ ->
                           applicantService.maybeEligibleProgramsForApplicant(
-                              applicantId, profile, request),
+                              verifiedApplicantId, profile, request),
                       classLoaderExecutionContext.current())
                   .thenApplyAsync(Optional::of);
             })
@@ -184,7 +200,7 @@ public final class UpsellController extends CiviFormController {
                       .setCompletedProgramSlug(programSlugHandler.getProgramSlug(programParam))
                       .setCustomConfirmationMessage(
                           roApplicantProgramService.join().getCustomConfirmationMessage())
-                      .setApplicantId(applicantId)
+                      .setApplicantId(verifiedApplicantId)
                       .setDateSubmitted(formattedDate);
 
               if (isPreScreener.join()) {

--- a/server/app/controllers/applicant/UpsellController.java
+++ b/server/app/controllers/applicant/UpsellController.java
@@ -20,8 +20,6 @@ import models.AccountModel;
 import models.ApplicationModel;
 import org.apache.commons.lang3.StringUtils;
 import org.pac4j.play.java.Secure;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import play.i18n.MessagesApi;
 import play.libs.concurrent.ClassLoaderExecutionContext;
 import play.mvc.Http;
@@ -45,8 +43,6 @@ import views.applicant.upsell.UpsellParams;
 
 /** Controller for handling methods for upselling applicants. */
 public final class UpsellController extends CiviFormController {
-  private static final Logger logger = LoggerFactory.getLogger(UpsellController.class);
-
   private final ClassLoaderExecutionContext classLoaderExecutionContext;
   private final ApplicantService applicantService;
   private final ApplicationService applicationService;
@@ -113,12 +109,6 @@ public final class UpsellController extends CiviFormController {
       return CompletableFuture.completedFuture(notFound());
     }
     long verifiedApplicantId = maybeApplication.get().getApplicant().id;
-
-    if (profileUtils.currentUserProfile(request).isTrustedIntermediary()) {
-      // if(applicantId != verifiedApplicantId) {
-      //  logger.warn("Request supplied applicantId");
-      // }
-    }
 
     long programId =
         programSlugHandler

--- a/server/app/controllers/applicant/UpsellController.java
+++ b/server/app/controllers/applicant/UpsellController.java
@@ -91,6 +91,7 @@ public final class UpsellController extends CiviFormController {
   @Secure
   public CompletionStage<Result> considerRegister(
       Http.Request request,
+      Optional<Long> applicantId,
       String programParam,
       long applicationId,
       String redirectTo,

--- a/server/app/controllers/applicant/UpsellController.java
+++ b/server/app/controllers/applicant/UpsellController.java
@@ -109,11 +109,11 @@ public final class UpsellController extends CiviFormController {
     if (maybeApplication.isEmpty()) {
       return CompletableFuture.completedFuture(notFound());
     }
-    long verifiedApplicantId = maybeApplication.get().getApplicant().id;
+    long appApplicantId = maybeApplication.get().getApplicant().id;
 
     long programId =
         programSlugHandler
-            .resolveProgramParam(programParam, verifiedApplicantId, programSlugUrlsEnabled)
+            .resolveProgramParam(programParam, appApplicantId, programSlugUrlsEnabled)
             .toCompletableFuture()
             .join();
 
@@ -124,24 +124,24 @@ public final class UpsellController extends CiviFormController {
             .toCompletableFuture();
 
     CompletableFuture<ApplicantPersonalInfo> applicantPersonalInfo =
-        applicantService.getPersonalInfo(verifiedApplicantId).toCompletableFuture();
+        applicantService.getPersonalInfo(appApplicantId).toCompletableFuture();
 
     CompletableFuture<AccountModel> account =
         applicantPersonalInfo
             .thenComposeAsync(
-                v -> checkApplicantAuthorization(request, verifiedApplicantId),
+                v -> checkApplicantAuthorization(request, appApplicantId),
                 classLoaderExecutionContext.current())
             .thenComposeAsync(v -> profile.getAccount(), classLoaderExecutionContext.current())
             .toCompletableFuture();
 
     CompletableFuture<ReadOnlyApplicantProgramService> roApplicantProgramService =
         applicantService
-            .getReadOnlyApplicantProgramService(verifiedApplicantId, programId)
+            .getReadOnlyApplicantProgramService(appApplicantId, programId)
             .toCompletableFuture();
 
     CompletableFuture<ApplicantService.ApplicationPrograms> relevantProgramsFuture =
         applicantService
-            .relevantProgramsForApplicant(verifiedApplicantId, profile, request)
+            .relevantProgramsForApplicant(appApplicantId, profile, request)
             .toCompletableFuture();
 
     return CompletableFuture.allOf(
@@ -156,12 +156,12 @@ public final class UpsellController extends CiviFormController {
               }
 
               return applicantPersonalInfo
-                  .thenComposeAsync(v -> checkApplicantAuthorization(request, verifiedApplicantId))
+                  .thenComposeAsync(v -> checkApplicantAuthorization(request, appApplicantId))
                   .thenComposeAsync(
                       // We are already checking if profile is empty
                       _ ->
                           applicantService.maybeEligibleProgramsForApplicant(
-                              verifiedApplicantId, profile, request),
+                              appApplicantId, profile, request),
                       classLoaderExecutionContext.current())
                   .thenApplyAsync(Optional::of);
             })
@@ -192,7 +192,7 @@ public final class UpsellController extends CiviFormController {
                       .setCompletedProgramSlug(programSlugHandler.getProgramSlug(programParam))
                       .setCustomConfirmationMessage(
                           roApplicantProgramService.join().getCustomConfirmationMessage())
-                      .setApplicantId(verifiedApplicantId)
+                      .setApplicantId(appApplicantId)
                       .setDateSubmitted(formattedDate);
 
               if (isPreScreener.join()) {

--- a/server/app/controllers/applicant/UpsellController.java
+++ b/server/app/controllers/applicant/UpsellController.java
@@ -87,6 +87,7 @@ public final class UpsellController extends CiviFormController {
   @Secure
   public CompletionStage<Result> considerRegister(
       Http.Request request,
+      // TODO(#13249): Remove after the change to Optional is released.
       Optional<Long> applicantId,
       String programParam,
       long applicationId,

--- a/server/app/controllers/applicant/UpsellController.java
+++ b/server/app/controllers/applicant/UpsellController.java
@@ -108,16 +108,16 @@ public final class UpsellController extends CiviFormController {
 
     // Derive the applicant ID from the application.
     Optional<ApplicationModel> maybeApplication =
-      applicationService.getApplicationAsync(applicationId).toCompletableFuture().join();
+        applicationService.getApplicationAsync(applicationId).toCompletableFuture().join();
     if (maybeApplication.isEmpty()) {
       return CompletableFuture.completedFuture(notFound());
     }
     long verifiedApplicantId = maybeApplication.get().getApplicant().id;
 
-    if(profileUtils.currentUserProfile(request).isTrustedIntermediary()) {
-      //if(applicantId != verifiedApplicantId) {
+    if (profileUtils.currentUserProfile(request).isTrustedIntermediary()) {
+      // if(applicantId != verifiedApplicantId) {
       //  logger.warn("Request supplied applicantId");
-      //}
+      // }
     }
 
     long programId =

--- a/server/conf/routes
+++ b/server/conf/routes
@@ -256,7 +256,7 @@ GET     /programAdmin                                       controllers.admin.Pr
 
 # Upsell methods
 GET     /download                                           controllers.applicant.UpsellController.download(request: Request, applicationId: Long, applicantId: Long)
-GET     /considerSignIn                                     controllers.applicant.UpsellController.considerRegister(request: Request, applicantId: Long, programParam: String, applicationId: Long, redirectTo: String, submitTime: String)
+GET     /considerSignIn                                     controllers.applicant.UpsellController.considerRegister(request: Request, applicantId: java.util.Optional[java.lang.Long], programParam: String, applicationId: Long, redirectTo: String, submitTime: String)
 
 # Authentication callback from local auth - nonfederated.  Requires CSRF token.
 # Provides client name as url parameter.

--- a/server/test/controllers/applicant/UpsellControllerTest.java
+++ b/server/test/controllers/applicant/UpsellControllerTest.java
@@ -207,6 +207,31 @@ public class UpsellControllerTest extends WithMockedProfiles {
   }
 
   @Test
+  public void considerRegister_otherUsersApplication_returnsUnauthorized() {
+    ProgramDefinition programDefinition =
+        ProgramBuilder.newActiveProgram("test program", "desc").buildDefinition();
+    createApplicantWithMockedProfile();
+    ApplicantModel otherApplicant = createApplicant();
+    ApplicationModel otherApplication =
+        resourceCreator.insertActiveApplication(otherApplicant, programDefinition.toProgram());
+    otherApplication.setSubmitTimeForTest(FAKE_SUBMIT_TIME);
+
+    Request request = fakeRequestBuilder().build();
+    Result result =
+        subject
+            .considerRegister(
+                request,
+                Optional.of(otherApplicant.id),
+                String.valueOf(programDefinition.id()),
+                otherApplication.id,
+                "someUrl",
+                otherApplication.getSubmitTime().toString())
+            .toCompletableFuture()
+            .join();
+    assertThat(result.status()).isEqualTo(UNAUTHORIZED);
+  }
+
+  @Test
   public void considerRegister_invalidApplicationId_returnsNotFound() {
 
     Request request = fakeRequestBuilder().build();

--- a/server/test/controllers/applicant/UpsellControllerTest.java
+++ b/server/test/controllers/applicant/UpsellControllerTest.java
@@ -181,6 +181,7 @@ public class UpsellControllerTest extends WithMockedProfiles {
   }
 
   @Test
+  // Test deprecation of Applicant ID
   public void considerRegister_ignoresProvidedApplicantId_usesApplicationApplicant() {
     ProgramDefinition programDefinition =
         ProgramBuilder.newActiveProgram("test program", "desc").buildDefinition();
@@ -190,7 +191,7 @@ public class UpsellControllerTest extends WithMockedProfiles {
     application.setSubmitTimeForTest(FAKE_SUBMIT_TIME);
 
     // Pass a bogus applicantId — the controller should ignore it and use the application's
-    // applicant instead, so the request still succeeds.
+    // applicant instead.
     Request request = fakeRequestBuilder().build();
     Result result =
         subject

--- a/server/test/controllers/applicant/UpsellControllerTest.java
+++ b/server/test/controllers/applicant/UpsellControllerTest.java
@@ -15,6 +15,7 @@ import auth.ProfileFactory;
 import auth.ProfileUtils;
 import controllers.WithMockedProfiles;
 import java.time.Instant;
+import java.util.Optional;
 import models.ApplicantModel;
 import models.ApplicationModel;
 import org.junit.Before;
@@ -79,7 +80,7 @@ public class UpsellControllerTest extends WithMockedProfiles {
         subject
             .considerRegister(
                 request,
-                applicant.id,
+                Optional.of(applicant.id),
                 String.valueOf(programDefinition.id()),
                 application.id,
                 redirectLocation,
@@ -108,7 +109,7 @@ public class UpsellControllerTest extends WithMockedProfiles {
         subject
             .considerRegister(
                 request,
-                applicant.id,
+                Optional.of(applicant.id),
                 String.valueOf(programDefinition.id()),
                 application.id,
                 redirectLocation,
@@ -137,7 +138,7 @@ public class UpsellControllerTest extends WithMockedProfiles {
         subject
             .considerRegister(
                 request,
-                applicant.id,
+                Optional.of(applicant.id),
                 programDefinition.slug(),
                 application.id,
                 redirectLocation,
@@ -167,7 +168,7 @@ public class UpsellControllerTest extends WithMockedProfiles {
         subject
             .considerRegister(
                 request,
-                applicant.id,
+                Optional.of(applicant.id),
                 programDefinition.slug(),
                 application.id,
                 redirectLocation,
@@ -190,13 +191,12 @@ public class UpsellControllerTest extends WithMockedProfiles {
 
     // Pass a bogus applicantId — the controller should ignore it and use the application's
     // applicant instead, so the request still succeeds.
-    long bogusApplicantId = applicant.id + 9999;
     Request request = fakeRequestBuilder().build();
     Result result =
         subject
             .considerRegister(
                 request,
-                bogusApplicantId,
+                Optional.of(applicant.id + 9999),
                 String.valueOf(programDefinition.id()),
                 application.id,
                 "someUrl",
@@ -215,7 +215,7 @@ public class UpsellControllerTest extends WithMockedProfiles {
         subject
             .considerRegister(
                 request,
-                applicant.id,
+                Optional.empty(),
                 "some-program",
                 /* applicationId= */ 0,
                 "someUrl",

--- a/server/test/controllers/applicant/UpsellControllerTest.java
+++ b/server/test/controllers/applicant/UpsellControllerTest.java
@@ -208,7 +208,6 @@ public class UpsellControllerTest extends WithMockedProfiles {
 
   @Test
   public void considerRegister_invalidApplicationId_returnsNotFound() {
-    ApplicantModel applicant = createApplicantWithMockedProfile();
 
     Request request = fakeRequestBuilder().build();
     Result result =

--- a/server/test/controllers/applicant/UpsellControllerTest.java
+++ b/server/test/controllers/applicant/UpsellControllerTest.java
@@ -180,6 +180,52 @@ public class UpsellControllerTest extends WithMockedProfiles {
   }
 
   @Test
+  public void considerRegister_ignoresProvidedApplicantId_usesApplicationApplicant() {
+    ProgramDefinition programDefinition =
+        ProgramBuilder.newActiveProgram("test program", "desc").buildDefinition();
+    ApplicantModel applicant = createApplicantWithMockedProfile();
+    ApplicationModel application =
+        resourceCreator.insertActiveApplication(applicant, programDefinition.toProgram());
+    application.setSubmitTimeForTest(FAKE_SUBMIT_TIME);
+
+    // Pass a bogus applicantId — the controller should ignore it and use the application's
+    // applicant instead, so the request still succeeds.
+    long bogusApplicantId = applicant.id + 9999;
+    Request request = fakeRequestBuilder().build();
+    Result result =
+        subject
+            .considerRegister(
+                request,
+                bogusApplicantId,
+                String.valueOf(programDefinition.id()),
+                application.id,
+                "someUrl",
+                application.getSubmitTime().toString())
+            .toCompletableFuture()
+            .join();
+    assertThat(result.status()).isEqualTo(OK);
+  }
+
+  @Test
+  public void considerRegister_invalidApplicationId_returnsNotFound() {
+    ApplicantModel applicant = createApplicantWithMockedProfile();
+
+    Request request = fakeRequestBuilder().build();
+    Result result =
+        subject
+            .considerRegister(
+                request,
+                applicant.id,
+                "some-program",
+                /* applicationId= */ 0,
+                "someUrl",
+                FAKE_SUBMIT_TIME.toString())
+            .toCompletableFuture()
+            .join();
+    assertThat(result.status()).isEqualTo(NOT_FOUND);
+  }
+
+  @Test
   public void download_authenticatedApplicant() {
     ProgramDefinition programDefinition =
         ProgramBuilder.newActiveProgram("test program", "desc").buildDefinition();


### PR DESCRIPTION
### Description

#### Summary: Ensures the current user has access to the requested application as well normalizes the applicant shown.

While this seems like a potentially meaningful change the following will show why it likely won't be noticed and that it makes the page more consistent.

#### Background

`considerRegister` is only shown immediately after a user submits an application, it can't be navigated to in any other way.  The page shows a high level summary, links to the download page, and encourages a guest user to log in.

Information shown:
* Who submitted this application
* Confirmation number
* Date submitted

The url supplies parameters for both the `applicantId` and `applicationId` of the submission just done. This route is also used by TIs.

#### Change

This PR deprecates the `applicantId` param and instead looks up the owner of `applicationId` for the value. It maintains checking that the current user has access to that applicant.

This update does potentially have a user visible change, however the following shows how that UX was not really correct to start with.  It could use some product thought, but it is not high priority.

Deprecation: This change makes `applicantId` Optional. After a release cycle we can then remove the param from the route. Tracked in #13249

##### Access check

The above bridges a gap in verifying that the current user has access to the application by way of not using the user supplied applicant and using the application's actual owner. #13182

The current behavior allows for any application to be specified, though the details shown contain no meaningful user information.  The "who submitted" text is from the applicant, and the download link checks that the user has access to the application.  The ID is the one present in the url.

The only other information from the application is the submission time which is not considered sensitive on its own.

##### Normalizing display

The page display is a composite of data from the two sources:
* Who submitted this application: Applicant record.
* Confirmation number: Application ID from url param
* Date submitted: From url param

Because the existing code accepted the IDs for those separately, you could change the composite display by changing the IDs.

While the UI doesn't  afford the link values changing, one way this could be valid is if a user has multiple applicants, such as through the current Guest merge flow. (Which is being fixed to not do this)  You could load the URL with either `applicantID` and see a different name based on what was saved into the applicant. Despite the mismatch this is valid because the logged in user is primarily associated with an `account` and the `applicants` are both owned by the `account`.  While the UI doesn't generate those variants, this code change ensures that the applicant shown is stable based on the applicant.

###### On going issues to consider

The name value in the `applicant` is fungible, so you could reload the page and see a different name if you applied to something else and changed the name value in the interim.  We don't capture the name at the time of application etc, which would be required to make the display stable and accurate as of the submission.

This is mostly to say that this page is not perfect to start, and this change improves it some.

##### Account Merging

This change is necessary for the new Account Merging work because a material effect of that work is to change the guest's applications to be owned by the logged-in users applicant instead.

`considerRegister`'s login link navigates to the login/merge flow with a redirect back to it.  That redirect contains the guest's applicant ID and after the merge that applicant ID is no longer the owner of the application.

To otherwise make the existing page work, the merge code would have to update the `applicantId` present in the login callback. This is onerous and errorprone as that is a value in a redirect url which the log-in flow is not meant to have first-hand knowledge or control of.

Example of the rendered considerRegister page:
<img width="617" height="809" alt="Screenshot 2026-05-07 at 12 31 03 PM" src="https://github.com/user-attachments/assets/eef8a09d-57b4-4654-bae8-cd77bd5d8ac3" />

## Release notes

Updates the post-submission page verification checks and simplifies the server handling for it.


### Checklist

Remove any sections below that do not apply to your PR. For sections that do apply, complete all of the appropriate checklist items and check them off. If a checklist item doesn't apply to your PR, leave it unchecked but do not delete it.

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [ ] Added an additional reviewer as required if changes potentially affect the security of the application.
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

### Instructions for manual testing

Testing of the verification gap:
* Submit an application
* Changing the `applicantId` in the url 
* Notice: a 401 Unauthorized response.  (This should probably be a 403 Forbidden but changing that is out of scope)

Regression testing:

Submit an application and verify the data shown and links work as expected
* Repeat for TI and Applicant


### Issue(s) this completes

Fixes #13182, #12770
