### PR TITLE
Fix flake in create_new_application_updatesLastActivityTime test

### DIFF
--- a/server/test/models/ApplicationModelTest.java
+++ b/server/test/models/ApplicationModelTest.java
@@ -171,7 +171,7 @@ public class ApplicationModelTest extends ResetPostgres {
     ApplicantModel applicant = resourceCreator.insertApplicantWithAccount();
     Instant activitytimeBeforeUpdate = applicant.getAccount().getLastActivityTime();
     // Wait for the next tick to ensure the new application has a newer timestamp
-    while (!Instant.now().isAfter(activitytimeBeforeUpdate)) { }
+    while (!Instant.now().isAfter(activitytimeBeforeUpdate)) {}
     ApplicationModel application = resourceCreator.insertActiveApplication(applicant, program);
     application.refresh();
 

--- a/server/test/models/ApplicationModelTest.java
+++ b/server/test/models/ApplicationModelTest.java
@@ -170,6 +170,8 @@ public class ApplicationModelTest extends ResetPostgres {
   public void create_new_application_updatesLastActivityTime() {
     ApplicantModel applicant = resourceCreator.insertApplicantWithAccount();
     Instant activitytimeBeforeUpdate = applicant.getAccount().getLastActivityTime();
+    // Wait for the next tick to ensure the new application has a newer timestamp
+    while (!Instant.now().isAfter(activitytimeBeforeUpdate)) { }
     ApplicationModel application = resourceCreator.insertActiveApplication(applicant, program);
     application.refresh();
 


### PR DESCRIPTION
This test is sometimes flaky if it runs too quickly and the timestamp of the new application ends up being the same as the timestamp captured before application insert. This ensures there's at least one tick of the clock before we insert the application.

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [ ] Added an additional reviewer as required if changes potentially affect the security of the application.
- [ ] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.
