### PR TITLE
Build perf

### DIFF
--- a/.github/workflows/build_push_ci.yaml
+++ b/.github/workflows/build_push_ci.yaml
@@ -13,44 +13,102 @@ permissions: read-all
 # to master.  Also re-build the dependancy docker images only if their code has changed.
 # On a manual trigger, re-build all the images.
 jobs:
-  build_civiform:
+  build_civiform_prod:
     runs-on: ubuntu-latest
-    # Only build the latest version.
+    concurrency:
+      group: build_civiform-prod-${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+    name: Build civiform prod (linux/amd64)
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+      - run: echo "PUSH_IMAGE=1" >> $GITHUB_ENV
+        if: ${{ (github.event_name == 'workflow_dispatch') || (github.event_name == 'push') }}
+      - name: Run build-prod
+        env:
+          DOCKER_BUILDKIT: 1
+          PLATFORM: linux/amd64
+          DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+          DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USER_NAME }}
+        run: bin/build-prod
+
+  build_civiform_dev:
     strategy:
       fail-fast: false
       matrix:
-        version: ['prod', 'dev']
         include:
-          - version: prod
-            image: 'civiform/civiform:latest'
-            script: 'bin/build-prod'
-            platform: 'linux/amd64'
-          - version: dev
-            image: 'civiform/civiform-dev:latest'
-            script: 'bin/build-dev'
-            platform: 'linux/amd64,linux/arm64' # build for m1 mac, too
+          - runner: ubuntu-latest
+            platform: linux/amd64
+            arch: amd64
+          - runner: ubuntu-24.04-arm
+            platform: linux/arm64
+            arch: arm64
+    runs-on: ${{ matrix.runner }}
     concurrency:
-      group: build_civiform-${{ matrix.version }}-${{ github.workflow }}-${{ github.ref }}
+      group: build_civiform-dev-${{ matrix.arch }}-${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true
-    name: Build civiform ${{ matrix.version }} for ${{ matrix.platform }}
+    name: Build civiform-dev (${{ matrix.arch }})
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - name: Set up Docker QEMU
-        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
-      - name: Check if we should push
-        if: ${{ (github.event_name == 'workflow_dispatch') || (github.event_name == 'push') }}
-        run: echo "PUSH_IMAGE=1" >> $GITHUB_ENV
-      - name: Run build-${{ matrix.version }} ${{ matrix.image }} for ${{ matrix.platform }}
-        id: build_and_push
+      - name: Build & push by digest (${{ matrix.arch }})
         env:
           DOCKER_BUILDKIT: 1
           PLATFORM: ${{ matrix.platform }}
+          PUSH_BY_DIGEST: 1
+          METADATA_FILE: ${{ runner.temp }}/metadata.json
           DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
           DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USER_NAME }}
