### PR TITLE
[File Upload] ignore unrecognized extensions

### DIFF
--- a/server/app/parsers/FileTypeSpecifier.java
+++ b/server/app/parsers/FileTypeSpecifier.java
@@ -7,6 +7,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.util.Locale;
 import lombok.Getter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Allowlist extensions for {@link FileTypeValidation}. Each constant defines a supported extension
@@ -24,6 +26,8 @@ public enum FileTypeSpecifier {
   BMP(".bmp", "image/bmp"),
   WEBP(".webp", "image/webp"),
   TIFF(".tiff", "image/tiff");
+
+  private static final Logger logger = LoggerFactory.getLogger(FileTypeSpecifier.class);
 
   static final ImmutableMap<String, String> MIME_BY_EXTENSION_MAP = buildMimeByExtension();
 
@@ -79,8 +83,8 @@ public enum FileTypeSpecifier {
       }
       ImmutableList<FileTypeSpecifier> mimeList = mimeMatches.build();
       if (mimeList.isEmpty()) {
-        throw new IllegalArgumentException(
-            "Unknown file type specifier extension: " + allowlistPart);
+        logger.error("Unknown file type specifier: {}", allowlistPart);
+        continue;
       }
       builder.addAll(mimeList);
     }


### PR DESCRIPTION
### Description

Previously, if a CiviForm instance had an unrecognized extension in their FILE_UPLOAD_ALLOWED_FILE_TYPE_SPECIFIERS, the file upload would fail. Now, it just ignores the extension type and logs an error.

### Checklist

Remove any sections below that do not apply to your PR. For sections that do apply, complete all of the appropriate checklist items and check them off. If a checklist item doesn't apply to your PR, leave it unchecked but do not delete it.

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [ ] Added an additional reviewer as required if changes potentially affect the security of the application.
- [ ] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

### Issue(s) this completes

Fixes #13322
