### PR TITLE
Caching fix

### DIFF
--- a/server/app/repository/ProgramRepository.java
+++ b/server/app/repository/ProgramRepository.java
@@ -3,6 +3,7 @@ package repository;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.util.concurrent.CompletableFuture.supplyAsync;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -10,6 +11,7 @@ import io.ebean.DB;
 import io.ebean.Database;
 import io.ebean.ExpressionList;
 import io.ebean.PagedList;
+import io.ebean.PersistenceContextScope;
 import io.ebean.Query;
 import io.ebean.SqlRow;
 import io.ebean.Transaction;
@@ -121,12 +123,61 @@ public final class ProgramRepository {
     return program;
   }
 
+  /**
+   * Returns all versions the program is associated with.
+   *
+   * <p>Results are cached when the program cache is enabled and no draft version exists. The cache
+   * key includes the active version id because publishing associates unedited programs with the new
+   * version - entries cached under the previous active version id naturally stop being read instead
+   * of serving stale associations. The cache is populated from a fresh database fetch rather than
+   * from the passed-in program, whose lazily-loaded versions collection (and the version entities
+   * inside it) may be stale (issue #9451).
+   */
   public ImmutableList<VersionModel> getVersionsForProgram(ProgramModel program) {
-    if (settingsManifest.getProgramCacheEnabled()) {
-      return versionsByProgramCache.getOrElseUpdate(
-          String.valueOf(program.id), program::getVersions);
+    if (!settingsManifest.getProgramCacheEnabled()) {
+      return program.getVersions();
     }
-    return program.getVersions();
+    Optional<Long> activeVersionId = versionRepository.get().getActiveVersionIdIfNoDraft();
+    if (activeVersionId.isEmpty()) {
+      // While a draft version exists, program-version associations may still change, so we
+      // neither read nor populate the cache.
+      return program.getVersions();
+    }
+    String cacheKey = versionsByProgramCacheKey(program.id, activeVersionId.get());
+    Optional<ImmutableList<VersionModel>> cachedVersions = versionsByProgramCache.get(cacheKey);
+    if (cachedVersions.isPresent()) {
+      return cachedVersions.get();
+    }
+    ImmutableList<VersionModel> versions =
+        getVersionsForProgramFresh(program.id).orElseGet(program::getVersions);
+    // A draft association appearing here means a draft version was created after the check
+    // above; don't cache in-flux data.
+    if (versions.stream()
+        .noneMatch(version -> version.getLifecycleStage() == LifecycleStage.DRAFT)) {
+      versionsByProgramCache.set(cacheKey, versions);
+    }
+    return versions;
+  }
+
+  @VisibleForTesting
+  static String versionsByProgramCacheKey(long programId, long activeVersionId) {
+    return programId + ":" + activeVersionId;
+  }
+
+  /**
+   * Fetches a fresh copy of the program's version associations from the database, bypassing the
+   * transaction's persistence context. Empty if the program row no longer exists.
+   */
+  private Optional<ImmutableList<VersionModel>> getVersionsForProgramFresh(long programId) {
+    return database
+        .find(ProgramModel.class)
+        .setId(programId)
+        .fetch("versions")
+        .setPersistenceContextScope(PersistenceContextScope.QUERY)
+        .setLabel("ProgramModel.findByIdFresh")
+        .setProfileLocation(queryProfileLocationBuilder.create("getVersionsForProgramFresh"))
+        .findOneOrEmpty()
+        .map(ProgramModel::getVersions);
   }
 
   public ImmutableSet<String> getAllProgramNames() {

--- a/server/app/repository/VersionRepository.java
+++ b/server/app/repository/VersionRepository.java
@@ -13,6 +13,7 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import io.ebean.DB;
 import io.ebean.Database;
+import io.ebean.PersistenceContextScope;
 import io.ebean.SerializableConflictException;
 import io.ebean.Transaction;
 import io.ebean.TxScope;
@@ -454,6 +455,48 @@ public final class VersionRepository {
   }
 
   /**
+   * Returns the id of the active version if and only if no draft version currently exists, and
+   * empty otherwise. Combines the draft-existence check and the active version lookup into a single
+   * query.
+   */
+  public Optional<Long> getActiveVersionIdIfNoDraft() {
+    ImmutableList<VersionModel> versions =
+        ImmutableList.copyOf(
+            database
+                .find(VersionModel.class)
+                .where()
+                .in("lifecycle_stage", LifecycleStage.ACTIVE, LifecycleStage.DRAFT)
+                .setLabel("VersionModel.findActiveAndDraft")
+                .setProfileLocation(profileLocationBuilder.create("getActiveVersionIdIfNoDraft"))
+                .findList());
+    if (versions.stream()
+        .anyMatch(version -> version.getLifecycleStage() == LifecycleStage.DRAFT)) {
+      return Optional.empty();
+    }
+    // More than one active version has been witnessed in production (see issue #9451); when that
+    // happens the newest one is the one the system actually serves.
+    return versions.stream().map(version -> version.id).max(Long::compareTo);
+  }
+
+  /**
+   * Fetches a fresh copy of a version from the database with the given relation ("questions" or
+   * "programs") eagerly loaded, bypassing the transaction's persistence context.
+   *
+   * <p>Used when populating the version caches so that the cached data reflects the database state
+   * rather than the possibly-stale state of a caller-supplied entity.
+   */
+  private Optional<VersionModel> getFreshVersion(long versionId, String relationToFetch) {
+    return database
+        .find(VersionModel.class)
+        .setId(versionId)
+        .fetch(relationToFetch)
+        .setPersistenceContextScope(PersistenceContextScope.QUERY)
+        .setLabel("VersionModel.findFresh")
+        .setProfileLocation(profileLocationBuilder.create("getFreshVersion"))
+        .findOneOrEmpty();
+  }
+
+  /**
    * Returns the previous version to the one passed in. If there is only one version there isn't a
    * previous version so the Optional result will be empty.
    *
@@ -565,8 +608,25 @@ public final class VersionRepository {
   public ImmutableList<QuestionModel> getQuestionsForVersion(VersionModel version) {
     // Only set the version cache for active and obsolete versions
     if (settingsManifest.getVersionCacheEnabled() && version.id <= getActiveVersion().id) {
-      return questionsByVersionCache.getOrElseUpdate(
-          String.valueOf(version.id), version::getQuestions);
+      String cacheKey = String.valueOf(version.id);
+      Optional<ImmutableList<QuestionModel>> cachedQuestions =
+          questionsByVersionCache.get(cacheKey);
+      if (cachedQuestions.isPresent()) {
+        return cachedQuestions.get();
+      }
+      // Populate the cache from a fresh database fetch rather than from the passed-in object.
+      // The caller's object may carry a lazily-loaded questions collection that was populated
+      // while the version was still a draft - before publishing associated the carried-over
+      // active questions with it. Caching that incomplete collection permanently poisons the
+      // entry for this version and produces NULL_QUESTION errors for every subsequent reader
+      // until the server restarts (issue #9451).
+      Optional<VersionModel> freshVersion = getFreshVersion(version.id, "questions");
+      if (freshVersion.isPresent()
+          && freshVersion.get().getLifecycleStage() != LifecycleStage.DRAFT) {
+        ImmutableList<QuestionModel> questions = freshVersion.get().getQuestions();
+        questionsByVersionCache.set(cacheKey, questions);
+        return questions;
+      }
     }
     return getQuestionsForVersionWithoutCache(version);
   }
@@ -630,8 +690,21 @@ public final class VersionRepository {
   public ImmutableList<ProgramModel> getProgramsForVersion(VersionModel version) {
     // Only set the version cache for active and obsolete versions
     if (settingsManifest.getVersionCacheEnabled() && version.id <= getActiveVersion().id) {
-      return programsByVersionCache.getOrElseUpdate(
-          String.valueOf(version.id), version::getPrograms);
+      String cacheKey = String.valueOf(version.id);
+      Optional<ImmutableList<ProgramModel>> cachedPrograms = programsByVersionCache.get(cacheKey);
+      if (cachedPrograms.isPresent()) {
+        return cachedPrograms.get();
+      }
+      // Populate the cache from a fresh database fetch rather than from the passed-in object,
+      // whose lazily-loaded programs collection may be stale. See the equivalent comment in
+      // getQuestionsForVersion (issue #9451).
+      Optional<VersionModel> freshVersion = getFreshVersion(version.id, "programs");
+      if (freshVersion.isPresent()
+          && freshVersion.get().getLifecycleStage() != LifecycleStage.DRAFT) {
+        ImmutableList<ProgramModel> programs = freshVersion.get().getPrograms();
+        programsByVersionCache.set(cacheKey, programs);
+        return programs;
+      }
     }
     return getProgramsForVersionWithoutCache(version);
   }

--- a/server/app/services/program/ProgramService.java
+++ b/server/app/services/program/ProgramService.java
@@ -33,11 +33,14 @@ import models.ApplicationModel;
 import models.ApplicationStep;
 import models.CategoryModel;
 import models.DisplayMode;
+import models.LifecycleStage;
 import models.ProgramModel;
 import models.ProgramNotificationPreference;
 import models.VersionModel;
 import modules.MainModule;
 import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import play.i18n.Messages;
 import play.libs.concurrent.ClassLoaderExecutionContext;
 import play.mvc.Http.Request;
@@ -73,6 +76,8 @@ import services.statuses.StatusDefinitions;
  * services.question.QuestionService}.
  */
 public final class ProgramService {
+
+  private static final Logger logger = LoggerFactory.getLogger(ProgramService.class);
 
   private static final String MISSING_DISPLAY_NAME_MSG =
       "A public display name for the program is required";
@@ -1970,8 +1975,25 @@ public final class ProgramService {
       // program definition is not in the cache.
       if (programDef.hasEligibilityEnabled()
           && !programRepository.getFullProgramDefinitionFromCache(p).isPresent()) {
+        ImmutableList<VersionModel> versionsForProgram = programRepository.getVersionsForProgram(p);
+        // Deterministically pick the most recent published (active or obsolete) version. A draft
+        // version's question set is incomplete - it only contains edited questions - so picking
+        // one (which the previous findAny() usually did when a draft existed) resolves
+        // unedited questions to NULL_QUESTION definitions.
         VersionModel v =
-            programRepository.getVersionsForProgram(p).stream().findAny().orElseThrow();
+            versionsForProgram.stream()
+                .filter(version -> version.getLifecycleStage() != LifecycleStage.DRAFT)
+                .max(Comparator.comparingLong(version -> version.id))
+                .orElseGet(
+                    () -> {
+                      logger.warn(
+                          "Program {} has no active or obsolete version; falling back to its"
+                              + " latest version to sync questions.",
+                          programDef.id());
+                      return versionsForProgram.stream()
+                          .max(Comparator.comparingLong(version -> version.id))
+                          .orElseThrow();
+                    });
         ReadOnlyQuestionService questionServiceForVersion = versionToQuestionService.get(v.id);
         if (questionServiceForVersion == null) {
           questionServiceForVersion =

--- a/server/test/repository/ProgramRepositoryTest.java
+++ b/server/test/repository/ProgramRepositoryTest.java
@@ -382,7 +382,39 @@ public class ProgramRepositoryTest extends ResetPostgres {
 
     ImmutableList<VersionModel> versions = repo.getVersionsForProgram(program);
 
-    assertThat(versionsByProgramCache.get(String.valueOf(program.id)).get()).isEqualTo(versions);
+    String cacheKey =
+        ProgramRepository.versionsByProgramCacheKey(program.id, versionRepo.getActiveVersion().id);
+    assertThat(versionsByProgramCache.get(cacheKey).get()).isEqualTo(versions);
+  }
+
+  @Test
+  public void getVersionsForProgram_doesNotCacheWhileDraftVersionExists() {
+    Mockito.when(mockSettingsManifest.getProgramCacheEnabled()).thenReturn(true);
+    ProgramModel program = resourceCreator.insertActiveProgram("some program");
+    resourceCreator.insertDraftProgram("draft program");
+
+    ImmutableList<VersionModel> versions = repo.getVersionsForProgram(program);
+
+    assertThat(versions).hasSize(1);
+    String cacheKey =
+        ProgramRepository.versionsByProgramCacheKey(program.id, versionRepo.getActiveVersion().id);
+    assertThat(versionsByProgramCache.get(cacheKey)).isEmpty();
+  }
+
+  @Test
+  public void getVersionsForProgram_returnsNewAssociationsAfterPublish() {
+    Mockito.when(mockSettingsManifest.getProgramCacheEnabled()).thenReturn(true);
+    ProgramModel program = resourceCreator.insertActiveProgram("some program");
+
+    // Prime the cache under the current active version.
+    assertThat(repo.getVersionsForProgram(program)).hasSize(1);
+
+    // Publish a new version; the unedited program gets associated with it.
+    resourceCreator.insertDraftProgram("draft program");
+    versionRepo.publishNewSynchronizedVersion();
+
+    // The cached single-version list from before the publish must not be served.
+    assertThat(repo.getVersionsForProgram(program)).hasSize(2);
   }
 
   @Test

--- a/server/test/repository/VersionRepositoryTest.java
+++ b/server/test/repository/VersionRepositoryTest.java
@@ -1081,6 +1081,63 @@ public class VersionRepositoryTest extends ResetPostgres {
   }
 
   @Test
+  public void getQuestions_staleVersionObjectDoesNotPoisonCache() {
+    Mockito.when(mockSettingsManifest.getVersionCacheEnabled()).thenReturn(true);
+
+    // Publish an initial version containing a question.
+    VersionModel version1 = versionRepository.getDraftVersionOrCreate();
+    QuestionModel firstQuestion = resourceCreator.insertQuestion("first-question");
+    firstQuestion.addVersion(version1).save();
+    versionRepository.publishNewSynchronizedVersion();
+
+    // Start a draft with a second question and hold onto the draft version object with its
+    // questions collection lazily loaded while it is still a draft: it only contains the new
+    // question, not the active questions that publishing will associate with it.
+    VersionModel draft = versionRepository.getDraftVersionOrCreate();
+    QuestionModel secondQuestion = resourceCreator.insertQuestion("second-question");
+    secondQuestion.addVersion(draft).save();
+    draft.refresh();
+    assertThat(draft.getQuestions()).hasSize(1);
+
+    // Publish (e.g. from another request or server instance). The held object is now stale: its
+    // id is the active version's id, but its loaded collection is missing the first question.
+    versionRepository.publishNewSynchronizedVersion();
+
+    // Reading through the stale object must return the full question set and must not poison
+    // the cache with the stale draft-era collection (issue #9451).
+    ImmutableList<QuestionModel> questions = versionRepository.getQuestionsForVersion(draft);
+
+    assertThat(questions).hasSize(2);
+    assertThat(questionsByVersionCache.get(String.valueOf(draft.id)).get()).isEqualTo(questions);
+    assertThat(versionRepository.getQuestionsForVersion(draft)).hasSize(2);
+  }
+
+  @Test
+  public void getPrograms_staleVersionObjectDoesNotPoisonCache() {
+    Mockito.when(mockSettingsManifest.getVersionCacheEnabled()).thenReturn(true);
+
+    // Publish an initial version containing a program.
+    resourceCreator.insertDraftProgram("first-program");
+    versionRepository.publishNewSynchronizedVersion();
+
+    // Start a draft with a second program and lazily load the draft version's programs
+    // collection while it is still a draft.
+    VersionModel draft = versionRepository.getDraftVersionOrCreate();
+    resourceCreator.insertDraftProgram("second-program");
+    draft.refresh();
+    assertThat(draft.getPrograms()).hasSize(1);
+
+    // Publish, making the held object stale.
+    versionRepository.publishNewSynchronizedVersion();
+
+    // Reading through the stale object must not poison the cache with the incomplete list.
+    ImmutableList<ProgramModel> programs = versionRepository.getProgramsForVersion(draft);
+
+    assertThat(programs).hasSize(2);
+    assertThat(programsByVersionCache.get(String.valueOf(draft.id)).get()).isEqualTo(programs);
+  }
+
+  @Test
   public void getPrograms_usesCacheIfEnabledForObsoleteVersion() {
     Mockito.when(mockSettingsManifest.getVersionCacheEnabled()).thenReturn(true);
 
@@ -1133,6 +1190,16 @@ public class VersionRepositoryTest extends ResetPostgres {
     versionRepository.getProgramsForVersion(version1);
 
     assertThat(programsByVersionCache.get(version1Key).isPresent()).isFalse();
+  }
+
+  @Test
+  public void getActiveVersionIdIfNoDraft() {
+    assertThat(versionRepository.getActiveVersionIdIfNoDraft())
+        .hasValue(versionRepository.getActiveVersion().id);
+
+    versionRepository.getDraftVersionOrCreate();
+
+    assertThat(versionRepository.getActiveVersionIdIfNoDraft()).isEmpty();
   }
 
   @Test


### PR DESCRIPTION
Ran Fable model to try to fix the possible caching bug.

> Root cause confirmed, with one addition to nb1701's analysis: the complete no-debugger production chain is
> 
> 1. During admin editing, `ProgramRepository.getVersionsForProgram` caches **live draft-era `VersionModel` entities** in the `program-versions` cache (keyed by program id only). The admin flow (`ProgramService.syncProgramAssociations`) lazy-loads the draft version's `questions` collection while it only contains the edited questions.
> 2. A publish (any server) makes that formerly-draft version ACTIVE. The stale cached entity survives in `program-versions`.
> 3. Applicant traffic (`ApplicantService.relevantProgramsForApplicant` → `syncQuestionsToProgramDefinitions`) hits the stale cache entry; `findAny()` picks the stale version object; `getQuestionsForVersion`'s `version.id <= activeId` guard now passes; `getOrElseUpdate(id, version::getQuestions)` publishes the stale draft-era collection into the server-global `version-questions` cache. Every subsequent reader gets NULL_QUESTION until restart.
> 
> Changes (all uncommitted on this branch):
> 
> - `VersionRepository.getQuestionsForVersion` / `getProgramsForVersion`: on cache miss, populate from a **fresh DB fetch by version id** (`PersistenceContextScope.QUERY`, relation eagerly fetched) and only cache when the freshly-read lifecycle stage is not DRAFT. The non-cached path still reads the passed-in object, which preserves the DRY_RUN publish preview's reliance on in-memory temporary state — no `ThreadLocal skipCache` bandaid needed (unlike PR #12933).
> - `VersionRepository.getActiveVersionIdIfNoDraft()` added (single query for draft-existence + active id).
> - `ProgramRepository.getVersionsForProgram`: bypasses the cache entirely while a draft version exists; cache key now includes the active version id (`programId:activeVersionId`) so publishes naturally invalidate; populates from a fresh DB fetch; refuses to cache lists containing a DRAFT version.
> - `ProgramService.syncQuestionsToProgramDefinitions`: `findAny()` replaced with deterministic "latest non-draft version" selection (falls back to latest overall with a warning instead of throwing).
> 
> Regression tests (`VersionRepositoryTest.getQuestions_staleVersionObjectDoesNotPoisonCache`, `getPrograms_staleVersionObjectDoesNotPoisonCache`, `ProgramRepositoryTest.getVersionsForProgram_returnsNewAssociationsAfterPublish`, `..._doesNotCacheWhileDraftVersionExists`) reproduce nb1701's scenario without a debugger; the questions-poisoning test was verified to fail against the old implementation.
> 
> Not addressed (follow-ups): `lookupProgram`'s narrow check-then-cache race with draft creation; the broader "caches hold live Ebean entities" design smell (caching immutable definitions would be more robust); the pre-existing two-simultaneous-ACTIVE-versions data anomaly.
