### PR TITLE
[Enumerators] Add program import validation for new-flow enums.

### DIFF
--- a/server/app/services/migration/ProgramMigrationService.java
+++ b/server/app/services/migration/ProgramMigrationService.java
@@ -175,6 +175,7 @@ public final class ProgramMigrationService {
         .addAll(
             QuestionValidationUtils.validateRepeatedQuestions(
                 program, questions, existingAdminNames))
+        .addAll(QuestionValidationUtils.validateNewFlowEnumerators(questions, existingAdminNames))
         .build();
   }
 

--- a/server/app/services/migration/QuestionValidationUtils.java
+++ b/server/app/services/migration/QuestionValidationUtils.java
@@ -186,9 +186,8 @@ final class QuestionValidationUtils {
    *   <li>1. The question identified by {@code enumeratorInitialQuestionId} has an {@code
    *       enumeratorId} set to the enumerator's ID.
    *   <li>2. The enumerator and initial question must both be only present newly in the import or
-   *       pre-existing in the question bank, they can't be mixed between the two as it would
-   *       change the semantics of which ever is in the question bank and that may break existing
-   *       uses.
+   *       pre-existing in the question bank, they can't be mixed between the two as it would change
+   *       the semantics of which ever is in the question bank and that may break existing uses.
    * </ul>
    */
   static ImmutableSet<CiviFormError> validateNewFlowEnumerators(

--- a/server/app/services/migration/QuestionValidationUtils.java
+++ b/server/app/services/migration/QuestionValidationUtils.java
@@ -180,9 +180,8 @@ final class QuestionValidationUtils {
    *
    * <ul>
    *   <li>1. Only enumerators can have an initial question.
-   *   <li>2. Only the initial question must be in the import and not an enumerator.
-   *   <li>3. The question identified by {@code enumeratorInitialQuestionId} has an {@code
-   *       enumeratorId} set to the enumerator's ID.
+   *   <li>2. The initial question must be in the import and not an enumerator.
+   *   <li>3. The initial question has an {@code enumeratorId} set to the enumerator's ID.
    *   <li>4. The enumerator and initial question must both be only present newly in the import or
    *       pre-existing in the question bank, they can't be mixed between the two as it would change
    *       the semantics of which ever is in the question bank and that may break existing uses.

--- a/server/app/services/migration/QuestionValidationUtils.java
+++ b/server/app/services/migration/QuestionValidationUtils.java
@@ -3,6 +3,8 @@ package services.migration;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import java.util.HashSet;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -103,12 +105,15 @@ final class QuestionValidationUtils {
   /**
    * Ensures that repeated questions (1) each have an associated enumerator, and (2) only exists in
    * the question bank if the associated enumerator also already exists in the question bank.
+   *
+   * <p>Note: This in effect only validates old-flow enums for backwards compatibility, however
+   * these checks are also necessary and complementary for the new-flow, such as ensuring the
+   * enumerator is in the program.
    */
   static ImmutableSet<CiviFormError> validateRepeatedQuestions(
       ProgramDefinition program,
       ImmutableList<QuestionDefinition> questions,
       ImmutableList<String> existingAdminNames) {
-    // TODO(#13445): Support enumeratorInitialQuestionId for the new flow.
     ImmutableMap<QuestionDefinition, Optional<QuestionDefinition>> repeatedQsToEnumerators =
         questions.stream()
             .filter(q -> q.getEnumeratorId().isPresent())
@@ -121,15 +126,18 @@ final class QuestionValidationUtils {
                             .findFirst()));
     ImmutableSet.Builder<CiviFormError> errors = ImmutableSet.builder();
     ImmutableSet.Builder<String> repeatedQsMissingEnumeratorsBuilder = ImmutableSet.builder();
-    // First we check that all repeated questions have an enumerator
+    // Check that all repeated questions have an enumerator set.
     repeatedQsMissingEnumeratorsBuilder.addAll(
-        repeatedQsToEnumerators.keySet().stream()
-            .filter(q -> !repeatedQsToEnumerators.get(q).isPresent())
+        repeatedQsToEnumerators.entrySet().stream()
+            .filter(e -> e.getValue().isEmpty())
+            .map(Map.Entry::getKey)
             .map(QuestionDefinition::getName)
             .collect(ImmutableSet.toImmutableSet()));
+    // Check that the enumerator IDs are present in the program.
+    HashSet<Long> programQuestionIds = new HashSet<>(program.getQuestionIdsInProgram());
     repeatedQsMissingEnumeratorsBuilder.addAll(
         repeatedQsToEnumerators.keySet().stream()
-            .filter(q -> !program.getQuestionIdsInProgram().contains(q.getEnumeratorId().get()))
+            .filter(q -> !programQuestionIds.contains(q.getEnumeratorId().get()))
             .map(QuestionDefinition::getName)
             .collect(ImmutableSet.toImmutableSet()));
     ImmutableSet<String> repeatedQsMissingEnumerators = repeatedQsMissingEnumeratorsBuilder.build();
@@ -138,10 +146,10 @@ final class QuestionValidationUtils {
           CiviFormError.of(
               "Some repeated questions reference enumerators that could not be found in the program"
                   + " and/or question definitions: "
-                  + repeatedQsMissingEnumerators.stream().collect(Collectors.joining(", "))));
+                  + String.join(", ", repeatedQsMissingEnumerators)));
     }
-    // Then we check that repeated questions only exist in the question bank if their enumerator
-    // does too
+    // Check that repeated questions only exist in the question bank if their enumerator
+    // does too.
     ImmutableList<QuestionDefinition> repeatedQsAlreadyExistWithoutExistingEnumerators =
         repeatedQsToEnumerators.keySet().stream()
             .filter(
@@ -161,6 +169,102 @@ final class QuestionValidationUtils {
                       .collect(Collectors.joining(", "))));
     }
 
