### PR TITLE
Migrate openapi schema viewer

### DIFF
--- a/browser-test/src/api_docs_schema_viewer.test.ts
+++ b/browser-test/src/api_docs_schema_viewer.test.ts
@@ -1,12 +1,14 @@
 import {test, expect} from './support/civiform_fixtures'
-import {loginAsAdmin, waitForPageJsLoad} from './support'
+import {enableFeatureFlag, loginAsAdmin} from './support'
 import {ProgramVisibility} from './support/admin_programs'
+import {ApiSchemaViewerPage} from './page/admin/docs/api_schema_viewer_page'
 
-test.describe('Viewing API docs', () => {
+test.describe('Viewing API schema', () => {
   const program1 = 'comprehensive-sample-program'
   const program2 = 'minimal-sample-program'
 
-  test.beforeEach(async ({seeding}) => {
+  test.beforeEach(async ({page, seeding}) => {
+    await enableFeatureFlag(page, 'ADMIN_UI_MIGRATION_SC_ENABLED')
     await seeding.seedProgramsAndCategories()
   })
 
@@ -15,44 +17,47 @@ test.describe('Viewing API docs', () => {
   })
 
   test('Views OpenApi Schema', async ({page, adminPrograms}) => {
+    const schemaViewerPage = new ApiSchemaViewerPage(page)
+
     await test.step('Login as admin and publish drafts', async () => {
       await page.goto('/')
       await loginAsAdmin(page)
       await adminPrograms.publishAllDrafts()
     })
 
-    await test.step(`Going to slugless route defaults ${program1}`, async () => {
-      await page.goto('/docs/api/schemas')
-      await waitForPageJsLoad(page)
-      await expect(page.getByRole('heading', {name: program1})).toBeAttached()
+    await test.step(`Going to slugless route defaults to ${program1}`, async () => {
+      await schemaViewerPage.goto()
+      await expect(
+        schemaViewerPage.getSwaggerProgramHeading(program1),
+      ).toBeAttached()
     })
 
     await test.step(`Change program to ${program2}`, async () => {
-      await page.getByRole('combobox', {name: 'Program'}).selectOption(program2)
-      await waitForPageJsLoad(page)
-      await expect(page.getByRole('heading', {name: program2})).toBeAttached()
+      await schemaViewerPage.selectProgram(program2)
+      await expect(
+        schemaViewerPage.getSwaggerProgramHeading(program2),
+      ).toBeAttached()
     })
 
     await test.step(`Change status to draft for ${program2} shows error message`, async () => {
-      await page.getByRole('combobox', {name: 'Status'}).selectOption('draft')
-      await waitForPageJsLoad(page)
-      await expect(page.getByTestId('ui-error')).toContainText(
+      await schemaViewerPage.selectStatus('draft')
+      await expect(schemaViewerPage.getErrorMessage()).toContainText(
         'A program with this status could not be found',
       )
     })
 
-    await test.step(`Change status to active for ${program2}`, async () => {
-      await page.getByRole('combobox', {name: 'Status'}).selectOption('active')
-      await waitForPageJsLoad(page)
-      await expect(page.getByRole('heading', {name: program2})).toBeAttached()
+    await test.step(`Change status back to active for ${program2}`, async () => {
+      await schemaViewerPage.selectStatus('active')
+      await expect(
+        schemaViewerPage.getSwaggerProgramHeading(program2),
+      ).toBeAttached()
     })
 
-    await test.step(`Change openapi version to swagger-v2`, async () => {
-      await page
-        .getByRole('combobox', {name: 'OpenApi Version'})
-        .selectOption('swagger-v2')
-      await waitForPageJsLoad(page)
-      await expect(page.getByRole('heading', {name: program2})).toBeAttached()
+    await test.step('Change openapi version to swagger-v2', async () => {
+      await schemaViewerPage.selectOpenApiVersion('swagger-v2')
+      await expect(
+        schemaViewerPage.getSwaggerProgramHeading(program2),
+      ).toBeAttached()
     })
 
     await test.step('Add external program does not show in program options', async () => {
@@ -62,12 +67,11 @@ test.describe('Viewing API docs', () => {
         'https://usa.gov',
         ProgramVisibility.PUBLIC,
       )
-      await page.goto('/docs/api/schemas')
-      await waitForPageJsLoad(page)
+      await schemaViewerPage.goto()
 
-      await expect(
-        page.getByRole('combobox', {name: 'Program'}),
-      ).not.toContainText('external-program-name')
+      await expect(schemaViewerPage.getProgramSelect()).not.toContainText(
+        'external-program-name',
+      )
     })
   })
 })

--- a/browser-test/src/api_docs_schema_viewer_legacy.test.ts
+++ b/browser-test/src/api_docs_schema_viewer_legacy.test.ts
@@ -1,0 +1,74 @@
+import {test, expect} from './support/civiform_fixtures'
+import {disableFeatureFlag, loginAsAdmin, waitForPageJsLoad} from './support'
+import {ProgramVisibility} from './support/admin_programs'
+
+test.describe('Viewing API docs', () => {
+  const program1 = 'comprehensive-sample-program'
+  const program2 = 'minimal-sample-program'
+
+  test.beforeEach(async ({page, seeding}) => {
+    await disableFeatureFlag(page, 'ADMIN_UI_MIGRATION_SC_ENABLED')
+    await seeding.seedProgramsAndCategories()
+  })
+
+  test.use({
+    bypassCSP: true,
+  })
+
+  test('Views OpenApi Schema', async ({page, adminPrograms}) => {
+    await test.step('Login as admin and publish drafts', async () => {
+      await page.goto('/')
+      await loginAsAdmin(page)
+      await adminPrograms.publishAllDrafts()
+    })
+
+    await test.step(`Going to slugless route defaults ${program1}`, async () => {
+      await page.goto('/docs/api/schemas')
+      await waitForPageJsLoad(page)
+      await expect(page.getByRole('heading', {name: program1})).toBeAttached()
+    })
+
+    await test.step(`Change program to ${program2}`, async () => {
+      await page.getByRole('combobox', {name: 'Program'}).selectOption(program2)
+      await waitForPageJsLoad(page)
+      await expect(page.getByRole('heading', {name: program2})).toBeAttached()
+    })
+
+    await test.step(`Change status to draft for ${program2} shows error message`, async () => {
+      await page.getByRole('combobox', {name: 'Status'}).selectOption('draft')
+      await waitForPageJsLoad(page)
+      await expect(page.getByTestId('ui-error')).toContainText(
+        'A program with this status could not be found',
+      )
+    })
+
+    await test.step(`Change status to active for ${program2}`, async () => {
+      await page.getByRole('combobox', {name: 'Status'}).selectOption('active')
+      await waitForPageJsLoad(page)
+      await expect(page.getByRole('heading', {name: program2})).toBeAttached()
+    })
+
+    await test.step(`Change openapi version to swagger-v2`, async () => {
+      await page
+        .getByRole('combobox', {name: 'OpenApi Version'})
+        .selectOption('swagger-v2')
+      await waitForPageJsLoad(page)
+      await expect(page.getByRole('heading', {name: program2})).toBeAttached()
+    })
+
+    await test.step('Add external program does not show in program options', async () => {
+      await adminPrograms.addExternalProgram(
+        'External Program Name',
+        'short program description',
+        'https://usa.gov',
+        ProgramVisibility.PUBLIC,
+      )
+      await page.goto('/docs/api/schemas')
+      await waitForPageJsLoad(page)
+
+      await expect(
+        page.getByRole('combobox', {name: 'Program'}),
+      ).not.toContainText('external-program-name')
+    })
+  })
+})

--- a/browser-test/src/page/admin/docs/api_schema_viewer_page.ts
+++ b/browser-test/src/page/admin/docs/api_schema_viewer_page.ts
@@ -1,0 +1,69 @@
+import {Locator, Page} from '@playwright/test'
+import {BaseAdminPage} from '../base_admin_page'
+import {waitForPageJsLoad} from '../../../support/wait'
+
+/**
+ * This is representation of the /docs/api/schemas page.
+ */
+export class ApiSchemaViewerPage extends BaseAdminPage {
+  constructor(page: Page) {
+    super(page)
+  }
+
+  async goto() {
+    await this.page.goto('/docs/api/schemas')
+    await waitForPageJsLoad(this.page)
+  }
+
+  async gotoViaNav() {
+    await this.clickPrimaryNavSubMenuLink('API', 'Schema viewer')
+    await waitForPageJsLoad(this.page)
+  }
+
+  getPageHeading(): Locator {
+    return super.getPageHeading('API schema viewer')
+  }
+
+  getDocsTab(): Locator {
+    return this.page.getByRole('link', {name: 'Docs'})
+  }
+
+  getSchemaTab(): Locator {
+    return this.page.getByRole('link', {name: 'Schema viewer'})
+  }
+
+  getProgramSelect(): Locator {
+    return this.page.getByRole('combobox', {name: 'Program'})
+  }
+
+  getStatusSelect(): Locator {
+    return this.page.getByRole('combobox', {name: 'Status'})
+  }
+
+  getOpenApiVersionSelect(): Locator {
+    return this.page.getByRole('combobox', {name: 'OpenApi Version'})
+  }
+
+  async selectProgram(slug: string) {
+    await this.getProgramSelect().selectOption(slug)
+    await waitForPageJsLoad(this.page)
+  }
+
+  async selectStatus(status: 'active' | 'draft') {
+    await this.getStatusSelect().selectOption(status)
+    await waitForPageJsLoad(this.page)
+  }
+
+  async selectOpenApiVersion(version: string) {
+    await this.getOpenApiVersionSelect().selectOption(version)
+    await waitForPageJsLoad(this.page)
+  }
+
+  getSwaggerProgramHeading(programName: string): Locator {
+    return this.page.getByRole('heading', {name: programName})
+  }
+
+  getErrorMessage(): Locator {
+    return this.page.getByTestId('ui-error')
+  }
+}

--- a/server/app/assets/javascripts/pages/admin/api_docs_schema_page.ts
+++ b/server/app/assets/javascripts/pages/admin/api_docs_schema_page.ts
@@ -1,0 +1,98 @@
+import {assertNotNull} from '@/util'
+
+declare const SwaggerUIBundle: {
+  (config: {
+    url: string
+    dom_id: string
+    validatorUrl: null
+    presets: unknown[]
+    layout: string
+    plugins: unknown[]
+    supportedSubmitMethods: string[]
+    responseInterceptor: (response: SwaggerResponse) => SwaggerResponse
+  }): void
+  presets: {
+    apis: unknown
+  }
+}
+declare const SwaggerUIStandalonePreset: unknown
+
+interface SwaggerResponse {
+  status: number
+  [key: string]: unknown
+}
+
+function init(): void {
+  // The swagger-ui library does not expose a way specify the theme as light or dark. They
+  // added native dark mode at some point and it is set by the users browser/os settings
+  // and looking at the prefers-color-scheme option in their css. Because the entire site
+  // does not have a dark mode it makes the rendered dark mode version of swagger-ui look
+  // very out of place. There was no other way to force it into light mode other than
+  // overriding `window.matchMedia`. Give this is a low touch page and the override is
+  // only on this page it is a suitable solution until the library provides a direct
+  // option to configure it.
+  const _matchMedia = window.matchMedia.bind(window)
+  window.matchMedia = function (query) {
+    if (query && query.includes('prefers-color-scheme')) {
+      return {
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: () => {},
+        removeListener: () => {},
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        dispatchEvent: () => false,
+      }
+    }
+    return _matchMedia(query)
+  }
+
+  SwaggerUIBundle({
+    url: document.querySelector<HTMLInputElement>('#api-url')?.value || '',
+    dom_id: '#swagger-ui',
+    validatorUrl: null,
+    presets: [SwaggerUIBundle.presets.apis, SwaggerUIStandalonePreset],
+    layout: 'StandaloneLayout',
+    supportedSubmitMethods: [],
+    plugins: [
+      () => ({
+        wrapComponents: {
+          authorizeBtn: () => () => null,
+          authorizeOperationBtn: () => () => null,
+        },
+      }),
+    ],
+    responseInterceptor: (response: SwaggerResponse) => {
+      if (response.status === 404) {
+        const uiError = assertNotNull(
+          document.querySelector('.swagger-ui.swagger-container'),
+        )
+        uiError.setAttribute('data-testid', 'ui-error')
+
+        const wrapper = document.createElement('div')
+        wrapper.style.cssText =
+          'display: flex; justify-content: center; margin: 4rem; font-size: 1.6rem;'
+        wrapper.textContent = 'A program with this status could not be found.'
+
+        uiError.replaceChildren(wrapper)
+      }
+      return response
+    },
+  })
+
+  const submitForm = () =>
+    document.querySelector<HTMLFormElement>('#selectionForm')?.submit()
+
+  document.getElementById('programSlug')?.addEventListener('change', submitForm)
+  document.getElementById('stage')?.addEventListener('change', submitForm)
+  document
+    .getElementById('openApiVersion')
+    ?.addEventListener('change', submitForm)
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', init)
+} else {
+  init()
+}

--- a/server/app/controllers/docs/OpenApiSchemaController.java
+++ b/server/app/controllers/docs/OpenApiSchemaController.java
@@ -2,7 +2,6 @@ package controllers.docs;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static play.mvc.Results.badRequest;
-import static play.mvc.Results.internalServerError;
 import static play.mvc.Results.notFound;
 import static play.mvc.Results.ok;
 
@@ -11,41 +10,49 @@ import com.google.common.collect.ImmutableSet;
 import java.util.Locale;
 import java.util.Optional;
 import javax.inject.Inject;
+import mapping.admin.docs.SchemaPageMapper;
 import models.LifecycleStage;
 import org.pac4j.play.java.Secure;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import play.i18n.MessagesApi;
 import play.mvc.Http;
 import play.mvc.Result;
 import services.DeploymentType;
+import services.docs.ApiDocsService;
 import services.openapi.OpenApiSchemaGenerator;
 import services.openapi.OpenApiSchemaGeneratorFactory;
 import services.openapi.OpenApiSchemaSettings;
 import services.openapi.OpenApiVersion;
 import services.program.ProgramDefinition;
-import services.program.ProgramDraftNotFoundException;
-import services.program.ProgramService;
 import services.settings.SettingsManifest;
+import views.admin.docs.SchemaPageView;
 import views.docs.SchemaView;
 
 /** This handles endpoints related to serving openapi schema data */
 public final class OpenApiSchemaController {
-  private final ProgramService programService;
+  private final ApiDocsService apiDocsService;
   private final SettingsManifest settingsManifest;
   private final DeploymentType deploymentType;
   private final SchemaView schemaView;
+  private final SchemaPageView schemaPageView;
+  private final MessagesApi messagesApi;
   private static final Logger logger = LoggerFactory.getLogger(OpenApiSchemaController.class);
 
   @Inject
   public OpenApiSchemaController(
-      ProgramService programService,
+      ApiDocsService apiDocsService,
       SettingsManifest settingsManifest,
       DeploymentType deploymentType,
-      SchemaView schemaView) {
-    this.programService = checkNotNull(programService);
+      SchemaView schemaView,
+      SchemaPageView schemaPageView,
+      MessagesApi messagesApi) {
+    this.apiDocsService = checkNotNull(apiDocsService);
     this.settingsManifest = checkNotNull(settingsManifest);
     this.deploymentType = checkNotNull(deploymentType);
     this.schemaView = checkNotNull(schemaView);
+    this.schemaPageView = checkNotNull(schemaPageView);
+    this.messagesApi = checkNotNull(messagesApi);
   }
 
   /** Endpoint to return the generated openapi schema */
@@ -62,12 +69,10 @@ public final class OpenApiSchemaController {
             .orElse(LifecycleStage.ACTIVE);
 
     Optional<ProgramDefinition> optionalProgramDefinition =
-        programService.getAllNonExternalProgramSlugs().contains(programSlug)
-            ? getProgramDefinition(programSlug, lifecycleStage)
-            : Optional.empty();
+        apiDocsService.getProgramDefinition(programSlug, lifecycleStage);
 
     if (optionalProgramDefinition.isEmpty()) {
-      return notFound("No program found");
+      return notFound(messagesApi.preferred(request).at("adminApiDocs.notFound"));
     }
 
     try {
@@ -86,38 +91,16 @@ public final class OpenApiSchemaController {
       return ok(response).as("text/yaml");
     } catch (RuntimeException ex) {
       String errorMsg =
-          String.format(
-              "Unable to generate OpenApi version '%s' for program '%s' at stage '%s'.",
-              openApiVersion.orElse(""), programSlug, lifecycleStage.getValue());
+          messagesApi
+              .preferred(request)
+              .at(
+                  "adminSchemaViewer.yamlError",
+                  openApiVersion.orElse(""),
+                  programSlug,
+                  lifecycleStage.getValue());
+
       logger.error(errorMsg, ex);
       return badRequest(errorMsg);
-    }
-  }
-
-  /** Get program definition for the specific slug and version */
-  private Optional<ProgramDefinition> getProgramDefinition(
-      String programSlug, LifecycleStage lifecycleStage) {
-    try {
-      switch (lifecycleStage) {
-        case ACTIVE -> {
-          ProgramDefinition activeProgramDefinition =
-              programService
-                  .getActiveFullProgramDefinitionAsync(programSlug)
-                  .toCompletableFuture()
-                  .join();
-          return Optional.of(activeProgramDefinition);
-        }
-        case DRAFT -> {
-          ProgramDefinition draftProgramDefinition =
-              programService.getDraftFullProgramDefinition(programSlug);
-          return Optional.of(draftProgramDefinition);
-        }
-        default -> {
-          return Optional.empty();
-        }
-      }
-    } catch (RuntimeException | ProgramDraftNotFoundException e) {
-      return Optional.empty();
     }
   }
 
@@ -140,7 +123,7 @@ public final class OpenApiSchemaController {
       Optional<String> openApiVersion) {
 
     ImmutableSet<String> allNonExternalProgramSlugs =
-        programService.getAllNonExternalProgramSlugs();
+        apiDocsService.getAllNonExternalProgramSlugs();
 
     if (programSlug.isEmpty() || !allNonExternalProgramSlugs.contains(programSlug)) {
       programSlug = allNonExternalProgramSlugs.stream().findFirst().orElse("");
@@ -148,23 +131,32 @@ public final class OpenApiSchemaController {
 
     // This will only happen if there are no programs at all in the system
     if (programSlug.isEmpty()) {
-      return ok("Please add a program.");
+      return ok(messagesApi.preferred(request).at("adminApiDocs.notFound"));
     }
 
-    try {
-      String url =
-          routes.OpenApiSchemaController.getSchemaByProgramSlug(
+    String url =
+        routes.OpenApiSchemaController.getSchemaByProgramSlug(
+                programSlug,
+                Optional.of(stage.orElse(LifecycleStage.ACTIVE.getValue())),
+                Optional.of(openApiVersion.orElse(OpenApiVersion.OPENAPI_V3_0.toString())))
+            .url();
+
+    if (settingsManifest.getAdminUiMigrationScEnabled(request)) {
+      return ok(schemaPageView.render(
+              request,
+              SchemaPageMapper.map(
+                  messagesApi.preferred(request),
                   programSlug,
-                  Optional.of(stage.orElse(LifecycleStage.ACTIVE.getValue())),
-                  Optional.of(openApiVersion.orElse(OpenApiVersion.OPENAPI_V3_0.toString())))
-              .url();
-
-      SchemaView.Form form = new SchemaView.Form(programSlug, stage, openApiVersion);
-
-      return ok(schemaView.render(request, form, url, allNonExternalProgramSlugs));
-    } catch (RuntimeException ex) {
-      return internalServerError();
+                  stage,
+                  openApiVersion,
+                  url,
+                  allNonExternalProgramSlugs)))
+          .as(Http.MimeTypes.HTML);
     }
+
+    SchemaView.Form form = new SchemaView.Form(programSlug, stage, openApiVersion);
+
+    return ok(schemaView.render(request, form, url, allNonExternalProgramSlugs));
   }
 
   /** Redirect to the swagger ui to view the select swagger/openapi */

--- a/server/app/mapping/admin/docs/SchemaPageMapper.java
+++ b/server/app/mapping/admin/docs/SchemaPageMapper.java
@@ -1,0 +1,76 @@
+package mapping.admin.docs;
+
+import com.google.common.collect.ImmutableSet;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import models.LifecycleStage;
+import play.i18n.Messages;
+import services.openapi.OpenApiVersion;
+import views.admin.docs.SchemaPageViewModel;
+import views.admin.docs.SchemaPageViewModel.ProgramSlugOption;
+import views.admin.docs.SchemaPageViewModel.SelectOption;
+
+/** Maps schema page data to the SchemaPageViewModel. */
+public final class SchemaPageMapper {
+
+  public static SchemaPageViewModel map(
+      Messages messages,
+      String programSlug,
+      Optional<String> stage,
+      Optional<String> openApiVersion,
+      String apiUrl,
+      ImmutableSet<String> allProgramSlugs) {
+
+    String resolvedStage = stage.orElse(LifecycleStage.ACTIVE.getValue());
+    String resolvedOpenApiVersion = openApiVersion.orElse(OpenApiVersion.OPENAPI_V3_0.toString());
+
+    List<ProgramSlugOption> slugOptions =
+        allProgramSlugs.stream()
+            .sorted()
+            .map(
+                slug ->
+                    ProgramSlugOption.builder()
+                        .slug(slug)
+                        .selected(slug.equalsIgnoreCase(programSlug))
+                        .build())
+            .collect(Collectors.toList());
+
+    List<SelectOption> stageOptions =
+        List.of(
+            SelectOption.builder()
+                .label(messages.at("adminApiDocs.version.active"))
+                .value("active")
+                .selected("active".equalsIgnoreCase(resolvedStage))
+                .build(),
+            SelectOption.builder()
+                .label(messages.at("adminApiDocs.version.draft"))
+                .value("draft")
+                .selected("draft".equalsIgnoreCase(resolvedStage))
+                .build());
+
+    List<SelectOption> openApiVersionOptions =
+        Arrays.stream(OpenApiVersion.values())
+            .sorted(Comparator.comparing(OpenApiVersion::toString))
+            .map(
+                v ->
+                    SelectOption.builder()
+                        .label(v.getVersionNumber())
+                        .value(v.toString())
+                        .selected(v.toString().equalsIgnoreCase(resolvedOpenApiVersion))
+                        .build())
+            .collect(Collectors.toList());
+
+    return SchemaPageViewModel.builder()
+        .programSlug(programSlug)
+        .stage(resolvedStage)
+        .openApiVersion(resolvedOpenApiVersion)
+        .programSlugs(slugOptions)
+        .stageOptions(stageOptions)
+        .openApiVersionOptions(openApiVersionOptions)
+        .apiUrl(apiUrl)
+        .build();
+  }
+}

--- a/server/app/views/admin/docs/SchemaPage.html
+++ b/server/app/views/admin/docs/SchemaPage.html
@@ -1,0 +1,97 @@
+<!--/*@thymesVar id="templateGlobals" type="views.shared.TemplateGlobals"*/-->
+<!--/*@thymesVar id="model" type="views.admin.docs.SchemaPageViewModel"*/-->
+<th:block
+  th:fragment="content"
+  xmlns:th="http://www.thymeleaf.org"
+  xmlns:cf="https://civiform.us/thymeleaf/cf"
+>
+  <div class="spacing-4">
+    <!--/* Tabs */-->
+    <nav
+      th:aria-label="#{adminApiDocs.tabs.ariaLabel}"
+      class="cf-navigation-tabs"
+    >
+      <a
+        class="usa-link"
+        th:href="${model.apiDocsTabUrl}"
+        th:text="#{adminApiDocs.tabs.docs}"
+      ></a>
+      <span class="cf-navigation-tabs__separator" aria-hidden="true"> / </span>
+      <a
+        th:href="${model.schemaTabUrl}"
+        aria-current="page"
+        th:text="#{adminApiDocs.tabs.schema}"
+      ></a>
+    </nav>
+
+    <p th:text="#{adminSchemaViewer.intro1}"></p>
+    <p th:text="#{adminSchemaViewer.intro2}"></p>
+
+    <!--/* Form with selects */-->
+    <form
+      id="selectionForm"
+      th:action="${model.formActionUrl}"
+      method="GET"
+      class="display-flex flex-align-end flex-wrap flex-gap"
+    >
+      <cf:select
+        id="programSlug"
+        name="programSlug"
+        th:label="#{adminSchemaViewer.selectProgram}"
+      >
+        <option
+          th:each="opt : ${model.programSlugs}"
+          th:value="${opt.slug}"
+          th:text="${opt.slug}"
+          th:selected="${opt.selected}"
+        ></option>
+      </cf:select>
+
+      <cf:select
+        id="stage"
+        name="stage"
+        th:label="#{adminSchemaViewer.selectStatus}"
+      >
+        <option
+          th:each="opt : ${model.stageOptions}"
+          th:value="${opt.value}"
+          th:text="${opt.label}"
+          th:selected="${opt.selected}"
+        ></option>
+      </cf:select>
+
+      <cf:select
+        id="openApiVersion"
+        name="openApiVersion"
+        th:label="#{adminSchemaViewer.selectVersion}"
+      >
+        <option
+          th:each="opt : ${model.openApiVersionOptions}"
+          th:value="${opt.value}"
+          th:text="${opt.label}"
+          th:selected="${opt.selected}"
+        ></option>
+      </cf:select>
+    </form>
+
+    <input type="hidden" id="api-url" th:value="${model.apiUrl}" />
+
+    <!--/* Inlining this css because it is only used to modify the swagger-ui and is never useful elsewhere */-->
+    <style th:attr="nonce=${templateGlobals.cspNonce()}">
+      .swagger-ui {
+        > .topbar,
+        .scheme-container {
+          display: none;
+        }
+        .wrapper {
+          padding: 0;
+        }
+        .info {
+          margin: 0 0 1rem 0;
+        }
+      }
+    </style>
+
+    <div id="swagger-ui"></div>
+  </div>
+</th:block>

--- a/server/app/views/admin/docs/SchemaPageView.java
+++ b/server/app/views/admin/docs/SchemaPageView.java
@@ -1,0 +1,55 @@
+package views.admin.docs;
+
+import com.google.common.collect.ImmutableList;
+import javax.inject.Inject;
+import play.i18n.Messages;
+import views.admin.AdminLayout;
+import views.admin.AdminLayoutBaseView;
+import views.shared.LayoutDeps;
+import views.shared.ScriptElementSettings;
+
+public final class SchemaPageView extends AdminLayoutBaseView<SchemaPageViewModel> {
+  @Inject
+  public SchemaPageView(LayoutDeps adminLayoutDeps) {
+    super(adminLayoutDeps);
+  }
+
+  @Override
+  protected String pageTitle(SchemaPageViewModel model, Messages messages) {
+    return messages.at("adminSchemaViewer.pageTitle");
+  }
+
+  @Override
+  protected AdminLayout.NavPage activeNavigationPage() {
+    return AdminLayout.NavPage.API_DOCS;
+  }
+
+  @Override
+  protected String pageTemplate() {
+    return "admin/docs/SchemaPage.html";
+  }
+
+  @Override
+  protected ImmutableList<String> getPageStylesheets() {
+    return ImmutableList.of(bundledAssetsFinder.getSwaggerUiCss());
+  }
+
+  @Override
+  protected ImmutableList<ScriptElementSettings> getPageHeadScripts() {
+    return ImmutableList.of(
+        ScriptElementSettings.builder()
+            .src(bundledAssetsFinder.getSwaggerUiJs())
+            .type("text/javascript")
+            .crossOrigin("anonymous")
+            .build(),
+        ScriptElementSettings.builder()
+            .src(bundledAssetsFinder.getSwaggeruiPresetJs())
+            .type("text/javascript")
+            .crossOrigin("anonymous")
+            .build(),
+        ScriptElementSettings.builder()
+            .src(bundledAssetsFinder.getPageBundle("admin/api_docs_schema_page"))
+            .type("module")
+            .build());
+  }
+}

--- a/server/app/views/admin/docs/SchemaPageViewModel.java
+++ b/server/app/views/admin/docs/SchemaPageViewModel.java
@@ -1,0 +1,50 @@
+package views.admin.docs;
+
+import java.util.List;
+import java.util.Optional;
+import lombok.Builder;
+import lombok.Data;
+import views.BaseViewModel;
+
+@Data
+@Builder
+public final class SchemaPageViewModel implements BaseViewModel {
+  private final String programSlug;
+  private final String stage;
+  private final String openApiVersion;
+  private final List<ProgramSlugOption> programSlugs;
+  private final List<SelectOption> stageOptions;
+  private final List<SelectOption> openApiVersionOptions;
+  private final String apiUrl;
+
+  public String getFormActionUrl() {
+    return controllers.docs.routes.OpenApiSchemaController.getSchemaUIRedirect(
+            Optional.empty(), Optional.empty(), Optional.empty())
+        .url();
+  }
+
+  public String getApiDocsTabUrl() {
+    return controllers.docs.routes.ApiDocsController.index().url();
+  }
+
+  public String getSchemaTabUrl() {
+    return controllers.docs.routes.OpenApiSchemaController.getSchemaUIRedirect(
+            Optional.empty(), Optional.empty(), Optional.empty())
+        .url();
+  }
+
+  @Data
+  @Builder
+  public static final class ProgramSlugOption {
+    private final String slug;
+    private final boolean selected;
+  }
+
+  @Data
+  @Builder
+  public static final class SelectOption {
+    private final String label;
+    private final String value;
+    private final boolean selected;
+  }
+}

--- a/server/conf/i18n/messages
+++ b/server/conf/i18n/messages
@@ -1379,6 +1379,25 @@ adminApiDocs.allOptions=All possible options:
 adminApiDocs.responsePreview=API response preview
 
 #------------------------------------------------------------------------------#
+#  ADMIN SCHEMA VIEWER                                                         #
+#------------------------------------------------------------------------------#
+
+# Admin API Docs page title
+adminSchemaViewer.pageTitle=API schema viewer
+# First intro paragraph on the OpenAPI schema viewer page.
+adminSchemaViewer.intro1=This page shows a visualization of the OpenAPI Schema. Both version 2 (formerly Swagger 2) and version 3 are available.
+# Second intro paragraph on the OpenAPI schema viewer page.
+adminSchemaViewer.intro2=We recommend only using version 3 unless there is a specific need for the older format.
+# Label for the program selector on the schema viewer page.
+adminSchemaViewer.selectProgram=Program:
+# Label for the program-status selector on the schema viewer page.
+adminSchemaViewer.selectStatus=Status:
+# Label for the OpenAPI version selector on the schema viewer page.
+adminSchemaViewer.selectVersion=OpenApi Version:
+# Error generating OpenAPI YAML
+adminSchemaViewer.yamlError=Unable to generate OpenApi version '{0}' for program '{1}' at stage '{2}'.
+
+#------------------------------------------------------------------------------#
 #  DEV TOOLS - text for the developer tools page                               #
 #------------------------------------------------------------------------------#
 # The text on the button to go to the home page from the dev tools page.

--- a/server/test/controllers/docs/OpenApiSchemaControllerTest.java
+++ b/server/test/controllers/docs/OpenApiSchemaControllerTest.java
@@ -20,7 +20,7 @@ import support.ProgramBuilder;
 
 public class OpenApiSchemaControllerTest extends ResetPostgres {
 
-  private static final String SCHEMA_UI_NO_PROGRAM_FOUND_ERROR = "Please add a program";
+  private static final String SCHEMA_UI_NO_PROGRAM_FOUND_ERROR = "No programs found.";
 
   @Before
   public void setUp() {


### PR DESCRIPTION
Migrates the api docs openapi schema viewer to the new format. 

Note: Everything below the dropdown boxes is not customizable.

<img width="1230" height="996" alt="image" src="https://github.com/user-attachments/assets/9406b8ff-0e99-4a8a-9995-9058b4ac9634" />

Related to: #12448
Fixes: #13122
