### PR TITLE
[File Upload] fix uploading tag + disable buttons while uploading

### DIFF
--- a/server/app/assets/javascripts/file_upload.ts
+++ b/server/app/assets/javascripts/file_upload.ts
@@ -3,7 +3,10 @@ import {default as uswdsFileInput} from '@uswds/uswds/js/usa-file-input'
 import {HtmxAfterRequestEvent} from '@/types/htmx'
 
 const CAN_UPLOAD_FILE_ATTR = 'data-can-upload-file'
+// Shows the question's "Uploading…" badge on the question container during upload
 const CF_FILE_UPLOADING_CLASS = 'cf-file-uploading'
+// Disables nav and all .cf-disable-when-uploading elements
+const CF_FILE_UPLOAD_IN_PROGRESS_CLASS = 'cf-file-upload-in-progress'
 const CF_FILE_UPLOAD_CONTAINER_SELECTOR = '[data-cf-file-upload-container]'
 const FILE_UPLOAD_HTMX_FAILURE = '[data-fileupload-error="request-failed"]'
 
@@ -46,10 +49,11 @@ export const init = () => {
         ),
         fileInput,
       )
+      fileUploadContainer.classList.add(CF_FILE_UPLOADING_CLASS)
     }
 
     fileUploadsInProgress++
-    document.body.classList.add(CF_FILE_UPLOADING_CLASS)
+    document.body.classList.add(CF_FILE_UPLOAD_IN_PROGRESS_CLASS)
     toggleDisabledState()
   })
 
@@ -65,7 +69,10 @@ export const init = () => {
     fileUploadsInProgress--
     if (fileUploadsInProgress <= 0) {
       fileUploadsInProgress = 0
-      document.body.classList.remove(CF_FILE_UPLOADING_CLASS)
+      document.body.classList.remove(CF_FILE_UPLOAD_IN_PROGRESS_CLASS)
+    }
+    if (fileUploadContainer) {
+      fileUploadContainer.classList.remove(CF_FILE_UPLOADING_CLASS)
     }
     toggleDisabledState()
     if (event.detail.successful) {
@@ -90,6 +97,7 @@ export const init = () => {
 
   document.body.addEventListener('htmx:afterSwap', () => {
     syncFileInputDisabledState()
+    toggleDisabledState()
   })
 
   document.body.addEventListener('change', (event) => {

--- a/server/app/assets/stylesheets/northstar/_uswds-theme-custom-styles.scss
+++ b/server/app/assets/stylesheets/northstar/_uswds-theme-custom-styles.scss
@@ -824,14 +824,26 @@ main {
   }
 }
 
-/* When a file is being uploaded... */
+/* Legacy: When a file is being uploaded... */
 .cf-file-uploading {
-  /* Show the file uploading tag */
+  /* Legacy: Show the file uploading tag */
   .cf-file-uploading-tag {
     display: inline-block;
   }
 
-  /* Apply disabled styling to any interactive elements */
+  /* Legacy: Apply disabled styling to any interactive elements */
+  .cf-disable-when-uploading {
+    @include u-bg('white');
+    @include u-text('base-light');
+    @include u-border('base-light');
+    @include u-border('1px');
+    pointer-events: none;
+    cursor: default;
+  }
+}
+
+/* Applicant File Upload Improvements: disable nav and file actions while any upload is in flight */
+.cf-file-upload-in-progress {
   .cf-disable-when-uploading {
     @include u-bg('white');
     @include u-text('base-light');

--- a/server/app/views/applicant/blocks/ApplicantProgramBlockEditTemplate.html
+++ b/server/app/views/applicant/blocks/ApplicantProgramBlockEditTemplate.html
@@ -92,12 +92,12 @@
                   <button
                     type="submit"
                     th:formaction="${previousFormAction}"
-                    class="usa-button usa-button--outline margin-bottom-1 zero-top-margin"
+                    class="usa-button usa-button--outline margin-bottom-1 zero-top-margin cf-disable-when-uploading"
                     th:text="#{button.back}"
                   ></button>
                   <button
                     type="submit"
-                    class="usa-button margin-bottom-1 zero-top-margin"
+                    class="usa-button margin-bottom-1 zero-top-margin cf-disable-when-uploading"
                     th:text="#{button.continue}"
                   ></button>
                 </div>
@@ -105,7 +105,7 @@
                   type="submit"
                   th:formaction="${reviewFormAction}"
                   id="review-application-button"
-                  class="usa-button usa-button--unstyled margin-bottom-4"
+                  class="usa-button usa-button--unstyled margin-bottom-4 cf-disable-when-uploading"
                   th:text="#{button.reviewAndExit}"
                 ></button>
               </div>

--- a/server/app/views/questiontypes/FileUploadOobFragments.html
+++ b/server/app/views/questiontypes/FileUploadOobFragments.html
@@ -45,7 +45,7 @@
         th:text="${fileName}"
       ></span>
       <button
-        class="usa-button usa-button--unstyled"
+        class="usa-button usa-button--unstyled cf-disable-when-uploading"
         hx-swap="none"
         th:aria-label="#{link.removeFileSr(${fileName})}"
         th:hx-post="${hxRemoveFileUrl}"

--- a/server/app/views/questiontypes/FileUploadQuestionFragment.html
+++ b/server/app/views/questiontypes/FileUploadQuestionFragment.html
@@ -102,9 +102,9 @@
     hx-swap="none"
   />
 
-  <!--/* Hidden by default. file_upload.ts adds the cf-file-uploading class to the
-       parent question div during upload, and CSS makes cf-file-uploading-tag
-       visible when that class is present. */-->
+  <!--/* Hidden by default. file_upload.ts adds the cf-file-uploading class to
+        this question div during upload, and CSS makes cf-file-uploading-tag
+        visible when that class is present. */-->
   <div
     class="cf-file-uploading-tag display-none padding-1 bg-warning-lighter text-warning-dark"
     role="alert"


### PR DESCRIPTION
### Description

Uploading tag was displaying for all file upload inputs on the same page. This fixes that.

Also, properly disable the buttons while uploading.

### Checklist

Remove any sections below that do not apply to your PR. For sections that do apply, complete all of the appropriate checklist items and check them off. If a checklist item doesn't apply to your PR, leave it unchecked but do not delete it.

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [ ] Added an additional reviewer as required if changes potentially affect the security of the application.
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.