+    return errors.build();
+  }
+
+  /**
+   * Validates that new-flow enumerators (circa Q3 2026) are correctly configured.
+   *
+   * <p>New-flow enumerators are identified by enumerators with {@code enumeratorInitialQuestionId}
+   * set.
+   *
+   * <p>Validation:
+   *
+   * <ul>
+   *   <li>1. The question identified by {@code enumeratorInitialQuestionId} has an {@code
+   *       enumeratorId} set to the enumerator's ID.
+   *   <li>2. The enumerator and initial question must both be only present newly in the import or
+   *       pre-existing in the question bank, they can't be mixed between the two. as it would
+   *       change the semantics of which ever is in the question bank and that may break existing
+   *       uses.
+   * </ul>
+   */
+  static ImmutableSet<CiviFormError> validateNewFlowEnumerators(
+      ImmutableList<QuestionDefinition> questions, ImmutableList<String> existingAdminNames) {
+    ImmutableMap<Long, QuestionDefinition> questionsById =
+        questions.stream().collect(ImmutableMap.toImmutableMap(QuestionDefinition::getId, q -> q));
+    ImmutableSet.Builder<CiviFormError> errors = ImmutableSet.builder();
+    for (QuestionDefinition question : questions) {
+      Optional<Long> maybeInitialQuestionId = question.getEnumeratorInitialQuestionId();
+      // Find new-flow enums by the presence of an initial question.
+      if (maybeInitialQuestionId.isEmpty()) {
+        continue;
+      }
+
+      // Only enumerators can have an initial question.
+      Long initialQuestionId = maybeInitialQuestionId.get();
+      if (!question.isEnumerator()) {
+        errors.add(
+            CiviFormError.of(
+                String.format(
+                    "Question '%s' has an enumeratorInitialQuestionId but is not an enumerator"
+                        + " question.",
+                    question.getName())));
+        continue;
+      }
+      // The initial question is not present.
+      Optional<QuestionDefinition> maybeInitialQuestion =
+          Optional.ofNullable(questionsById.get(initialQuestionId));
+      if (maybeInitialQuestion.isEmpty()) {
+        errors.add(
+            CiviFormError.of(
+                String.format(
+                    "Enumerator question '%s' references an enumeratorInitialQuestionId %d that is"
+                        + " not in the import.",
+                    question.getName(), initialQuestionId)));
+        continue;
+      }
+
+      // The initial question can not be an enumerator.
+      QuestionDefinition initialQuestion = maybeInitialQuestion.get();
+      if (initialQuestion.isEnumerator()) {
+        errors.add(
+            CiviFormError.of(
+                String.format(
+                    "Enumerator question '%s' references question '%s' as its initial question,"
+                        + " but that question is itself an enumerator.",
+                    question.getName(), initialQuestion.getName())));
+        continue;
+      }
+      // The initial question must also reference the enumerator.
+      Long newEnumQuestionId = question.getId();
+      if (initialQuestion.getEnumeratorId().filter(newEnumQuestionId::equals).isEmpty()) {
+        errors.add(
+            CiviFormError.of(
+                String.format(
+                    "Enumerator question '%s' references question '%s' as its initial question,"
+                        + " but that question does not reference it back as its "
+                        + "enumeratorId.",
+                    question.getName(), initialQuestion.getName())));
+      }
+
+      // The enumerator and initial question must both be in the question
+      // bank or both in the import
+      boolean enumInQB = existingAdminNames.contains(question.getName());
+      boolean initialQInQB = existingAdminNames.contains(initialQuestion.getName());
+      if (enumInQB != initialQInQB) {
+        errors.add(
+            CiviFormError.of(
+                String.format(
+                    "Enumerator question '%s' (%s) and its initial question "
+                        + "'%s' (%s) are in "
+                        + "different data sources and must be in the same.",
+                    question.getName(),
+                    enumInQB ? "question bank" : "import",
+                    initialQuestion.getName(),
+                    initialQInQB ? "question bank" : "import")));
+      }
+    }
     return errors.build();
   }
 }

--- a/server/app/services/migration/QuestionValidationUtils.java
+++ b/server/app/services/migration/QuestionValidationUtils.java
@@ -206,10 +206,11 @@ final class QuestionValidationUtils {
       if (!question.isEnumerator()) {
         errors.add(
             CiviFormError.of(
-                String.format(
-                    "Question '%s' has an enumeratorInitialQuestionId but is not an enumerator"
-                        + " question.",
-                    question.getName())));
+                """
+                Question '%s' has an enumeratorInitialQuestionId but is not an enumerator \
+                question.\
+                """
+                    .formatted(question.getName())));
         continue;
       }
       // The initial question is not present.
@@ -218,10 +219,11 @@ final class QuestionValidationUtils {
       if (maybeInitialQuestion.isEmpty()) {
         errors.add(
             CiviFormError.of(
-                String.format(
-                    "Enumerator question '%s' references an enumeratorInitialQuestionId %d that is"
-                        + " not in the import.",
-                    question.getName(), initialQuestionId)));
+                """
+                Enumerator question '%s' references an enumeratorInitialQuestionId %d that is \
+                not in the import.\
+                """
+                    .formatted(question.getName(), initialQuestionId)));
         continue;
       }
 
