### PR TITLE
Ebean Example and Solution for how Transactions and Async Ebean code interact

### DIFF
--- a/server/test/repository/EbeanInvariantTest.java
+++ b/server/test/repository/EbeanInvariantTest.java
@@ -1,11 +1,13 @@
 package repository;
 
+import static java.util.concurrent.CompletableFuture.supplyAsync;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
 import io.ebean.DB;
 import io.ebean.Database;
+import io.ebean.Query;
 import io.ebean.Transaction;
 import io.ebean.TxScope;
 import io.ebean.annotation.TxIsolation;
@@ -536,6 +538,59 @@ public class EbeanInvariantTest extends ResetPostgres {
         // Note: innerAccount is the same object as innerInnerAccount unexpectedly.
         assertThat(innerAccount).isSameAs(innerInnerAccount);
       }
+    }
+  }
+
+  /* Async
+   *
+   * Async code doesn't work with our Transaction setup.
+   *
+   * The current transaction is maintained in thread-local storage, however
+   * Async calls create a new thread with its own storage.
+   *
+   * We can explicitly specify the transaction in the Ebean queries though.
+   * This is likely onerous as a broad approach but specific needs may allow
+   * for it more cleanly.
+   */
+  @Test
+  @Parameters({"false", "true"})
+  public void async_mustExplicitlyManageTransaction(boolean setInnerTransaction) {
+    try (Transaction _ =
+        DB.beginTransaction(TxScope.required().setIsolation(TxIsolation.SERIALIZABLE))) {
+      // While we could have named the above transaction, this shows how to
+      // get the current one.
+      Transaction outerTransaction = Transaction.current();
+      // Insert a few just to reduce confusion with the 1 added in the Async
+      // call.
+      new AccountModel().insert();
+      new AccountModel().insert();
+
+      int beforeCount = database.find(AccountModel.class).findCount();
+      assertThat(beforeCount).isEqualTo(2);
+
+      // Using the current transaction in the Async code will reveal the outer
+      // code's updates to the inner, and vice versa.
+      int innerCount =
+          supplyAsync(
+                  () -> {
+                    Query<AccountModel> query = database.find(AccountModel.class);
+                    if (setInnerTransaction) {
+                      new AccountModel().insert(outerTransaction);
+                      query = query.usingTransaction(outerTransaction);
+                    } else {
+                      // The insert will have its own transaction.
+                      new AccountModel().insert();
+                    }
+                    return query.findCount();
+                  })
+              .toCompletableFuture()
+              .join();
+
+      // How many did the Async code see?
+      assertThat(innerCount).isEqualTo(setInnerTransaction ? 3 : 1);
+      // How may does the outer transaction see?
+      int afterCount = database.find(AccountModel.class).findCount();
+      assertThat(afterCount).isEqualTo(setInnerTransaction ? 3 : 2);
     }
   }
 }


### PR DESCRIPTION
### Description

Example code to illustrate how Transactions and Async code interact and how we can achieve Transactional utility through it.

### Checklist

Remove any sections below that do not apply to your PR. For sections that do apply, complete all of the appropriate checklist items and check them off. If a checklist item doesn't apply to your PR, leave it unchecked but do not delete it.

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [ ] Added an additional reviewer as required if changes potentially affect the security of the application.
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.
