### PR TITLE
Deny all node install scripts

### DIFF
--- a/browser-test/package.json
+++ b/browser-test/package.json
@@ -23,5 +23,8 @@
     "ts-node": "10.9.2",
     "ts-node-dev": "2.0.0",
     "typescript": "6.0.3"
+  },
+  "allowScripts": {
+    "sharp": false
   }
 }

--- a/mock-web-services/package.json
+++ b/mock-web-services/package.json
@@ -29,5 +29,8 @@
     "ts-node": "^10.9.2",
     "typescript": "^6.0.0"
   },
-  "license": "Apache-2.0"
+  "license": "Apache-2.0",
+  "allowScripts": {
+    "msw": false
+  }
 }

--- a/server/package.json
+++ b/server/package.json
@@ -55,5 +55,9 @@
     "last 2 versions",
     "IE 11",
     "not dead"
-  ]
+  ],
+  "allowScripts": {
+    "@parcel/watcher": false,
+    "@scarf/scarf": false
+  }
 }


### PR DESCRIPTION
Upcoming npm v12 will no longer run install scripts by default.

See: https://github.blog/changelog/2026-06-09-upcoming-breaking-changes-for-npm-v12/

This PR is denying all the scripts found by npm v11.16.0 to prepare as outlined in the blog post. `sharp` and `@parcel/watcher` may need to be approved, but they should be able to run on common platforms fine without. We can flag them as allowed if we find a platform we need to support doesn't work.

This will be ignored by npm versions earlier than v11.16.0