@@ -230,10 +232,11 @@ final class QuestionValidationUtils {
       if (initialQuestion.isEnumerator()) {
         errors.add(
             CiviFormError.of(
-                String.format(
-                    "Enumerator question '%s' references question '%s' as its initial question,"
-                        + " but that question is itself an enumerator.",
-                    question.getName(), initialQuestion.getName())));
+                """
+                Enumerator question '%s' references question '%s' as its initial question, \
+                but that question is itself an enumerator.\
+                """
+                    .formatted(question.getName(), initialQuestion.getName())));
         continue;
       }
       // The initial question must also reference the enumerator.
@@ -241,11 +244,11 @@ final class QuestionValidationUtils {
       if (initialQuestion.getEnumeratorId().filter(newEnumQuestionId::equals).isEmpty()) {
         errors.add(
             CiviFormError.of(
-                String.format(
-                    "Enumerator question '%s' references question '%s' as its initial question,"
-                        + " but that question does not reference it back as its "
-                        + "enumeratorId.",
-                    question.getName(), initialQuestion.getName())));
+                """
+                Enumerator question '%s' references question '%s' as its initial question, \
+                but that question does not reference it back as its enumeratorId.\
+                """
+                    .formatted(question.getName(), initialQuestion.getName())));
       }
 
       // The enumerator and initial question must both be in the question
@@ -255,14 +258,15 @@ final class QuestionValidationUtils {
       if (enumInQB != initialQInQB) {
         errors.add(
             CiviFormError.of(
-                String.format(
-                    "Enumerator question '%s' (%s) and its initial question "
-                        + "'%s' (%s) are in "
-                        + "different data sources and must be in the same.",
-                    question.getName(),
-                    enumInQB ? "question bank" : "import",
-                    initialQuestion.getName(),
-                    initialQInQB ? "question bank" : "import")));
+                """
+                Enumerator question '%s' (%s) and its initial question '%s' (%s) are in \
+                different data sources and must be in the same.\
+                """
+                    .formatted(
+                        question.getName(),
+                        enumInQB ? "question bank" : "import",
+                        initialQuestion.getName(),
+                        initialQInQB ? "question bank" : "import")));
       }
     }
     return errors.build();

