### PR TITLE
Add additional instructions to feature flag issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_flag.md
+++ b/.github/ISSUE_TEMPLATE/feature_flag.md
@@ -21,7 +21,8 @@ Follow detailed instructions in [Feature Flags wiki page](https://github.com/civ
 - [ ] Create feature flag
 - [ ] Implement code guarded with flag, including unit and browser tests that manipulate the state of the flag as needed
 - [ ] Enable flag [in dev](https://github.com/civiform/civiform/blob/main/server/conf/application.dev.conf)
-- [ ] Enable flag [in staging](https://github.com/civiform/civiform-staging-deploy/blob/main/aws_staging_civiform_config.sh)
+- [ ] Enable flag in [staging](https://github.com/civiform/civiform-staging-deploy/blob/main/aws_staging_civiform_config.sh), [QA](https://github.com/civiform/civiform-staging-deploy/blob/main/qa_civiform_config.sh), [eng](https://github.com/civiform/civiform-staging-deploy/blob/main/civiform_eng_civiform_config.sh), and [demo](https://github.com/civiform/civiform-staging-deploy/blob/main/civiform_demo_civiform_config.sh).
 - [ ] Coordinate with @shreyachatterjee00 to announce the feature to governments
+- [ ] Move the flag out of the "Experimental" section and into the "Feature Flags" section and remove the "(NOT FOR PRODUCTION USE)" warning from the description.
 - [ ] Deprecate flag (default to true unless overridden in config)
 - [ ] Remove flag completely


### PR DESCRIPTION
### Description

Add instructions to feature flag issue template to turn the flag on in all our test environments and to move it into the "Feature Flags" section before deprecating.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [ ] Added an additional reviewer as required if changes potentially affect the security of the application.
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.