### PR TITLE
Clean up dead toast message code

### DIFF
--- a/server/app/controllers/FlashKey.java
+++ b/server/app/controllers/FlashKey.java
@@ -12,7 +12,6 @@ public final class FlashKey {
   public static String PROVIDED_NAME = "providedName";
   public static String REDIRECTED_FROM_PROGRAM_SLUG = "redirected-from-program-slug";
   public static String SHOW_FAST_FORWARDED_MESSAGE = "showFastForwardedMessage";
-  public static String SUCCESS_BANNER = "success-banner";
   public static String DUPLICATE_SUBMISSION = "duplicate-submission";
   public static String CONCURRENT_UPDATE = "concurrent-update";
 }

--- a/server/app/controllers/applicant/ApplicantProgramBlocksController.java
+++ b/server/app/controllers/applicant/ApplicantProgramBlocksController.java
@@ -67,7 +67,6 @@ import services.settings.SettingsManifest;
 import views.applicant.addresscorrection.AddressCorrectionBlockView;
 import views.applicant.blocks.ApplicantProgramBlockEditView;
 import views.applicant.ineligible.ApplicantIneligibleView;
-import views.components.ToastMessage;
 import views.questiontypes.ApplicantQuestionRendererParams;
 import views.trustedintermediary.ApplicationBaseViewParams;
 
@@ -585,10 +584,6 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
     CompletionStage<ApplicantPersonalInfo> applicantStage =
         this.applicantService.getPersonalInfo(applicantId);
 