--- a/server/app/services/migration/QuestionValidationUtils.java
+++ b/server/app/services/migration/QuestionValidationUtils.java
@@ -105,10 +105,6 @@ final class QuestionValidationUtils {
   /**
    * Ensures that repeated questions (1) each have an associated enumerator, and (2) only exists in
    * the question bank if the associated enumerator also already exists in the question bank.
-   *
-   * <p>Note: This in effect only validates old-flow enums for backwards compatibility, however
-   * these checks are also necessary and complementary for the new-flow, such as ensuring the
-   * enumerator is in the program.
    */
   static ImmutableSet<CiviFormError> validateRepeatedQuestions(
       ProgramDefinition program,
@@ -183,9 +179,11 @@ final class QuestionValidationUtils {
    * <p>Validation:
    *
    * <ul>
-   *   <li>1. The question identified by {@code enumeratorInitialQuestionId} has an {@code
+   *   <li>1. Only enumerators can have an initial question.
+   *   <li>2. Only the initial question must be in the import and not an enumerator.
+   *   <li>3. The question identified by {@code enumeratorInitialQuestionId} has an {@code
    *       enumeratorId} set to the enumerator's ID.
-   *   <li>2. The enumerator and initial question must both be only present newly in the import or
+   *   <li>4. The enumerator and initial question must both be only present newly in the import or
    *       pre-existing in the question bank, they can't be mixed between the two as it would change
    *       the semantics of which ever is in the question bank and that may break existing uses.
    * </ul>

--- a/server/app/services/migration/QuestionValidationUtils.java
+++ b/server/app/services/migration/QuestionValidationUtils.java
@@ -126,6 +126,7 @@ final class QuestionValidationUtils {
                             .findFirst()));
     ImmutableSet.Builder<CiviFormError> errors = ImmutableSet.builder();
     ImmutableSet.Builder<String> repeatedQsMissingEnumeratorsBuilder = ImmutableSet.builder();
+
     // Check that all repeated questions have an enumerator set.
     repeatedQsMissingEnumeratorsBuilder.addAll(
         repeatedQsToEnumerators.entrySet().stream()
@@ -148,6 +149,7 @@ final class QuestionValidationUtils {
                   + " and/or question definitions: "
                   + String.join(", ", repeatedQsMissingEnumerators)));
     }
+
     // Check that repeated questions only exist in the question bank if their enumerator
     // does too.
     ImmutableList<QuestionDefinition> repeatedQsAlreadyExistWithoutExistingEnumerators =
@@ -184,7 +186,7 @@ final class QuestionValidationUtils {
    *   <li>1. The question identified by {@code enumeratorInitialQuestionId} has an {@code
    *       enumeratorId} set to the enumerator's ID.
    *   <li>2. The enumerator and initial question must both be only present newly in the import or
-   *       pre-existing in the question bank, they can't be mixed between the two. as it would
+   *       pre-existing in the question bank, they can't be mixed between the two as it would
    *       change the semantics of which ever is in the question bank and that may break existing
    *       uses.
    * </ul>
@@ -194,8 +196,10 @@ final class QuestionValidationUtils {
     ImmutableMap<Long, QuestionDefinition> questionsById =
         questions.stream().collect(ImmutableMap.toImmutableMap(QuestionDefinition::getId, q -> q));
     ImmutableSet.Builder<CiviFormError> errors = ImmutableSet.builder();
+
     for (QuestionDefinition question : questions) {
       Optional<Long> maybeInitialQuestionId = question.getEnumeratorInitialQuestionId();
+
       // Find new-flow enums by the presence of an initial question.
       if (maybeInitialQuestionId.isEmpty()) {
         continue;
@@ -213,7 +217,8 @@ final class QuestionValidationUtils {
                     .formatted(question.getName())));
         continue;
       }
-      // The initial question is not present.
+
+      // The initial question must be present.
       Optional<QuestionDefinition> maybeInitialQuestion =
           Optional.ofNullable(questionsById.get(initialQuestionId));
       if (maybeInitialQuestion.isEmpty()) {
@@ -239,7 +244,8 @@ final class QuestionValidationUtils {
                     .formatted(question.getName(), initialQuestion.getName())));
         continue;
       }
-      // The initial question must also reference the enumerator.
+
+      // The initial question must reference the enumerator.
       Long newEnumQuestionId = question.getId();
       if (initialQuestion.getEnumeratorId().filter(newEnumQuestionId::equals).isEmpty()) {
         errors.add(
@@ -252,7 +258,7 @@ final class QuestionValidationUtils {
       }
 
       // The enumerator and initial question must both be in the question
-      // bank or both in the import
+      // bank or both in the import.
       boolean enumInQB = existingAdminNames.contains(question.getName());
       boolean initialQInQB = existingAdminNames.contains(initialQuestion.getName());
       if (enumInQB != initialQInQB) {

--- a/server/app/services/question/types/EnumeratorQuestionDefinition.java
+++ b/server/app/services/question/types/EnumeratorQuestionDefinition.java
@@ -74,11 +74,6 @@ public class EnumeratorQuestionDefinition extends QuestionDefinition {
   }
 
   @JsonIgnore
-  public Optional<Long> getEnumeratorInitialQuestionId() {
-    return getConfig().enumeratorInitialQuestionId();
-  }
-
-  @JsonIgnore
   public OptionalInt getMinEntities() {
     return getEnumeratorValidationPredicates().minEntities();
   }

--- a/server/app/services/question/types/QuestionDefinition.java
+++ b/server/app/services/question/types/QuestionDefinition.java
@@ -287,8 +287,12 @@ public abstract class QuestionDefinition {
   }
 
   /**
-   * The id of the non-enumerator question whose answer should be used to pre-populate the first
-   * entity name for an enumerator question. Only present on enumerator questions via the new-flow.
+   * The id of the non-enumerator question that will be shown repeatedly on the enumerator screen as
+   * a way to get the list of repeated entities. Only present on enumerator questions via the
+   * new-flow.
+   *
+   * <p>For example, the enumerator question "List your household members", may have an initial
+   * question asking for the name of each household member.
    */
   @JsonIgnore
   public final Optional<Long> getEnumeratorInitialQuestionId() {

--- a/server/app/services/question/types/QuestionDefinition.java
+++ b/server/app/services/question/types/QuestionDefinition.java
@@ -287,6 +287,15 @@ public abstract class QuestionDefinition {
   }
 
   /**
+   * The id of the non-enumerator question whose answer should be used to pre-populate the first
+   * entity name for an enumerator question. Only present on enumerator questions via the new-flow.
+   */
+  @JsonIgnore
+  public final Optional<Long> getEnumeratorInitialQuestionId() {
+    return config.enumeratorInitialQuestionId();
+  }
+
+  /**
    * Get a human-readable description for the data this question collects.
    *
    * <p>NOTE: This field will not be localized as it is for admin use only.

--- a/server/test/services/migration/QuestionValidationUtilsTest.java
+++ b/server/test/services/migration/QuestionValidationUtilsTest.java
@@ -422,7 +422,8 @@ public final class QuestionValidationUtilsTest extends ResetPostgres {
 
     ImmutableSet<CiviFormError> errors =
         QuestionValidationUtils.validateNewFlowEnumerators(
-            ImmutableList.of(initialQuestion, enumerator), ImmutableList.of());
+            /* questions= */ ImmutableList.of(initialQuestion, enumerator),
+            /* existingAdminNames= */ ImmutableList.of());
 
     assertThat(errors).isEmpty();
   }
@@ -437,7 +438,8 @@ public final class QuestionValidationUtilsTest extends ResetPostgres {
 
     ImmutableSet<CiviFormError> errors =
         QuestionValidationUtils.validateNewFlowEnumerators(
-            ImmutableList.of(initialQuestion, textWithField), ImmutableList.of());
+            /* questions= */ ImmutableList.of(initialQuestion, textWithField),
+            /* existingAdminNames= */ ImmutableList.of());
 
     assertThat(errors).hasSize(1);
     assertThat(errors.iterator().next().message())
@@ -456,7 +458,8 @@ public final class QuestionValidationUtilsTest extends ResetPostgres {
 
     ImmutableSet<CiviFormError> errors =
         QuestionValidationUtils.validateNewFlowEnumerators(
-            ImmutableList.of(enumerator), ImmutableList.of());
+            /* questions= */ ImmutableList.of(enumerator),
+            /* existingAdminNames= */ ImmutableList.of());
 
     assertThat(errors).hasSize(1);
     assertThat(errors.iterator().next().message())
@@ -477,7 +480,8 @@ public final class QuestionValidationUtilsTest extends ResetPostgres {
 
     ImmutableSet<CiviFormError> errors =
         QuestionValidationUtils.validateNewFlowEnumerators(
-            ImmutableList.of(otherEnumerator, enumerator), ImmutableList.of());
+            /* questions= */ ImmutableList.of(otherEnumerator, enumerator),
+            /* existingAdminNames= */ ImmutableList.of());
 
     assertThat(errors).hasSize(1);
     assertThat(errors.iterator().next().message())
@@ -489,35 +493,17 @@ public final class QuestionValidationUtilsTest extends ResetPostgres {
   }
 
   @Test
-  public void validateNewFlowEnumerators_selfReference_returnsError() {
-    QuestionDefinition enumerator =
-        createQuestionDefinitionWithEnumInitialId(
-            "household", 30L, QuestionType.ENUMERATOR, /* enumeratorInitialQuestionId= */ 30L);
-
-    ImmutableSet<CiviFormError> errors =
-        QuestionValidationUtils.validateNewFlowEnumerators(
-            ImmutableList.of(enumerator), ImmutableList.of());
-
-    assertThat(errors).hasSize(1);
-    assertThat(errors.iterator().next().message())
-        .isEqualTo(
-            """
-            Enumerator question 'household' references question 'household' as its initial \
-            question, but that question is itself an enumerator.\
-            """);
-  }
-
-  @Test
   public void validateNewFlowEnumerators_initialQuestionMissingBackReference_returnsError() {
+    QuestionDefinition initialQuestion =
+        createQuestionDefinition("orphan-name", 51L, QuestionType.TEXT);
     QuestionDefinition enumerator =
         createQuestionDefinitionWithEnumInitialId(
             "household", 50L, QuestionType.ENUMERATOR, /* enumeratorInitialQuestionId= */ 51L);
-    QuestionDefinition initialQuestion =
-        createQuestionDefinition("orphan-name", 51L, QuestionType.TEXT);
 
     ImmutableSet<CiviFormError> errors =
         QuestionValidationUtils.validateNewFlowEnumerators(
-            ImmutableList.of(enumerator, initialQuestion), ImmutableList.of());
+            /* questions= */ ImmutableList.of(enumerator, initialQuestion),
+            /* existingAdminNames= */ ImmutableList.of());
 
     assertThat(errors).hasSize(1);
     assertThat(errors.iterator().next().message())
@@ -540,7 +526,8 @@ public final class QuestionValidationUtilsTest extends ResetPostgres {
 
     ImmutableSet<CiviFormError> errors =
         QuestionValidationUtils.validateNewFlowEnumerators(
-            ImmutableList.of(enumerator, initialQuestion), ImmutableList.of());
+            /* questions= */ ImmutableList.of(enumerator, initialQuestion),
+            /* existingAdminNames= */ ImmutableList.of());
 
     assertThat(errors).hasSize(1);
     assertThat(errors.iterator().next().message())
@@ -562,7 +549,8 @@ public final class QuestionValidationUtilsTest extends ResetPostgres {
 
     ImmutableSet<CiviFormError> errors =
         QuestionValidationUtils.validateNewFlowEnumerators(
-            ImmutableList.of(enumerator, initialQuestion), ImmutableList.of(enumerator.getName()));
+            /* questions= */ ImmutableList.of(enumerator, initialQuestion),
+            /* existingAdminNames= */ ImmutableList.of(enumerator.getName()));
 
     assertThat(errors).hasSize(1);
     assertThat(errors.iterator().next().message())
@@ -584,8 +572,8 @@ public final class QuestionValidationUtilsTest extends ResetPostgres {
 
     ImmutableSet<CiviFormError> errors =
         QuestionValidationUtils.validateNewFlowEnumerators(
-            ImmutableList.of(enumerator, initialQuestion),
-            ImmutableList.of(initialQuestion.getName()));
+            /* questions= */ ImmutableList.of(enumerator, initialQuestion),
+            /* existingAdminNames= */ ImmutableList.of(initialQuestion.getName()));
 
     assertThat(errors).hasSize(1);
     assertThat(errors.iterator().next().message())
@@ -607,8 +595,9 @@ public final class QuestionValidationUtilsTest extends ResetPostgres {
 
     ImmutableSet<CiviFormError> errors =
         QuestionValidationUtils.validateNewFlowEnumerators(
-            ImmutableList.of(enumerator, initialQuestion),
-            ImmutableList.of(enumerator.getName(), initialQuestion.getName()));
+            /* questions= */ ImmutableList.of(enumerator, initialQuestion),
+            /* existingAdminNames= */ ImmutableList.of(
+                enumerator.getName(), initialQuestion.getName()));
 
     assertThat(errors).isEmpty();
   }
@@ -624,7 +613,8 @@ public final class QuestionValidationUtilsTest extends ResetPostgres {
 
     ImmutableSet<CiviFormError> errors =
         QuestionValidationUtils.validateNewFlowEnumerators(
-            ImmutableList.of(enumerator, initialQuestion), ImmutableList.of());
+            /* questions= */ ImmutableList.of(enumerator, initialQuestion),
+            /* existingAdminNames= */ ImmutableList.of());
 
     assertThat(errors).isEmpty();
   }
@@ -637,7 +627,8 @@ public final class QuestionValidationUtilsTest extends ResetPostgres {
 
     ImmutableSet<CiviFormError> errors =
         QuestionValidationUtils.validateNewFlowEnumerators(
-            ImmutableList.of(enumerator, text), ImmutableList.of());
+            /* questions= */ ImmutableList.of(enumerator, text),
+            /* existingAdminNames= */ ImmutableList.of());
 
     assertThat(errors).isEmpty();
   }

--- a/server/test/services/migration/QuestionValidationUtilsTest.java
+++ b/server/test/services/migration/QuestionValidationUtilsTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static support.TestQuestionBank.createDropdownQuestionDefinition;
 import static support.TestQuestionBank.createQuestionDefinition;
 import static support.TestQuestionBank.createQuestionDefinitionWithEnumId;
+import static support.TestQuestionBank.createQuestionDefinitionWithEnumInitialId;
 import static support.TestQuestionBank.createYesNoQuestionDefinition;
 
 import com.google.common.collect.ImmutableList;
@@ -408,6 +409,222 @@ public final class QuestionValidationUtilsTest extends ResetPostgres {
             "YES_NO question 'valid-required-invalid-extra-question' contains invalid option"
                 + " 'invalid-option'. Only 'yes', 'no', 'maybe', and 'not-sure' options are"
                 + " allowed.");
+  }
+
+  @Test
+  public void validateNewFlowEnumerators_validReference_noErrors() {
+    QuestionDefinition enumerator =
+        createQuestionDefinitionWithEnumInitialId(
+            "household", 11L, QuestionType.ENUMERATOR, /* enumeratorInitialQuestionId= */ 10L);
+    QuestionDefinition initialQuestion =
+        createQuestionDefinitionWithEnumId(
+            "member-name", 10L, QuestionType.TEXT, /* enumeratorId= */ 11L);
+
+    ImmutableSet<CiviFormError> errors =
+        QuestionValidationUtils.validateNewFlowEnumerators(
+            ImmutableList.of(initialQuestion, enumerator), ImmutableList.of());
+
+    assertThat(errors).isEmpty();
+  }
+
+  @Test
+  public void validateNewFlowEnumerators_nonEnumeratorWithField_returnsError() {
+    QuestionDefinition initialQuestion =
+        createQuestionDefinition("seed-name", 10L, QuestionType.TEXT);
+    QuestionDefinition textWithField =
+        createQuestionDefinitionWithEnumInitialId(
+            "wrong-type", 12L, QuestionType.TEXT, /* enumeratorInitialQuestionId= */ 10L);
+
+    ImmutableSet<CiviFormError> errors =
+        QuestionValidationUtils.validateNewFlowEnumerators(
+            ImmutableList.of(initialQuestion, textWithField), ImmutableList.of());
+
+    assertThat(errors).hasSize(1);
+    assertThat(errors.iterator().next().message())
+        .isEqualTo(
+            "Question 'wrong-type' has an enumeratorInitialQuestionId but is not an enumerator"
+                + " question.");
+  }
+
+  @Test
+  public void validateNewFlowEnumerators_referencedQuestionMissing_returnsError() {
+    QuestionDefinition enumerator =
+        createQuestionDefinitionWithEnumInitialId(
+            "household", 11L, QuestionType.ENUMERATOR, /* enumeratorInitialQuestionId= */ 99L);
+
+    ImmutableSet<CiviFormError> errors =
+        QuestionValidationUtils.validateNewFlowEnumerators(
+            ImmutableList.of(enumerator), ImmutableList.of());
+
+    assertThat(errors).hasSize(1);
+    assertThat(errors.iterator().next().message())
+        .isEqualTo(
+            "Enumerator question 'household' references an enumeratorInitialQuestionId 99 that is"
+                + " not in the import.");
+  }
+
+  @Test
+  public void validateNewFlowEnumerators_referencesAnotherEnumerator_returnsError() {
+    QuestionDefinition otherEnumerator =
+        createQuestionDefinition("vehicles", 20L, QuestionType.ENUMERATOR);
+    QuestionDefinition enumerator =
+        createQuestionDefinitionWithEnumInitialId(
+            "household", 21L, QuestionType.ENUMERATOR, /* enumeratorInitialQuestionId= */ 20L);
+
+    ImmutableSet<CiviFormError> errors =
+        QuestionValidationUtils.validateNewFlowEnumerators(
+            ImmutableList.of(otherEnumerator, enumerator), ImmutableList.of());
+
+    assertThat(errors).hasSize(1);
+    assertThat(errors.iterator().next().message())
+        .isEqualTo(
+            "Enumerator question 'household' references question 'vehicles' as its initial"
+                + " question, but that question is itself an enumerator.");
+  }
+
+  @Test
+  public void validateNewFlowEnumerators_selfReference_returnsError() {
+    QuestionDefinition enumerator =
+        createQuestionDefinitionWithEnumInitialId(
+            "household", 30L, QuestionType.ENUMERATOR, /* enumeratorInitialQuestionId= */ 30L);
+
+    ImmutableSet<CiviFormError> errors =
+        QuestionValidationUtils.validateNewFlowEnumerators(
+            ImmutableList.of(enumerator), ImmutableList.of());
+
+    assertThat(errors).hasSize(1);
+    assertThat(errors.iterator().next().message())
+        .isEqualTo(
+            "Enumerator question 'household' references question 'household' as its initial"
+                + " question, but that question is itself an enumerator.");
+  }
+
+  @Test
+  public void validateNewFlowEnumerators_initialQuestionMissingBackReference_returnsError() {
+    QuestionDefinition enumerator =
+        createQuestionDefinitionWithEnumInitialId(
+            "household", 50L, QuestionType.ENUMERATOR, /* enumeratorInitialQuestionId= */ 51L);
+    QuestionDefinition initialQuestion =
+        createQuestionDefinition("orphan-name", 51L, QuestionType.TEXT);
+
+    ImmutableSet<CiviFormError> errors =
+        QuestionValidationUtils.validateNewFlowEnumerators(
+            ImmutableList.of(enumerator, initialQuestion), ImmutableList.of());
+
+    assertThat(errors).hasSize(1);
+    assertThat(errors.iterator().next().message())
+        .isEqualTo(
+            "Enumerator question 'household' references question 'orphan-name' as its initial"
+                + " question, but that question does not reference it back as its enumeratorId.");
+  }
+
+  @Test
+  public void
+      validateNewFlowEnumerators_initialQuestionBackReferencesDifferentEnumerator_returnsError() {
+    QuestionDefinition enumerator =
+        createQuestionDefinitionWithEnumInitialId(
+            "household", 60L, QuestionType.ENUMERATOR, /* enumeratorInitialQuestionId= */ 61L);
+    QuestionDefinition initialQuestion =
+        createQuestionDefinitionWithEnumId(
+            "wrong-parent-name", 61L, QuestionType.TEXT, /* enumeratorId= */ 999L);
+
+    ImmutableSet<CiviFormError> errors =
+        QuestionValidationUtils.validateNewFlowEnumerators(
+            ImmutableList.of(enumerator, initialQuestion), ImmutableList.of());
+
+    assertThat(errors).hasSize(1);
+    assertThat(errors.iterator().next().message())
+        .isEqualTo(
+            "Enumerator question 'household' references question 'wrong-parent-name' as its"
+                + " initial question, but that question does not reference it back as its"
+                + " enumeratorId.");
+  }
+
+  @Test
+  public void validateNewFlowEnumerators_enumeratorInBankInitialInImport_returnsError() {
+    QuestionDefinition enumerator =
+        createQuestionDefinitionWithEnumInitialId(
+            "household", 70L, QuestionType.ENUMERATOR, /* enumeratorInitialQuestionId= */ 71L);
+    QuestionDefinition initialQuestion =
+        createQuestionDefinitionWithEnumId(
+            "member-name", 71L, QuestionType.TEXT, /* enumeratorId= */ 70L);
+
+    ImmutableSet<CiviFormError> errors =
+        QuestionValidationUtils.validateNewFlowEnumerators(
+            ImmutableList.of(enumerator, initialQuestion), ImmutableList.of(enumerator.getName()));
+
+    assertThat(errors).hasSize(1);
+    assertThat(errors.iterator().next().message())
+        .isEqualTo(
+            "Enumerator question 'household' (question bank) and its initial question 'member-name'"
+                + " (import) are in different data sources and must be in the same.");
+  }
+
+  @Test
+  public void validateNewFlowEnumerators_enumeratorInImportInitialInBank_returnsError() {
+    QuestionDefinition enumerator =
+        createQuestionDefinitionWithEnumInitialId(
+            "household", 80L, QuestionType.ENUMERATOR, /* enumeratorInitialQuestionId= */ 81L);
+    QuestionDefinition initialQuestion =
+        createQuestionDefinitionWithEnumId(
+            "member-name", 81L, QuestionType.TEXT, /* enumeratorId= */ 80L);
+
+    ImmutableSet<CiviFormError> errors =
+        QuestionValidationUtils.validateNewFlowEnumerators(
+            ImmutableList.of(enumerator, initialQuestion),
+            ImmutableList.of(initialQuestion.getName()));
+
+    assertThat(errors).hasSize(1);
+    assertThat(errors.iterator().next().message())
+        .isEqualTo(
+            "Enumerator question 'household' (import) and its initial question 'member-name'"
+                + " (question bank) are in different data sources and must be in the same.");
+  }
+
+  @Test
+  public void validateNewFlowEnumerators_bothInBank_noErrors() {
+    QuestionDefinition enumerator =
+        createQuestionDefinitionWithEnumInitialId(
+            "household", 90L, QuestionType.ENUMERATOR, /* enumeratorInitialQuestionId= */ 91L);
+    QuestionDefinition initialQuestion =
+        createQuestionDefinitionWithEnumId(
+            "member-name", 91L, QuestionType.TEXT, /* enumeratorId= */ 90L);
+
+    ImmutableSet<CiviFormError> errors =
+        QuestionValidationUtils.validateNewFlowEnumerators(
+            ImmutableList.of(enumerator, initialQuestion),
+            ImmutableList.of(enumerator.getName(), initialQuestion.getName()));
+
+    assertThat(errors).isEmpty();
+  }
+
+  @Test
+  public void validateNewFlowEnumerators_bothInImport_noErrors() {
+    QuestionDefinition enumerator =
+        createQuestionDefinitionWithEnumInitialId(
+            "household", 100L, QuestionType.ENUMERATOR, /* enumeratorInitialQuestionId= */ 101L);
+    QuestionDefinition initialQuestion =
+        createQuestionDefinitionWithEnumId(
+            "member-name", 101L, QuestionType.TEXT, /* enumeratorId= */ 100L);
+
+    ImmutableSet<CiviFormError> errors =
+        QuestionValidationUtils.validateNewFlowEnumerators(
+            ImmutableList.of(enumerator, initialQuestion), ImmutableList.of());
+
+    assertThat(errors).isEmpty();
+  }
+
+  @Test
+  public void validateNewFlowEnumerators_noField_noErrors() {
+    QuestionDefinition enumerator =
+        createQuestionDefinition("household", 40L, QuestionType.ENUMERATOR);
+    QuestionDefinition text = createQuestionDefinition("name", 41L, QuestionType.TEXT);
+
+    ImmutableSet<CiviFormError> errors =
+        QuestionValidationUtils.validateNewFlowEnumerators(
+            ImmutableList.of(enumerator, text), ImmutableList.of());
+
+    assertThat(errors).isEmpty();
   }
 
   @Test

--- a/server/test/services/migration/QuestionValidationUtilsTest.java
+++ b/server/test/services/migration/QuestionValidationUtilsTest.java
@@ -442,8 +442,10 @@ public final class QuestionValidationUtilsTest extends ResetPostgres {
     assertThat(errors).hasSize(1);
     assertThat(errors.iterator().next().message())
         .isEqualTo(
-            "Question 'wrong-type' has an enumeratorInitialQuestionId but is not an enumerator"
-                + " question.");
+            """
+            Question 'wrong-type' has an enumeratorInitialQuestionId but is not an enumerator \
+            question.\
+            """);
   }
 
   @Test
