### PR TITLE
Small admin redesign bug fixes and tweaks

### DIFF
--- a/server/app/assets/javascripts/pages/admin/api_docs_page.ts
+++ b/server/app/assets/javascripts/pages/admin/api_docs_page.ts
@@ -1,17 +1,21 @@
-function init(): void {
-  const submitForm = () =>
-    document.querySelector<HTMLFormElement>('#selectionForm')?.submit()
+class ApiDocsPage {
+  static init(): void {
+    const submitForm = () =>
+      document.querySelector<HTMLFormElement>('#selectionForm')?.submit()
 
-  document.getElementById('programSlug')?.addEventListener('change', submitForm)
-  document.getElementById('stage')?.addEventListener('change', submitForm)
+    document
+      .getElementById('programSlug')
+      ?.addEventListener('change', submitForm)
+    document.getElementById('stage')?.addEventListener('change', submitForm)
+  }
 }
 
 if (document.readyState === 'loading') {
   // DOM is NOT ready yet: the event hasn't fired, so we can
   // safely add a listener for DOMContentLoaded
-  document.addEventListener('DOMContentLoaded', init)
+  document.addEventListener('DOMContentLoaded', ApiDocsPage.init)
 } else {
   // readyState is 'interactive' or 'complete': DOM is ALREADY ready,
   // DOMContentLoaded has fired (or won't help us), so just run init now
-  init()
+  ApiDocsPage.init()
 }

--- a/server/app/assets/javascripts/types/htmx.d.ts
+++ b/server/app/assets/javascripts/types/htmx.d.ts
@@ -56,9 +56,20 @@ export interface HtmxAfterSwapDetail extends HtmxRequestEventDetail {
   }
 }
 
+// https://htmx.org/events/#htmx:confirm
+export interface HtmxConfirmDetail extends HtmxEventDetail {
+  target: HTMLElement
+  path: string
+  verb: string
+  triggeringEvent: Event
+  question: string | null
+  issueRequest: (skipConfirmation?: boolean) => Promise<void>
+}
+
 export type HtmxEvent<T> = CustomEvent<T>
 
 export type HtmxConfigRequestEvent = HtmxEvent<HtmxConfigRequestDetail>
+export type HtmxConfirmEvent = HtmxEvent<HtmxConfirmDetail>
 export type HtmxBeforeRequestEvent = HtmxEvent<HtmxBeforeRequestDetail>
 export type HtmxAfterRequestEvent = HtmxEvent<HtmxAfterRequestDetail>
 export type HtmxAfterSwapEvent = HtmxEvent<HtmxAfterSwapDetail>