-    Optional<String> successBannerMessage = request.flash().get(FlashKey.SUCCESS_BANNER);
-    Optional<ToastMessage> flashSuccessBanner =
-        successBannerMessage.map(m -> ToastMessage.success(m));
-
     return applicantStage
         .thenComposeAsync(
             v -> checkApplicantAuthorization(request, applicantId),
@@ -630,8 +625,6 @@ public final class ApplicantProgramBlocksController extends CiviFormController {
                             questionName,
                             applicantRoutes,
                             profile)
-                        .setBannerToastMessage(flashSuccessBanner)
-                        .setBannerMessage(successBannerMessage)
                         .build();
                 return ok(applicantProgramBlockEditView.render(request, applicationParams))
                     .as(Http.MimeTypes.HTML);

--- a/server/app/controllers/applicant/ApplicantProgramReviewController.java
+++ b/server/app/controllers/applicant/ApplicantProgramReviewController.java
@@ -146,8 +146,6 @@ public class ApplicantProgramReviewController extends CiviFormController {
                         }
 
                         Optional<String> flashBannerMessage = request.flash().get(FlashKey.BANNER);
-                        Optional<String> flashSuccessBannerMessage =
-                            request.flash().get(FlashKey.SUCCESS_BANNER);
                         Messages messages = messagesApi.preferred(request);
 
                         AlertSettings eligibilityAlertSettings = AlertSettings.empty();
@@ -184,7 +182,6 @@ public class ApplicantProgramReviewController extends CiviFormController {
                                 .setTotalBlockCount(totalBlockCount)
                                 .setMessages(messages)
                                 .setAlertBannerMessage(flashBannerMessage)
-                                .setSuccessBannerMessage(flashSuccessBannerMessage)
                                 .setEligibilityAlertSettings(eligibilityAlertSettings)
                                 .setSummaryData(summaryData)
                                 .setProgramType(roApplicantProgramService.getProgramType())

--- a/server/app/views/applicant/review/ApplicantProgramSummaryView.java
+++ b/server/app/views/applicant/review/ApplicantProgramSummaryView.java
@@ -81,8 +81,6 @@ public final class ApplicantProgramSummaryView extends ApplicantBaseView {
 
     // Toasts
     context.setVariable("alertBannerMessage", params.alertBannerMessage());
-    context.setVariable("successBannerMessage", params.successBannerMessage());
-    context.setVariable("notEligibleBannerMessage", params.notEligibleBannerMessage());
     context.setVariable("errorBannerMessage", request.flash().get(FlashKey.ERROR));
 
     // Modals
@@ -233,10 +231,6 @@ public final class ApplicantProgramSummaryView extends ApplicantBaseView {
 
     abstract Optional<String> alertBannerMessage();
 
-    abstract Optional<String> successBannerMessage();
-
-    abstract Optional<String> notEligibleBannerMessage();
-
     abstract AlertSettings eligibilityAlertSettings();
 
     abstract ImmutableList<AnswerData> summaryData();
@@ -271,11 +265,6 @@ public final class ApplicantProgramSummaryView extends ApplicantBaseView {
       public abstract Builder setMessages(Messages messages);
 
       public abstract Builder setAlertBannerMessage(Optional<String> alertBannerMessage);
-
-      public abstract Builder setSuccessBannerMessage(Optional<String> successBannerMessage);
-
-      public abstract Builder setNotEligibleBannerMessage(
-          Optional<String> notEligibleBannerMessage);
 
       public abstract Builder setEligibilityAlertSettings(AlertSettings eligibilityAlertSettings);
 

--- a/server/app/views/components/ToastFragment.html
+++ b/server/app/views/components/ToastFragment.html
@@ -59,14 +59,10 @@
 
 <!--/* Render the toasts used in the Review/Summary page */-->
 <div th:fragment="summaryToasts">
-  <!--/* Success toast */-->
-  <div th:replace="~{this :: success(${successBannerMessage})}"></div>
   <!--/* Alert toast */-->
   <div th:replace="~{this :: alert(${alertBannerMessage})}"></div>
   <!--/* Error toast */-->
   <div th:replace="~{this :: error(${errorBannerMessage})}"></div>
-  <!--/* Not eligible toast */-->
-  <div th:replace="~{this :: alert(${notEligibleBannerMessage})}"></div>
   <div th:replace="~{this :: devOrStagingToast(${isDevOrStaging})}"></div>
 </div>
 

--- a/server/app/views/trustedintermediary/ApplicationBaseViewParams.java
+++ b/server/app/views/trustedintermediary/ApplicationBaseViewParams.java
@@ -11,7 +11,6 @@ import services.AlertSettings;
 import services.applicant.ApplicantPersonalInfo;
 import services.applicant.Block;
 import services.cloud.ApplicantStorageClient;
-import views.components.ToastMessage;
 import views.questiontypes.ApplicantQuestionRendererParams;
 
 @AutoValue
@@ -57,10 +56,6 @@ public abstract class ApplicationBaseViewParams {
   public abstract ApplicantPersonalInfo applicantPersonalInfo();
 
   public abstract ApplicantQuestionRendererParams.ErrorDisplayMode errorDisplayMode();
-
-  public abstract Optional<ToastMessage> bannerToastMessage();
-
-  public abstract Optional<String> bannerMessage();
 
   public abstract Optional<String> applicantSelectedQuestionName();
 
@@ -109,10 +104,6 @@ public abstract class ApplicationBaseViewParams {
 
     public abstract Builder setErrorDisplayMode(
         ApplicantQuestionRendererParams.ErrorDisplayMode errorDisplayMode);
-
-    public abstract Builder setBannerToastMessage(Optional<ToastMessage> banner);
-
-    public abstract Builder setBannerMessage(Optional<String> bannerMessage);
 
     public abstract Builder setApplicantPersonalInfo(ApplicantPersonalInfo personalInfo);
 


### PR DESCRIPTION
### Description

Removes dead code left over from PR #7965, in which we migrated the program summary toasts into inline USWDS alert messages.  The two toasts that aren't used anymore are:

- The success banner toast in the `ApplicantProgramSummaryView`
- The not eligible banner toast in the `ApplicantProgramSummaryView`

The producers of the toasts were removed at the time of the PR, but the consumers survived.  There are two `request.flash().get(FlashKey.SUCCESS_BANNER)` reads in `ApplicantProgramReviewController` / `ApplicantProgramBlocksController`, but because no caller ever invoked `setSuccessBannerMessage` / `setNotEligibleBannerMessage`/ `setBannerToastMessage`, the Optionals reaching the templates were permanently `Optional.empty()` and the `th:if="${optionalMessage.isPresent()}"` guard on the inner fragments made the render paths unreachable.  Removed the whole chain end-to-end (constant, controller reads, Params accessors, view variables, template lines, now-unused `ToastMessage` imports) to eliminate the misleading API surface.

Used Claude to help me find all the pieces of dead code.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [ ] Added an additional reviewer as required if changes potentially affect the security of the application.
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [x] Noted in the PR description which, if any, code in this PR was generated by AI.
