### PR TITLE
Extract multioption question code

### DIFF
--- a/server/app/assets/javascripts/main.ts
+++ b/server/app/assets/javascripts/main.ts
@@ -9,6 +9,7 @@
  */
 
 import {addEventListenerToElements, assertNotNull} from '@/util'
+import {MultiOptionQuestion} from '@/multi_option_question'
 
 function attachDropdown(elementId: string) {
   const dropdownId = elementId + '-dropdown'
@@ -84,126 +85,6 @@ function changeUpdateBlockButtonState() {
 }
 
 /**
- * Copy the specified hidden template and append it to the end of the parent divContainerId,
- * above the add button (addButtonId).
- * @param {string} inputTemplateId The ID of the input template to clone.
- * @param {string} addButtonId The ID of "add" button to add imput before.
- * @param {string} divContainerId The ID of the divContainer to add imput before.
-
- */
-function addNewInput(
-  inputTemplateId: string,
-  addButtonId: string,
-  divContainerId: string,
-) {
-  // Copy the answer template and remove ID and hidden properties.
-  const newField = document
-    .getElementById(inputTemplateId)!
-    .cloneNode(true) as HTMLElement
-  newField.classList.remove('hidden')
-  newField.removeAttribute('id')
-
-  // Register the click event handler for the buttons.
-  const deleteButton = newField.querySelector(
-    '.multi-option-question-field-remove-button',
-  )
-  if (deleteButton != null) {
-    deleteButton.addEventListener('click', removeInput)
-  }
-  const upButton = newField.querySelector(
-    '.multi-option-question-field-move-up-button',
-  )
-  if (upButton != null) {
-    upButton.addEventListener('click', moveMultiOptionQuestionUp)
-  }
-  const downButton = newField.querySelector(
-    '.multi-option-question-field-move-down-button',
-  )
-  if (downButton != null) {
-    downButton.addEventListener('click', moveMultiOptionQuestionDown)
-  }
-
-  // Find the add option button and insert the new option input field before it.
-  const button = document.getElementById(addButtonId)
-  document.getElementById(divContainerId)!.insertBefore(newField, button)
-}
-
-/**
- * Removes an input field and its associated elements, like the remove button. All
- * elements must be contained in a parent div.
- * @param {Event} event The event that triggered this action.
- */
-function removeInput(event: Event) {
-  // Get the parent div, which contains the input field and remove button, and remove it.
-  const clickedOption = assertNotNull(
-    (event.currentTarget as Element).parentNode,
-  ) as HTMLElement
-  clickedOption.remove()
-}
-
-/**
- * Swaps an input field and its associated elements with the one above it, if possible. All
- * elements must be contained in a parent div.
- * @param {Event} event The event that triggered this action.
- */
-function moveMultiOptionQuestionUp(event: Event) {
-  event.preventDefault()
-  const clickedOption = assertNotNull(
-    (event.currentTarget as Element).parentNode,
-  ) as HTMLElement
-
-  const parentContainer = clickedOption.parentElement
-  if (parentContainer == null) {
-    return
-  }
-
-  const options = Array.from(
-    document.querySelectorAll(
-      'div.cf-multi-option-question-option-editable:not(.hidden)',
-    ),
-  )
-  const clickedIndex = options.indexOf(clickedOption)
-
-  // If the clicked element is not the first element in the parent container,
-  // then move it up one index.
-  if (clickedIndex > 0) {
-    const previousElement = options[clickedIndex - 1]
-    parentContainer.insertBefore(clickedOption, previousElement)
-  }
-}
-
-/**
- * Swaps an input field and its associated elements with the one below it, if possible. All
- * elements must be contained in a parent div.
- * @param {Event} event The event that triggered this action.
- */
-function moveMultiOptionQuestionDown(event: Event) {
-  event.preventDefault()
-  const clickedOption = assertNotNull(
-    (event.currentTarget as Element).parentNode,
-  ) as HTMLElement
-
-  const parentContainer = clickedOption.parentElement
-  if (parentContainer == null) {
-    return
-  }
-
-  const options = Array.from(
-    document.querySelectorAll(
-      'div.cf-multi-option-question-option-editable:not(.hidden)',
-    ),
-  )
-  const clickedIndex = options.indexOf(clickedOption)
-
-  // If the clicked element is not the last element in the parent container,
-  // then move it down one index.
-  if (clickedIndex < options.length - 1) {
-    const nextElement = options[clickedIndex + 1]
-    parentContainer.insertBefore(nextElement, clickedOption)
-  }
-}
-
-/**
  * Remove line-clamp from div on click.
  *
  * NOTE: This is in no way discoverable, but it's just a temporary fix until we have a program
@@ -237,18 +118,6 @@ function attachFormDebouncers() {
         submitEl.setAttribute('disabled', '')
       })
     },
-  )
-}
-
-/**
- * Click handler for the admin question add new option button for
- * multi-option questions (checkboxes, radios, selects)
- */
-function addNewOptionHandler() {
-  addNewInput(
-    'multi-option-question-answer-template',
-    'add-new-option',
-    'question-settings',
   )
 }
 
@@ -318,12 +187,12 @@ export function init() {
     blockEditForm.addEventListener('input', changeUpdateBlockButtonState)
   }
 
-  // Configure the button on the admin question form to add more answer options
-  const questionOptionButton = document.getElementById('add-new-option')
-  if (questionOptionButton) {
-    questionOptionButton.removeEventListener('click', addNewOptionHandler)
-    questionOptionButton.addEventListener('click', addNewOptionHandler)
-  }
+  // Wire add/remove/reorder for multi-option question answers on the admin
+  // question form. The question editor is still the j2html page even when the
+  // SC migration flag is on, and no other bundle wires these handlers, so this
+  // must run unconditionally. init() is idempotent (options are tracked in a
+  // WeakSet), so there is no double-binding risk.
+  new MultiOptionQuestion().init()
 
   // Note that this formatting logic mimics QuestionDefinition.getQuestionNameKey()
   const formatQuestionName = (unformatted: string) => {
@@ -368,25 +237,6 @@ export function init() {
 
   addEventListener('resize', handleMediaQueryChange)
   handleMediaQueryChange()
-
-  // Bind click handler for remove options in multi-option edit view
-  addEventListenerToElements(
-    '.multi-option-question-field-remove-button',
-    'click',
-    removeInput,
-  )
-
-  // Bind click handler for re-arranging options in multi-option edit view
-  addEventListenerToElements(
-    '.multi-option-question-field-move-up-button',
-    'click',
-    moveMultiOptionQuestionUp,
-  )
-  addEventListenerToElements(
-    '.multi-option-question-field-move-down-button',
-    'click',
-    moveMultiOptionQuestionDown,
-  )
 
   /* Bind click handler to submit category filter form when any category is clicked
     and set the URL fragment to the most recently clicked category */

--- a/server/app/assets/javascripts/multi_option_question.ts
+++ b/server/app/assets/javascripts/multi_option_question.ts
@@ -1,0 +1,138 @@
+/**
+ * Client-side behavior for the admin multi-option question editor (checkbox,
+ * dropdown, radio): adding, removing, and reordering answer options.
+ *
+ * Shared by the legacy J2HTML page (wired in {@link module:main}) and the
+ * Thymeleaf page (wired in pages/admin/question_edit_page). Both DOMs expose the
+ * same contract: a `#multi-option-container` holding `.cf-multi-option-question-option`
+ * rows, an `#add-new-option` button, and a `<template id="multi-option-question-answer-template">`.
+ */
+export class MultiOptionQuestion {
+  private readonly containerId: string
+  private readonly templateId: string
+  private readonly addButtonId: string
+  private readonly wiredOptions = new WeakSet<Element>()
+
+  constructor(
+    containerId = 'multi-option-container',
+    templateId = 'multi-option-question-answer-template',
+    addButtonId = 'add-new-option',
+  ) {
+    this.containerId = containerId
+    this.templateId = templateId
+    this.addButtonId = addButtonId
+  }
+
+  /** Kick everything off. Call once after the DOM is ready. */
+  init() {
+    const container = document.getElementById(this.containerId)
+    if (container == null) return
+
+    // Wire server-rendered options already in the DOM.
+    container
+      .querySelectorAll('.cf-multi-option-question-option')
+      .forEach((el) => this.wireUpOptionButtons(el))
+
+    // Wire options added later (clones from the add button).
+    const observer = new MutationObserver((mutations) => {
+      for (const mutation of mutations) {
+        mutation.addedNodes.forEach((node) => {
+          if (
+            node instanceof HTMLElement &&
+            node.classList.contains('cf-multi-option-question-option')
+          ) {
+            this.wireUpOptionButtons(node)
+          }
+        })
+      }
+    })
+    observer.observe(container, {childList: true})
+
+    // Wire the "Add answer option" button.
+    document
+      .getElementById(this.addButtonId)
+      ?.addEventListener('click', this.addNewOption)
+  }
+
+  /** Clone the template and append it. The observer wires the buttons. */
+  private addNewOption = () => {
+    const template = document.getElementById(
+      this.templateId,
+    ) as HTMLTemplateElement | null
+    if (template == null) return
+
+    const newField = template.content.firstElementChild?.cloneNode(true) as
+      | HTMLDivElement
+      | undefined
+    if (newField == null) return
+
+    document.getElementById(this.containerId)?.appendChild(newField)
+  }
+
+  private wireUpOptionButtons(optionEl: Element) {
+    if (this.wiredOptions.has(optionEl)) return
+    this.wiredOptions.add(optionEl)
+
+    optionEl
+      .querySelector('.multi-option-question-field-remove-button')
+      ?.addEventListener('click', this.removeInput)
+
+    optionEl
+      .querySelector('.multi-option-question-field-move-up-button')
+      ?.addEventListener('click', this.moveUp)
+
+    optionEl
+      .querySelector('.multi-option-question-field-move-down-button')
+      ?.addEventListener('click', this.moveDown)
+  }
+
+  private removeInput = (event: Event) => {
+    const option = this.getOption(event)
+    option?.remove()
+  }
+
+  private moveUp = (event: Event) => {
+    event.preventDefault()
+    const option = this.getOption(event)
+    if (option == null) return
+
+    const parent = option.parentElement
+    if (parent == null) return
+
+    const options = this.getEditableOptions()
+    const index = options.indexOf(option)
+    if (index > 0) {
+      parent.insertBefore(option, options[index - 1])
+    }
+  }
+
+  private moveDown = (event: Event) => {
+    event.preventDefault()
+    const option = this.getOption(event)
+    if (option == null) return
+
+    const parent = option.parentElement
+    if (parent == null) return
+
+    const options = this.getEditableOptions()
+    const index = options.indexOf(option)
+    if (index < options.length - 1) {
+      parent.insertBefore(options[index + 1], option)
+    }
+  }
+
+  /** Resolve the enclosing option element from a button click. */
+  private getOption(event: Event): HTMLElement | null {
+    return (event.currentTarget as Element).closest(
+      '.cf-multi-option-question-option',
+    )
+  }
+
+  private getEditableOptions(): HTMLElement[] {
+    return Array.from(
+      document.querySelectorAll<HTMLElement>(
+        'div.cf-multi-option-question-option-editable:not(.hidden)',
+      ),
+    )
+  }
+}

--- a/server/app/views/admin/questions/QuestionConfig.java
+++ b/server/app/views/admin/questions/QuestionConfig.java
@@ -462,7 +462,7 @@ public final class QuestionConfig {
     }
 
     content
-        .with(optionsBuilder.build())
+        .with(div().withId("multi-option-container").with(optionsBuilder.build()))
         .with(
             ViewUtils.makeSvgTextButton("Add answer option", Icons.PLUS)
                 .withType("button")

--- a/server/app/views/admin/questions/QuestionEditView.java
+++ b/server/app/views/admin/questions/QuestionEditView.java
@@ -12,6 +12,7 @@ import static j2html.TagCreator.legend;
 import static j2html.TagCreator.p;
 import static j2html.TagCreator.span;
 import static j2html.TagCreator.strong;
+import static j2html.TagCreator.template;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
@@ -25,6 +26,7 @@ import j2html.tags.specialized.ButtonTag;
 import j2html.tags.specialized.DivTag;
 import j2html.tags.specialized.FieldsetTag;
 import j2html.tags.specialized.FormTag;
+import j2html.tags.specialized.TemplateTag;
 import java.util.Locale;
 import java.util.Optional;
 import models.QuestionDisplayMode;
@@ -320,17 +322,17 @@ public final class QuestionEditView extends BaseHtmlView {
         .with(multiOptionQuestionField());
   }
 
-  // A hidden template for multi-option questions.
-  private DivTag multiOptionQuestionField() {
-    return div()
+  // A <template> holding the markup for a new multi-option answer. The id lives
+  // on the <template> so the JS can clone its content (see MultiOptionQuestion);
+  // the cloned row is shown when appended, so it is not hidden here.
+  private TemplateTag multiOptionQuestionField() {
+    return template()
+        .withId("multi-option-question-answer-template")
         .with(
             QuestionConfig.multiOptionQuestionFieldTemplate(messages)
-                .withId("multi-option-question-answer-template")
-                // Add "hidden" to other classes, so that the template is not shown
                 .withClasses(
                     ReferenceClasses.MULTI_OPTION_QUESTION_OPTION,
                     ReferenceClasses.MULTI_OPTION_QUESTION_OPTION_EDITABLE,
-                    "hidden",
                     "grid",
                     "grid-cols-8",
                     "grid-rows-4",


### PR DESCRIPTION
Migrates the question new/edit related code for multioptions out of the globally shared `main.ts` file.

Makes some minor modifications to the j2html to align with the direction the thymeleaf template will take.


Related to #12428, #12429