### PR TITLE
[Enumerators] Allow more than one question on an enumerator screen 

### DIFF
--- a/server/app/services/ProgramBlockValidation.java
+++ b/server/app/services/ProgramBlockValidation.java
@@ -114,21 +114,21 @@ public final class ProgramBlockValidation {
    * and return the id of its {@link EnumeratorQuestionDefinition}.
    */
   private Optional<Long> getParentEnumeratorQuestionId(
-    ProgramDefinition program, BlockDefinition block) {
+      ProgramDefinition program, BlockDefinition block) {
     if (block.enumeratorId().isEmpty()) {
       return Optional.empty();
     }
     try {
       BlockDefinition enumeratorBlockDefinition =
-        program.getBlockDefinition(block.enumeratorId().get());
+          program.getBlockDefinition(block.enumeratorId().get());
       return enumeratorBlockDefinition.hasEnumeratorQuestion()
-        ? Optional.of(enumeratorBlockDefinition.getEnumeratorQuestionDefinition().getId())
-        : Optional.empty();
+          ? Optional.of(enumeratorBlockDefinition.getEnumeratorQuestionDefinition().getId())
+          : Optional.empty();
     } catch (ProgramBlockDefinitionNotFoundException e) {
       String errorMessage =
-        String.format(
-          "BlockDefinition %d has a broken enumerator block reference to id %d",
-          block.id(), block.enumeratorId().get());
+          String.format(
+              "BlockDefinition %d has a broken enumerator block reference to id %d",
+              block.id(), block.enumeratorId().get());
       throw new RuntimeException(errorMessage, e);
     }
   }
@@ -138,11 +138,13 @@ public final class ProgramBlockValidation {
    * is compatible if any of the following is true:
    *
    * <ul>
-   *   <li>Its enumeratorId matches the block's parent enumerator (standard repeated question case
-   *   or non-repeating question case).
-   *   <li>It is a non-repeating question being considered for a repeated block.
-   *   <li>Its enumeratorId matches the enumerator question on this block itself and enumerator
-   *       improvements are enabled (initial question being added to the enumerator's own block).
+   *   <li>Its enumeratorId equals the block's parent enumerator id — i.e. both are empty (top-level
+   *       question on a top-level block) or both point to the same enumerator (repeated question on
+   *       its matching repeated block).
+   *   <li>It is a non-repeated question being added to a repeated block, and enumerator
+   *       improvements are enabled.
+   *   <li>Its enumeratorId points to the enumerator question on this block itself, and enumerator
+   *       improvements are enabled (initial question case).
    * </ul>
    */
   private boolean hasMatchingEnumeratorId(

--- a/server/app/services/ProgramBlockValidation.java
+++ b/server/app/services/ProgramBlockValidation.java
@@ -160,6 +160,8 @@ public final class ProgramBlockValidation {
       return true;
     }
 
+    // At this point both items can't be empty, indicating at least one is associated with an
+    // enumerator
     if (enumeratorImprovementsEnabled) {
       // Non-repeating question being considered for a repeated block, shown as an option
       // in the question bank sidebar before the question is copied

--- a/server/app/services/ProgramBlockValidation.java
+++ b/server/app/services/ProgramBlockValidation.java
@@ -89,8 +89,7 @@ public final class ProgramBlockValidation {
         && isSingleBlockQuestion(question, fileUploadQuestionImprovementsEnabled)) {
       return AddQuestionResult.CANT_ADD_SINGLE_BLOCK_QUESTION_TO_NON_EMPTY_BLOCK;
     }
-    if (!question.getEnumeratorId().equals(getEnumeratorQuestionId(program, block))
-        && !(enumeratorImprovementsEnabled && question.getEnumeratorId().isEmpty())) {
+    if (!hasMatchingEnumeratorId(question, program, block, enumeratorImprovementsEnabled)) {
       return AddQuestionResult.ENUMERATOR_MISMATCH;
     }
     if (!activeAndDraftQuestions.getActiveQuestions().contains(question)
@@ -114,22 +113,65 @@ public final class ProgramBlockValidation {
    * Follow the {@link BlockDefinition#enumeratorId()} reference to the enumerator block definition,
    * and return the id of its {@link EnumeratorQuestionDefinition}.
    */
-  private Optional<Long> getEnumeratorQuestionId(ProgramDefinition program, BlockDefinition block) {
+  private Optional<Long> getParentEnumeratorQuestionId(
+    ProgramDefinition program, BlockDefinition block) {
     if (block.enumeratorId().isEmpty()) {
       return Optional.empty();
     }
     try {
       BlockDefinition enumeratorBlockDefinition =
-          program.getBlockDefinition(block.enumeratorId().get());
+        program.getBlockDefinition(block.enumeratorId().get());
       return enumeratorBlockDefinition.hasEnumeratorQuestion()
-          ? Optional.of(enumeratorBlockDefinition.getQuestionDefinition(0).getId())
-          : Optional.empty();
+        ? Optional.of(enumeratorBlockDefinition.getEnumeratorQuestionDefinition().getId())
+        : Optional.empty();
     } catch (ProgramBlockDefinitionNotFoundException e) {
       String errorMessage =
-          String.format(
-              "BlockDefinition %d has a broken enumerator block reference to id %d",
-              block.id(), block.enumeratorId().get());
+        String.format(
+          "BlockDefinition %d has a broken enumerator block reference to id %d",
+          block.id(), block.enumeratorId().get());
       throw new RuntimeException(errorMessage, e);
     }
+  }
+
+  /**
+   * Checks whether a question's {@code enumeratorId} is compatible with the given block. A question
+   * is compatible if any of the following is true:
+   *
+   * <ul>
+   *   <li>Its enumeratorId matches the block's parent enumerator (standard repeated question case
+   *   or non-repeating question case).
+   *   <li>It is a non-repeating question being considered for a repeated block.
+   *   <li>Its enumeratorId matches the enumerator question on this block itself and enumerator
+   *       improvements are enabled (initial question being added to the enumerator's own block).
+   * </ul>
+   */
+  private boolean hasMatchingEnumeratorId(
+      QuestionDefinition question,
+      ProgramDefinition program,
+      BlockDefinition block,
+      boolean enumeratorImprovementsEnabled) {
+    Optional<Long> questionEnumeratorId = question.getEnumeratorId();
+
+    // Standard case: question repeats under the block's parent enumerator or the question
+    // is a top-level question (both the question and parent's enumeratorIds are empty).
+    if (questionEnumeratorId.equals(getParentEnumeratorQuestionId(program, block))) {
+      return true;
+    }
+
+    if (enumeratorImprovementsEnabled) {
+      // Non-repeating question being considered for a repeated block, shown as an option
+      // in the question bank sidebar before the question is copied
+      if (questionEnumeratorId.isEmpty()) {
+        return true;
+      }
+      // Initial question: its enumeratorId points to the enumerator on THIS block.
+      if (block.hasEnumeratorQuestion()
+          && questionEnumeratorId.equals(
+              Optional.of(block.getEnumeratorQuestionDefinition().getId()))) {
+        return true;
+      }
+    }
+
+    return false;
   }
 }

--- a/server/app/services/applicant/ReadOnlyApplicantProgramService.java
+++ b/server/app/services/applicant/ReadOnlyApplicantProgramService.java
@@ -622,7 +622,7 @@ public final class ReadOnlyApplicantProgramService {
       if (blockDefinition.hasEnumeratorQuestion()) {
         // Get all the repeated entities enumerated by this enumerator question.
         EnumeratorQuestionDefinition enumeratorQuestionDefinition =
-            blockDefinition.getEnumerationQuestionDefinition();
+            blockDefinition.getEnumeratorQuestionDefinition();
         ImmutableList<RepeatedEntity> repeatedEntities =
             maybeRepeatedEntity
                 .map(

--- a/server/app/services/program/BlockDefinition.java
+++ b/server/app/services/program/BlockDefinition.java
@@ -127,10 +127,14 @@ public abstract class BlockDefinition {
   }
 
   @JsonIgnore
-  public EnumeratorQuestionDefinition getEnumerationQuestionDefinition() {
+  public EnumeratorQuestionDefinition getEnumeratorQuestionDefinition() {
     if (hasEnumeratorQuestion()) {
-      return (EnumeratorQuestionDefinition) getQuestionDefinition(0);
+      return (EnumeratorQuestionDefinition) getQuestionDefinitions().stream()
+        .filter(QuestionDefinition::isEnumerator)
+        .findFirst()
+        .orElseThrow();
     }
+
     throw new RuntimeException(
         "Only an enumerator block can have an enumeration question definition.");
   }
@@ -244,6 +248,13 @@ public abstract class BlockDefinition {
   @JsonIgnore
   public QuestionDefinition getQuestionDefinition(int questionIndex) {
     return programQuestionDefinitions().get(questionIndex).getQuestionDefinition();
+  }
+
+  @JsonIgnore
+  public ImmutableList<QuestionDefinition> getQuestionDefinitions() {
+    return programQuestionDefinitions().stream()
+      .map(ProgramQuestionDefinition::getQuestionDefinition)
+      .collect(ImmutableList.toImmutableList());
   }
 
   @JsonIgnore

--- a/server/app/services/program/BlockDefinition.java
+++ b/server/app/services/program/BlockDefinition.java
@@ -129,14 +129,15 @@ public abstract class BlockDefinition {
   @JsonIgnore
   public EnumeratorQuestionDefinition getEnumeratorQuestionDefinition() {
     if (hasEnumeratorQuestion()) {
-      return (EnumeratorQuestionDefinition) getQuestionDefinitions().stream()
-        .filter(QuestionDefinition::isEnumerator)
-        .findFirst()
-        .orElseThrow();
+      return (EnumeratorQuestionDefinition)
+          getQuestionDefinitions().stream()
+              .filter(QuestionDefinition::isEnumerator)
+              .findFirst()
+              .orElseThrow();
     }
 
     throw new RuntimeException(
-        "Only an enumerator block can have an enumeration question definition.");
+        "Only an enumerator block can have an enumerator question definition.");
   }
 
   @JsonIgnore
@@ -253,8 +254,8 @@ public abstract class BlockDefinition {
   @JsonIgnore
   public ImmutableList<QuestionDefinition> getQuestionDefinitions() {
     return programQuestionDefinitions().stream()
-      .map(ProgramQuestionDefinition::getQuestionDefinition)
-      .collect(ImmutableList.toImmutableList());
+        .map(ProgramQuestionDefinition::getQuestionDefinition)
+        .collect(ImmutableList.toImmutableList());
   }
 
   @JsonIgnore

--- a/server/app/services/program/ProgramService.java
+++ b/server/app/services/program/ProgramService.java
@@ -2363,7 +2363,7 @@ public final class ProgramService {
           Optional.of(
               programDefinition
                   .getBlockDefinition(blockDefinition.enumeratorId().get())
-                  .getEnumerationQuestionDefinition()
+                  .getEnumeratorQuestionDefinition()
                   .getId());
       // Create the copy question, handle potential errors below
       ErrorAnd<QuestionDefinition, CiviFormError> maybeCopy =

--- a/server/app/views/components/ProgramQuestionBank.java
+++ b/server/app/views/components/ProgramQuestionBank.java
@@ -375,7 +375,7 @@ public final class ProgramQuestionBank {
         return Optional.empty();
       }
       return Optional.of(
-          Long.toString(parentEnumeratorBlock.getEnumerationQuestionDefinition().getId()));
+          Long.toString(parentEnumeratorBlock.getEnumeratorQuestionDefinition().getId()));
     } catch (ProgramBlockDefinitionNotFoundException e) {
       throw new RuntimeException(e);
     }

--- a/server/test/services/ProgramBlockValidationTest.java
+++ b/server/test/services/ProgramBlockValidationTest.java
@@ -47,8 +47,7 @@ public class ProgramBlockValidationTest extends ResetPostgres {
     version.addQuestion(householdMemberQuestion);
     version.addQuestion(nestedHouseholdMemberWageQuestion);
     repeatedHouseholdMemberNameQuestion =
-        resourceCreator.insertRepeatedTextQuestion(
-            "householdMemberName", householdMemberQuestion);
+        resourceCreator.insertRepeatedTextQuestion("householdMemberName", householdMemberQuestion);
     version.addQuestion(repeatedHouseholdMemberNameQuestion);
     version.save();
     ProgramBlockValidationFactory programBlockValidationFactory =
@@ -251,7 +250,6 @@ public class ProgramBlockValidationTest extends ResetPostgres {
     ProgramDefinition program =
         ProgramBuilder.newDraftProgram("program1")
             .withBlock()
-            // Add an enumerator question
             .withRequiredQuestionDefinition(householdMemberQuestion.getQuestionDefinition())
             .buildDefinition();
     assertThat(

--- a/server/test/services/ProgramBlockValidationTest.java
+++ b/server/test/services/ProgramBlockValidationTest.java
@@ -56,7 +56,7 @@ public class ProgramBlockValidationTest extends ResetPostgres {
   }
 
   @Test
-  public void canAddQuestions_cantAddArchivedQuestion() throws Exception {
+  public void canAddQuestions_cannotAddArchivedQuestion() throws Exception {
     ProgramDefinition program =
         ProgramBuilder.newDraftProgram("program1")
             .withBlock()
@@ -73,7 +73,7 @@ public class ProgramBlockValidationTest extends ResetPostgres {
   }
 
   @Test
-  public void canAddQuestions_cantAddQuestionNotInActiveDraftState() throws Exception {
+  public void canAddQuestions_cannotAddQuestionNotInActiveDraftState() throws Exception {
     QuestionDefinition householdMemberQuestion =
         testQuestionBank.enumeratorApplicantHouseholdMembers().getQuestionDefinition();
     QuestionDefinition householdMemberNameQuestion =
@@ -150,7 +150,7 @@ public class ProgramBlockValidationTest extends ResetPostgres {
   }
 
   @Test
-  public void canAddQuestion_cantAddSingleQuestionBlock() throws Exception {
+  public void canAddQuestion_cannotAddSingleQuestionBlock() throws Exception {
     QuestionDefinition nameQuestion = testQuestionBank.nameApplicantName().getQuestionDefinition();
     QuestionDefinition fileQuestion =
         testQuestionBank.fileUploadApplicantFile().getQuestionDefinition();
@@ -170,7 +170,7 @@ public class ProgramBlockValidationTest extends ResetPostgres {
   }
 
   @Test
-  public void canAddQuestion_cantAddRepeatedQuestionWhenNoEnumeratorQuestionInProgram()
+  public void canAddQuestion_cannotAddRepeatedQuestionWhenNoEnumeratorQuestionInProgram()
       throws Exception {
     QuestionDefinition repeatedQuestion =
         testQuestionBank.nameRepeatedApplicantHouseholdMemberName().getQuestionDefinition();
@@ -188,7 +188,7 @@ public class ProgramBlockValidationTest extends ResetPostgres {
 
   @Test
   public void
-      canAddQuestion_cantAddEnumeratorQuestionToNonEnumeratorBlock_whenEnumeratorImprovementsEnabled()
+      canAddQuestion_cannotAddEnumeratorQuestionToNonEnumeratorBlock_whenEnumeratorImprovementsEnabled()
           throws Exception {
     QuestionDefinition question =
         QuestionDefinition.questionDefinitionSample(QuestionType.ENUMERATOR);
@@ -205,7 +205,7 @@ public class ProgramBlockValidationTest extends ResetPostgres {
   }
 
   @Test
-  public void canAddQuestion_cantAddRepeatedQuestionThatIsNotAssociatedWithEnumeratorQuestion()
+  public void canAddQuestion_cannotAddRepeatedQuestionThatIsNotAssociatedWithEnumeratorQuestion()
       throws Exception {
     QuestionDefinition nameQuestion = testQuestionBank.nameApplicantName().getQuestionDefinition();
     QuestionDefinition enumeratorQuestion =
@@ -284,7 +284,7 @@ public class ProgramBlockValidationTest extends ResetPostgres {
 
   @Test
   public void
-      canAddQuestion_cantAddRepeatedQuestionToWrongEnumeratorBlock_whenEnumeratorImprovementsEnabled()
+      canAddQuestion_cannotAddRepeatedQuestionToWrongEnumeratorBlock_whenEnumeratorImprovementsEnabled()
           throws Exception {
     QuestionModel otherEnumerator = resourceCreator.insertEnum("otherEnumerator");
     QuestionModel otherRepeatedQuestion =

--- a/server/test/services/ProgramBlockValidationTest.java
+++ b/server/test/services/ProgramBlockValidationTest.java
@@ -25,6 +25,7 @@ public class ProgramBlockValidationTest extends ResetPostgres {
   private VersionModel version;
   private QuestionModel householdMemberQuestion;
   private QuestionModel nestedHouseholdMemberWageQuestion;
+  private QuestionModel repeatedHouseholdMemberNameQuestion;
 
   @Before
   public void setProgramBlockValidation()
@@ -45,6 +46,10 @@ public class ProgramBlockValidationTest extends ResetPostgres {
             "householdMemberWageQuestion", householdMemberQuestion);
     version.addQuestion(householdMemberQuestion);
     version.addQuestion(nestedHouseholdMemberWageQuestion);
+    repeatedHouseholdMemberNameQuestion =
+        resourceCreator.insertRepeatedTextQuestion(
+            "householdMemberName", householdMemberQuestion);
+    version.addQuestion(repeatedHouseholdMemberNameQuestion);
     version.save();
     ProgramBlockValidationFactory programBlockValidationFactory =
         new ProgramBlockValidationFactory(versionRepository, questionService);
@@ -238,5 +243,70 @@ public class ProgramBlockValidationTest extends ResetPostgres {
                 /* enumeratorImprovementsEnabled= */ false,
                 /* fileUploadQuestionImprovementsEnabled= */ false))
         .isEqualTo(AddQuestionResult.ELIGIBLE);
+  }
+
+  @Test
+  public void canAddQuestion_canAddRepeatedQuestionToEnumeratorBlock_IfEnumeratorIdMatches()
+      throws Exception {
+    ProgramDefinition program =
+        ProgramBuilder.newDraftProgram("program1")
+            .withBlock()
+            // Add an enumerator question
+            .withRequiredQuestionDefinition(householdMemberQuestion.getQuestionDefinition())
+            .buildDefinition();
+    assertThat(
+            programBlockValidation.canAddQuestion(
+                program,
+                program.getLastBlockDefinition(),
+                repeatedHouseholdMemberNameQuestion.getQuestionDefinition(),
+                /* enumeratorImprovementsEnabled= */ true,
+                /* fileUploadQuestionImprovementsEnabled= */ false))
+        .isEqualTo(AddQuestionResult.ELIGIBLE);
+  }
+
+  @Test
+  public void
+      canAddQuestion_canAddNonRepeatedQuestionToRepeatedBlock_whenEnumeratorImprovementsEnabled()
+          throws Exception {
+    ProgramDefinition program =
+        ProgramBuilder.newDraftProgram("program1")
+            .withBlock()
+            .withRequiredQuestionDefinition(householdMemberQuestion.getQuestionDefinition())
+            .withRepeatedBlock()
+            .buildDefinition();
+    assertThat(
+            programBlockValidation.canAddQuestion(
+                program,
+                program.getLastBlockDefinition(),
+                questionForEligible.getQuestionDefinition(),
+                /* enumeratorImprovementsEnabled= */ true,
+                /* fileUploadQuestionImprovementsEnabled= */ false))
+        .isEqualTo(AddQuestionResult.ELIGIBLE);
+  }
+
+  @Test
+  public void
+      canAddQuestion_cantAddRepeatedQuestionToWrongEnumeratorBlock_whenEnumeratorImprovementsEnabled()
+          throws Exception {
+    QuestionModel otherEnumerator = resourceCreator.insertEnum("otherEnumerator");
+    QuestionModel otherRepeatedQuestion =
+        resourceCreator.insertRepeatedTextQuestion("otherRepeated", otherEnumerator);
+    version.addQuestion(otherEnumerator);
+    version.addQuestion(otherRepeatedQuestion);
+    version.save();
+
+    ProgramDefinition program =
+        ProgramBuilder.newDraftProgram("program1")
+            .withBlock()
+            .withRequiredQuestionDefinition(householdMemberQuestion.getQuestionDefinition())
+            .buildDefinition();
+    assertThat(
+            programBlockValidation.canAddQuestion(
+                program,
+                program.getLastBlockDefinition(),
+                otherRepeatedQuestion.getQuestionDefinition(),
+                /* enumeratorImprovementsEnabled= */ true,
+                /* fileUploadQuestionImprovementsEnabled= */ false))
+        .isEqualTo(AddQuestionResult.ENUMERATOR_MISMATCH);
   }
 }

--- a/server/test/services/program/BlockDefinitionTest.java
+++ b/server/test/services/program/BlockDefinitionTest.java
@@ -1,6 +1,7 @@
 package services.program;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Optional;
 import org.junit.Test;
@@ -277,6 +278,68 @@ public class BlockDefinitionTest {
             .build();
 
     assertThat(blockDefinition.hasNullQuestion()).isFalse();
+  }
+
+  @Test
+  public void getEnumeratorQuestionDefinition_findsEnumeratorWhenNotAtIndexZero() {
+    QuestionDefinition otherQuestion =
+        testQuestionBank.textApplicantFavoriteColor().getQuestionDefinition();
+    QuestionDefinition enumeratorQuestion =
+        testQuestionBank.enumeratorApplicantHouseholdMembers().getQuestionDefinition();
+    BlockDefinition blockDefinition =
+        BlockDefinition.builder()
+            .setId(123L)
+            .setName("Block Name")
+            .setDescription("Block Description")
+            .setLocalizedName(LocalizedStrings.withDefaultValue("Block Name"))
+            .setLocalizedDescription(LocalizedStrings.withDefaultValue("Block Description"))
+            .addQuestion(
+                ProgramQuestionDefinition.create(
+                    otherQuestion, /* programDefinitionId= */ Optional.empty()))
+            .addQuestion(
+                ProgramQuestionDefinition.create(
+                    enumeratorQuestion, /* programDefinitionId= */ Optional.empty()))
+            .build();
+
+    assertThat(blockDefinition.getEnumeratorQuestionDefinition().getId())
+        .isEqualTo(enumeratorQuestion.getId());
+  }
+
+  @Test
+  public void getEnumeratorQuestionDefinition_throwsWhenBlockHasNoEnumerator() {
+    BlockDefinition blockDefinition = makeBlockDefinitionWithQuestions();
+
+    assertThatThrownBy(blockDefinition::getEnumeratorQuestionDefinition)
+        .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining("Only an enumerator block");
+  }
+
+  @Test
+  public void getQuestionDefinitions_returnsAllQuestionsInOrder() {
+    QuestionDefinition nameQuestion = testQuestionBank.nameApplicantName().getQuestionDefinition();
+    QuestionDefinition addressQuestion =
+        testQuestionBank.addressApplicantAddress().getQuestionDefinition();
+    QuestionDefinition colorQuestion =
+        testQuestionBank.textApplicantFavoriteColor().getQuestionDefinition();
+    BlockDefinition blockDefinition = makeBlockDefinitionWithQuestions();
+
+    assertThat(blockDefinition.getQuestionDefinitions())
+        .extracting(QuestionDefinition::getId)
+        .containsExactly(nameQuestion.getId(), addressQuestion.getId(), colorQuestion.getId());
+  }
+
+  @Test
+  public void getQuestionDefinitions_isEmptyWhenBlockHasNoQuestions() {
+    BlockDefinition blockDefinition =
+        BlockDefinition.builder()
+            .setId(123L)
+            .setName("Block Name")
+            .setDescription("Block Description")
+            .setLocalizedName(LocalizedStrings.withDefaultValue("Block Name"))
+            .setLocalizedDescription(LocalizedStrings.withDefaultValue("Block Description"))
+            .build();
+
+    assertThat(blockDefinition.getQuestionDefinitions()).isEmpty();
   }
 
   @Test

--- a/server/test/services/program/BlockDefinitionTest.java
+++ b/server/test/services/program/BlockDefinitionTest.java
@@ -284,8 +284,8 @@ public class BlockDefinitionTest {
   public void getEnumeratorQuestionDefinition_findsEnumeratorWhenNotAtIndexZero() {
     QuestionDefinition otherQuestion =
         testQuestionBank.textApplicantFavoriteColor().getQuestionDefinition();
-    QuestionDefinition enumeratorQuestion =
-        testQuestionBank.enumeratorApplicantHouseholdMembers().getQuestionDefinition();
+    QuestionDefinition enumeratorQuestionId =
+        testQuestionBank.enumeratorApplicantHouseholdMembers().getQuestionDefinition().getId();
     BlockDefinition blockDefinition =
         BlockDefinition.builder()
             .setId(123L)
@@ -302,7 +302,7 @@ public class BlockDefinitionTest {
             .build();
 
     assertThat(blockDefinition.getEnumeratorQuestionDefinition().getId())
-        .isEqualTo(enumeratorQuestion.getId());
+        .isEqualTo(enumeratorQuestionId);
   }
 
   @Test
@@ -316,16 +316,17 @@ public class BlockDefinitionTest {
 
   @Test
   public void getQuestionDefinitions_returnsAllQuestionsInOrder() {
-    QuestionDefinition nameQuestion = testQuestionBank.nameApplicantName().getQuestionDefinition();
-    QuestionDefinition addressQuestion =
-        testQuestionBank.addressApplicantAddress().getQuestionDefinition();
-    QuestionDefinition colorQuestion =
-        testQuestionBank.textApplicantFavoriteColor().getQuestionDefinition();
+    QuestionDefinition nameQuestionId =
+        testQuestionBank.nameApplicantName().getQuestionDefinition().getId();
+    QuestionDefinition addressQuestionId =
+        testQuestionBank.addressApplicantAddress().getQuestionDefinition().getId();
+    QuestionDefinition colorQuestionId =
+        testQuestionBank.textApplicantFavoriteColor().getQuestionDefinition().getId();
     BlockDefinition blockDefinition = makeBlockDefinitionWithQuestions();
 
     assertThat(blockDefinition.getQuestionDefinitions())
         .extracting(QuestionDefinition::getId)
-        .containsExactly(nameQuestion.getId(), addressQuestion.getId(), colorQuestion.getId());
+        .containsExactly(nameQuestionId, addressQuestionId, colorQuestionId);
   }
 
   @Test

--- a/server/test/services/program/BlockDefinitionTest.java
+++ b/server/test/services/program/BlockDefinitionTest.java
@@ -284,8 +284,8 @@ public class BlockDefinitionTest {
   public void getEnumeratorQuestionDefinition_findsEnumeratorWhenNotAtIndexZero() {
     QuestionDefinition otherQuestion =
         testQuestionBank.textApplicantFavoriteColor().getQuestionDefinition();
-    QuestionDefinition enumeratorQuestionId =
-        testQuestionBank.enumeratorApplicantHouseholdMembers().getQuestionDefinition().getId();
+    QuestionDefinition enumeratorQuestion =
+        testQuestionBank.enumeratorApplicantHouseholdMembers().getQuestionDefinition();
     BlockDefinition blockDefinition =
         BlockDefinition.builder()
             .setId(123L)
@@ -302,7 +302,7 @@ public class BlockDefinitionTest {
             .build();
 
     assertThat(blockDefinition.getEnumeratorQuestionDefinition().getId())
-        .isEqualTo(enumeratorQuestionId);
+        .isEqualTo(enumeratorQuestion.getId());
   }
 
   @Test
@@ -316,11 +316,10 @@ public class BlockDefinitionTest {
 
   @Test
   public void getQuestionDefinitions_returnsAllQuestionsInOrder() {
-    QuestionDefinition nameQuestionId =
-        testQuestionBank.nameApplicantName().getQuestionDefinition().getId();
-    QuestionDefinition addressQuestionId =
+    long nameQuestionId = testQuestionBank.nameApplicantName().getQuestionDefinition().getId();
+    long addressQuestionId =
         testQuestionBank.addressApplicantAddress().getQuestionDefinition().getId();
-    QuestionDefinition colorQuestionId =
+    long colorQuestionId =
         testQuestionBank.textApplicantFavoriteColor().getQuestionDefinition().getId();
     BlockDefinition blockDefinition = makeBlockDefinitionWithQuestions();
 

--- a/server/test/support/ResourceCreator.java
+++ b/server/test/support/ResourceCreator.java
@@ -126,6 +126,21 @@ public class ResourceCreator {
     return enumQuestion;
   }
 
+  public QuestionModel insertRepeatedTextQuestion(String name, QuestionModel enumerator) {
+    QuestionDefinition definition =
+        new TextQuestionDefinition(
+            QuestionDefinitionConfig.builder()
+                .setName(name)
+                .setDescription("")
+                .setQuestionText(LocalizedStrings.of())
+                .setQuestionHelpText(LocalizedStrings.empty())
+                .setEnumeratorId(Optional.of(enumerator.id))
+                .build());
+    QuestionModel question = new QuestionModel(definition);
+    question.save();
+    return question;
+  }
+
   public QuestionModel insertQuestion() {
     String name = UUID.randomUUID().toString();
     QuestionDefinition definition =


### PR DESCRIPTION
### Description

Change the block validation conditions so that we don't get an enumerator mismatch error when we add the initial question.

Also, refactor the if-condition for the enumerator mismatch so that it's easier to read.

Lastly, stop relying on the index to find the enumerator question so that we don’t get any surprises if ever we switch the question order. Use the question type instead.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [ ] Added an additional reviewer as required if changes potentially affect the security of the application.
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

### Instructions for manual testing

There isn't a good way to test this manually yet because we haven't implemented initial questions.

### Issue(s) this completes

Fixes #13327 