-        run: ${{ matrix.script }}
+        run: bin/build-dev
+      - name: Export digest
+        run: |
+          mkdir -p "${{ runner.temp }}/digests"
+          digest=$(jq -r '.["containerimage.digest"]' "${{ runner.temp }}/metadata.json")
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: digests-${{ matrix.arch }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # Assemble the multi-arch :latest manifest from the two pushed digests.
+  merge_civiform_dev:
+    needs: build_civiform_dev
+    runs-on: ubuntu-latest
+    name: Merge civiform-dev manifest
+    concurrency:
+      group: merge-civiform-dev-${{ github.ref }}
+      cancel-in-progress: false
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
+      - name: Verify both digests present
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          count=$(ls -1 | wc -l)
+          if [ "$count" -ne 2 ]; then
+            echo "Expected 2 digests, got ${count}:"
+            ls -la
+            exit 1
+          fi
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+      - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
+        with:
+          username: ${{ secrets.DOCKER_HUB_USER_NAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+      - name: Create manifest list
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          docker buildx imagetools create -t civiform/civiform-dev:latest \
+            $(printf 'civiform/civiform-dev@sha256:%s ' *)
+      - name: Inspect
+        run: docker buildx imagetools inspect civiform/civiform-dev:latest
 
   build_dependancies:
     runs-on: ubuntu-latest
@@ -125,7 +183,7 @@ jobs:
         if: ${{ (github.event_name == 'workflow_dispatch') || (github.event_name == 'push') }}
         run: echo "PUSH_IMAGE=1" >> $GITHUB_ENV
 
-      - name: Run build-${{ matrix.version }} ${{ matrix.image }} for ${{ matrix.platform }}
+      - name: Run build-${{ matrix.version }}
         if: ${{ steps.check_build.outputs.build == 'build' }}
         id: build_and_push
         env:

--- a/bin/build-dev
+++ b/bin/build-dev
@@ -2,11 +2,15 @@
 
 # DOC: Build a new development docker image
 # DOC: Optional environment variables:
-# DOC:   PUSH_IMAGE - Push the newly built image to Docker Hub if set to any value
-# DOC:   NAMESPACE  - Overrides the default docker namespace of civiform. To push
-# DOC:                to an alternative registry include it in the NAMESPACE.
-# DOC:                Example: ghcr.io/civiform/civiform would push to to GitHub container registry
-# DOC:   PLATFORM   - Platform architecture to build (e.g. linux/amd64, arm64v8)
+# DOC:   PUSH_IMAGE     - Push the newly built image to Docker Hub if set to any value
+# DOC:   PUSH_BY_DIGEST - (CI only) Build a single arch and push it by digest, writing a
+# DOC:                    buildx metadata file to $METADATA_FILE, instead of pushing a
+# DOC:                    :latest tag. A later job assembles the multi-arch manifest.
+# DOC:   METADATA_FILE  - Path for buildx --metadata-file output (with PUSH_BY_DIGEST)
+# DOC:   NAMESPACE      - Overrides the default docker namespace of civiform. To push
+# DOC:                    to an alternative registry include it in the NAMESPACE.
+# DOC:                    Example: ghcr.io/civiform/civiform would push to GitHub container registry
+# DOC:   PLATFORM       - Platform architecture to build (e.g. linux/amd64, arm64v8)
 
 source bin/lib.sh
 
@@ -15,8 +19,7 @@ readonly IMAGE="civiform-dev"
 readonly LOCATION="."
 readonly DOCKERFILE="Dockerfile"
 
-BUILD_ARGS=(--file "${DOCKERFILE}"
-  --tag "${NAMESPACE}/${IMAGE}:latest"
+COMMON_ARGS=(--file "${DOCKERFILE}"
   --cache-from "${NAMESPACE}/${IMAGE}"
   --build-arg BUILDKIT_INLINE_CACHE=1
   --build-arg SBT_VERSION="${SBT_VERSION}"
@@ -26,6 +29,21 @@ PLATFORM_ARG=()
 if [[ "${PLATFORM}" ]]; then
   PLATFORM_ARG=(--platform "${PLATFORM}")
 fi
+
+# --- CI path: build one arch, push by digest, no :latest tag. ---
+if [[ "${PUSH_BY_DIGEST}" ]]; then
+  docker::do_dockerhub_login
+  echo "build & push ${IMAGE} by digest for ${PLATFORM}"
+  docker buildx build \
+    "${PLATFORM_ARG[@]}" \
+    "${COMMON_ARGS[@]}" \
+    --output "type=image,name=${NAMESPACE}/${IMAGE},push-by-digest=true,name-canonical=true,push=true" \
+    --metadata-file "${METADATA_FILE:-metadata.json}"
+  exit 0
+fi
+
+# --- Default path: unchanged behaviour for local dev and prod. ---
+BUILD_ARGS=(--tag "${NAMESPACE}/${IMAGE}:latest" "${COMMON_ARGS[@]}")
 
 # Build the multi-platform image
 echo "start ${IMAGE} build"


### PR DESCRIPTION
The _Build and Push Docker Images_ (build_push_ci.yaml) workflow creates docker images of `civiform-dev` for amd64 (pc users) and arm64 (mac users). The way we build the arm64 version was with QEMU under an amd64 github action runner. This turns out to be very slow as it is emulating the arm64 under amd64.

I've made some tweaks to `bin/build-dev` and `build_push_ci.yaml` that:
- Splits the civiform-dev build so that it uses a native amd64 and arm64 ubuntu runner on github. This way they can each build natively.
- Pushes the large docker images as untagged digests. They will not replace the `latest` tag initially.
- After both dev images are pushed the merge step then tags them making them `latest`.
- Separates the `civiform` prod image from the dev job.

This reduces the time this job takes to run by an order of magnitude from around 50-55 minutes down to 4-5 minutes.

I've tested it a little running it manually, but that doesn't fully verify it is working right. I need to merge to main, let it run normally and then we verify the docker image is working on mac/linux. 

Before
<img width="316" height="475" alt="image" src="https://github.com/user-attachments/assets/55175151-cd76-4bb4-b572-0e71d77bc4e5" />

After
<img width="628" height="580" alt="image" src="https://github.com/user-attachments/assets/a17c2e00-fa52-4f5d-ba60-d4ad7d9a91b5" />

Claude was used to review the initial logs from Github and point me in the correct direction. 