### PR TITLE
Use aria-describedby to associate edit links with section headers (#1…

### DIFF
--- a/server/app/views/applicant/review/BlockSummaryFragment.html
+++ b/server/app/views/applicant/review/BlockSummaryFragment.html
@@ -4,12 +4,14 @@
       <!-- We want h3 style, but using h3 directly is an accessibility violation. -->
       <span
         class="left-align cf-prose-h3"
+        th:id="'block-summary-header-' + ${blockSummary.block().getId()}"
         th:text="${blockSummary.block().getLocalizedName(preferredLanguage.toLocale())}"
       ></span>
       <a
         class="usa-button usa-button--outline right-align auto-width summary-edit-button margin-left-0"
         th:href="${blockSummary.editUrl()}"
         th:text="#{button.edit}"
+        th:aria-describedby="'block-summary-header-' + ${blockSummary.block().getId()}"
       ></a>
     </div>
 


### PR DESCRIPTION
### Description

Adds `aria-describedby` to the "Edit" links on the application review/summary page so that screen readers can associate each link with its adjacent section header.

Previously, every "Edit" link had identical accessible text ("Edit"), making it impossible for screen reader users to distinguish which section each link corresponded to. Now, each edit link references the `id` of its section header via `aria-describedby`, so assistive technology announces something like "Edit, Personal Information" instead of just "Edit".

**Changes:**
- Added a unique `id` (`block-summary-header-{blockId}`) to each section header `<span>` in `BlockSummaryFragment.html`
- Added `aria-describedby` on each "Edit" `<a>` link referencing that header `id`

This satisfies [WCAG 2.1 SC 2.4.4 — Link Purpose (In Context)](https://www.w3.org/TR/WCAG21/#link-purpose-in-context).

AI-generated code was used in this PR
used [antigravity.google](https://antigravity.google/) to set up development environment

### Checklist

#### General

- [x] Added the correct label: `bug`
- [ ] Assigned to `civiform/developers`
- [x] Added an additional reviewer from `civiform/eng-admin` as FYI
- [x] Removed the release notes section — title is sufficient
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Ensured PII wasn't added to any new logs
- [x] Noted in the PR description which, if any, code in this PR was generated by AI.

#### User visible changes

- [ ] Wrote browser tests using the `validateAccessibility` method
- [ ] Tested on mobile view
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order
- [x] Performed manual accessibility tests for applicant-facing changes
- [ ] Manually tested with a right-to-left language

### Instructions for manual testing

1. Start the dev server (`bin/run-dev`)
2. As an applicant, start or continue an application that has multiple sections/blocks
3. Navigate to the review/summary page
4. Use a screen reader (or inspect the DOM) to verify that each "Edit" link now has an `aria-describedby` attribute pointing to its section header's `id`
5. Confirm that the screen reader announces the section name alongside "Edit" (e.g., "Edit, Personal Information")

### Issue(s) this completes

Fixes #13430
