### PR TITLE
Scope duplicate submission screenshot to dialog element

### DIFF
--- a/browser-test/src/applicant/applicant_prevent_duplicate_submission.test.ts
+++ b/browser-test/src/applicant/applicant_prevent_duplicate_submission.test.ts
@@ -62,7 +62,10 @@ test.describe('Prevent Duplicate Submission', () => {
         page.getByText('There are no changes to save for the ' + programName),
       ).toBeVisible()
 
-      await validateScreenshot(page, 'prevent-duplicate-submission')
+      await validateScreenshot(
+        page.getByRole('dialog'),
+        'prevent-duplicate-submission',
+      )
       await validateAccessibility(page)
     })
 


### PR DESCRIPTION
### Description

This is related to https://github.com/civiform/civiform/issues/11186 clean-up 

Changed validateScreenshot in the prevent duplicate submission browser test to capture only the dialog element (page.getByRole('dialog')) instead of the full page. This makes the screenshot comparison more stable and focused on the relevant modal UI rather than capturing unrelated page content that could cause flaky diffs.

No AI-generated code was used in this PR.

#### General

Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): enhancement
Assigned reviewer to civiform/developers (https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
Added an additional reviewer from civiform/eng-admin as FYI 
Performed testing by running bin/run-browser-tests src/applicant/applicant_prevent_duplicate_submission.test.ts
Ensured PII wasn't added to any new logs, unless it was guarded by isDevOrStaging
Noted in the PR description which, if any, code in this PR was generated by AI.
