### PR TITLE
[File Upload] implement controller route for program image upload

### DIFF
--- a/server/app/controllers/admin/AdminProgramImageController.java
+++ b/server/app/controllers/admin/AdminProgramImageController.java
@@ -101,8 +101,11 @@ public final class AdminProgramImageController extends CiviFormController {
   }
 
   /**
-   * Uploads a program summary image and saves its alt text. Used by the Thymeleaf program image
-   * page when file upload improvements are enabled.
+   * Uploads a program summary image and saves its alt text.
+   *
+   * <p>TODO: Wire {@code ProgramImageStreamingMultipartBodyParser} via {@code @BodyParser.Of} once
+   * the parser PR lands. Until then, each {@code FilePart}'s ref must carry the cloud-storage file
+   * key produced by that parser.
    */
   @Secure(authorizers = Authorizers.Labels.CIVIFORM_ADMIN)
   public Result uploadProgramImage(Http.Request request, long programId, String editStatus) {
@@ -110,7 +113,41 @@ public final class AdminProgramImageController extends CiviFormController {
     if (!settingsManifest.getFileUploadQuestionImprovementsEnabled(request)) {
       return notFound();
     }
-    // TODO: persist uploaded image and description.
+
+    Http.MultipartFormData<String> body = request.body().asMultipartFormData();
+    if (body == null) {
+      return badRequest();
+    }
+
+    String[] descriptionValues =
+        body.asFormUrlEncoded().get(ProgramImageDescriptionForm.SUMMARY_IMAGE_DESCRIPTION);
+    String newDescription =
+        descriptionValues != null && descriptionValues.length > 0 ? descriptionValues[0] : "";
+
+    Http.MultipartFormData.FilePart<String> filePart = body.getFile("file");
+    if (filePart != null) {
+      String fileKey = filePart.getRef();
+      if (!PublicFileNameFormatter.isFileKeyForPublicProgramImage(fileKey)) {
+        throw new IllegalArgumentException(
+            "Key incorrectly formatted for public program image file");
+      }
+      try {
+        programService.setSummaryImageFileKey(programId, fileKey);
+      } catch (ProgramNotFoundException e) {
+        return notFound(e.toString());
+      }
+    }
+
+    try {
+      programService.setSummaryImageDescription(
+          programId, LocalizedStrings.DEFAULT_LOCALE, newDescription);
+    } catch (ProgramNotFoundException e) {
+      return notFound(e.toString());
+    } catch (ImageDescriptionNotRemovableException e) {
+      final String indexUrl = routes.AdminProgramImageController.index(programId, editStatus).url();
+      return redirect(indexUrl).flashing("error", e.getMessage());
+    }
+
     return redirect(routes.AdminProgramBlocksController.index(programId).url());
   }
 

--- a/server/test/controllers/admin/AdminProgramImageControllerTest.java
+++ b/server/test/controllers/admin/AdminProgramImageControllerTest.java
@@ -11,7 +11,9 @@ import static support.cloud.FakePublicStorageClient.FAKE_BUCKET_NAME;
 
 import auth.ProfileUtils;
 import com.google.common.collect.ImmutableMap;
+import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.stream.Collectors;
 import junitparams.JUnitParamsRunner;
 import models.ProgramModel;
@@ -29,6 +31,7 @@ import services.program.ProgramDefinition;
 import services.program.ProgramNotFoundException;
 import services.program.ProgramService;
 import services.settings.SettingsManifest;
+import support.FakeRequestBuilder;
 import support.ProgramBuilder;
 import support.cloud.FakePublicStorageClient;
 import views.admin.programs.ProgramEditStatus;
@@ -70,6 +73,102 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
             ProgramEditStatus.CREATION.name());
 
     assertThat(result.status()).isEqualTo(NOT_FOUND);
