### PR TITLE
[Session Timeout] enable session timeout by default (to be merged after 5/26)

### DIFF
--- a/browser-test/src/applicant/application_address_correction.test.ts
+++ b/browser-test/src/applicant/application_address_correction.test.ts
@@ -130,7 +130,7 @@ test.describe('address correction single-block, single-address program', () => {
           'CA',
           '92373',
         )
-        await page.getByText('متابعة').click()
+        await page.getByRole('button', {name: 'متابعة'}).click()
       })
 
       await test.step('Validate address correction page rendered right to left', async () => {

--- a/browser-test/src/session_timeout.test.ts
+++ b/browser-test/src/session_timeout.test.ts
@@ -1,10 +1,5 @@
 import {test, expect} from './support/civiform_fixtures'
-import {
-  enableFeatureFlag,
-  loginAsAdmin,
-  loginAsTestUser,
-  validateScreenshot,
-} from './support'
+import {loginAsAdmin, loginAsTestUser, validateScreenshot} from './support'
 import {Page} from '@playwright/test'
 
 // Config values from application.dev-browser-tests.conf:
@@ -23,7 +18,6 @@ test.describe('Session timeout for admins', () => {
     // This way server timestamps and browser time should be in sync
     await page.clock.install({time: realTime})
     await loginAsAdmin(page)
-    await enableFeatureFlag(page, 'session_timeout_enabled')
   })
 
   test('shows inactivity warning modal after 50 minutes and logs user out after 90 more minutes', async ({
@@ -77,7 +71,6 @@ test.describe('Session timeout for applicants', () => {
     // Install clock at the current real time
     // This way server timestamps and browser time should be in sync
     await page.clock.install({time: realTime})
-    await enableFeatureFlag(page, 'session_timeout_enabled')
   })
 
   test('shows inactivity warning modal after 50 minutes and session length warning modal after 55 minutes', async ({

--- a/server/app/controllers/SessionController.java
+++ b/server/app/controllers/SessionController.java
@@ -32,7 +32,7 @@ public class SessionController extends Controller {
    *     timeouts are disabled
    */
   public Result extendSession(Http.Request request) {
-    if (!settingsManifest.getSessionTimeoutEnabled(request)) {
+    if (!settingsManifest.getSessionTimeoutEnabled()) {
       return badRequest();
     }
 

--- a/server/app/filters/CiviFormSessionFilter.java
+++ b/server/app/filters/CiviFormSessionFilter.java
@@ -120,7 +120,7 @@ public class CiviFormSessionFilter extends EssentialFilter {
                         }
 
                         // Validate session length
-                        if (settingsManifest.get().getSessionTimeoutEnabled(request)
+                        if (settingsManifest.get().getSessionTimeoutEnabled()
                             && optionalSession.isPresent()) {
                           long sessionStartTimeInMillis =
                               optionalSession.get().getCreationTime().toEpochMilli();

--- a/server/app/services/settings/SettingsManifest.java
+++ b/server/app/services/settings/SettingsManifest.java
@@ -1098,8 +1098,8 @@ public final class SettingsManifest extends AbstractSettingsManifest {
   }
 
   /** Enable session timeout based on inactivity and maximum duration. */
-  public boolean getSessionTimeoutEnabled(RequestHeader request) {
-    return getBool("SESSION_TIMEOUT_ENABLED", request);
+  public boolean getSessionTimeoutEnabled() {
+    return getBool("SESSION_TIMEOUT_ENABLED");
   }
 
   /** (NOT FOR PRODUCTION USE) Use program slugs instead of program IDs in URLs. */
@@ -2387,7 +2387,7 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                           "Enable session timeout based on inactivity and maximum duration.",
                           /* isRequired= */ false,
                           SettingType.BOOLEAN,
-                          SettingMode.ADMIN_WRITEABLE))))
+                          SettingMode.ADMIN_READABLE))))
           .put(
               "Experimental",
               SettingsSection.create(

--- a/server/app/services/settings/SettingsService.java
+++ b/server/app/services/settings/SettingsService.java
@@ -149,10 +149,6 @@ public final class SettingsService {
 
     Stream<Pair<SettingDescription, String>> newEntries =
         different.entriesOnlyOnLeft().entrySet().stream()
-            .filter(
-                entry ->
-                    settingDescriptions.stream()
-                        .anyMatch(sd -> sd.variableName().equals(entry.getKey())))
             .map(
                 entry ->
                     Pair.of(
@@ -161,10 +157,6 @@ public final class SettingsService {
 
     Stream<Pair<SettingDescription, String>> changedEntries =
         different.entriesDiffering().entrySet().stream()
-            .filter(
-                entry ->
-                    settingDescriptions.stream()
-                        .anyMatch(sd -> sd.variableName().equals(entry.getKey())))
             .map(
                 entry ->
                     Pair.of(

--- a/server/app/services/settings/SettingsService.java
+++ b/server/app/services/settings/SettingsService.java
@@ -149,6 +149,10 @@ public final class SettingsService {
 
     Stream<Pair<SettingDescription, String>> newEntries =
         different.entriesOnlyOnLeft().entrySet().stream()
+            .filter(
+                entry ->
+                    settingDescriptions.stream()
+                        .anyMatch(sd -> sd.variableName().equals(entry.getKey())))
             .map(
                 entry ->
                     Pair.of(
@@ -157,6 +161,10 @@ public final class SettingsService {
 
     Stream<Pair<SettingDescription, String>> changedEntries =
         different.entriesDiffering().entrySet().stream()
+            .filter(
+                entry ->
+                    settingDescriptions.stream()
+                        .anyMatch(sd -> sd.variableName().equals(entry.getKey())))
             .map(
                 entry ->
                     Pair.of(

--- a/server/app/views/BaseHtmlLayout.java
+++ b/server/app/views/BaseHtmlLayout.java
@@ -185,7 +185,7 @@ public class BaseHtmlLayout {
   }
 
   protected void addSessionTimeoutModals(HtmlBundle bundle, Messages messages) {
-    if (settingsManifest.getSessionTimeoutEnabled(bundle.getRequest())
+    if (settingsManifest.getSessionTimeoutEnabled()
         && bundle.getRequest() instanceof Http.Request) {
       // Add the session timeout modals to the bundle
       Http.Request request = (Http.Request) bundle.getRequest();

--- a/server/app/views/applicant/ApplicantBaseView.java
+++ b/server/app/views/applicant/ApplicantBaseView.java
@@ -176,7 +176,7 @@ public abstract class ApplicantBaseView {
     context.setVariable("isDevOrStaging", isDevOrStaging);
 
     maybeSetUpNotProductionBanner(context, request, messages);
-    boolean sessionTimeoutEnabled = settingsManifest.getSessionTimeoutEnabled(request);
+    boolean sessionTimeoutEnabled = settingsManifest.getSessionTimeoutEnabled();
     context.setVariable("sessionTimeoutEnabled", sessionTimeoutEnabled);
     if (sessionTimeoutEnabled) {
       context.setVariable("extendSessionUrl", routes.SessionController.extendSession().url());

--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -663,8 +663,7 @@ file_upload_allowed_file_type_specifiers = ${?FILE_UPLOAD_ALLOWED_FILE_TYPE_SPEC
 # Total session length timeout: User is logged out after maximum_session_duration_minutes.
 #    A warning modal appears beforehand, but cannot be extended.
 #
-session_timeout_enabled = false
-session_timeout_enabled = ${?SESSION_TIMEOUT_ENABLED}
+# session_timeout_enabled is defined in helper/feature-flags.conf
 
 # Maximum total session length before user is logged out
 maximum_session_duration_minutes = 600

--- a/server/conf/application.dev-browser-tests.conf
+++ b/server/conf/application.dev-browser-tests.conf
@@ -38,7 +38,6 @@ yes_no_question_enabled = true
 durable_jobs.poll_interval_seconds = 3600
 
 # Session timeout settings for browser tests
-session_timeout_enabled = false
 session_inactivity_warning_threshold_minutes = 10
 session_inactivity_timeout_minutes = 60
 session_duration_warning_threshold_minutes = 10

--- a/server/conf/application.dev.conf
+++ b/server/conf/application.dev.conf
@@ -106,7 +106,6 @@ session_inactivity_timeout_minutes= 5760
 # Feature flags
 program_filtering_enabled = true
 name_suffix_dropdown_enabled = true
-session_timeout_enabled = true
 custom_theme_colors_enabled = true
 expanded_form_logic_enabled = true
 new_applicant_guest_merging_strategy_dry_run_enabled = true

--- a/server/conf/env-var-docs.json
+++ b/server/conf/env-var-docs.json
@@ -960,7 +960,7 @@
         "required": false
       },
       "SESSION_TIMEOUT_ENABLED": {
-        "mode": "ADMIN_WRITEABLE",
+        "mode": "ADMIN_READABLE",
         "description": "Enable session timeout based on inactivity and maximum duration.",
         "type": "bool",
         "required": false

--- a/server/conf/helper/feature-flags.conf
+++ b/server/conf/helper/feature-flags.conf
@@ -110,3 +110,7 @@ new_applicant_guest_merging_strategy_dry_run_enabled = ${?NEW_APPLICANT_GUEST_ME
 # Enables improvements to the admin and applicant experience for file upload questions
 file_upload_question_improvements_enabled = false
 file_upload_question_improvements_enabled = ${?FILE_UPLOAD_QUESTION_IMPROVEMENTS_ENABLED}
+
+# Session timeout based on inactivity and maximum session duration
+session_timeout_enabled = true
+session_timeout_enabled = ${?SESSION_TIMEOUT_ENABLED}

--- a/server/test/controllers/SessionControllerTest.java
+++ b/server/test/controllers/SessionControllerTest.java
@@ -43,7 +43,7 @@ public class SessionControllerTest {
   @Test
   public void extendSession_withValidRequest_updatesLastActivityTime() {
     Http.Request request = fakeRequestBuilder().build();
-    when(mockSettingsManifest.getSessionTimeoutEnabled(request)).thenReturn(true);
+    when(mockSettingsManifest.getSessionTimeoutEnabled()).thenReturn(true);
 
     Result result = controller.extendSession(request);
 
@@ -54,7 +54,7 @@ public class SessionControllerTest {
   @Test
   public void extendSession_whenTimeoutDisabled_returnsBadRequest() {
     Http.Request request = fakeRequestBuilder().build();
-    when(mockSettingsManifest.getSessionTimeoutEnabled(request)).thenReturn(false);
+    when(mockSettingsManifest.getSessionTimeoutEnabled()).thenReturn(false);
 
     Result result = controller.extendSession(request);
 
@@ -66,7 +66,7 @@ public class SessionControllerTest {
   public void extendSession_withNoProfile_returnsUnauthorized() {
     Http.Request request = fakeRequestBuilder().build();
 
-    when(mockSettingsManifest.getSessionTimeoutEnabled(request)).thenReturn(true);
+    when(mockSettingsManifest.getSessionTimeoutEnabled()).thenReturn(true);
 
     when(profileUtils.optionalCurrentUserProfile(any(Http.Request.class)))
         .thenReturn(Optional.empty());

--- a/server/test/filters/CiviFormSessionFilterTest.java
+++ b/server/test/filters/CiviFormSessionFilterTest.java
@@ -124,7 +124,7 @@ public class CiviFormSessionFilterTest extends WithApplication {
   public void testValidProfile_sessionTimeoutDisabled_noUpdatesLastActivityTime() throws Exception {
     RequestHeader request = fakeRequestBuilder().method("GET").uri("/programs/1").build();
     when(profileUtils.optionalCurrentUserProfile(request)).thenReturn(Optional.of(mockProfile));
-    when(settingsManifest.getSessionTimeoutEnabled(request)).thenReturn(false);
+    when(settingsManifest.getSessionTimeoutEnabled()).thenReturn(false);
 
     Result result = executeFilter(request);
 
@@ -136,7 +136,7 @@ public class CiviFormSessionFilterTest extends WithApplication {
   public void testInvalidSession_redirectsToLogout() throws Exception {
     RequestHeader request = fakeRequestBuilder().method("GET").uri("/programs/1").build();
     when(profileUtils.optionalCurrentUserProfile(request)).thenReturn(Optional.of(mockProfile));
-    when(settingsManifest.getSessionTimeoutEnabled(request)).thenReturn(false);
+    when(settingsManifest.getSessionTimeoutEnabled()).thenReturn(false);
 
     // Session ID not found in active sessions
     when(mockAccount.getActiveSession(anyString())).thenReturn(Optional.empty());
@@ -172,7 +172,7 @@ public class CiviFormSessionFilterTest extends WithApplication {
             .cookie(Http.Cookie.builder(TIMEOUT_COOKIE_NAME, "somevalue").withPath("/").build())
             .build();
     when(profileUtils.optionalCurrentUserProfile(request)).thenReturn(Optional.of(mockProfile));
-    when(settingsManifest.getSessionTimeoutEnabled(request)).thenReturn(false);
+    when(settingsManifest.getSessionTimeoutEnabled()).thenReturn(false);
 
     Result result = executeFilter(request);
 
@@ -186,7 +186,7 @@ public class CiviFormSessionFilterTest extends WithApplication {
   public void testTimeoutDisabled_noCookie_passesThrough() throws Exception {
     RequestHeader request = fakeRequestBuilder().method("GET").uri("/programs/1").build();
     when(profileUtils.optionalCurrentUserProfile(request)).thenReturn(Optional.of(mockProfile));
-    when(settingsManifest.getSessionTimeoutEnabled(request)).thenReturn(false);
+    when(settingsManifest.getSessionTimeoutEnabled()).thenReturn(false);
 
     Result result = executeFilter(request);
 
@@ -198,7 +198,7 @@ public class CiviFormSessionFilterTest extends WithApplication {
   public void testTimeoutEnabled_validSession_setsCookieAndUpdatesActivity() throws Exception {
     RequestHeader request = fakeRequestBuilder().method("GET").uri("/programs/1").build();
     when(profileUtils.optionalCurrentUserProfile(request)).thenReturn(Optional.of(mockProfile));
-    when(settingsManifest.getSessionTimeoutEnabled(request)).thenReturn(true);
+    when(settingsManifest.getSessionTimeoutEnabled()).thenReturn(true);
     when(sessionTimeoutService.isSessionTimedOut(eq(mockProfile), anyLong())).thenReturn(false);
 
     Result result = executeFilter(request);
@@ -228,7 +228,7 @@ public class CiviFormSessionFilterTest extends WithApplication {
   public void testNoSessionStartTime_redirectsToLogout() throws Exception {
     RequestHeader request = fakeRequestBuilder().method("GET").uri("/programs/1").build();
     when(profileUtils.optionalCurrentUserProfile(request)).thenReturn(Optional.of(mockProfile));
-    when(settingsManifest.getSessionTimeoutEnabled(request)).thenReturn(true);
+    when(settingsManifest.getSessionTimeoutEnabled()).thenReturn(true);
     when(mockAccount.getActiveSession(SESSION_ID)).thenReturn(Optional.empty());
 
     Result result = executeFilter(request);
@@ -241,7 +241,7 @@ public class CiviFormSessionFilterTest extends WithApplication {
   public void testSessionTimedOut_redirectsToLogout() throws Exception {
     RequestHeader request = fakeRequestBuilder().method("GET").uri("/programs/1").build();
     when(profileUtils.optionalCurrentUserProfile(request)).thenReturn(Optional.of(mockProfile));
-    when(settingsManifest.getSessionTimeoutEnabled(request)).thenReturn(true);
+    when(settingsManifest.getSessionTimeoutEnabled()).thenReturn(true);
     when(sessionTimeoutService.isSessionTimedOut(eq(mockProfile), anyLong())).thenReturn(true);
 
     Result result = executeFilter(request);

--- a/server/test/views/admin/AdminLayoutTest.java
+++ b/server/test/views/admin/AdminLayoutTest.java
@@ -109,7 +109,7 @@ public class AdminLayoutTest extends ResetPostgres {
   @Test
   public void render_includesSessionTimeoutModals_whenEnabled() {
     Http.Request request = fakeRequestBuilder().build();
-    when(settingsManifest.getSessionTimeoutEnabled(request)).thenReturn(true);
+    when(settingsManifest.getSessionTimeoutEnabled()).thenReturn(true);
 
     HtmlBundle bundle = new HtmlBundle(request);
     bundle
@@ -125,7 +125,7 @@ public class AdminLayoutTest extends ResetPostgres {
   @Test
   public void render_doesNotIncludeSessionTimeoutModals_whenDisabled() {
     Http.Request request = fakeRequestBuilder().build();
-    when(settingsManifest.getSessionTimeoutEnabled(request)).thenReturn(false);
+    when(settingsManifest.getSessionTimeoutEnabled()).thenReturn(false);
 
     HtmlBundle bundle = new HtmlBundle(request);
     bundle

--- a/server/test/views/applicant/ApplicantLayoutTest.java
+++ b/server/test/views/applicant/ApplicantLayoutTest.java
@@ -64,7 +64,7 @@ public class ApplicantLayoutTest extends ResetPostgres {
   @Test
   public void render_includesSessionTimeoutModals_whenEnabledAndProfilePresent() {
     Http.Request request = fakeRequestBuilder().build();
-    when(settingsManifest.getSessionTimeoutEnabled(request)).thenReturn(true);
+    when(settingsManifest.getSessionTimeoutEnabled()).thenReturn(true);
     when(profileUtils.optionalCurrentUserProfile(request)).thenReturn(Optional.of(profile));
 
     HtmlBundle bundle = new HtmlBundle(request);
@@ -82,7 +82,7 @@ public class ApplicantLayoutTest extends ResetPostgres {
   @Test
   public void render_doesNotIncludeSessionTimeoutModals_whenDisabled() {
     Http.Request request = fakeRequestBuilder().build();
-    when(settingsManifest.getSessionTimeoutEnabled(request)).thenReturn(false);
+    when(settingsManifest.getSessionTimeoutEnabled()).thenReturn(false);
     when(profileUtils.optionalCurrentUserProfile(request)).thenReturn(Optional.of(profile));
 
     HtmlBundle bundle = new HtmlBundle(request);
@@ -100,7 +100,7 @@ public class ApplicantLayoutTest extends ResetPostgres {
   @Test
   public void render_doesNotIncludeSessionTimeoutModals_whenNoProfile() {
     Http.Request request = fakeRequestBuilder().build();
-    when(settingsManifest.getSessionTimeoutEnabled(request)).thenReturn(true);
+    when(settingsManifest.getSessionTimeoutEnabled()).thenReturn(true);
     when(profileUtils.optionalCurrentUserProfile(request)).thenReturn(Optional.empty());
 
     HtmlBundle bundle = new HtmlBundle(request);


### PR DESCRIPTION
### Description

Makes session timeout read only and enables it by default.

## Release notes

With this release, Session Timeout is enabled by default in production environments. There are two types of session timeouts, each with its own warning modal:

**Inactivity timeout:** User is logged out after a period of no server activity. A warning modal appears beforehand, allowing the user to extend their session. The default for the inactivity timeout is 30 mins, with the warning 5 minutes prior to timeout.
**Total session length timeout:** User is logged out after a maximum session duration. A warning modal appears beforehand, but the length of the session cannot be extended. The default for the session length timeout is 10 hours, with the warning modal 10 mins prior to timeout.

Length of these timeouts can be changed in individual deployment configurations.

### Checklist

Remove any sections below that do not apply to your PR. For sections that do apply, complete all of the appropriate checklist items and check them off. If a checklist item doesn't apply to your PR, leave it unchecked but do not delete it.

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [ ] Added an additional reviewer as required if changes potentially affect the security of the application.
- [ ] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.