### PR TITLE
Only remove the cmdtest package if it's installed

### DIFF
--- a/browser-test/playwright.Dockerfile
+++ b/browser-test/playwright.Dockerfile
@@ -7,7 +7,8 @@ RUN apt-get update -y && \
     curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
     echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list && \
     # Cleanup packages and update the repos
-    apt-get remove -y --purge cmdtest && \
+    # Only remove cmdtest if it is installed
+    (dpkg -s cmdtest >/dev/null 2>&1 && apt-get remove -y --purge cmdtest || true) && \
     apt-get update && \
     # Install the packages
     apt-get install -y nodejs fonts-ubuntu && \

--- a/browser-test/playwright.Dockerfile
+++ b/browser-test/playwright.Dockerfile
@@ -7,8 +7,6 @@ RUN apt-get update -y && \
     curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
     echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list && \
     # Cleanup packages and update the repos
-    # Only remove cmdtest if it is installed
-    (dpkg -s cmdtest >/dev/null 2>&1 && apt-get remove -y --purge cmdtest || true) && \
     apt-get update && \
     # Install the packages
     apt-get install -y nodejs fonts-ubuntu && \


### PR DESCRIPTION
### Description

The browser test Dockerfile attempts to clean up the image by removing the `cmdtest` package; However, the latest Ubuntu Docker image doesn't contain the `cmdtest` package so the attempt to remove it is causing the build to fail.  This change only removes the package if it's present.

### Checklist

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [ ] Added an additional reviewer as required if changes potentially affect the security of the application.
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

