### PR TITLE
[Enumerators] Not showing screen name prefix on admin translations page

### DIFF
--- a/browser-test/src/end_to_end_enumerators.test.ts
+++ b/browser-test/src/end_to_end_enumerators.test.ts
@@ -756,10 +756,9 @@ test.describe('End to end enumerator test with enumerators feature flag on', () 
       })
     })
 
-    test('Enumerator block name edit retains prefix in the screen editing modal and translation page', async ({
+    test('Enumerator block name edit retains prefix', async ({
       page,
       adminPrograms,
-      adminTranslations,
     }) => {
       await test.step('Go to the program block edit page', async () => {
         await adminPrograms.gotoEditDraftProgramPage('Enumerator test program')
@@ -802,27 +801,6 @@ test.describe('End to end enumerator test with enumerators feature flag on', () 
 
         const currentModalPrefix = page.getByTestId('name-prefix')
         await expect(currentModalPrefix).toHaveText('[parent label] -')
-
-        await page.getByRole('button', {name: 'Close'}).click()
-      })
-
-      await test.step('Translation page shows prefix as read-only before the screen name input', async () => {
-        await adminPrograms.gotoDraftProgramManageTranslationsPage(
-          'Enumerator test program',
-        )
-        await adminTranslations.selectLanguage('Spanish')
-
-        const translationPrefix = page.getByText('[parent label] -', {
-          exact: true,
-        })
-        await expect(translationPrefix).toBeVisible()
-
-        // Verify that the prefix is not editable.
-        await expect(
-          translationPrefix.evaluate((el) =>
-            ['INPUT', 'TEXTAREA'].includes(el.tagName),
-          ),
-        ).resolves.toBe(false)
       })
     })
 

--- a/server/app/views/admin/programs/ProgramTranslationView.java
+++ b/server/app/views/admin/programs/ProgramTranslationView.java
@@ -1,9 +1,7 @@
 package views.admin.programs;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static j2html.TagCreator.div;
 import static j2html.TagCreator.input;
-import static j2html.TagCreator.label;
 import static j2html.TagCreator.legend;
 import static j2html.TagCreator.span;
 
@@ -12,7 +10,6 @@ import com.google.common.collect.ImmutableList;
 import controllers.admin.routes;
 import forms.translation.ProgramTranslationForm;
 import j2html.tags.DomContent;
-import j2html.tags.specialized.DivTag;
 import j2html.tags.specialized.FormTag;
 import java.util.Locale;
 import java.util.Optional;
@@ -28,7 +25,6 @@ import services.program.ProgramDefinition;
 import services.program.ProgramType;
 import services.statuses.StatusDefinitions;
 import views.HtmlBundle;
-import views.ViewUtils;
 import views.admin.AdminLayout;
 import views.admin.AdminLayout.NavPage;
 import views.admin.AdminLayoutFactory;
@@ -338,20 +334,28 @@ public final class ProgramTranslationView extends TranslationFormView {
               .filter(blockDefinition -> blockDefinition.id() == screenUpdateData.blockIdToUpdate())
               .findFirst()
               .get();
-      ImmutableList.Builder<DomContent> fieldsBuilder = ImmutableList.<DomContent>builder();
-      fieldsBuilder
-          .add(
-              fieldWithDefaultLocaleTextHint(
-                  renderScreenNameField(block, screenUpdateData), block.localizedName()))
-          .add(
-              fieldWithDefaultLocaleTextHint(
-                  FieldWithLabel.input()
-                      .setFieldName(ProgramTranslationForm.localizedScreenDescription(block.id()))
-                      .setLabelText("Screen description")
-                      .setScreenReaderText("Screen description")
-                      .setValue(screenUpdateData.localizedDescription())
-                      .getInputTag(),
-                  block.localizedDescription()));
+      ImmutableList.Builder<DomContent> fieldsBuilder =
+          ImmutableList.<DomContent>builder()
+              .add(
+                  fieldWithDefaultLocaleTextHint(
+                      FieldWithLabel.input()
+                          .setFieldName(ProgramTranslationForm.localizedScreenName(block.id()))
+                          .setLabelText("Screen name")
+                          .setScreenReaderText("Screen name")
+                          .setValue(screenUpdateData.localizedName())
+                          .setRequired(true)
+                          .getInputTag(),
+                      block.localizedName()))
+              .add(
+                  fieldWithDefaultLocaleTextHint(
+                      FieldWithLabel.input()
+                          .setFieldName(
+                              ProgramTranslationForm.localizedScreenDescription(block.id()))
+                          .setLabelText("Screen description")
+                          .setScreenReaderText("Screen description")
+                          .setValue(screenUpdateData.localizedDescription())
+                          .getInputTag(),
+                      block.localizedDescription()));
       if (block.localizedEligibilityMessage().isPresent()) {
         fieldsBuilder.add(
             fieldWithDefaultLocaleTextHint(
@@ -378,55 +382,5 @@ public final class ProgramTranslationView extends TranslationFormView {
                           .asAnchorText()),
               fieldsBuilder.build()));
     }
-  }
-
-  /**
-   * Renders the screen-name input. When the block has a name prefix (repeated blocks), the prefix
-   * is shown read-only side-by-side with the input, mirroring the screen-name edit modal on the
-   * program block edit page.
-   */
-  private DomContent renderScreenNameField(
-      BlockDefinition block, LocalizationUpdate.ScreenUpdate screenUpdateData) {
-    String fieldName = ProgramTranslationForm.localizedScreenName(block.id());
-    Optional<String> prefix = block.namePrefix().filter(p -> !p.isEmpty());
-    if (prefix.isEmpty()) {
-      return FieldWithLabel.input()
-          .setFieldName(fieldName)
-          .setLabelText("Screen name")
-          .setScreenReaderText("Screen name")
-          .setValue(screenUpdateData.localizedName())
-          .setRequired(true)
-          .getInputTag();
-    }
-    String inputId = "screen-name-input-" + block.id();
-    DivTag flexRow =
-        div()
-            .withClasses("flex")
-            .with(div(prefix.get()).withClasses("text-black", "text-lg", "py-2"));
-    flexRow.with(
-        input()
-            .withName(fieldName)
-            .withValue(screenUpdateData.localizedName())
-            .withId(inputId)
-            .isRequired()
-            .withMaxlength(String.valueOf(FieldWithLabel.MAX_INPUT_TEXT_LENGTH_DEFAULT))
-            .withClasses(
-                "flex-auto",
-                "px-3",
-                "text-lg",
-                "py-2",
-                "outline-none",
-                "ml-1",
-                "border",
-                "border-gray-500",
-                "rounded-lg",
-                "focus:border-civiform-blue"));
-    return div()
-        .with(
-            label("Screen name")
-                .with(ViewUtils.requiredQuestionIndicator())
-                .attr("for", inputId)
-                .withClasses("text-gray-600", "text-base", "px-1", "pt-2", "block"),
-            flexRow);
   }
 }

--- a/server/app/views/components/FieldWithLabel.java
+++ b/server/app/views/components/FieldWithLabel.java
@@ -101,7 +101,7 @@ public class FieldWithLabel {
   private final ImmutableMap.Builder<String, Optional<String>> attributesMapBuilder =
       ImmutableMap.builder();
 
-  public static final int MAX_INPUT_TEXT_LENGTH_DEFAULT = 10000;
+  private static final int MAX_INPUT_TEXT_LENGTH_DEFAULT = 10000;
 
   private static final class FieldErrorsInfo {
     String fieldErrorsId;


### PR DESCRIPTION
### Description

Revert PR #13311.  After a conversation with UX, we decided that showing the screen name "[parent label] - " prefix on the  admin translations page was confusing and information overload.  It was also very difficult to do in an accessible way.  Admins are just copying and pasting translations onto the inputs on that page.  They don't need to think about the screen name prefix since it isn't part of the translations.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [ ] Added an additional reviewer as required if changes potentially affect the security of the application.
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.