### PR TITLE
enable name_suffix_dropdown_enabled

### DIFF
--- a/browser-test/src/admin/admin_application_download.test.ts
+++ b/browser-test/src/admin/admin_application_download.test.ts
@@ -269,7 +269,6 @@ test.describe('csv json pdf download test- two applications', () => {
     adminPrograms,
     applicantQuestions,
   }) => {
-    await enableFeatureFlag(page, 'name_suffix_dropdown_enabled')
     test.slow()
 
     const noApplyFilters = false

--- a/browser-test/src/admin/admin_predicates.test.ts
+++ b/browser-test/src/admin/admin_predicates.test.ts
@@ -457,7 +457,6 @@ test.describe('create and edit predicates', () => {
     adminPredicates,
   }) => {
     await loginAsAdmin(page)
-    await enableFeatureFlag(page, 'name_suffix_dropdown_enabled')
 
     const programName =
       'Test name question as a eligibility condition excluding suffix'

--- a/browser-test/src/applicant/questions/name.test.ts
+++ b/browser-test/src/applicant/questions/name.test.ts
@@ -3,7 +3,6 @@ import {test, expect} from '../../support/civiform_fixtures'
 import {
   AdminQuestions,
   AdminPrograms,
-  enableFeatureFlag,
   loginAsAdmin,
   logout,
   validateAccessibility,
@@ -260,7 +259,6 @@ test.describe('name applicant flow', () => {
           adminQuestions,
           adminPrograms,
         )
-        await enableFeatureFlag(page, 'name_suffix_dropdown_enabled')
       })
 
       test('name questions with suffix field being available to use', async ({

--- a/browser-test/src/trusted_intermediary.test.ts
+++ b/browser-test/src/trusted_intermediary.test.ts
@@ -1,6 +1,5 @@
 import {test, expect} from './support/civiform_fixtures'
 import {
-  enableFeatureFlag,
   ClientInformation,
   loginAsAdmin,
   loginAsTrustedIntermediary,
@@ -113,10 +112,12 @@ test.describe('Trusted intermediaries', () => {
     await test.step('publish programs with categories', async () => {
       await adminPrograms.publishAllDrafts()
     })
+
     await test.step('Navigate to homepage', async () => {
       await logout(page)
       await loginAsTrustedIntermediary(page)
     })
+
     await test.step('Create a new client', async () => {
       await waitForPageJsLoad(page)
       const client: ClientInformation = {
@@ -130,6 +131,7 @@ test.describe('Trusted intermediaries', () => {
       await tiDashboard.expectDashboardContainClient(client)
       await tiDashboard.clickOnViewApplications()
     })
+
     await test.step('Apply to a program and verify that applied program is under my applicatins section of view application page', async () => {
       await applicantQuestions.applyProgram(primaryProgramName)
       await applicantQuestions.answerTextQuestion('first answer')
@@ -192,6 +194,7 @@ test.describe('Trusted intermediaries', () => {
         /* filtersOn= */ false,
       )
     })
+
     await test.step('Select a filter, click the filter submit button and verify the Recommended and Other programs sections with finished application', async () => {
       await applicantQuestions.filterProgramsAndExpectInCorrectSections(
         {
@@ -208,6 +211,7 @@ test.describe('Trusted intermediaries', () => {
       )
     })
   })
+
   test('expect Client Date Of Birth to be Updated', async ({
     page,
     tiDashboard,
@@ -242,6 +246,7 @@ test.describe('Trusted intermediaries', () => {
     await waitForPageJsLoad(page)
     await tiDashboard.expectDashboardContainClient(updatedClient)
   })
+
   test('expect client info to be updated with empty emails', async ({
     page,
     tiDashboard,
@@ -854,6 +859,7 @@ test.describe('Trusted intermediaries', () => {
     adminTiGroups,
   }) => {
     await loginAsAdmin(page)
+
     await test.step('set up group aaa with 3 memebers', async () => {
       await adminTiGroups.gotoAdminTIPage()
       await adminTiGroups.fillInGroupBasics('aaa', 'aaa')
@@ -877,31 +883,34 @@ test.describe('Trusted intermediaries', () => {
 
     await adminTiGroups.gotoAdminTIPage()
     await page.locator('#cf-ti-list').selectOption('tiname-asc')
-    const tiNamesAsc = await page.getByTestId('ti-info').allInnerTexts()
-    console.log(page.getByTestId('ti-info'))
-    expect(tiNamesAsc).toEqual(['aaa\naaa', 'bbb\nbbb', 'ccc\nccc'])
+    await expect(page.getByTestId('ti-info')).toHaveText([
+      'aaaaaa',
+      'bbbbbb',
+      'cccccc',
+    ])
     await validateScreenshot(page, 'ti-list-sort-dropdown-tiname-asc')
 
     await page.locator('#cf-ti-list').selectOption('tiname-desc')
-    const tiNamesDesc = await page.getByTestId('ti-info').allInnerTexts()
-    expect(tiNamesDesc).toEqual(['ccc\nccc', 'bbb\nbbb', 'aaa\naaa'])
+    await expect(page.getByTestId('ti-info')).toHaveText([
+      'cccccc',
+      'bbbbbb',
+      'aaaaaa',
+    ])
     await validateScreenshot(page, 'ti-list-sort-dropdown-tiname-desc')
 
     await page.locator('#cf-ti-list').selectOption('nummember-desc')
-    const tiMemberDesc = await page.getByTestId('ti-member').allInnerTexts()
-    expect(tiMemberDesc).toEqual([
-      'Members: 3\nClients: 0',
-      'Members: 1\nClients: 0',
-      'Members: 0\nClients: 0',
+    await expect(page.getByTestId('ti-member')).toHaveText([
+      'Members: 3Clients: 0',
+      'Members: 1Clients: 0',
+      'Members: 0Clients: 0',
     ])
     await validateScreenshot(page, 'ti-list-sort-dropdown-nummember-desc')
 
     await page.locator('#cf-ti-list').selectOption('nummember-asc')
-    const tiMemberAsc = await page.getByTestId('ti-member').allInnerTexts()
-    expect(tiMemberAsc).toEqual([
-      'Members: 0\nClients: 0',
-      'Members: 1\nClients: 0',
-      'Members: 3\nClients: 0',
+    await expect(page.getByTestId('ti-member')).toHaveText([
+      'Members: 0Clients: 0',
+      'Members: 1Clients: 0',
+      'Members: 3Clients: 0',
     ])
     await validateScreenshot(page, 'ti-list-sort-dropdown-nummember-asc')
   })
@@ -1408,6 +1417,7 @@ test.describe('Trusted intermediaries', () => {
         dobDate: '2001-01-01',
         notes: 'Notes',
       }
+
       await test.step('verify the client info is shown in the TI Dashboard', async () => {
         await tiDashboard.gotoTIDashboardPage(page, true)
         await waitForPageJsLoad(page)
@@ -1421,10 +1431,6 @@ test.describe('Trusted intermediaries', () => {
   })
 
   test.describe('ti can add suffix information with suffix feature flag enabled', () => {
-    test.beforeEach(async ({page}) => {
-      await enableFeatureFlag(page, 'name_suffix_dropdown_enabled')
-    })
-
     test('TI is able to fill out name suffix info for the applicant', async ({
       page,
       tiDashboard,

--- a/server/app/services/settings/SettingsManifest.java
+++ b/server/app/services/settings/SettingsManifest.java
@@ -1060,8 +1060,8 @@ public final class SettingsManifest extends AbstractSettingsManifest {
   }
 
   /** Enables suffix dropdown field in name question. */
-  public boolean getNameSuffixDropdownEnabled(RequestHeader request) {
-    return getBool("NAME_SUFFIX_DROPDOWN_ENABLED", request);
+  public boolean getNameSuffixDropdownEnabled() {
+    return getBool("NAME_SUFFIX_DROPDOWN_ENABLED");
   }
 
   /** Remove the CSV/JSON/PDF download capability for Program Admins. */
@@ -2343,7 +2343,7 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                           "Enables suffix dropdown field in name question.",
                           /* isRequired= */ false,
                           SettingType.BOOLEAN,
-                          SettingMode.ADMIN_WRITEABLE),
+                          SettingMode.ADMIN_READABLE),
                       SettingDescription.create(
                           "REMOVE_DOWNLOAD_FOR_PROGRAM_ADMINS_ENABLED",
                           "Remove the CSV/JSON/PDF download capability for Program Admins.",

--- a/server/app/views/admin/questions/QuestionPreview.java
+++ b/server/app/views/admin/questions/QuestionPreview.java
@@ -78,8 +78,7 @@ public class QuestionPreview extends ApplicantBaseView {
     context.setVariable("stateAbbreviations", AddressQuestion.STATE_ABBREVIATIONS);
     context.setVariable("enumMaxEntityCount", EnumeratorQuestionForm.MAX_ENUM_ENTITIES_ALLOWED);
 
-    context.setVariable(
-        "isNameSuffixEnabled", settingsManifest.getNameSuffixDropdownEnabled(params.request()));
+    context.setVariable("isNameSuffixEnabled", settingsManifest.getNameSuffixDropdownEnabled());
     context.setVariable("nameSuffixOptions", ApplicantModel.Suffix.values());
     context.setVariable("isYesNoQuestionEnabled", settingsManifest.getYesNoQuestionEnabled());
     context.setVariable("maxFileSizeMb", 100);

--- a/server/app/views/applicant/blocks/ApplicantProgramBlockEditView.java
+++ b/server/app/views/applicant/blocks/ApplicantProgramBlockEditView.java
@@ -190,8 +190,7 @@ public final class ApplicantProgramBlockEditView extends ApplicantBaseView {
       context.setVariable("stateAbbreviations", AddressQuestion.STATE_ABBREVIATIONS);
       context.setVariable("nameSuffixOptions", Suffix.values());
       context.setVariable("enumMaxEntityCount", EnumeratorQuestionForm.MAX_ENUM_ENTITIES_ALLOWED);
-      context.setVariable(
-          "isNameSuffixEnabled", settingsManifest.getNameSuffixDropdownEnabled(request));
+      context.setVariable("isNameSuffixEnabled", settingsManifest.getNameSuffixDropdownEnabled());
       context.setVariable("isYesNoQuestionEnabled", settingsManifest.getYesNoQuestionEnabled());
       return templateEngine.process("applicant/blocks/ApplicantProgramBlockEditTemplate", context);
     }

--- a/server/app/views/trustedintermediary/EditTiClientView.java
+++ b/server/app/views/trustedintermediary/EditTiClientView.java
@@ -219,7 +219,7 @@ public class EditTiClientView extends TrustedIntermediaryDashboardView {
       Messages messages) {
     Optional<ApplicantModel> optionalApplicant = Optional.empty();
     FormTag formTag;
-    Boolean isNameSuffixEnabled = settingsManifest.getNameSuffixDropdownEnabled(request);
+    Boolean isNameSuffixEnabled = settingsManifest.getNameSuffixDropdownEnabled();
     if (optionalAccount.isPresent()) {
       optionalApplicant = optionalAccount.get().representativeApplicant();
 

--- a/server/conf/application.dev-browser-tests.conf
+++ b/server/conf/application.dev-browser-tests.conf
@@ -30,7 +30,6 @@ reporting_use_deterministic_stats = true
 version_cache_enabled=true
 program_cache_enabled=true
 question_cache_enabled=true
-name_suffix_dropdown_enabled = true
 
 # In the test environment we don't need to have the jobs running at the
 # default 5 second interval

--- a/server/conf/application.dev.conf
+++ b/server/conf/application.dev.conf
@@ -105,6 +105,5 @@ session_inactivity_timeout_minutes= 5760
 
 # Feature flags
 program_filtering_enabled = true
-name_suffix_dropdown_enabled = true
 expanded_form_logic_enabled = true
 new_applicant_guest_merging_strategy_enabled = true

--- a/server/conf/application.test.conf
+++ b/server/conf/application.test.conf
@@ -38,7 +38,6 @@ esri_address_service_area_validation_attributes = ["CITYNAME"]
 api_keys_ban_global_subnet = true
 
 question_cache_enabled=true
-name_suffix_dropdown_enabled = true
 
 # In the test environment we don't need to have the jobs running at the
 # default 5 second interval

--- a/server/conf/env-var-docs.json
+++ b/server/conf/env-var-docs.json
@@ -919,7 +919,7 @@
         "required": false
       },
       "NAME_SUFFIX_DROPDOWN_ENABLED": {
-        "mode": "ADMIN_WRITEABLE",
+        "mode": "ADMIN_READABLE",
         "description": "Enables suffix dropdown field in name question.",
         "type": "bool"
       },

--- a/server/conf/helper/feature-flags.conf
+++ b/server/conf/helper/feature-flags.conf
@@ -40,7 +40,7 @@ show_not_production_banner_enabled = false
 show_not_production_banner_enabled = ${?SHOW_NOT_PRODUCTION_BANNER_ENABLED}
 
 # Name suffix dropdown field
-name_suffix_dropdown_enabled = false
+name_suffix_dropdown_enabled = true
 name_suffix_dropdown_enabled = ${?NAME_SUFFIX_DROPDOWN_ENABLED}
 
 # Custom eligibility message


### PR DESCRIPTION
### Description

Please explain the changes you made here.

## Release notes

Remove this section if the feature is still under development or if title of the pull request can be used as the default release notes description. If more detail is needed to communicate to partners the scope of the PR's changes, use this release notes section (and remove this placeholder text).

When the Release engineer creates Release Notes, they will not look for this section for Under Development tagged PRs, and will use it if present for all other PRs included in the Release Notes.

### Checklist

Remove any sections below that do not apply to your PR. For sections that do apply, complete all of the appropriate checklist items and check them off. If a checklist item doesn't apply to your PR, leave it unchecked but do not delete it.

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [ ] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [ ] Added an additional reviewer as required if changes potentially affect the security of the application.
- [ ] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

#### Database evolutions

Read the guidelines [here](https://github.com/civiform/civiform/wiki/Database#writing-database-evolutions)

- [ ] Assigned two reviewers
- [ ] Guarded against already existing resources using `IF NOT EXISTS` and `IF EXISTS`
- [ ] Downs created to undo changes in Ups
- [ ] Every comment in script should begin with -- and not # --- unless it denotes Ups or Downs. See [here](https://www.playframework.com/documentation/2.9.x/Evolutions) for details.
- [ ] Tested both the Downs and the Ups scripts manually (When testing, include all comments from the evolution in your test script to ensure any syntax errors in the comments are caught.)
- [ ] Data migrations aren't being done (please use a [Durable Job](https://github.com/civiform/civiform/wiki/Database#durable-jobs-for-data-updates) if doing a data migration)
- [ ] Update the model documentation in our [wiki](https://github.com/civiform/civiform/wiki/Database) if necessary

#### Durable jobs

Read the docs [here](https://github.com/civiform/civiform/wiki/Database#durable-jobs-for-data-updates)

- [ ] Assigned two reviewers
- [ ] Included a rollback plan and a job to undo the data changes if appropriate

#### User visible changes

- [ ] Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
  - [ ] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [ ] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order
- [ ] Performed manual accessibility tests for any applicant-facing changes or any new admin-facing features. See [manual-accessibility-testing](https://github.com/civiform/civiform/wiki/Accessibility#manual-accessibility-testing)
- [ ] Manually tested with a right-to-left language

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/helper/feature-flags.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://github.com/civiform/civiform/wiki/Feature-Flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Instructions for manual testing

If instructions are needed for manual testing by reviewers, include them here.

### Issue(s) this completes

Fixes #<issue_number>; Fixes #<issue_number>...