@@ -68,6 +79,7 @@ export type HtmxResponseErrorEvent = HtmxEvent<HtmxResponseErrorDetail>
 declare global {
   interface GlobalEventHandlersEventMap {
     'htmx:configRequest': HtmxConfigRequestEvent
+    'htmx:confirm': HtmxConfirmEvent
     'htmx:beforeRequest': HtmxBeforeRequestEvent
     'htmx:afterRequest': HtmxAfterRequestEvent
     'htmx:afterSwap': HtmxAfterSwapEvent

--- a/server/app/assets/stylesheets/uswds/_spacing.scss
+++ b/server/app/assets/stylesheets/uswds/_spacing.scss
@@ -8,7 +8,7 @@
 // owl selector (`> * + *`) below is the sole source of vertical rhythm.
 
 $spacing-scopes: '.spacing-0, .spacing-05, .spacing-1, .spacing-105, .spacing-2, .spacing-3, .spacing-4, .spacing-8';
-$reset-targets: 'h1, h2, h3, h4, h5, h6, .usa-form-group, .usa-card';
+$reset-targets: 'h1, h2, h3, h4, h5, h6, .usa-form-group, .usa-card, .usa-input';
 
 // Reset margin-top on spacing-* direct children to enforce a good starting point for
 // when the spacing-* is applied.

--- a/server/app/views/tags/AbstractElementModelProcessor.java
+++ b/server/app/views/tags/AbstractElementModelProcessor.java
@@ -235,7 +235,7 @@ public abstract class AbstractElementModelProcessor
   /** Filter full attribute map for data-* and aria-* attributes */
   protected static Map<String, String> getDataAndAriaAttributes(Map<String, String> attributeMap) {
     var ignoredAttributes = Set.of("aria-describedby", "aria-invalid");
-    var allowedAttributePrefixes = ImmutableList.of("data-", "th:data-", "aria-", "th:aria-");
+    var allowedAttributePrefixes = ImmutableList.of("data-", "th:data-", "aria-", "th:aria-", "form", "th:form");
 
     Map<String, String> attrs = new LinkedHashMap<>();
 

--- a/server/app/views/tags/AbstractElementModelProcessor.java
+++ b/server/app/views/tags/AbstractElementModelProcessor.java
@@ -235,7 +235,8 @@ public abstract class AbstractElementModelProcessor
   /** Filter full attribute map for data-* and aria-* attributes */
   protected static Map<String, String> getDataAndAriaAttributes(Map<String, String> attributeMap) {
     var ignoredAttributes = Set.of("aria-describedby", "aria-invalid");
-    var allowedAttributePrefixes = ImmutableList.of("data-", "th:data-", "aria-", "th:aria-", "form", "th:form");
+    var allowedAttributePrefixes =
+        ImmutableList.of("data-", "th:data-", "aria-", "th:aria-", "form", "th:form");
 
     Map<String, String> attrs = new LinkedHashMap<>();
 

--- a/server/app/views/tags/settings/TextAreaFormSettings.java
+++ b/server/app/views/tags/settings/TextAreaFormSettings.java
@@ -61,7 +61,7 @@ public class TextAreaFormSettings extends FormSettings {
 
   @Override
   public String sizeCssClass() {
-    return "usa-textarea--%s".formatted(size().value());
+    return "usa-input--%s".formatted(size().value());
   }
 
   @Override

--- a/server/test/views/tags/TextAreaElementTagModelProcessorTest.java
+++ b/server/test/views/tags/TextAreaElementTagModelProcessorTest.java
@@ -421,7 +421,7 @@ public class TextAreaElementTagModelProcessorTest extends BaseElementTagModelPro
 <div class="usa-form-group">
 <label class="usa-label" for="summary">Summary</label>
 <span id="error-message-summary" class="usa-error-message" role="alert" hidden="hidden"></span>
-<textarea class="usa-textarea usa-textarea--small" id="summary" name="summary"></textarea>
+<textarea class="usa-textarea usa-input--small" id="summary" name="summary"></textarea>
 </div>
 """);
 
@@ -438,7 +438,7 @@ public class TextAreaElementTagModelProcessorTest extends BaseElementTagModelPro
 <div class="usa-form-group">
 <label class="usa-label" for="summary">Summary</label>
 <span id="error-message-summary" class="usa-error-message" role="alert" hidden="hidden"></span>
-<textarea class="usa-textarea usa-textarea--small" id="summary" name="summary"></textarea>
+<textarea class="usa-textarea usa-input--small" id="summary" name="summary"></textarea>
 </div>
 """);
   }
@@ -463,7 +463,7 @@ public class TextAreaElementTagModelProcessorTest extends BaseElementTagModelPro
 <div class="usa-form-group">
 <label class="usa-label" for="description">Description</label>
 <span id="error-message-description" class="usa-error-message" role="alert" hidden="hidden"></span>
-<textarea class="usa-textarea usa-textarea--medium" id="description" name="description"></textarea>
+<textarea class="usa-textarea usa-input--medium" id="description" name="description"></textarea>
 </div>
 """);
   }
@@ -502,7 +502,7 @@ public class TextAreaElementTagModelProcessorTest extends BaseElementTagModelPro
 <label class="usa-label" for="feedback">Feedback</label>
 <div id="help-text-feedback" class="usa-hint">Please be specific</div>
 <span id="error-message-feedback" class="usa-error-message" role="alert" hidden="hidden"></span>
-<textarea class="usa-textarea usa-textarea--md" id="feedback" name="feedback" placeholder="Enter your feedback" required="required" aria-describedby="help-text-feedback" minlength="1" maxlength="10">Initial feedback</textarea>
+<textarea class="usa-textarea usa-input--md" id="feedback" name="feedback" placeholder="Enter your feedback" required="required" aria-describedby="help-text-feedback" minlength="1" maxlength="10">Initial feedback</textarea>
 </div>
 """);
 
@@ -526,7 +526,7 @@ public class TextAreaElementTagModelProcessorTest extends BaseElementTagModelPro
 <label class="usa-label" for="feedback">Feedback</label>
 <div id="help-text-feedback" class="usa-hint">Please be specific</div>
 <span id="error-message-feedback" class="usa-error-message" role="alert" hidden="hidden"></span>
-<textarea class="usa-textarea usa-textarea--md" id="feedback" name="feedback" placeholder="Enter your feedback" required="required" aria-describedby="help-text-feedback" minlength="1" maxlength="10">Initial feedback</textarea>
+<textarea class="usa-textarea usa-input--md" id="feedback" name="feedback" placeholder="Enter your feedback" required="required" aria-describedby="help-text-feedback" minlength="1" maxlength="10">Initial feedback</textarea>
 </div>
 """);
   }

--- a/server/test/views/tags/TextAreaElementTagModelProcessorTest.java
+++ b/server/test/views/tags/TextAreaElementTagModelProcessorTest.java
@@ -59,7 +59,7 @@ public class TextAreaElementTagModelProcessorTest extends BaseElementTagModelPro
             th:name="${model.name()}"
             th:label="${model.label()}" />
         """,
-        """
+"""
 <div class="usa-form-group">
 <label class="usa-label" for="description">Description</label>
 <span id="error-message-description" class="usa-error-message" role="alert" hidden="hidden"></span>
@@ -75,7 +75,7 @@ public class TextAreaElementTagModelProcessorTest extends BaseElementTagModelPro
             name="description"
             label="Description" />
         """,
-        """
+"""
 <div class="usa-form-group">
 <label class="usa-label" for="description">Description</label>
 <span id="error-message-description" class="usa-error-message" role="alert" hidden="hidden"></span>
@@ -96,7 +96,7 @@ public class TextAreaElementTagModelProcessorTest extends BaseElementTagModelPro
             th:label="${model.label()}"
             th:disabled="${model.disabled()}" />
         """,
-        """
+"""
 <div class="usa-form-group">
 <label class="usa-label" for="comments">Comments</label>
 <span id="error-message-comments" class="usa-error-message" role="alert" hidden="hidden"></span>
@@ -113,7 +113,7 @@ public class TextAreaElementTagModelProcessorTest extends BaseElementTagModelPro
             label="Comments"
             disabled="true" />
         """,
-        """
+"""
 <div class="usa-form-group">
 <label class="usa-label" for="comments">Comments</label>
 <span id="error-message-comments" class="usa-error-message" role="alert" hidden="hidden"></span>
@@ -134,7 +134,7 @@ public class TextAreaElementTagModelProcessorTest extends BaseElementTagModelPro
             th:label="${model.label()}"
             th:readonly="${model.readonly()}" />
         """,
-        """
+"""
 <div class="usa-form-group">
 <label class="usa-label" for="notes">Notes</label>
 <span id="error-message-notes" class="usa-error-message" role="alert" hidden="hidden"></span>
@@ -151,7 +151,7 @@ public class TextAreaElementTagModelProcessorTest extends BaseElementTagModelPro
             label="Notes"
             readonly="true" />
         """,
-        """
+"""
 <div class="usa-form-group">
 <label class="usa-label" for="notes">Notes</label>
 <span id="error-message-notes" class="usa-error-message" role="alert" hidden="hidden"></span>
@@ -177,7 +177,7 @@ public class TextAreaElementTagModelProcessorTest extends BaseElementTagModelPro
             th:label="${model.label()}"
             th:value="${model.value()}" />
         """,
-        """
+"""
 <div class="usa-form-group">
 <label class="usa-label" for="comments">Comments</label>
 <span id="error-message-comments" class="usa-error-message" role="alert" hidden="hidden"></span>
@@ -194,7 +194,7 @@ public class TextAreaElementTagModelProcessorTest extends BaseElementTagModelPro
             label="Comments"
             value="Initial text content" />
         """,
-        """
+"""
 <div class="usa-form-group">
 <label class="usa-label" for="comments">Comments</label>
 <span id="error-message-comments" class="usa-error-message" role="alert" hidden="hidden"></span>
@@ -220,7 +220,7 @@ public class TextAreaElementTagModelProcessorTest extends BaseElementTagModelPro
             th:label="${model.label()}"
             th:placeholder="${model.placeholder()}" />
         """,
-        """
+"""
 <div class="usa-form-group">
 <label class="usa-label" for="notes">Notes</label>
 <span id="error-message-notes" class="usa-error-message" role="alert" hidden="hidden"></span>
@@ -237,7 +237,7 @@ public class TextAreaElementTagModelProcessorTest extends BaseElementTagModelPro
             label="Notes"
             placeholder="Enter your notes here" />
         """,
-        """
+"""
 <div class="usa-form-group">
 <label class="usa-label" for="notes">Notes</label>
 <span id="error-message-notes" class="usa-error-message" role="alert" hidden="hidden"></span>
@@ -263,7 +263,7 @@ public class TextAreaElementTagModelProcessorTest extends BaseElementTagModelPro
             th:label="${model.label()}"
             th:help-text="${model.helpText()}" />
         """,
-        """
+"""
 <div class="usa-form-group">
 <label class="usa-label" for="bio">Biography</label>
 <div id="help-text-bio" class="usa-hint">Please provide a brief biography</div>
@@ -281,7 +281,7 @@ public class TextAreaElementTagModelProcessorTest extends BaseElementTagModelPro
             label="Biography"
             help-text="Please provide a brief biography" />
         """,
-        """
+"""
 <div class="usa-form-group">
 <label class="usa-label" for="bio">Biography</label>
 <div id="help-text-bio" class="usa-hint">Please provide a brief biography</div>
@@ -310,7 +310,7 @@ public class TextAreaElementTagModelProcessorTest extends BaseElementTagModelPro
             th:is-valid="${model.isValid()}"
             th:validation-message="${model.validationMessage()}" />
         """,
-        """
+"""
 <div class="usa-form-group usa-form-group--error">
 <label class="usa-label" for="message">Message</label>
 <span id="error-message-message" class="usa-error-message" role="alert">Message is required</span>
@@ -328,7 +328,7 @@ public class TextAreaElementTagModelProcessorTest extends BaseElementTagModelPro
             is-valid="false"
             validation-message="Message is required" />
         """,
-        """
+"""
 <div class="usa-form-group usa-form-group--error">
 <label class="usa-label" for="message">Message</label>
 <span id="error-message-message" class="usa-error-message" role="alert">Message is required</span>
@@ -357,7 +357,7 @@ public class TextAreaElementTagModelProcessorTest extends BaseElementTagModelPro
             th:is-valid="${model.isValid()}"
             th:validation-message="${model.validationMessage()}" />
         """,
-        """
+"""
 <div class="usa-form-group usa-form-group--error">
 <label class="usa-label" for="feedback">Feedback</label>
 <div id="help-text-feedback" class="usa-hint">Tell us what you think</div>
@@ -379,7 +379,7 @@ public class TextAreaElementTagModelProcessorTest extends BaseElementTagModelPro
             th:label="${model.label()}"
             th:required="${model.required()}" />
         """,
-        """
+"""
 <div class="usa-form-group">
 <label class="usa-label" for="terms">Terms</label>
 <span id="error-message-terms" class="usa-error-message" role="alert" hidden="hidden"></span>
@@ -396,7 +396,7 @@ public class TextAreaElementTagModelProcessorTest extends BaseElementTagModelPro
             label="Terms"
             required="true" />
         """,
-        """
+"""
 <div class="usa-form-group">
 <label class="usa-label" for="terms">Terms</label>
 <span id="error-message-terms" class="usa-error-message" role="alert" hidden="hidden"></span>
@@ -417,7 +417,7 @@ public class TextAreaElementTagModelProcessorTest extends BaseElementTagModelPro
             th:label="${model.label()}"
             th:size="${model.size()}" />
         """,
-        """
+"""
 <div class="usa-form-group">
 <label class="usa-label" for="summary">Summary</label>
 <span id="error-message-summary" class="usa-error-message" role="alert" hidden="hidden"></span>
@@ -434,7 +434,7 @@ public class TextAreaElementTagModelProcessorTest extends BaseElementTagModelPro
             label="Summary"
             size="small" />
         """,
-        """
+"""
 <div class="usa-form-group">
 <label class="usa-label" for="summary">Summary</label>
 <span id="error-message-summary" class="usa-error-message" role="alert" hidden="hidden"></span>
@@ -459,7 +459,7 @@ public class TextAreaElementTagModelProcessorTest extends BaseElementTagModelPro
             th:label="${model.label()}"
             th:size="${model.size()}" />
         """,
-        """
+"""
 <div class="usa-form-group">
 <label class="usa-label" for="description">Description</label>
 <span id="error-message-description" class="usa-error-message" role="alert" hidden="hidden"></span>
@@ -497,7 +497,7 @@ public class TextAreaElementTagModelProcessorTest extends BaseElementTagModelPro
             th:minlength="${model.minLength()}"
             th:maxlength="${model.maxLength()}" />
         """,
-        """
+"""
 <div class="usa-form-group">
 <label class="usa-label" for="feedback">Feedback</label>
 <div id="help-text-feedback" class="usa-hint">Please be specific</div>
@@ -521,7 +521,7 @@ public class TextAreaElementTagModelProcessorTest extends BaseElementTagModelPro
             minlength="1"
             maxlength="10" />
         """,
-        """
+"""
 <div class="usa-form-group">
 <label class="usa-label" for="feedback">Feedback</label>
 <div id="help-text-feedback" class="usa-hint">Please be specific</div>
@@ -544,7 +544,7 @@ public class TextAreaElementTagModelProcessorTest extends BaseElementTagModelPro
             data-testid="tracking-textarea"
             data-analytics="track-me" />
         """,
-        """
+"""
 <div class="usa-form-group">
 <label class="usa-label" for="tracking">Tracking</label>
 <span id="error-message-tracking" class="usa-error-message" role="alert" hidden="hidden"></span>
@@ -563,7 +563,7 @@ public class TextAreaElementTagModelProcessorTest extends BaseElementTagModelPro
             th:data-testid="${model.id()}"
             th:data-analytics="${model.name()}" />
         """,
-        """
+"""
 <div class="usa-form-group">
 <label class="usa-label" for="tracking">Tracking</label>
 <span id="error-message-tracking" class="usa-error-message" role="alert" hidden="hidden"></span>
@@ -584,7 +584,7 @@ public class TextAreaElementTagModelProcessorTest extends BaseElementTagModelPro
             th:label="${model.label()}"
             aria-label="Comment box" />
         """,
-        """
+"""
 <div class="usa-form-group">
 <label class="usa-label" for="comments">Comments</label>
 <span id="error-message-comments" class="usa-error-message" role="alert" hidden="hidden"></span>
@@ -602,7 +602,7 @@ public class TextAreaElementTagModelProcessorTest extends BaseElementTagModelPro
             th:label="${model.label()}"
             th:aria-label="${model.label()}" />
         """,
-        """
+"""
 <div class="usa-form-group">
 <label class="usa-label" for="comments">Comments</label>
 <span id="error-message-comments" class="usa-error-message" role="alert" hidden="hidden"></span>
@@ -627,7 +627,7 @@ public class TextAreaElementTagModelProcessorTest extends BaseElementTagModelPro
             th:label="${model.label()}"
             th:is-valid="${model.isValid()}" />
         """,
-        """
+"""
 <div class="usa-form-group">
 <label class="usa-label" for="complex">Biography</label>
 <span id="error-message-user-profile-bio" class="usa-error-message" role="alert" hidden="hidden"></span>
@@ -646,7 +646,7 @@ public class TextAreaElementTagModelProcessorTest extends BaseElementTagModelPro
             name="mixedTextarea"
             label="Mixed Textarea" />
         """,
-        """
+"""
 <div class="usa-form-group">
 <label class="usa-label" for="mixed">Mixed Textarea</label>
 <span id="error-message-mixedTextarea" class="usa-error-message" role="alert" hidden="hidden"></span>
@@ -667,7 +667,7 @@ public class TextAreaElementTagModelProcessorTest extends BaseElementTagModelPro
             th:validation-class="${model.getClassName()}"
             validation-field="description"/>
         """,
-        """
+"""
 <div class="usa-form-group">
 <label class="usa-label" for="description">Description</label>
 <span id="error-message-description" class="usa-error-message" role="alert" hidden="hidden"></span>


### PR DESCRIPTION
Small bug fixes and tweaks for admin redesign work batched into this PR.

- Removing empty htmx_request.ts file
- Fixing a js module load collision
- Adding htmx:confirm to the htmx type definitions
- Removes vertical spacing from usa-input on the spacing-* children
- Allows setting the form on the custom thymeleaf form components
- Bug fix on the textarea component with sizing on uswds css classes.