### PR TITLE
Moving category filtering code out of main.ts

### DIFF
--- a/server/app/assets/javascripts/category_filter.ts
+++ b/server/app/assets/javascripts/category_filter.ts
@@ -1,0 +1,47 @@
+/**
+ * Behavior for the program category filter on the applicant program index page.
+ *
+ * The filter form (`#ns-category-filter-form`) is HTMX-driven: selecting
+ * categories and pressing "Apply selections" (`#filter-submit`) issues the
+ * `hx-get` and swaps the results in place, so there is no form-submission logic
+ * here. This class handles responsive checkbox styling and resetting the
+ * checkboxes when the "Clear selections" button is pressed.
+ */
+import {addEventListenerToElements} from '@/util'
+
+export class CategoryFilter {
+  /** Kick everything off. Call once after the DOM is ready. */
+  init() {
+    addEventListener('resize', () => this.handleMediaQueryChange())
+    this.handleMediaQueryChange()
+
+    /* Uncheck all program filter checkboxes when the clear filters button is clicked */
+    addEventListenerToElements('#clear-filters', 'click', () => {
+      const checkboxes = document.querySelectorAll('[id*="ns-check-category"]')
+
+      checkboxes.forEach((checkbox) => {
+        const checkboxInput = checkbox as HTMLInputElement
+        checkboxInput.checked = false
+      })
+    })
+  }
+
+  /**
+   * Add USWDS checkbox tile CSS class to program filter checkboxes for tablet
+   * and mobile.
+   */
+  private handleMediaQueryChange() {
+    const mediaQuery = window.matchMedia('(max-width: 63.9em)')
+    const checkboxes = document.querySelectorAll('[id*="ns-check-category-"]')
+
+    if (mediaQuery.matches) {
+      checkboxes.forEach((checkbox) => {
+        checkbox.classList.add('usa-checkbox__input--tile')
+      })
+    } else {
+      checkboxes.forEach((checkbox) => {
+        checkbox.classList.remove('usa-checkbox__input--tile')
+      })
+    }
+  }
+}

--- a/server/app/assets/javascripts/main.ts
+++ b/server/app/assets/javascripts/main.ts
@@ -219,52 +219,6 @@ export function init() {
     })
   }
 
-  // Add USWDS checkbox tile CSS class to program filter checkboxes for tablet and mobile
-  const handleMediaQueryChange = () => {
-    const mediaQuery = window.matchMedia('(max-width: 63.9em)')
-    const checkboxes = document.querySelectorAll('[id*="ns-check-category-"]')
-
-    if (mediaQuery.matches) {
-      checkboxes.forEach((checkbox) => {
-        checkbox.classList.add('usa-checkbox__input--tile')
-      })
-    } else {
-      checkboxes.forEach((checkbox) => {
-        checkbox.classList.remove('usa-checkbox__input--tile')
-      })
-    }
-  }
-
-  addEventListener('resize', handleMediaQueryChange)
-  handleMediaQueryChange()
-
-  /* Bind click handler to submit category filter form when any category is clicked
-    and set the URL fragment to the most recently clicked category */
-  addEventListenerToElements('[id*="check-category"]', 'click', (event) => {
-    const form = document.getElementById(
-      'category-filter-form',
-    ) as HTMLFormElement
-
-    // Update the form action URL with the current selected category as a fragment
-    if (event.srcElement) {
-      const srcElement = event.srcElement as HTMLElement
-      const action = form.action + '#' + srcElement.id
-      form.action = action
-    }
-
-    form.submit()
-  })
-
-  /* Uncheck all program filter checkboxes when the clear filters button is clicked */
-  addEventListenerToElements('#clear-filters', 'click', () => {
-    const checkboxes = document.querySelectorAll('[id*="ns-check-category"]')
-
-    checkboxes.forEach((checkbox) => {
-      const checkboxInput = checkbox as HTMLInputElement
-      checkboxInput.checked = false
-    })
-  })
-
   attachFormDebouncers()
 
   attachRedirectToPageListeners()

--- a/server/app/assets/javascripts/pages/applicant/applicant_entry_point.ts
+++ b/server/app/assets/javascripts/pages/applicant/applicant_entry_point.ts
@@ -4,6 +4,7 @@
  */
 import '@/components/shared/modal'
 import * as main from '@/main'
+import {CategoryFilter} from '@/category_filter'
 import * as languageSelector from '@/language_selector'
 import * as enumerator from '@/enumerator'
 import * as radio from '@/radio'
@@ -32,6 +33,7 @@ window.addEventListener('load', () => {
   const AZURE_APPLICANT_FILEUPLOAD_FORM_ID = 'cf-block-form'
 
   main.init()
+  new CategoryFilter().init()
   languageSelector.init()
   enumerator.init()
   radio.init()


### PR DESCRIPTION
Moving category filtering code out of main.ts.

Removes pre-northstar code that was throwing an error.