+  }
+
+  @Test
+  public void uploadProgramImage_programNotDraft_throws() {
+    ProgramModel program = ProgramBuilder.newActiveProgram().build();
+
+    assertThatThrownBy(
+            () ->
+                controller.uploadProgramImage(
+                    fakeRequestBuilder()
+                        .addCiviFormSetting("FILE_UPLOAD_QUESTION_IMPROVEMENTS_ENABLED", "true")
+                        .method("POST")
+                        .build(),
+                    program.id,
+                    ProgramEditStatus.CREATION.name()))
+        .isInstanceOf(NotChangeableException.class);
+  }
+
+  @Test
+  public void uploadProgramImage_withFileAndDescription_setsKeyAndRedirects()
+      throws ProgramNotFoundException {
+    ProgramModel program = ProgramBuilder.newDraftProgram("test name").build();
+    String fileKey = "program-summary-image/program-" + program.id + "/myImage.png";
+
+    Result result =
+        controller.uploadProgramImage(
+            createUploadRequest(fileKey, "Alt text description"),
+            program.id,
+            ProgramEditStatus.CREATION.name());
+
+    assertThat(result.status()).isEqualTo(SEE_OTHER);
+    assertThat(result.redirectLocation())
+        .hasValue(routes.AdminProgramBlocksController.index(program.id).url());
+
+    ProgramDefinition updatedProgram = programService.getFullProgramDefinition(program.id);
+    assertThat(updatedProgram.summaryImageFileKey()).contains(fileKey);
+    assertThat(updatedProgram.localizedSummaryImageDescription())
+        .map(LocalizedStrings::getDefault)
+        .contains("Alt text description");
+  }
+
+  @Test
+  public void uploadProgramImage_descriptionOnly_updatesDescription()
+      throws ProgramNotFoundException {
+    ProgramModel program = ProgramBuilder.newDraftProgram("test name").build();
+
+    Result result =
+        controller.uploadProgramImage(
+            createUploadRequest(/* fileKey= */ null, "Description only"),
+            program.id,
+            ProgramEditStatus.EDIT.name());
+
+    assertThat(result.status()).isEqualTo(SEE_OTHER);
+    assertThat(result.redirectLocation())
+        .hasValue(routes.AdminProgramBlocksController.index(program.id).url());
+
+    ProgramDefinition updatedProgram = programService.getFullProgramDefinition(program.id);
+    assertThat(updatedProgram.summaryImageFileKey()).isEmpty();
+    assertThat(updatedProgram.localizedSummaryImageDescription())
+        .map(LocalizedStrings::getDefault)
+        .contains("Description only");
+  }
+
+  @Test
+  public void uploadProgramImage_invalidFileKey_throws() {
+    ProgramModel program = ProgramBuilder.newDraftProgram("test name").build();
+
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(
+            () ->
+                controller.uploadProgramImage(
+                    createUploadRequest("applicant-10/myFile.png", "Alt text"),
+                    program.id,
+                    ProgramEditStatus.CREATION.name()))
+        .withMessageContaining("Key incorrectly formatted");
+  }
+
+  @Test
+  public void uploadProgramImage_descriptionNotRemovable_redirectsWithError()
+      throws ProgramNotFoundException {
+    ProgramModel program = ProgramBuilder.newDraftProgram("test name").build();
+    String fileKey = "program-summary-image/program-" + program.id + "/myImage.png";
+    programService.setSummaryImageFileKey(program.id, fileKey);
+
+    Result result =
+        controller.uploadProgramImage(
+            createUploadRequest(/* fileKey= */ null, ""),
+            program.id,
+            ProgramEditStatus.EDIT.name());
+
+    assertThat(result.status()).isEqualTo(SEE_OTHER);
+    assertThat(result.redirectLocation())
+        .hasValue(
+            routes.AdminProgramImageController.index(program.id, ProgramEditStatus.EDIT.name())
+                .url());
+    assertThat(result.flash().data().get("error")).contains("Description can't be removed");
   }
 
   @Test
@@ -703,5 +802,24 @@ public class AdminProgramImageControllerTest extends ResetPostgres {
     assertThat(programWithKey.summaryImageFileKey()).isNotEmpty();
     assertThat(programWithKey.summaryImageFileKey().get()).isEqualTo(VALID_FILE_KEY);
     return result;
+  }
+
+  private Http.Request createUploadRequest(String fileKey, String description) {
+    FakeRequestBuilder requestBuilder =
+        fakeRequestBuilder()
+            .addCiviFormSetting("FILE_UPLOAD_QUESTION_IMPROVEMENTS_ENABLED", "true");
+    if (fileKey == null) {
+      return requestBuilder
+          .method("POST")
+          .bodyMultipart(Map.of("summaryImageDescription", new String[] {description}), List.of())
+          .build();
+    }
+    return requestBuilder
+        .method("POST")
+        .bodyMultipart(
+            Map.of("summaryImageDescription", new String[] {description}),
+            List.of(
+                new Http.MultipartFormData.FilePart<>("file", "myImage.png", "image/png", fileKey)))
+        .build();
   }
 }


### PR DESCRIPTION
### Description

Implements the image and description saving for program image upload.

The issue describes using returning HTMX partials, but we are not implementing with HTMX anymore.

### Checklist

Remove any sections below that do not apply to your PR. For sections that do apply, complete all of the appropriate checklist items and check them off. If a checklist item doesn't apply to your PR, leave it unchecked but do not delete it.

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [ ] Added an additional reviewer as required if changes potentially affect the security of the application.
- [ ] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

### Issue(s) this completes

Fixes #13230
