### PR TITLE
Add serializer fallback for future pac4j backwards compatibility

### DIFF
--- a/server/app/auth/CiviFormSessionStoreFactory.java
+++ b/server/app/auth/CiviFormSessionStoreFactory.java
@@ -1,5 +1,6 @@
 package auth;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
 import com.typesafe.config.Config;
 import java.nio.charset.StandardCharsets;
@@ -62,21 +63,22 @@ public class CiviFormSessionStoreFactory implements SessionStoreFactory {
   }
 
   public SessionStore newSessionStore() {
-    // This is a weird one.  :)  The cookie session store refuses to serialize any
-    // classes it doesn't explicitly trust.  A bug in pac4j interacts badly with
-    // sbt's autoreload, so we have a little workaround here.  configure() gets called on every
-    // startup,
-    // but the JAVA_SERIALIZER object is only initialized on initial startup.
-    // So, on a second startup, we'll add the CiviFormProfileData a second time.  The
-    // trusted classes set should dedupe CiviFormProfileData against the old CiviFormProfileData,
-    // but it's technically a different class with the same name at that point,
-    // which triggers the bug.  So, we just clear the classes, which will be empty
-    // on first startup and will contain the profile on subsequent startups,
-    // so that it's always safe to add the profile.
-    // We will need to do this for every class we want to store in the cookie.
-    var serializer = new org.pac4j.core.util.serializer.JavaSerializer();
-    serializer.clearTrustedClasses();
-    serializer.addTrustedClass(CiviFormProfileData.class);
+    var jsonSerializerPrimary = new org.pac4j.core.util.serializer.JsonSerializer();
+    // Play's request threads can have a context classloader that doesn't include the
+    // application classes, so Jackson's DefaultTyping fails to resolve type ids like
+    // "auth.CiviFormProfileData" with "no such class found". Bind the TypeFactory to the
+    // classloader that actually loaded our app classes.
+    ObjectMapper jsonMapper = jsonSerializerPrimary.getObjectMapper();
+    jsonMapper.setTypeFactory(
+        jsonMapper.getTypeFactory().withClassLoader(CiviFormProfileData.class.getClassLoader()));
+
+    // Remove after a few releases so we can move forward on updating the pac4j dependency
+    // and remove the deprecated JavaSerializer
+    var javaSerializerFallback = new org.pac4j.core.util.serializer.JavaSerializer();
+    javaSerializerFallback.clearTrustedClasses();
+    javaSerializerFallback.addTrustedClass(CiviFormProfileData.class);
+
+    var serializer = new FallbackSerializer(jsonSerializerPrimary, javaSerializerFallback);
 
     var sessionStore = new PlayCookieSessionStore(encrypter);
     sessionStore.setSerializer(serializer);

--- a/server/app/auth/FallbackSerializer.java
+++ b/server/app/auth/FallbackSerializer.java
@@ -1,0 +1,61 @@
+package auth;
+
+import org.pac4j.core.util.serializer.JavaSerializer;
+import org.pac4j.core.util.serializer.JsonSerializer;
+import org.pac4j.core.util.serializer.Serializer;
+
+/**
+ * Pac4j has deprecated the {@link JavaSerializer} in v6.5.0, so we are stuck on v6.4.x until we are
+ * ready to remove the {@link JavaSerializer}.
+ *
+ * <p>This custom {@link Serializer} is used to provide transition time for existing user sessions
+ * to migrate from the {@link JavaSerializer} to the {@link JsonSerializer}. It follows the same
+ * pattern used for the {@link FallbackDataEncrypter}.
+ */
+public class FallbackSerializer implements Serializer {
+  private final Serializer primary;
+  private final Serializer fallback;
+
+  public FallbackSerializer(Serializer primary, Serializer fallback) {
+    this.primary = primary;
+    this.fallback = fallback;
+  }
+
+  @Override
+  public byte[] serializeToBytes(Object o) {
+    return primary.serializeToBytes(o);
+  }
+
+  @Override
+  public String serializeToString(Object o) {
+    return primary.serializeToString(o);
+  }
+
+  @Override
+  public Object deserializeFromBytes(byte[] bytes) {
+    // pac4j's AbstractSerializer.deserializeFromBytes catches parse exceptions internally
+    // and returns null. So we fallback on null OR a thrown exception.
+    try {
+      Object result = primary.deserializeFromBytes(bytes);
+      if (result != null) {
+        return result;
+      }
+    } catch (RuntimeException e) {
+      // fall through to fallback
+    }
+    return fallback.deserializeFromBytes(bytes);
+  }
+
+  @Override
+  public Object deserializeFromString(String value) {
+    try {
+      Object result = primary.deserializeFromString(value);
+      if (result != null) {
+        return result;
+      }
+    } catch (RuntimeException e) {
+      // fall through to fallback
+    }
+    return fallback.deserializeFromString(value);
+  }
+}

--- a/server/test/auth/CiviFormSessionStoreFactoryTest.java
+++ b/server/test/auth/CiviFormSessionStoreFactoryTest.java
@@ -7,14 +7,20 @@ import static support.FakeRequestBuilder.fakeRequestBuilder;
 import com.google.common.collect.ImmutableMap;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
+import java.io.ByteArrayInputStream;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.zip.GZIPInputStream;
 import org.apache.shiro.crypto.AesCipherService;
 import org.junit.Test;
 import org.pac4j.core.context.session.SessionStore;
 import org.pac4j.core.util.serializer.JavaSerializer;
 import org.pac4j.play.PlayWebContext;
+import org.pac4j.play.store.JdkAesDataEncrypter;
 import org.pac4j.play.store.PlayCookieSessionStore;
 import play.mvc.Http.Request;
 
@@ -127,6 +133,109 @@ public class CiviFormSessionStoreFactoryTest {
     PlayWebContext context2 = newContextWithSessionFrom(context1);
 
     assertThatThrownBy(() -> store2.get(context2, "test-key")).isInstanceOf(RuntimeException.class);
+  }
+
+  @Test
+  public void newSessionStore_readsLegacyJavaSerializedCookieFromPreviousDeploy() throws Exception {
+    CiviFormSessionStoreFactory factory = new CiviFormSessionStoreFactory(createConfig(SECRET1));
+
+    // Mimic what a previous deploy would have written: a populated CiviFormProfileData inside
+    // the cookie's value map, serialized with vanilla JavaSerializer.
+    CiviFormProfileData profileData = new CiviFormProfileData();
+    profileData.setId("42");
+    profileData.addAttribute("custom-attr", "custom-value");
+
+    Map<String, Object> values = new HashMap<>();
+    values.put("profile-key", profileData);
+
+    JavaSerializer serializer = new JavaSerializer();
+    serializer.addTrustedClass(CiviFormProfileData.class);
+    byte[] serialized = serializer.serializeToBytes(values);
+    byte[] compressed = PlayCookieSessionStore.compressBytes(serialized);
+
+    byte[] aesKey = CiviFormSessionStoreFactory.deriveAes128Key(SECRET1);
+    JdkAesDataEncrypter encrypter = new JdkAesDataEncrypter(aesKey);
+    byte[] encrypted = encrypter.encrypt(compressed);
+    String cookieValue = Base64.getEncoder().encodeToString(encrypted);
+
+    Request request = fakeRequestBuilder().addSessionValue("pac4j", cookieValue).build();
+    PlayWebContext context = new PlayWebContext(request);
+
+    SessionStore store = factory.newSessionStore();
+
+    Optional<Object> readBack = store.get(context, "profile-key");
+    assertThat(readBack).isPresent();
+    CiviFormProfileData restored = (CiviFormProfileData) readBack.get();
+    assertThat(restored.getId()).isEqualTo("42");
+    assertThat(restored.getAttribute("custom-attr")).isEqualTo("custom-value");
+  }
+
+  @Test
+  public void newSessionStore_writesJsonNotJavaSerializedBytes() throws Exception {
+    CiviFormSessionStoreFactory factory = new CiviFormSessionStoreFactory(createConfig(SECRET1));
+    SessionStore store = factory.newSessionStore();
+
+    PlayWebContext context = new PlayWebContext(fakeRequestBuilder().build());
+    store.set(context, "test-key", "test-value");
+
+    Request requestWithSession = context.supplementRequest(fakeRequestBuilder().build());
+    String cookieValue = requestWithSession.session().get("pac4j").orElseThrow();
+
+    byte[] aesKey = CiviFormSessionStoreFactory.deriveAes128Key(SECRET1);
+    JdkAesDataEncrypter encrypter = new JdkAesDataEncrypter(aesKey);
+    byte[] encrypted = Base64.getDecoder().decode(cookieValue);
+    byte[] compressed = encrypter.decrypt(encrypted);
+    byte[] plaintext;
+    try (GZIPInputStream gzip = new GZIPInputStream(new ByteArrayInputStream(compressed))) {
+      plaintext = gzip.readAllBytes();
+    }
+
+    // pac4j's JsonSerializer uses Jackson with DefaultTyping.NON_FINAL, which wraps a
+    // Map<String, Object> as a tagged JSON array: ["java.util.HashMap", {...}]. So the first
+    // byte is '[' (0x5B). Negative-assert against the Java serialization magic
+    // (0xAC 0xED) to guard against accidental revert to JavaSerializer as primary.
+    assertThat(plaintext[0]).isEqualTo((byte) '[');
+    assertThat(plaintext[0]).isNotEqualTo((byte) 0xAC);
+    assertThat(plaintext[1]).isNotEqualTo((byte) 0xED);
+  }
+
+  @Test
+  public void newSessionStore_roundTripsPopulatedCiviFormProfileData() throws Exception {
+    CiviFormSessionStoreFactory factory = new CiviFormSessionStoreFactory(createConfig(SECRET1));
+    SessionStore store = factory.newSessionStore();
+
+    CiviFormProfileData profileData = new CiviFormProfileData();
+    profileData.setId("42");
+    profileData.addAttribute("emailKey", "user@example.com");
+    profileData.addAttribute("longAttr", 12345L);
+    String uuid = UUID.randomUUID().toString();
+    profileData.addAttribute("uuidAttr", uuid);
+    profileData.setRoles(Set.of("ROLE_APPLICANT", "ROLE_ADMIN"));
+    profileData.setClientName("test-client");
+    profileData.setLinkedId("linked-123");
+
+    PlayWebContext context1 = new PlayWebContext(fakeRequestBuilder().build());
+    store.set(context1, "profile-key", profileData);
+
+    Request requestWithSession = context1.supplementRequest(fakeRequestBuilder().build());
+    String cookieValue = requestWithSession.session().get("pac4j").orElseThrow();
+
+    // Play's cookie size limit is ~4KB. Leave headroom for headers / additional session keys
+    // so the JSON-format cookie doesn't push us against the limit once profiles grow.
+    assertThat(cookieValue.length()).isLessThan(3500);
+
+    PlayWebContext context2 = new PlayWebContext(requestWithSession);
+    Optional<Object> readBack = store.get(context2, "profile-key");
+    assertThat(readBack).isPresent();
+    CiviFormProfileData restored = (CiviFormProfileData) readBack.get();
+
+    assertThat(restored.getId()).isEqualTo("42");
+    assertThat(restored.getAttribute("emailKey")).isEqualTo("user@example.com");
+    assertThat(restored.getAttribute("longAttr")).isEqualTo(12345L);
+    assertThat(restored.getAttribute("uuidAttr")).isEqualTo(uuid);
+    assertThat(restored.getRoles()).containsExactlyInAnyOrder("ROLE_APPLICANT", "ROLE_ADMIN");
+    assertThat(restored.getClientName()).isEqualTo("test-client");
+    assertThat(restored.getLinkedId()).isEqualTo("linked-123");
   }
 
   @Test

--- a/server/test/auth/FallbackSerializerTest.java
+++ b/server/test/auth/FallbackSerializerTest.java
@@ -1,0 +1,130 @@
+package auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.nio.charset.StandardCharsets;
+import org.junit.Test;
+import org.pac4j.core.util.serializer.Serializer;
+
+public class FallbackSerializerTest {
+
+  /** Minimal stub that records calls and returns a configured value or throws. */
+  private static final class StubSerializer implements Serializer {
+    int serializeCalls = 0;
+    int deserializeCalls = 0;
+    private final byte[] serializeResult;
+    private final Object deserializeResult;
+    private final RuntimeException deserializeThrow;
+
+    static StubSerializer returning(byte[] serialized, Object deserialized) {
+      return new StubSerializer(serialized, deserialized, null);
+    }
+
+    static StubSerializer throwingOnDeserialize(RuntimeException toThrow) {
+      return new StubSerializer(new byte[0], null, toThrow);
+    }
+
+    private StubSerializer(byte[] serializeResult, Object deserializeResult, RuntimeException ex) {
+      this.serializeResult = serializeResult;
+      this.deserializeResult = deserializeResult;
+      this.deserializeThrow = ex;
+    }
+
+    @Override
+    public byte[] serializeToBytes(Object o) {
+      serializeCalls++;
+      return serializeResult;
+    }
+
+    @Override
+    public String serializeToString(Object o) {
+      serializeCalls++;
+      return new String(serializeResult, StandardCharsets.UTF_8);
+    }
+
+    @Override
+    public Object deserializeFromBytes(byte[] bytes) {
+      deserializeCalls++;
+      if (deserializeThrow != null) {
+        throw deserializeThrow;
+      }
+      return deserializeResult;
+    }
+
+    @Override
+    public Object deserializeFromString(String value) {
+      deserializeCalls++;
+      if (deserializeThrow != null) {
+        throw deserializeThrow;
+      }
+      return deserializeResult;
+    }
+  }
+
+  @Test
+  public void serialize_alwaysUsesPrimary() {
+    StubSerializer primary = StubSerializer.returning(new byte[] {1, 2, 3}, "primary");
+    StubSerializer fallback = StubSerializer.returning(new byte[] {9, 9, 9}, "fallback");
+    FallbackSerializer combined = new FallbackSerializer(primary, fallback);
+
+    byte[] result = combined.serializeToBytes(new Object());
+
+    assertThat(result).isEqualTo(new byte[] {1, 2, 3});
+    assertThat(primary.serializeCalls).isEqualTo(1);
+    assertThat(fallback.serializeCalls).isEqualTo(0);
+  }
+
+  @Test
+  public void deserialize_returnsPrimaryResultWhenPrimarySucceeds() {
+    StubSerializer primary = StubSerializer.returning(new byte[0], "primary-result");
+    StubSerializer fallback = StubSerializer.returning(new byte[0], "fallback-result");
+    FallbackSerializer combined = new FallbackSerializer(primary, fallback);
+
+    Object result = combined.deserializeFromBytes(new byte[] {1, 2, 3});
+
+    assertThat(result).isEqualTo("primary-result");
+    assertThat(primary.deserializeCalls).isEqualTo(1);
+    assertThat(fallback.deserializeCalls).isEqualTo(0);
+  }
+
+  @Test
+  public void deserialize_fallsBackWhenPrimaryThrowsRuntimeException() {
+    StubSerializer primary = StubSerializer.throwingOnDeserialize(new RuntimeException("primary"));
+    StubSerializer fallback = StubSerializer.returning(new byte[0], "fallback-result");
+    FallbackSerializer combined = new FallbackSerializer(primary, fallback);
+
+    Object result = combined.deserializeFromBytes(new byte[] {1, 2, 3});
+
+    assertThat(result).isEqualTo("fallback-result");
+    assertThat(primary.deserializeCalls).isEqualTo(1);
+    assertThat(fallback.deserializeCalls).isEqualTo(1);
+  }
+
+  @Test
+  public void deserialize_fallsBackWhenPrimaryReturnsNull() {
+    // pac4j's AbstractSerializer.deserializeFromBytes catches parse errors internally and
+    // returns null rather than throwing — this test pins that path.
+    StubSerializer primary = StubSerializer.returning(new byte[0], null);
+    StubSerializer fallback = StubSerializer.returning(new byte[0], "fallback-result");
+    FallbackSerializer combined = new FallbackSerializer(primary, fallback);
+
+    Object result = combined.deserializeFromBytes(new byte[] {1, 2, 3});
+
+    assertThat(result).isEqualTo("fallback-result");
+    assertThat(primary.deserializeCalls).isEqualTo(1);
+    assertThat(fallback.deserializeCalls).isEqualTo(1);
+  }
+
+  @Test
+  public void deserialize_propagatesFallbackExceptionWhenBothThrow() {
+    StubSerializer primary = StubSerializer.throwingOnDeserialize(new RuntimeException("primary"));
+    StubSerializer fallback =
+        StubSerializer.throwingOnDeserialize(new RuntimeException("fallback"));
+    FallbackSerializer combined = new FallbackSerializer(primary, fallback);
+
+    assertThatThrownBy(() -> combined.deserializeFromBytes(new byte[] {1, 2, 3}))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessage("fallback");
+  }
+}


### PR DESCRIPTION
### Description

In pac4j v6.5.0 the `JavaSerializer` has been deprecated. This is preventing us from updating past the v6.4.x line. This makes the `JsonSerializer` the default `Serializer` and creates a fallback class that functions in the same way as the `FallbackDataEncrypter` so we are able to release without killing existing sessions based on the older serializer. After a few releases we can remove it and upgrade to the newest pac4j release.

A cleanup issue will be created after this is merged.

AI usage: Created with claude code, tweaked by hand.

### Release Notes

This release includes updates to handle future changes in our authentication library. You may see this error logged `com.fasterxml.jackson.core.JsonParseException: Unexpected character ('' (code 65533 / 0xfffd)): expected a valid value (JSON String, Number, Array, Object or token 'null', 'true' or 'false'`. This can be ignored and will phase out as user sessions get updated or timeout.

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [x] Added an additional reviewer as required if changes potentially affect the security of the application.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing
- [x] Noted in the PR description which, if any, code in this PR was generated by

### Issue(s) this completes

Related to #13263