@@ -459,8 +461,10 @@ public final class QuestionValidationUtilsTest extends ResetPostgres {
     assertThat(errors).hasSize(1);
     assertThat(errors.iterator().next().message())
         .isEqualTo(
-            "Enumerator question 'household' references an enumeratorInitialQuestionId 99 that is"
-                + " not in the import.");
+            """
+            Enumerator question 'household' references an enumeratorInitialQuestionId 99 that is \
+            not in the import.\
+            """);
   }
 
   @Test
@@ -478,8 +482,10 @@ public final class QuestionValidationUtilsTest extends ResetPostgres {
     assertThat(errors).hasSize(1);
     assertThat(errors.iterator().next().message())
         .isEqualTo(
-            "Enumerator question 'household' references question 'vehicles' as its initial"
-                + " question, but that question is itself an enumerator.");
+            """
+            Enumerator question 'household' references question 'vehicles' as its initial \
+            question, but that question is itself an enumerator.\
+            """);
   }
 
   @Test
@@ -495,8 +501,10 @@ public final class QuestionValidationUtilsTest extends ResetPostgres {
     assertThat(errors).hasSize(1);
     assertThat(errors.iterator().next().message())
         .isEqualTo(
-            "Enumerator question 'household' references question 'household' as its initial"
-                + " question, but that question is itself an enumerator.");
+            """
+            Enumerator question 'household' references question 'household' as its initial \
+            question, but that question is itself an enumerator.\
+            """);
   }
 
   @Test
