### PR TITLE
Only initialize the multi question option js once

### DIFF
--- a/server/app/assets/javascripts/multi_option_question.ts
+++ b/server/app/assets/javascripts/multi_option_question.ts
@@ -28,6 +28,12 @@ export class MultiOptionQuestion {
     const container = document.getElementById(this.containerId)
     if (container == null) return
 
+    if (container.dataset.multiOptionInitialized != null) {
+      return
+    }
+
+    container.dataset.multiOptionInitialized = 'true'
+
     // Wire server-rendered options already in the DOM.
     container
       .querySelectorAll('.cf-multi-option-question-option')


### PR DESCRIPTION
This should fix the failing tests on CI.

Turns out the question preview loads the applicant javascript bundle in addition to the the admin bundle. This was causing this file to run on both thus binding the add option button twice adding two things when you clicked the button.

Change adds a check to make sure it has only loaded once.