### PR TITLE
Add optional thread leak detection

### DIFF
--- a/server/app/services/settings/SettingsManifest.java
+++ b/server/app/services/settings/SettingsManifest.java
@@ -894,6 +894,14 @@ public final class SettingsManifest extends AbstractSettingsManifest {
   }
 
   /**
+   * How long in milliseconds a database connection can be borrowed from the pool before a warning
+   * log is generated indicating a potential connection leak. Minimum value is 2000.
+   */
+  public Optional<Integer> getLeakDetectionThreshold() {
+    return getInt("LEAK_DETECTION_THRESHOLD");
+  }
+
+  /**
    * A cryptographic [secret salt](https://en.wikipedia.org/wiki/Salt_(cryptography)) used for
    * salting API keys before storing their hash values in the database. This value should be kept
    * strictly secret. If one suspects the secret has been leaked or otherwise comprised it should be
@@ -2126,6 +2134,14 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                               + " scripts are added to the CiviForm pages.",
                           /* isRequired= */ false,
                           SettingType.STRING,
+                          SettingMode.ADMIN_READABLE),
+                      SettingDescription.create(
+                          "LEAK_DETECTION_THRESHOLD",
+                          "How long in milliseconds a database connection can be borrowed from the"
+                              + " pool before a warning log is generated indicating a potential"
+                              + " connection leak. Minimum value is 2000.",
+                          /* isRequired= */ false,
+                          SettingType.INT,
                           SettingMode.ADMIN_READABLE))))
           .put(
               "Data Export API",

--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -525,6 +525,10 @@ play.evolutions {
 fixedConnectionPool = 9
 fixedConnectionPool = ${?DATABASE_CONNECTION_POOL_SIZE}
 
+# Default of 0 turns leak detection logging off
+leakDetectionThreshold = 0
+leakDetectionThreshold = ${?LEAK_DETECTION_THRESHOLD}
+
 play.db {
   # The combination of these two settings results in "db.default" as the
   # default JDBC pool:
@@ -537,9 +541,7 @@ play.db {
     # Sets a fixed JDBC connection pool size
     hikaricp.minimumIdle = ${fixedConnectionPool}
     hikaricp.maximumPoolSize = ${fixedConnectionPool}
-    # Default of 0 turns leak detection logging off
-    hikaricp.leakDetectionThreshold = 0
-    hikaricp.leakDetectionThreshold = ${?LEAK_DETECTION_THRESHOLD}
+    hikaricp.leakDetectionThreshold = ${leakDetectionThreshold}
   }
 }
 

--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -541,7 +541,7 @@ play.db {
     # Sets a fixed JDBC connection pool size
     hikaricp.minimumIdle = ${fixedConnectionPool}
     hikaricp.maximumPoolSize = ${fixedConnectionPool}
-    hikaricp.leak_detection_threshold = ${leakDetectionThreshold}
+    hikaricp.leakDetectionThreshold = ${leak_detection_threshold}
   }
 }
 

--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -537,6 +537,9 @@ play.db {
     # Sets a fixed JDBC connection pool size
     hikaricp.minimumIdle = ${fixedConnectionPool}
     hikaricp.maximumPoolSize = ${fixedConnectionPool}
+    # Default of 0 turns leak detection logging off
+    hikaricp.leakDetectionThreshold = 0
+    hikaricp.leakDetectionThreshold = ${?LEAK_DETECTION_THRESHOLD}
   }
 }
 

--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -526,8 +526,8 @@ fixedConnectionPool = 9
 fixedConnectionPool = ${?DATABASE_CONNECTION_POOL_SIZE}
 
 # Default of 0 turns leak detection logging off
-leakDetectionThreshold = 0
-leakDetectionThreshold = ${?LEAK_DETECTION_THRESHOLD}
+leak_detection_threshold = 0
+leak_detection_threshold = ${?LEAK_DETECTION_THRESHOLD}
 
 play.db {
   # The combination of these two settings results in "db.default" as the
@@ -541,7 +541,7 @@ play.db {
     # Sets a fixed JDBC connection pool size
     hikaricp.minimumIdle = ${fixedConnectionPool}
     hikaricp.maximumPoolSize = ${fixedConnectionPool}
-    hikaricp.leakDetectionThreshold = ${leakDetectionThreshold}
+    hikaricp.leak_detection_threshold = ${leakDetectionThreshold}
   }
 }
 

--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -525,7 +525,7 @@ play.evolutions {
 fixedConnectionPool = 9
 fixedConnectionPool = ${?DATABASE_CONNECTION_POOL_SIZE}
 
-# Default of 0 turns leak detection logging off
+# Values < 2000 turn leak detection logging off
 leak_detection_threshold = 0
 leak_detection_threshold = ${?LEAK_DETECTION_THRESHOLD}
 

--- a/server/conf/env-var-docs.json
+++ b/server/conf/env-var-docs.json
@@ -777,6 +777,11 @@
         "mode": "ADMIN_READABLE",
         "description": "The Google Analytics tracking ID.  If set, Google Analytics JavaScript scripts are added to the CiviForm pages.",
         "type": "string"
+      },
+      "LEAK_DETECTION_THRESHOLD": {
+        "mode": "ADMIN_READABLE",
+        "description": "How long in milliseconds a database connection can be borrowed from the pool before a warning log is generated indicating a potential connection leak. Minimum value is 2000.",
+        "type": "int"
       }
     }
   },


### PR DESCRIPTION
### Description

This PR adds a config var `LEAK_DETECTION_THRESHOLD` that governments can enable to log possible database thread leaks. 

## Release notes

To enable logging for potential thread leaks, set `LEAK_DETECTION_THRESHOLD` in your deployment config to a value greater than `2000` (2 minutes) and less than `1800000` (30 mins). This represents the amount of time (in milliseconds) a database connection can be checked out of the pool before a warning message is logged indicating a potential connection leak. The default value is 0 which turns logging off. We recommend starting with a timeout of `5000` (5 minutes) and then adjusting longer if the logs are too noisy.

More info on min and max values: Values less than `2000` reset to 0 which turns logging off. The max of `1800000` corresponds to the default value for `hikaricp.maxLifetime` in JavaPlay applications. `maxLifetime` is the maximum amount of time a connection can stay in the pool before it is retired and replaced.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [x] Added an additional reviewer as required if changes potentially affect the security of the application.
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.


### Instructions for manual testing

This change should have no impact on the functionality of the app. I tested this in the following way:
- Setup a deployment instance with the code from the last release
- Deployed with my changes but no value set in the config and manually tested the app
- Deployed with my changes + a value set in the config and manually tested the app

We'll merge this after the next release is cut to ensure prober tests have plenty of time to run on it before releasing it to governments.

### Issue(s) this completes

Related to #13480 