@@ -514,8 +522,10 @@ public final class QuestionValidationUtilsTest extends ResetPostgres {
     assertThat(errors).hasSize(1);
     assertThat(errors.iterator().next().message())
         .isEqualTo(
-            "Enumerator question 'household' references question 'orphan-name' as its initial"
-                + " question, but that question does not reference it back as its enumeratorId.");
+            """
+            Enumerator question 'household' references question 'orphan-name' as its initial \
+            question, but that question does not reference it back as its enumeratorId.\
+            """);
   }
 
   @Test
@@ -535,9 +545,10 @@ public final class QuestionValidationUtilsTest extends ResetPostgres {
     assertThat(errors).hasSize(1);
     assertThat(errors.iterator().next().message())
         .isEqualTo(
-            "Enumerator question 'household' references question 'wrong-parent-name' as its"
-                + " initial question, but that question does not reference it back as its"
-                + " enumeratorId.");
+            """
+            Enumerator question 'household' references question 'wrong-parent-name' as its \
+            initial question, but that question does not reference it back as its enumeratorId.\
+            """);
   }
 
   @Test
@@ -556,8 +567,10 @@ public final class QuestionValidationUtilsTest extends ResetPostgres {
     assertThat(errors).hasSize(1);
     assertThat(errors.iterator().next().message())
         .isEqualTo(
-            "Enumerator question 'household' (question bank) and its initial question 'member-name'"
-                + " (import) are in different data sources and must be in the same.");
+            """
+            Enumerator question 'household' (question bank) and its initial question \
+            'member-name' (import) are in different data sources and must be in the same.\
+            """);
   }
 
   @Test
