### PR TITLE
Refactor for QuestionNotFoundException not being thrown

### DIFF
--- a/server/app/controllers/admin/AdminExportController.java
+++ b/server/app/controllers/admin/AdminExportController.java
@@ -19,7 +19,6 @@ import services.program.ProgramDefinition;
 import services.program.ProgramNotFoundException;
 import services.program.ProgramService;
 import services.question.QuestionService;
-import services.question.exceptions.QuestionNotFoundException;
 import services.question.types.QuestionDefinition;
 import views.admin.migration.AdminExportView;
 import views.admin.migration.AdminProgramExportForm;
@@ -70,15 +69,10 @@ public class AdminExportController extends CiviFormController {
     ImmutableList<QuestionDefinition> questionsUsedByProgram =
         program.getQuestionIdsInProgram().stream()
             .map(
-                questionId -> {
-                  try {
-                    return questionService
+                questionId ->
+                    questionService
                         .getReadOnlyQuestionServiceSync()
-                        .getQuestionDefinition(questionId);
-                  } catch (QuestionNotFoundException e) {
-                    throw new RuntimeException(e);
-                  }
-                })
+                        .getQuestionDefinition(questionId))
             .collect(ImmutableList.toImmutableList());
 
     ErrorAnd<String, String> serializeResult =

--- a/server/app/controllers/admin/AdminProgramBlockPredicatesController.java
+++ b/server/app/controllers/admin/AdminProgramBlockPredicatesController.java
@@ -65,8 +65,6 @@ import services.program.predicate.PredicateGenerator;
 import services.program.predicate.PredicateLogicalOperator;
 import services.program.predicate.PredicateUseCase;
 import services.program.predicate.SelectedValue;
-import services.question.QuestionService;
-import services.question.ReadOnlyQuestionService;
 import services.question.exceptions.InvalidQuestionTypeException;
 import services.question.exceptions.QuestionNotFoundException;
 import services.question.exceptions.UnsupportedQuestionTypeException;
