### PR TITLE
Reformat slack payload in translations workflow

### DIFF
--- a/.github/workflows/translations_context_remider.yaml
+++ b/.github/workflows/translations_context_remider.yaml
@@ -26,9 +26,7 @@ jobs:
             // GitHub username -> Slack user ID mapping
             const slackUserMap = {
               'tallulahkay': 'U08ELT9CAB0',
-              'fernandez-jack': 'U09HKV8L57V',
               'melanie-exygy': 'U057V0H2K0W',
-              'AlvieH': 'U09K2RWPA00',
             };
 
             const files = await github.rest.pulls.listFiles({
@@ -39,10 +37,35 @@ jobs:
             const messagesModified = files.data.some(file => file.filename === 'server/conf/i18n/messages');
             core.setOutput('modified', messagesModified);
 
-            const ghUser = context.payload.pull_request.user.login;
-            const slackUserId = slackUserMap[ghUser];
+            if (!messagesModified) return;
+
+            const pr = context.payload.pull_request;
+            const slackUserId = slackUserMap[pr.user.login];
             const mention = slackUserId ? `<@${slackUserId}>` : '';
             core.setOutput('mention', mention);
+
+            const text =
+              `${mention}: *Reminder to update translations in Transifex for this PR:*\n` +
+              `<${pr.html_url}|${pr.title}>\n\n` +
+              `The base messages file was modified. Please:\n` +
+              `1. Add context for any new or updated strings in <https://app.transifex.com/civiform/|Transifex> (add the context string under 'String Instructions')\n` +
+              `2. If you don't want strings to be translated yet, mark them as locked by typing "locked" in the Tags field\n\n` +
+              `See the <https://github.com/civiform/civiform/wiki/Internationalization-(i18n)#adding-new-strings|wiki> for full instructions.`;
+
+            const payload = {
+              text: "Translations update needed",
+              blocks: [
+                {
+                  type: "section",
+                  text: {
+                    type: "mrkdwn",
+                    text: text,
+                  },
+                },
+              ],
+            };
+
+            core.setOutput('payload', JSON.stringify(payload));
 
       - name: Send Slack notification
         if: steps.check_messages.outputs.modified == 'true' && steps.check_messages.outputs.mention != ''
@@ -50,17 +73,4 @@ jobs:
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook
-          payload: |
-            {
-              "text": "Translations update needed",
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "${{ steps.check_messages.outputs.mention }}: *Reminder to update translations in Transifex for this PR:*\n<${{ github.event.pull_request.html_url }}|${{ github.event.pull_request.title }}>\n\nThe base messages file was modified. Please:\n1. Add context for any new or updated strings in <https://app.transifex.com/civiform/|Transifex> (add the context string under 'String Instructions')\n2. If you don't want strings to be translated yet, mark them as locked by typing \"locked\" in the Tags field\n\nSee the <https://github.com/civiform/civiform/wiki/Internationalization-(i18n)#adding-new-strings|wiki> for full instructions."
-                  }
-                }
-              ]
-            }
-
+          payload: ${{ steps.check_messages.outputs.payload }}


### PR DESCRIPTION
### Description

Reformats the slack payload for better readability and to sanitize the title which is a user controlled value.

Also removes people from the list are no longer on the team.

## Release notes

Remove this section if the feature is still under development or if title of the pull request can be used as the default release notes description. If more detail is needed to communicate to partners the scope of the PR's changes, use this release notes section (and remove this placeholder text).

When the Release engineer creates Release Notes, they will not look for this section for Under Development tagged PRs, and will use it if present for all other PRs included in the Release Notes.

### Checklist

Remove any sections below that do not apply to your PR. For sections that do apply, complete all of the appropriate checklist items and check them off. If a checklist item doesn't apply to your PR, leave it unchecked but do not delete it.

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [ ] Added an additional reviewer as required if changes potentially affect the security of the application.
- [ ] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

#### Database evolutions

Read the guidelines [here](https://github.com/civiform/civiform/wiki/Database#writing-database-evolutions)

- [ ] Assigned two reviewers
- [ ] Guarded against already existing resources using `IF NOT EXISTS` and `IF EXISTS`
- [ ] Downs created to undo changes in Ups
- [ ] Every comment in script should begin with -- and not # --- unless it denotes Ups or Downs. See [here](https://www.playframework.com/documentation/2.9.x/Evolutions) for details.
- [ ] Tested both the Downs and the Ups scripts manually (When testing, include all comments from the evolution in your test script to ensure any syntax errors in the comments are caught.)
- [ ] Data migrations aren't being done (please use a [Durable Job](https://github.com/civiform/civiform/wiki/Database#durable-jobs-for-data-updates) if doing a data migration)
- [ ] Update the model documentation in our [wiki](https://github.com/civiform/civiform/wiki/Database) if necessary

#### Durable jobs

Read the docs [here](https://github.com/civiform/civiform/wiki/Database#durable-jobs-for-data-updates)

- [ ] Assigned two reviewers
- [ ] Included a rollback plan and a job to undo the data changes if appropriate

#### User visible changes

- [ ] Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
  - [ ] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [ ] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order
- [ ] Performed manual accessibility tests for any applicant-facing changes or any new admin-facing features. See [manual-accessibility-testing](https://github.com/civiform/civiform/wiki/Accessibility#manual-accessibility-testing)
- [ ] Manually tested with a right-to-left language

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/helper/feature-flags.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://github.com/civiform/civiform/wiki/Feature-Flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Instructions for manual testing

If instructions are needed for manual testing by reviewers, include them here.
