### PR TITLE
Use npm that's bundled with Node for browser-test build stability

### DIFF
--- a/browser-test/playwright.Dockerfile
+++ b/browser-test/playwright.Dockerfile
@@ -11,8 +11,6 @@ RUN apt-get update -y && \
     apt-get update && \
     # Install the packages
     apt-get install -y nodejs fonts-ubuntu && \
-    # Update npm
-    npm install -g npm && \
     # Smoke tests
     node --version && \
     npm --version && \


### PR DESCRIPTION
### Description

In trying to update to the latest Ubuntu digest (https://github.com/civiform/civiform/pull/13113), we hit an "unknown dependency" issue from one of npm's own dependencies.  CoPilot suggested that we stabilize our browser test build by using the npm version that is bundled with Node (a more reliably stable version) rather than dynamically updating to the latest npm version.  We don't need the bleeding-edge npm version for our browser tests.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [ ] Added an additional reviewer as required if changes potentially affect the security of the application.
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.