@@ -103,7 +101,6 @@ public class AdminProgramBlockPredicatesController extends CiviFormController {
 
   private final PredicateGenerator predicateGenerator;
   private final ProgramService programService;
-  private final QuestionService questionService;
   private final ProgramPredicatesEditView legacyPredicatesEditView;
   private final ProgramPredicateConfigureView legacyPredicatesConfigureView;
   private final EditPredicatePageView editPredicatePageView;
@@ -142,7 +139,6 @@ public class AdminProgramBlockPredicatesController extends CiviFormController {
   public AdminProgramBlockPredicatesController(
       PredicateGenerator predicateGenerator,
       ProgramService programService,
-      QuestionService questionService,
       ProgramPredicatesEditView legacyPredicatesEditView,
       ProgramPredicateConfigureView legacyPredicatesConfigureView,
       EditPredicatePageView editPredicatePageView,
@@ -159,7 +155,6 @@ public class AdminProgramBlockPredicatesController extends CiviFormController {
     super(profileUtils, versionRepository);
     this.predicateGenerator = checkNotNull(predicateGenerator);
     this.programService = checkNotNull(programService);
-    this.questionService = checkNotNull(questionService);
     this.legacyPredicatesEditView = checkNotNull(legacyPredicatesEditView);
     this.legacyPredicatesConfigureView = checkNotNull(legacyPredicatesConfigureView);
     this.editPredicatePageView = checkNotNull(editPredicatePageView);
@@ -308,15 +303,11 @@ public class AdminProgramBlockPredicatesController extends CiviFormController {
   public Result updateVisibility(Request request, long programId, long blockDefinitionId) {
     requestChecker.throwIfProgramNotDraft(programId);
 
-    ReadOnlyQuestionService roQuestionService =
-        questionService.getReadOnlyQuestionService().toCompletableFuture().join();
-
     try {
       PredicateDefinition predicateDefinition =
           predicateGenerator.legacyGeneratePredicateDefinition(
               programService.getFullProgramDefinition(programId),
-              formFactory.form().bindFromRequest(request),
-              roQuestionService);
+              formFactory.form().bindFromRequest(request));
 
       programService.setBlockVisibilityPredicate(
           programId, blockDefinitionId, Optional.of(predicateDefinition));
@@ -325,9 +316,7 @@ public class AdminProgramBlockPredicatesController extends CiviFormController {
     } catch (ProgramBlockDefinitionNotFoundException e) {
       return notFound(
           String.format("Block ID %d not found for Program %d", blockDefinitionId, programId));
-    } catch (IllegalPredicateOrderingException
-        | QuestionNotFoundException
-        | ProgramQuestionDefinitionNotFoundException e) {
+    } catch (IllegalPredicateOrderingException | ProgramQuestionDefinitionNotFoundException e) {
       return redirect(
               routes.AdminProgramBlockPredicatesController.editVisibility(
                   programId, blockDefinitionId))
@@ -670,17 +659,13 @@ public class AdminProgramBlockPredicatesController extends CiviFormController {
   public Result updateEligibility(Request request, long programId, long blockDefinitionId) {
     requestChecker.throwIfProgramNotDraft(programId);
 
-    ReadOnlyQuestionService roQuestionService =
-        questionService.getReadOnlyQuestionService().toCompletableFuture().join();
-
     try {
       EligibilityDefinition eligibility =
           EligibilityDefinition.builder()
               .setPredicate(
                   predicateGenerator.legacyGeneratePredicateDefinition(
                       programService.getFullProgramDefinition(programId),
-                      formFactory.form().bindFromRequest(request),
-                      roQuestionService))
+                      formFactory.form().bindFromRequest(request)))
               .build();
 
       programService.setBlockEligibilityDefinition(
@@ -691,7 +676,6 @@ public class AdminProgramBlockPredicatesController extends CiviFormController {
       return notFound(
           String.format("Block ID %d not found for Program %d", blockDefinitionId, programId));
     } catch (IllegalPredicateOrderingException
-        | QuestionNotFoundException
         | ProgramQuestionDefinitionNotFoundException
         | EligibilityNotValidForProgramTypeException e) {
       return redirect(
@@ -788,9 +772,6 @@ public class AdminProgramBlockPredicatesController extends CiviFormController {
     }
     requestChecker.throwIfProgramNotDraft(programId);
 
-    ReadOnlyQuestionService roQuestionService =
-        questionService.getReadOnlyQuestionService().toCompletableFuture().join();
-
     try {
       DynamicForm form = formFactory.form().bindFromRequest(request);
 
@@ -820,11 +801,7 @@ public class AdminProgramBlockPredicatesController extends CiviFormController {
 
       PredicateDefinition predicateDefinition =
           predicateGenerator.generatePredicateDefinition(
-              programService.getFullProgramDefinition(programId),
-              form,
-              roQuestionService,
-              settingsManifest,
-              request);
+              programService.getFullProgramDefinition(programId), form, settingsManifest, request);
       if (predicateDefinition.getQuestions().isEmpty()) {
         // If there are no questions in the predicate, that means there are no conditions and we
         // should remove the predicate.
@@ -862,7 +839,6 @@ public class AdminProgramBlockPredicatesController extends CiviFormController {
       return notFound(
           String.format("Block ID %d not found for Program %d", blockDefinitionId, programId));
     } catch (IllegalPredicateOrderingException
-        | QuestionNotFoundException
         | ProgramQuestionDefinitionNotFoundException
         | EligibilityNotValidForProgramTypeException
         | BadRequestException e) {

--- a/server/app/controllers/admin/AdminProgramBlockQuestionsController.java
+++ b/server/app/controllers/admin/AdminProgramBlockQuestionsController.java
@@ -119,8 +119,6 @@ public class AdminProgramBlockQuestionsController extends Controller {
       return notFound(String.format("Program ID %d not found.", programId));
     } catch (ProgramBlockDefinitionNotFoundException e) {
       return notFound(String.format("Block ID %d not found for Program %d", blockId, programId));
-    } catch (QuestionNotFoundException e) {
-      return notFound(String.format("Question IDs %s not found", latestQuestionIds));
     } catch (CantAddQuestionToBlockException e) {
       return notFound(e.externalMessage());
     }
@@ -213,8 +211,6 @@ public class AdminProgramBlockQuestionsController extends Controller {
       return notFound(String.format("Program ID %d not found.", programId));
     } catch (ProgramBlockDefinitionNotFoundException e) {
       return notFound(String.format("Block ID %d not found for Program %d", blockId, programId));
-    } catch (QuestionNotFoundException e) {
-      return notFound(String.format("Question IDs %s not found", latestQuestionIds));
     } catch (CantAddQuestionToBlockException e) {
       return notFound(e.externalMessage());
     } catch (ProgramQuestionDefinitionNotFoundException e) {

--- a/server/app/controllers/admin/AdminProgramBlocksController.java
+++ b/server/app/controllers/admin/AdminProgramBlocksController.java
@@ -35,7 +35,6 @@ import services.program.ProgramNotFoundException;
 import services.program.ProgramService;
 import services.question.QuestionService;
 import services.question.ReadOnlyQuestionService;
-import services.question.exceptions.QuestionNotFoundException;
 import services.settings.SettingsManifest;
 import views.admin.programs.BlockType;
 import views.admin.programs.ProgramBlocksView;
@@ -238,7 +237,6 @@ public final class AdminProgramBlocksController extends CiviFormController {
           // Invalid question ID format, ignore and continue
         } catch (ProgramNotFoundException
             | ProgramBlockDefinitionNotFoundException
-            | QuestionNotFoundException
             | CantAddQuestionToBlockException e) {
           // If adding fails, show the block without the new question and flash an error toast
           // message

--- a/server/app/controllers/admin/AdminQuestionController.java
+++ b/server/app/controllers/admin/AdminQuestionController.java
@@ -156,12 +156,7 @@ public final class AdminQuestionController extends CiviFormController {
         .getReadOnlyQuestionService()
         .thenApplyAsync(
             readOnlyService -> {
-              QuestionDefinition questionDefinition;
-              try {
-                questionDefinition = readOnlyService.getQuestionDefinition(id);
-              } catch (QuestionNotFoundException e) {
-                return badRequest(e.toString());
-              }
+              QuestionDefinition questionDefinition = readOnlyService.getQuestionDefinition(id);
 
               Optional<QuestionDefinition> maybeEnumerationQuestion =
                   maybeGetEnumerationQuestion(readOnlyService, questionDefinition);
@@ -309,12 +304,7 @@ public final class AdminQuestionController extends CiviFormController {
         .getReadOnlyQuestionService()
         .thenApplyAsync(
             readOnlyService -> {
-              QuestionDefinition questionDefinition;
-              try {
-                questionDefinition = readOnlyService.getQuestionDefinition(id);
-              } catch (QuestionNotFoundException e) {
-                return badRequest(e.toString());
-              }
+              QuestionDefinition questionDefinition = readOnlyService.getQuestionDefinition(id);
 
               // Handle case someone tries to edit a live question that already has a draft version.
               // In this case we should redirect to the draft version.
@@ -374,12 +364,7 @@ public final class AdminQuestionController extends CiviFormController {
     ReadOnlyQuestionService roService =
         service.getReadOnlyQuestionService().toCompletableFuture().join();
 
-    Optional<QuestionDefinition> maybeExisting;
-    try {
-      maybeExisting = Optional.of(roService.getQuestionDefinition(id));
-    } catch (QuestionNotFoundException e) {
-      maybeExisting = Optional.empty();
-    }
+    Optional<QuestionDefinition> maybeExisting = Optional.of(roService.getQuestionDefinition(id));
 
     QuestionDefinition questionDefinition;
     try {
@@ -673,14 +658,7 @@ public final class AdminQuestionController extends CiviFormController {
     return questionDefinition
         .getEnumeratorId()
         .flatMap(
-            enumeratorId -> {
-              try {
-                return Optional.of(readOnlyQuestionService.getQuestionDefinition(enumeratorId));
-              } catch (QuestionNotFoundException e) {
-                throw new RuntimeException(
-                    "This repeated question's enumerator id reference does not refer to a real"
-                        + " question!");
-              }
-            });
+            enumeratorId ->
+                Optional.of(readOnlyQuestionService.getQuestionDefinition(enumeratorId)));
   }
 }

--- a/server/app/controllers/dev/seeding/DevDatabaseSeedTask.java
+++ b/server/app/controllers/dev/seeding/DevDatabaseSeedTask.java
@@ -69,7 +69,6 @@ import services.program.predicate.PredicateDefinition;
 import services.program.predicate.PredicateExpressionNode;
 import services.program.predicate.PredicateValue;
 import services.question.QuestionService;
-import services.question.exceptions.QuestionNotFoundException;
 import services.question.types.QuestionDefinition;
 import services.statuses.DuplicateStatusException;
 import services.statuses.StatusDefinitions;
@@ -220,7 +219,6 @@ public final class DevDatabaseSeedTask {
 
     } catch (ProgramNotFoundException
         | ProgramBlockDefinitionNotFoundException
-        | QuestionNotFoundException
         | CantAddQuestionToBlockException
         | ProgramQuestionDefinitionNotFoundException e) {
       throw new RuntimeException(e);
@@ -435,7 +433,6 @@ public final class DevDatabaseSeedTask {
     } catch (ProgramNotFoundException
         | ProgramBlockDefinitionNotFoundException
         | IllegalPredicateOrderingException
-        | QuestionNotFoundException
         | CantAddQuestionToBlockException
         | ProgramQuestionDefinitionNotFoundException
         | DuplicateStatusException e) {

--- a/server/app/services/program/ProgramService.java
+++ b/server/app/services/program/ProgramService.java
@@ -1611,7 +1611,6 @@ public final class ProgramService {
    * @throws ProgramNotFoundException when programId does not correspond to a real Program.
    * @throws ProgramBlockDefinitionNotFoundException when blockDefinitionId does not correspond to a
    *     real Block.
-   * @throws QuestionNotFoundException when questionIds does not correspond to real Questions.
    * @throws CantAddQuestionToBlockException if one of the questions can't be added to the block.
    */
   public ProgramDefinition addQuestionsToBlock(
@@ -1621,7 +1620,6 @@ public final class ProgramService {
       boolean enumeratorImprovementsEnabled,
       boolean fileUploadQuestionImprovementsEnabled)
       throws CantAddQuestionToBlockException,
-          QuestionNotFoundException,
           ProgramNotFoundException,
           ProgramBlockDefinitionNotFoundException {
     ProgramDefinition programDefinition = getFullProgramDefinition(programId);
@@ -1994,14 +1992,9 @@ public final class ProgramService {
                   if (programRepository.getFullProgramDefinitionFromCache(programId).isPresent()) {
                     return programRepository.getFullProgramDefinitionFromCache(programId).get();
                   }
-                  try {
-                    return syncProgramDefinitionQuestions(
-                        programDef, programToQuestionService.get(programId));
-                    /* END TEMP BUG FIX */
-                  } catch (QuestionNotFoundException e) {
-                    throw new RuntimeException(
-                        String.format("Question not found for Program %s", programDef.id()), e);
-                  }
+                  return syncProgramDefinitionQuestions(
+                      programDef, programToQuestionService.get(programId));
+                  /* END TEMP BUG FIX */
                 })
             .collect(ImmutableList.toImmutableList()));
   }
@@ -2256,34 +2249,20 @@ public final class ProgramService {
         .getReadOnlyQuestionService()
         .thenApplyAsync(
             roQuestionService -> {
-              try {
-                return syncProgramDefinitionQuestions(programDefinition, roQuestionService);
-              } catch (QuestionNotFoundException e) {
-                throw new RuntimeException(
-                    String.format("Question not found for Program %s", programDefinition.id()), e);
-              }
+              return syncProgramDefinitionQuestions(programDefinition, roQuestionService);
             },
             classLoaderExecutionContext.current());
   }
 
   private ProgramDefinition syncProgramDefinitionQuestions(
       ProgramDefinition programDefinition, VersionModel version) {
-    try {
-      return syncProgramDefinitionQuestions(
-          programDefinition,
-          questionService.getReadOnlyVersionedQuestionService(version, versionRepository));
-    } catch (QuestionNotFoundException e) {
-      throw new RuntimeException(
-          String.format(
-              "Question not found for Program %s at Version %s",
-              programDefinition.id(), version.id),
-          e);
-    }
+    return syncProgramDefinitionQuestions(
+        programDefinition,
+        questionService.getReadOnlyVersionedQuestionService(version, versionRepository));
   }
 
   private ProgramDefinition syncProgramDefinitionQuestions(
-      ProgramDefinition programDefinition, ReadOnlyQuestionService roQuestionService)
-      throws QuestionNotFoundException {
+      ProgramDefinition programDefinition, ReadOnlyQuestionService roQuestionService) {
     ProgramDefinition.Builder programDefinitionBuilder = programDefinition.toBuilder();
     ImmutableList.Builder<BlockDefinition> blockListBuilder = ImmutableList.builder();
 
@@ -2300,8 +2279,7 @@ public final class ProgramService {
   private BlockDefinition syncBlockDefinitionQuestions(
       long programDefinitionId,
       BlockDefinition blockDefinition,
-      ReadOnlyQuestionService roQuestionService)
-      throws QuestionNotFoundException {
+      ReadOnlyQuestionService roQuestionService) {
     BlockDefinition.Builder blockBuilder = blockDefinition.toBuilder();
 
     ImmutableList.Builder<ProgramQuestionDefinition> pqdListBuilder = ImmutableList.builder();
@@ -2318,8 +2296,7 @@ public final class ProgramService {
   private ProgramQuestionDefinition syncProgramQuestionDefinition(
       long programDefinitionId,
       ProgramQuestionDefinition pqd,
-      ReadOnlyQuestionService roQuestionService)
-      throws QuestionNotFoundException {
+      ReadOnlyQuestionService roQuestionService) {
     QuestionDefinition questionDefinition = roQuestionService.getQuestionDefinition(pqd.id());
     return pqd.loadCompletely(programDefinitionId, questionDefinition);
   }

--- a/server/app/services/program/predicate/PredicateGenerator.java
+++ b/server/app/services/program/predicate/PredicateGenerator.java
@@ -23,8 +23,6 @@ import services.applicant.question.Scalar;
 import services.program.ProgramDefinition;
 import services.program.ProgramQuestionDefinition;
 import services.program.ProgramQuestionDefinitionNotFoundException;
-import services.question.ReadOnlyQuestionService;
-import services.question.exceptions.QuestionNotFoundException;
 import services.settings.SettingsManifest;
 
 /** Creates {@link PredicateDefinition}s from form inputs. */
@@ -74,17 +72,11 @@ public final class PredicateGenerator {
    *
    * @param programDefinition the program this predicate is being generated for.
    * @param predicateForm contains key-value pairs specifying the predicate.
-   * @param roQuestionService a {@link ReadOnlyQuestionService} for validating that questions
-   *     referenced in the form are active or draft.
-   * @throws QuestionNotFoundException if the form references a question ID that is not in the
-   *     {@link ReadOnlyQuestionService}.
    * @throws BadRequestException if the form is invalid.
    */
   public PredicateDefinition legacyGeneratePredicateDefinition(
-      ProgramDefinition programDefinition,
-      DynamicForm predicateForm,
-      ReadOnlyQuestionService roQuestionService)
-      throws QuestionNotFoundException, ProgramQuestionDefinitionNotFoundException {
+      ProgramDefinition programDefinition, DynamicForm predicateForm)
+      throws ProgramQuestionDefinitionNotFoundException {
     final PredicateAction predicateAction;
 
     try {
@@ -96,7 +88,7 @@ public final class PredicateGenerator {
     }
 
     Multimap<Integer, LeafExpressionNode> leafNodes =
-        legacyGetLeafNodes(programDefinition, predicateForm, roQuestionService);
+        legacyGetLeafNodes(programDefinition, predicateForm);
 
     return switch (detectFormat(leafNodes)) {
       case MULTIPLE_CONDITIONS ->
@@ -134,14 +126,10 @@ public final class PredicateGenerator {
    *
    * @throws ProgramQuestionDefinitionNotFoundException if a parsed questionId is not in the {@link
    *     ProgramDefinition}
-   * @throws QuestionNotFoundException if a parsed questionId is not in the current active or draft
-   *     version.
    */
   private static Multimap<Integer, LeafExpressionNode> legacyGetLeafNodes(
-      ProgramDefinition programDefinition,
-      DynamicForm predicateForm,
-      ReadOnlyQuestionService roQuestionService)
-      throws QuestionNotFoundException, ProgramQuestionDefinitionNotFoundException {
+      ProgramDefinition programDefinition, DynamicForm predicateForm)
+      throws ProgramQuestionDefinitionNotFoundException {
     Multimap<Integer, LeafExpressionNode> leafNodes = LinkedHashMultimap.create();
     HashSet<String> consumedKeys = new HashSet<>();
 
@@ -159,8 +147,7 @@ public final class PredicateGenerator {
       final int groupId = Integer.parseInt(matcher.group(1));
       final long questionId = Long.parseLong(matcher.group(2));
 
-      // Validate the questionId - these throw exceptions
-      roQuestionService.getQuestionDefinition(questionId);
+      // Validate the questionId - throws an exception
       programDefinition.getProgramQuestionDefinition(questionId);
 
       final Scalar scalar =
@@ -270,19 +257,14 @@ public final class PredicateGenerator {
    *
    * @param programDefinition the program this predicate is being generated for.
    * @param predicateForm contains key-value pairs specifying the predicate.
-   * @param roQuestionService a {@link ReadOnlyQuestionService} for validating that questions
-   *     referenced in the form are active or draft.
-   * @throws QuestionNotFoundException if the form references a question ID that is not in the
-   *     {@link ReadOnlyQuestionService}.
    * @throws BadRequestException if the form is invalid.
    */
   public PredicateDefinition generatePredicateDefinition(
       ProgramDefinition programDefinition,
       DynamicForm predicateForm,
-      ReadOnlyQuestionService roQuestionService,
       SettingsManifest settingsManifest,
       Request request)
-      throws QuestionNotFoundException, ProgramQuestionDefinitionNotFoundException {
+      throws ProgramQuestionDefinitionNotFoundException {
     if (!settingsManifest.getExpandedFormLogicEnabled(request)) {
       throw new BadRequestException("Expanded form logic is not enabled for this request.");
     }
@@ -297,7 +279,7 @@ public final class PredicateGenerator {
     }
 
     Map<Integer, Map<Integer, PredicateExpressionNode>> leafNodes =
-        getLeafNodes(programDefinition, predicateForm, roQuestionService);
+        getLeafNodes(programDefinition, predicateForm);
 
     // Single leaf node predicate
     if (leafNodes.size() == 1 && leafNodes.values().iterator().next().size() == 1) {
@@ -337,14 +319,10 @@ public final class PredicateGenerator {
    *
    * @throws ProgramQuestionDefinitionNotFoundException if a parsed questionId is not in the {@link
    *     ProgramDefinition}
-   * @throws QuestionNotFoundException if a parsed questionId is not in the current active or draft
-   *     version.
    */
   private static Map<Integer, Map<Integer, PredicateExpressionNode>> getLeafNodes(
-      ProgramDefinition programDefinition,
-      DynamicForm predicateForm,
-      ReadOnlyQuestionService roQuestionService)
-      throws QuestionNotFoundException, ProgramQuestionDefinitionNotFoundException {
+      ProgramDefinition programDefinition, DynamicForm predicateForm)
+      throws ProgramQuestionDefinitionNotFoundException {
     Map<Integer, Map<Integer, PredicateExpressionNode>> leafNodes = new HashMap<>();
     HashSet<String> processedFormKeys = new HashSet<>();
 
@@ -366,8 +344,7 @@ public final class PredicateGenerator {
       int subconditionId = Integer.parseInt(matcher.group(2));
       long questionId = getQuestionId(predicateForm, conditionId, subconditionId);
 
-      // Validate the questionId - these throw exceptions
-      roQuestionService.getQuestionDefinition(questionId);
+      // Validate the questionId - throws an exception
       ProgramQuestionDefinition questionDefinition =
           programDefinition.getProgramQuestionDefinition(questionId);
 

--- a/server/app/services/question/ReadOnlyCurrentQuestionServiceImpl.java
+++ b/server/app/services/question/ReadOnlyCurrentQuestionServiceImpl.java
@@ -10,7 +10,6 @@ import models.VersionModel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import repository.VersionRepository;
-import services.question.exceptions.QuestionNotFoundException;
 import services.question.types.EnumeratorQuestionDefinition;
 import services.question.types.NullQuestionDefinition;
 import services.question.types.QuestionDefinition;
@@ -92,7 +91,7 @@ public final class ReadOnlyCurrentQuestionServiceImpl implements ReadOnlyQuestio
   }
 
   @Override
-  public QuestionDefinition getQuestionDefinition(long id) throws QuestionNotFoundException {
+  public QuestionDefinition getQuestionDefinition(long id) {
     if (questionsById.containsKey(id)) {
       return questionsById.get(id);
     }

--- a/server/app/services/question/ReadOnlyQuestionService.java
+++ b/server/app/services/question/ReadOnlyQuestionService.java
@@ -1,7 +1,6 @@
 package services.question;
 
 import com.google.common.collect.ImmutableList;
-import services.question.exceptions.QuestionNotFoundException;
 import services.question.types.EnumeratorQuestionDefinition;
 import services.question.types.QuestionDefinition;
 
@@ -26,10 +25,6 @@ public interface ReadOnlyQuestionService {
   /** Get the data object about the questions that are in the active or draft version. */
   ActiveAndDraftQuestions getActiveAndDraftQuestions();
 
-  /**
-   * Gets the question definition for a ID.
-   *
-   * @throws QuestionNotFoundException if the question for the ID does not exist.
-   */
-  QuestionDefinition getQuestionDefinition(long id) throws QuestionNotFoundException;
+  /** Gets the question definition for an ID. */
+  QuestionDefinition getQuestionDefinition(long id);
 }

--- a/server/app/services/question/ReadOnlyVersionedQuestionServiceImpl.java
+++ b/server/app/services/question/ReadOnlyVersionedQuestionServiceImpl.java
@@ -6,7 +6,6 @@ import models.VersionModel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import repository.VersionRepository;
-import services.question.exceptions.QuestionNotFoundException;
 import services.question.types.EnumeratorQuestionDefinition;
 import services.question.types.NullQuestionDefinition;
 import services.question.types.QuestionDefinition;
@@ -63,7 +62,7 @@ public final class ReadOnlyVersionedQuestionServiceImpl implements ReadOnlyQuest
   }
 
   @Override
-  public QuestionDefinition getQuestionDefinition(long id) throws QuestionNotFoundException {
+  public QuestionDefinition getQuestionDefinition(long id) {
     if (questionsById.containsKey(id)) {
       return questionsById.get(id);
     }

--- a/server/test/controllers/admin/AdminProgramBlockPredicatesControllerTest.java
+++ b/server/test/controllers/admin/AdminProgramBlockPredicatesControllerTest.java
@@ -43,7 +43,6 @@ import services.program.predicate.PredicateExpressionNode;
 import services.program.predicate.PredicateGenerator;
 import services.program.predicate.PredicateUseCase;
 import services.program.predicate.PredicateValue;
-import services.question.QuestionService;
 import services.settings.SettingsManifest;
 import support.ProgramBuilder;
 import views.admin.programs.ProgramPredicateConfigureView;
@@ -86,7 +85,6 @@ public class AdminProgramBlockPredicatesControllerTest extends ResetPostgres {
         new AdminProgramBlockPredicatesController(
             instanceOf(PredicateGenerator.class),
             instanceOf(ProgramService.class),
-            instanceOf(QuestionService.class),
             instanceOf(ProgramPredicatesEditView.class),
             instanceOf(ProgramPredicateConfigureView.class),
             instanceOf(EditPredicatePageView.class),

--- a/server/test/services/program/predicate/PredicateGeneratorTest.java
+++ b/server/test/services/program/predicate/PredicateGeneratorTest.java
@@ -22,11 +22,9 @@ import play.data.FormFactory;
 import repository.ResetPostgres;
 import services.applicant.question.Scalar;
 import services.program.ProgramDefinition;
-import services.question.ReadOnlyQuestionService;
-import services.question.exceptions.QuestionNotFoundException;
+import services.program.ProgramQuestionDefinitionNotFoundException;
 import services.settings.SettingsManifest;
 import support.CfTestHelpers;
-import support.FakeReadOnlyQuestionService;
 import support.ProgramBuilder;
 import support.TestQuestionBank;
 
@@ -45,13 +43,6 @@ public class PredicateGeneratorTest extends ResetPostgres {
           .withBlock()
           .withRequiredQuestion(testQuestionBank.checkboxApplicantKitchenTools())
           .buildDefinition();
-  private ReadOnlyQuestionService readOnlyQuestionService =
-      new FakeReadOnlyQuestionService(
-          ImmutableList.of(
-              testQuestionBank.numberApplicantJugglingNumber().getQuestionDefinition(),
-              testQuestionBank.addressApplicantAddress().getQuestionDefinition(),
-              testQuestionBank.dateApplicantBirthdate().getQuestionDefinition(),
-              testQuestionBank.checkboxApplicantKitchenTools().getQuestionDefinition()));
 
   @Before
   public void setUp() {
@@ -94,9 +85,8 @@ public class PredicateGeneratorTest extends ResetPostgres {
     PredicateDefinition predicateDefinition =
         expandedFormLogicEnabled
             ? predicateGenerator.generatePredicateDefinition(
-                programDefinition, form, readOnlyQuestionService, settingsManifest, fakeRequest())
-            : predicateGenerator.legacyGeneratePredicateDefinition(
-                programDefinition, form, readOnlyQuestionService);
+                programDefinition, form, settingsManifest, fakeRequest())
+            : predicateGenerator.legacyGeneratePredicateDefinition(programDefinition, form);
 
     assertThat(predicateDefinition.predicateFormat())
         .isEqualTo(PredicateDefinition.PredicateFormat.SINGLE_CONDITION);
@@ -152,9 +142,8 @@ public class PredicateGeneratorTest extends ResetPostgres {
     PredicateDefinition predicateDefinition =
         expandedFormLogicEnabled
             ? predicateGenerator.generatePredicateDefinition(
-                programDefinition, form, readOnlyQuestionService, settingsManifest, fakeRequest())
-            : predicateGenerator.legacyGeneratePredicateDefinition(
-                programDefinition, form, readOnlyQuestionService);
+                programDefinition, form, settingsManifest, fakeRequest())
+            : predicateGenerator.legacyGeneratePredicateDefinition(programDefinition, form);
 
     assertThat(predicateDefinition.predicateFormat())
         .isEqualTo(PredicateDefinition.PredicateFormat.SINGLE_CONDITION);
@@ -210,9 +199,8 @@ public class PredicateGeneratorTest extends ResetPostgres {
     PredicateDefinition predicateDefinition =
         expandedFormLogicEnabled
             ? predicateGenerator.generatePredicateDefinition(
-                programDefinition, form, readOnlyQuestionService, settingsManifest, fakeRequest())
-            : predicateGenerator.legacyGeneratePredicateDefinition(
-                programDefinition, form, readOnlyQuestionService);
+                programDefinition, form, settingsManifest, fakeRequest())
+            : predicateGenerator.legacyGeneratePredicateDefinition(programDefinition, form);
 
     assertThat(predicateDefinition.predicateFormat())
         .isEqualTo(PredicateDefinition.PredicateFormat.SINGLE_CONDITION);
@@ -265,9 +253,8 @@ public class PredicateGeneratorTest extends ResetPostgres {
     PredicateDefinition predicateDefinition =
         expandedFormLogicEnabled
             ? predicateGenerator.generatePredicateDefinition(
-                programDefinition, form, readOnlyQuestionService, settingsManifest, fakeRequest())
-            : predicateGenerator.legacyGeneratePredicateDefinition(
-                programDefinition, form, readOnlyQuestionService);
+                programDefinition, form, settingsManifest, fakeRequest())
+            : predicateGenerator.legacyGeneratePredicateDefinition(programDefinition, form);
 
     assertThat(predicateDefinition.predicateFormat())
         .isEqualTo(PredicateDefinition.PredicateFormat.SINGLE_CONDITION);
@@ -323,9 +310,8 @@ public class PredicateGeneratorTest extends ResetPostgres {
     PredicateDefinition predicateDefinition =
         expandedFormLogicEnabled
             ? predicateGenerator.generatePredicateDefinition(
-                programDefinition, form, readOnlyQuestionService, settingsManifest, fakeRequest())
-            : predicateGenerator.legacyGeneratePredicateDefinition(
-                programDefinition, form, readOnlyQuestionService);
+                programDefinition, form, settingsManifest, fakeRequest())
+            : predicateGenerator.legacyGeneratePredicateDefinition(programDefinition, form);
 
     assertThat(predicateDefinition.predicateFormat())
         .isEqualTo(PredicateDefinition.PredicateFormat.SINGLE_CONDITION);
@@ -376,9 +362,8 @@ public class PredicateGeneratorTest extends ResetPostgres {
     PredicateDefinition predicateDefinition =
         expandedFormLogicEnabled
             ? predicateGenerator.generatePredicateDefinition(
-                programDefinition, form, readOnlyQuestionService, settingsManifest, fakeRequest())
-            : predicateGenerator.legacyGeneratePredicateDefinition(
-                programDefinition, form, readOnlyQuestionService);
+                programDefinition, form, settingsManifest, fakeRequest())
+            : predicateGenerator.legacyGeneratePredicateDefinition(programDefinition, form);
 
     assertThat(predicateDefinition.predicateFormat())
         .isEqualTo(PredicateDefinition.PredicateFormat.SINGLE_CONDITION);
@@ -429,9 +414,8 @@ public class PredicateGeneratorTest extends ResetPostgres {
     PredicateDefinition predicateDefinition =
         expandedFormLogicEnabled
             ? predicateGenerator.generatePredicateDefinition(
-                programDefinition, form, readOnlyQuestionService, settingsManifest, fakeRequest())
-            : predicateGenerator.legacyGeneratePredicateDefinition(
-                programDefinition, form, readOnlyQuestionService);
+                programDefinition, form, settingsManifest, fakeRequest())
+            : predicateGenerator.legacyGeneratePredicateDefinition(programDefinition, form);
 
     assertThat(predicateDefinition.predicateFormat())
         .isEqualTo(PredicateDefinition.PredicateFormat.SINGLE_CONDITION);
@@ -482,9 +466,8 @@ public class PredicateGeneratorTest extends ResetPostgres {
     PredicateDefinition predicateDefinition =
         expandedFormLogicEnabled
             ? predicateGenerator.generatePredicateDefinition(
-                programDefinition, form, readOnlyQuestionService, settingsManifest, fakeRequest())
-            : predicateGenerator.legacyGeneratePredicateDefinition(
-                programDefinition, form, readOnlyQuestionService);
+                programDefinition, form, settingsManifest, fakeRequest())
+            : predicateGenerator.legacyGeneratePredicateDefinition(programDefinition, form);
 
     assertThat(predicateDefinition.predicateFormat())
         .isEqualTo(PredicateDefinition.PredicateFormat.SINGLE_CONDITION);
@@ -533,9 +516,8 @@ public class PredicateGeneratorTest extends ResetPostgres {
     PredicateDefinition predicateDefinition =
         expandedFormLogicEnabled
             ? predicateGenerator.generatePredicateDefinition(
-                programDefinition, form, readOnlyQuestionService, settingsManifest, fakeRequest())
-            : predicateGenerator.legacyGeneratePredicateDefinition(
-                programDefinition, form, readOnlyQuestionService);
+                programDefinition, form, settingsManifest, fakeRequest())
+            : predicateGenerator.legacyGeneratePredicateDefinition(programDefinition, form);
 
     assertThat(predicateDefinition.predicateFormat())
         .isEqualTo(PredicateDefinition.PredicateFormat.SINGLE_CONDITION);
@@ -591,9 +573,8 @@ public class PredicateGeneratorTest extends ResetPostgres {
     PredicateDefinition predicateDefinition =
         expandedFormLogicEnabled
             ? predicateGenerator.generatePredicateDefinition(
-                programDefinition, form, readOnlyQuestionService, settingsManifest, fakeRequest())
-            : predicateGenerator.legacyGeneratePredicateDefinition(
-                programDefinition, form, readOnlyQuestionService);
+                programDefinition, form, settingsManifest, fakeRequest())
+            : predicateGenerator.legacyGeneratePredicateDefinition(programDefinition, form);
 
     assertThat(predicateDefinition.predicateFormat())
         .isEqualTo(PredicateDefinition.PredicateFormat.SINGLE_CONDITION);
@@ -644,9 +625,8 @@ public class PredicateGeneratorTest extends ResetPostgres {
     PredicateDefinition predicateDefinition =
         expandedFormLogicEnabled
             ? predicateGenerator.generatePredicateDefinition(
-                programDefinition, form, readOnlyQuestionService, settingsManifest, fakeRequest())
-            : predicateGenerator.legacyGeneratePredicateDefinition(
-                programDefinition, form, readOnlyQuestionService);
+                programDefinition, form, settingsManifest, fakeRequest())
+            : predicateGenerator.legacyGeneratePredicateDefinition(programDefinition, form);
 
     assertThat(predicateDefinition.predicateFormat())
         .isEqualTo(PredicateDefinition.PredicateFormat.SINGLE_CONDITION);
@@ -697,9 +677,8 @@ public class PredicateGeneratorTest extends ResetPostgres {
     PredicateDefinition predicateDefinition =
         expandedFormLogicEnabled
             ? predicateGenerator.generatePredicateDefinition(
-                programDefinition, form, readOnlyQuestionService, settingsManifest, fakeRequest())
-            : predicateGenerator.legacyGeneratePredicateDefinition(
-                programDefinition, form, readOnlyQuestionService);
+                programDefinition, form, settingsManifest, fakeRequest())
+            : predicateGenerator.legacyGeneratePredicateDefinition(programDefinition, form);
 
     assertThat(predicateDefinition.predicateFormat())
         .isEqualTo(PredicateDefinition.PredicateFormat.SINGLE_CONDITION);
@@ -757,9 +736,8 @@ public class PredicateGeneratorTest extends ResetPostgres {
     PredicateDefinition predicateDefinition =
         expandedFormLogicEnabled
             ? predicateGenerator.generatePredicateDefinition(
-                programDefinition, form, readOnlyQuestionService, settingsManifest, fakeRequest())
-            : predicateGenerator.legacyGeneratePredicateDefinition(
-                programDefinition, form, readOnlyQuestionService);
+                programDefinition, form, settingsManifest, fakeRequest())
+            : predicateGenerator.legacyGeneratePredicateDefinition(programDefinition, form);
 
     assertThat(predicateDefinition.predicateFormat())
         .isEqualTo(PredicateDefinition.PredicateFormat.SINGLE_CONDITION);
@@ -851,9 +829,8 @@ public class PredicateGeneratorTest extends ResetPostgres {
     PredicateDefinition predicateDefinition =
         expandedFormLogicEnabled
             ? predicateGenerator.generatePredicateDefinition(
-                programDefinition, form, readOnlyQuestionService, settingsManifest, fakeRequest())
-            : predicateGenerator.legacyGeneratePredicateDefinition(
-                programDefinition, form, readOnlyQuestionService);
+                programDefinition, form, settingsManifest, fakeRequest())
+            : predicateGenerator.legacyGeneratePredicateDefinition(programDefinition, form);
 
     assertThat(predicateDefinition.predicateFormat())
         .isEqualTo(PredicateDefinition.PredicateFormat.MULTIPLE_CONDITIONS);
@@ -939,7 +916,7 @@ public class PredicateGeneratorTest extends ResetPostgres {
 
     PredicateDefinition predicateDefinition =
         predicateGenerator.generatePredicateDefinition(
-            programDefinition, form, readOnlyQuestionService, settingsManifest, fakeRequest());
+            programDefinition, form, settingsManifest, fakeRequest());
 
     assertThat(predicateDefinition.predicateFormat())
         .isEqualTo(PredicateDefinition.PredicateFormat.MULTIPLE_CONDITIONS);
@@ -1012,7 +989,7 @@ public class PredicateGeneratorTest extends ResetPostgres {
 
     PredicateDefinition predicateDefinition =
         predicateGenerator.generatePredicateDefinition(
-            programDefinition, form, readOnlyQuestionService, settingsManifest, fakeRequest());
+            programDefinition, form, settingsManifest, fakeRequest());
 
     assertThat(predicateDefinition.predicateFormat())
         .isEqualTo(PredicateDefinition.PredicateFormat.SINGLE_CONDITION);
@@ -1069,7 +1046,7 @@ public class PredicateGeneratorTest extends ResetPostgres {
 
     PredicateDefinition predicateDefinition =
         predicateGenerator.generatePredicateDefinition(
-            programDefinition, form, readOnlyQuestionService, settingsManifest, fakeRequest());
+            programDefinition, form, settingsManifest, fakeRequest());
 
     assertThat(predicateDefinition.predicateFormat())
         .isEqualTo(PredicateDefinition.PredicateFormat.MULTIPLE_CONDITIONS);
@@ -1142,9 +1119,8 @@ public class PredicateGeneratorTest extends ResetPostgres {
     PredicateDefinition predicateDefinition =
         expandedFormLogicEnabled
             ? predicateGenerator.generatePredicateDefinition(
-                programDefinition, form, readOnlyQuestionService, settingsManifest, fakeRequest())
-            : predicateGenerator.legacyGeneratePredicateDefinition(
-                programDefinition, form, readOnlyQuestionService);
+                programDefinition, form, settingsManifest, fakeRequest())
+            : predicateGenerator.legacyGeneratePredicateDefinition(programDefinition, form);
 
     assertThat(predicateDefinition.predicateFormat())
         .isEqualTo(PredicateDefinition.PredicateFormat.SINGLE_CONDITION);
@@ -1182,9 +1158,7 @@ public class PredicateGeneratorTest extends ResetPostgres {
                 "seattle"));
 
     assertThatThrownBy(
-            () ->
-                predicateGenerator.legacyGeneratePredicateDefinition(
-                    programDefinition, form, readOnlyQuestionService))
+            () -> predicateGenerator.legacyGeneratePredicateDefinition(programDefinition, form))
         .isInstanceOf(BadRequestException.class);
   }
 
@@ -1205,11 +1179,7 @@ public class PredicateGeneratorTest extends ResetPostgres {
     assertThatThrownBy(
             () ->
                 predicateGenerator.generatePredicateDefinition(
-                    programDefinition,
-                    form,
-                    readOnlyQuestionService,
-                    settingsManifest,
-                    fakeRequest()))
+                    programDefinition, form, settingsManifest, fakeRequest()))
         .isInstanceOf(BadRequestException.class);
   }
 
@@ -1230,10 +1200,8 @@ public class PredicateGeneratorTest extends ResetPostgres {
                 "98144"));
 
     assertThatThrownBy(
-            () ->
-                predicateGenerator.legacyGeneratePredicateDefinition(
-                    programDefinition, form, readOnlyQuestionService))
-        .isInstanceOf(QuestionNotFoundException.class);
+            () -> predicateGenerator.legacyGeneratePredicateDefinition(programDefinition, form))
+        .isInstanceOf(ProgramQuestionDefinitionNotFoundException.class);
   }
 
   @Test
@@ -1252,12 +1220,8 @@ public class PredicateGeneratorTest extends ResetPostgres {
     assertThatThrownBy(
             () ->
                 predicateGenerator.generatePredicateDefinition(
-                    programDefinition,
-                    form,
-                    readOnlyQuestionService,
-                    settingsManifest,
-                    fakeRequest()))
-        .isInstanceOf(QuestionNotFoundException.class);
+                    programDefinition, form, settingsManifest, fakeRequest()))
+        .isInstanceOf(ProgramQuestionDefinitionNotFoundException.class);
   }
 
   @Test
@@ -1279,9 +1243,7 @@ public class PredicateGeneratorTest extends ResetPostgres {
                 "98144"));
 
     assertThatThrownBy(
-            () ->
-                predicateGenerator.legacyGeneratePredicateDefinition(
-                    programDefinition, form, readOnlyQuestionService))
+            () -> predicateGenerator.legacyGeneratePredicateDefinition(programDefinition, form))
         .isInstanceOf(BadRequestException.class);
   }
 
@@ -1301,11 +1263,7 @@ public class PredicateGeneratorTest extends ResetPostgres {
     assertThatThrownBy(
             () ->
                 predicateGenerator.generatePredicateDefinition(
-                    programDefinition,
-                    form,
-                    readOnlyQuestionService,
-                    settingsManifest,
-                    fakeRequest()))
+                    programDefinition, form, settingsManifest, fakeRequest()))
         .isInstanceOf(BadRequestException.class);
   }
 
@@ -1325,9 +1283,7 @@ public class PredicateGeneratorTest extends ResetPostgres {
                 "1"));
 
     assertThatThrownBy(
-            () ->
-                predicateGenerator.legacyGeneratePredicateDefinition(
-                    programDefinition, form, readOnlyQuestionService))
+            () -> predicateGenerator.legacyGeneratePredicateDefinition(programDefinition, form))
         .isInstanceOf(BadRequestException.class);
   }
 
@@ -1346,11 +1302,7 @@ public class PredicateGeneratorTest extends ResetPostgres {
     assertThatThrownBy(
             () ->
                 predicateGenerator.generatePredicateDefinition(
-                    programDefinition,
-                    form,
-                    readOnlyQuestionService,
-                    settingsManifest,
-                    fakeRequest()))
+                    programDefinition, form, settingsManifest, fakeRequest()))
         .isInstanceOf(BadRequestException.class);
   }
 
@@ -1373,9 +1325,7 @@ public class PredicateGeneratorTest extends ResetPostgres {
                 "1"));
 
     assertThatThrownBy(
-            () ->
-                predicateGenerator.legacyGeneratePredicateDefinition(
-                    programDefinition, form, readOnlyQuestionService))
+            () -> predicateGenerator.legacyGeneratePredicateDefinition(programDefinition, form))
         .isInstanceOf(BadRequestException.class);
   }
 
@@ -1395,11 +1345,7 @@ public class PredicateGeneratorTest extends ResetPostgres {
     assertThatThrownBy(
             () ->
                 predicateGenerator.generatePredicateDefinition(
-                    programDefinition,
-                    form,
-                    readOnlyQuestionService,
-                    settingsManifest,
-                    fakeRequest()))
+                    programDefinition, form, settingsManifest, fakeRequest()))
         .isInstanceOf(BadRequestException.class);
   }
 
@@ -1418,9 +1364,7 @@ public class PredicateGeneratorTest extends ResetPostgres {
                 "1"));
 
     assertThatThrownBy(
-            () ->
-                predicateGenerator.legacyGeneratePredicateDefinition(
-                    programDefinition, form, readOnlyQuestionService))
+            () -> predicateGenerator.legacyGeneratePredicateDefinition(programDefinition, form))
         .isInstanceOf(BadRequestException.class);
   }
 
@@ -1439,11 +1383,7 @@ public class PredicateGeneratorTest extends ResetPostgres {
     assertThatThrownBy(
             () ->
                 predicateGenerator.generatePredicateDefinition(
-                    programDefinition,
-                    form,
-                    readOnlyQuestionService,
-                    settingsManifest,
-                    fakeRequest()))
+                    programDefinition, form, settingsManifest, fakeRequest()))
         .isInstanceOf(BadRequestException.class);
   }
 
@@ -1466,9 +1406,7 @@ public class PredicateGeneratorTest extends ResetPostgres {
                 "98144"));
 
     assertThatThrownBy(
-            () ->
-                predicateGenerator.legacyGeneratePredicateDefinition(
-                    programDefinition, form, readOnlyQuestionService))
+            () -> predicateGenerator.legacyGeneratePredicateDefinition(programDefinition, form))
         .isInstanceOf(BadRequestException.class);
   }
 
@@ -1488,11 +1426,7 @@ public class PredicateGeneratorTest extends ResetPostgres {
     assertThatThrownBy(
             () ->
                 predicateGenerator.generatePredicateDefinition(
-                    programDefinition,
-                    form,
-                    readOnlyQuestionService,
-                    settingsManifest,
-                    fakeRequest()))
+                    programDefinition, form, settingsManifest, fakeRequest()))
         .isInstanceOf(BadRequestException.class);
   }
 

--- a/server/test/support/FakeReadOnlyQuestionService.java
+++ b/server/test/support/FakeReadOnlyQuestionService.java
@@ -3,8 +3,8 @@ package support;
 import com.google.common.collect.ImmutableList;
 import services.question.ActiveAndDraftQuestions;
 import services.question.ReadOnlyQuestionService;
-import services.question.exceptions.QuestionNotFoundException;
 import services.question.types.EnumeratorQuestionDefinition;
+import services.question.types.NullQuestionDefinition;
 import services.question.types.QuestionDefinition;
 
 /** Wraps a list of {@link QuestionDefinition}s for testing purposes. */
@@ -45,10 +45,10 @@ public class FakeReadOnlyQuestionService implements ReadOnlyQuestionService {
   }
 
   @Override
-  public QuestionDefinition getQuestionDefinition(long id) throws QuestionNotFoundException {
+  public QuestionDefinition getQuestionDefinition(long id) {
     return questions.stream()
         .filter(qd -> qd.getId() == id)
         .findAny()
-        .orElseThrow(() -> new QuestionNotFoundException(id));
+        .orElseGet(() -> new NullQuestionDefinition(id));
   }
 }


### PR DESCRIPTION
### Description

Although the `ReadOnlyQuestionService.getQuestionDefinition` method signature declared `throws QuestionNotFoundException`, both production implementations did not actually throw a `QuestionNotFoundException`.  The testing implementation `FakeReadOnlyQuestionService` did throw the exception, but that resulted in an inconsistency between our testing context and our production context.  

I removed the `throws` declaration from all implementations and modified the test implementation to return a `NullQuestionDefinition`, which mimics what both production implementations do.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [ ] Added an additional reviewer as required if changes potentially affect the security of the application.
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