@@ -577,8 +590,10 @@ public final class QuestionValidationUtilsTest extends ResetPostgres {
     assertThat(errors).hasSize(1);
     assertThat(errors.iterator().next().message())
         .isEqualTo(
-            "Enumerator question 'household' (import) and its initial question 'member-name'"
-                + " (question bank) are in different data sources and must be in the same.");
+            """
+            Enumerator question 'household' (import) and its initial question 'member-name' \
+            (question bank) are in different data sources and must be in the same.\
+            """);
   }
 
   @Test


### PR DESCRIPTION
### Description

Adds validation when importing new-flow enumerators.

During program import we validate that the imported configuration is correct, as well we validate that the Admin's choices around reusing questions from the question bank or not are consistent with the configuration.

Note: The old flow enum validation is still necessary for new-flow enums and that is noted here, as well I tried to clean up that validation a tad to make it more readable and efficient.

AI: Claude wrote most of the tests. Claude did the scaffold for the validation but I heavily reviewed/updated it.

### Checklist

Remove any sections below that do not apply to your PR. For sections that do apply, complete all of the appropriate checklist items and check them off. If a checklist item doesn't apply to your PR, leave it unchecked but do not delete it.

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [ ] Added an additional reviewer as required if changes potentially affect the security of the application.
- [ ] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [x] Noted in the PR description which, if any, code in this PR was generated by AI.


### Instructions for manual testing

Setup:
1. Create a program with an enumerator and repeated question
2. Export the program.

Test:

Success:
1. Set the enumerators `enumeratorInitialQuestionId`  to the repeated questions id .

Failures:
Starting with the success config above, for each of the following, import the program and verify the error is reported
1. Set the enumerators `enumeratorInitialQuestionId` to an Question Id that doesn't exist.
2. Set the enumerators `enumeratorInitialQuestionId` to its own id - fails initial question can't ben an enum check.
3. Set the Initial Question's `enumeratorId` to another enumerator - fails that they must link to each other check.

### Issue(s) this completes

Fixes #13445
