### PR TITLE
Perf fix on setting feature flags from browser tests

### DIFF
--- a/browser-test/src/admin/dev_tools.test.ts
+++ b/browser-test/src/admin/dev_tools.test.ts
@@ -32,6 +32,8 @@ test.describe('developer tools', () => {
   }) => {
     await enableFeatureFlag(page, 'staging_disable_demo_mode_logins')
 
+    await page.goto('/programs')
+
     const header = page.locator('nav')
 
     await test.step('link not shown in the header', async () => {

--- a/browser-test/src/applicant/not_production_banner.test.ts
+++ b/browser-test/src/applicant/not_production_banner.test.ts
@@ -7,6 +7,8 @@ test.describe('Ineligible Page Tests', () => {
   })
 
   test('View "Not Production" banner', async ({page}) => {
+    await page.goto('/programs')
+
     await test.step('Verify banner', async () => {
       await expect(
         page.getByText(

--- a/browser-test/src/header.test.ts
+++ b/browser-test/src/header.test.ts
@@ -121,6 +121,7 @@ test.describe('Header', () => {
 
   test('Government name hidden', async ({page}) => {
     await enableFeatureFlag(page, 'hide_civic_entity_name_in_header')
+    await page.goto('/programs')
 
     await test.step('Header on desktop shows logo and hides gov name', async () => {
       await page.setViewportSize({width: 1280, height: 720})

--- a/browser-test/src/support/helpers.ts
+++ b/browser-test/src/support/helpers.ts
@@ -29,19 +29,19 @@ export const selectApplicantLanguage = async (
 
 export const disableFeatureFlag = async (page: Page, flag: string) => {
   await test.step(`Disable feature flag: ${flag}`, async () => {
-    const response = await page.goto(`/dev/feature/${flag}/disable`)
-    expect(response?.status(), {
+    const response = await page.request.get(`/dev/feature/${flag}/disable`)
+    await expect(response, {
       message: `Could not disable feature flag '${flag}'. Make sure the flag exists.`,
-    }).toBe(200)
+    }).toBeOK()
   })
 }
 
 export const enableFeatureFlag = async (page: Page, flag: string) => {
   await test.step(`Enable feature flag: ${flag}`, async () => {
-    const response = await page.goto(`/dev/feature/${flag}/enable`)
-    expect(response?.status(), {
+    const response = await page.request.get(`/dev/feature/${flag}/enable`)
+    await expect(response, {
       message: `Could not enable feature flag '${flag}'. Make sure the flag exists.`,
-    }).toBe(200)
+    }).toBeOK()
   })
 }
 

--- a/server/app/controllers/dev/FeatureFlagOverrideController.java
+++ b/server/app/controllers/dev/FeatureFlagOverrideController.java
@@ -5,7 +5,6 @@ import com.google.common.collect.ImmutableMap;
 import java.util.Locale;
 import javax.inject.Inject;
 import play.mvc.Controller;
-import play.mvc.Http.HeaderNames;
 import play.mvc.Http.Request;
 import play.mvc.Result;
 import services.settings.SettingsManifest;
@@ -27,14 +26,14 @@ public final class FeatureFlagOverrideController extends Controller {
   }
 
   public Result enable(Request request, String rawFlagName) {
-    return updateFlag(request, rawFlagName, "true");
+    return updateFlag(rawFlagName, "true");
   }
 
   public Result disable(Request request, String rawFlagName) {
-    return updateFlag(request, rawFlagName, "false");
+    return updateFlag(rawFlagName, "false");
   }
 
-  private Result updateFlag(Request request, String rawFlagName, String newValue) {
+  private Result updateFlag(String rawFlagName, String newValue) {
     var flagName = rawFlagName.toUpperCase(Locale.ROOT);
     var currentSettings =
         settingsService.loadSettings().toCompletableFuture().join().orElse(ImmutableMap.of());
@@ -50,6 +49,6 @@ public final class FeatureFlagOverrideController extends Controller {
     newSettings.put(flagName, newValue);
     settingsService.updateSettings(newSettings.build(), "dev mode");
 
-    return redirect(request.header(HeaderNames.REFERER).orElse("/"));
+    return ok(String.format("Set feature flag %s to %s.", flagName, newValue));
   }
 }

--- a/server/test/controllers/dev/FeatureFlagOverrideControllerTest.java
+++ b/server/test/controllers/dev/FeatureFlagOverrideControllerTest.java
@@ -1,7 +1,7 @@
 package controllers.dev;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static play.mvc.Http.Status.SEE_OTHER;
+import static play.mvc.Http.Status.OK;
 import static support.FakeRequestBuilder.fakeRequest;
 
 import com.google.common.collect.ImmutableMap;
@@ -32,7 +32,7 @@ public class FeatureFlagOverrideControllerTest extends ResetPostgres {
     var result = controller.disable(fakeRequest(), FLAG_NAME);
 
     // Verify
-    assertThat(result.status()).isEqualTo(SEE_OTHER);
+    assertThat(result.status()).isEqualTo(OK);
     assertThat(getSettings().get(FLAG_NAME)).isEqualTo("false");
   }
 
@@ -45,7 +45,7 @@ public class FeatureFlagOverrideControllerTest extends ResetPostgres {
     var result = controller.enable(fakeRequest(), FLAG_NAME);
 
     // Verify
-    assertThat(result.status()).isEqualTo(SEE_OTHER);
+    assertThat(result.status()).isEqualTo(OK);
     assertThat(getSettings().get(FLAG_NAME)).isEqualTo("true");
   }
 


### PR DESCRIPTION
In the browser tests we frequently call to enable/disable feature flags. This improves the performance on a single call to the typescript methods `enabledFeatureFlag` and `disableFeatureFlag`. It was redirecting back to a page, which we don't actually need to do. We just need to toggle the flag.

Removing the redirect and doing a direct network request reduces the time from 200-250ms to 5-10ms each call.

Update three tests that expected to be on `/programs`