### PR TITLE
fix: group address correction labels with form fields for a11y

### DIFF
--- a/server/app/views/applicant/addresscorrection/AddressCorrectionBlockTemplate.html
+++ b/server/app/views/applicant/addresscorrection/AddressCorrectionBlockTemplate.html
@@ -51,15 +51,23 @@
                 th:value="${addressJson}"
               />
               <fieldset class="cf-no-margin-padding border-0">
+                <legend
+                  class="usa-sr-only"
+                  th:text="#{title.confirmAddress}"
+                ></legend>
                 <!--/* If this question is used for eligibility, we must use the corrected address */-->
                 <div th:if="${!isEligibilityEnabled}" class="usa-prose">
-                  <h4 th:text="#{content.addressEntered}"></h4>
+                  <h4
+                    id="address-entered-heading"
+                    th:text="#{content.addressEntered}"
+                  ></h4>
                   <div
                     th:replace="~{applicant/addresscorrection/AddressCorrectionOptionFragment :: address-correction-option(
                         ${addressSuggestionGroup.getOriginalAddress()},
                         ${!anySuggestions},
                         ${!anySuggestions},
-                        'USER_KEEPING_ADDRESS_VALUE')}"
+                        'USER_KEEPING_ADDRESS_VALUE',
+                        'address-entered-heading')}"
                   ></div>
                 </div>
 
@@ -69,10 +77,12 @@
                   class="usa-prose section-internal"
                 >
                   <h4
+                    id="suggested-address-heading"
                     th:if="${suggestions.size() == 1}"
                     th:text="#{content.suggestedAddress}"
                   ></h4>
                   <h4
+                    id="suggested-address-heading"
                     th:if="${suggestions.size() > 1}"
                     th:text="#{content.suggestedAddresses}"
                   ></h4>
@@ -86,7 +96,8 @@
                         ${suggestions.get(iterator.index).getAddress()},
                         ${iterator.index == 0},
                         false,
-                        ${suggestion.getSingleLineAddress()})}"
+                        ${suggestion.getSingleLineAddress()},
+                        'suggested-address-heading')}"
                     ></div>
                   </th:block>
                 </div>

--- a/server/app/views/applicant/addresscorrection/AddressCorrectionOptionFragment.html
+++ b/server/app/views/applicant/addresscorrection/AddressCorrectionOptionFragment.html
@@ -1,5 +1,5 @@
 <div
-  th:fragment="address-correction-option(address, selected, hideButton, singleLineAddress)"
+  th:fragment="address-correction-option(address, selected, hideButton, singleLineAddress, headingId)"
   th:class="${hideButton ? 'cf-zero-top-margin' : 'usa-radio section-internal'}"
   th:with="inputId=${'id-' + #strings.randomAlphanumeric(8)}"
 >
@@ -11,6 +11,7 @@
     th:checked="${selected}"
     th:attr="hidden=${hideButton ? '' : null}"
     th:id="${inputId}"
+    th:aria-describedby="${headingId}"
   />
   <label th:class="${hideButton ? '' : 'usa-radio__label'}" th:for="${inputId}">
     <div


### PR DESCRIPTION
### Description

Fixes an accessibility issue where the address correction page's radio buttons were not properly grouped with their section headings for screen readers.

**Changes:**
- Added a visually-hidden `<legend>` ("Confirm your address") to the existing `<fieldset>` wrapping the radio button group, giving screen readers a group label
- Added `id` attributes to the `<h4>` section headings ("Address you entered:" / "Suggested address(es):")
- Added `aria-describedby` on each radio `<input>` referencing its section heading, so screen readers announce whether a radio option is the user-entered address or a suggested address

No new i18n keys — the legend reuses the existing `title.confirmAddress` message.

AI Disclosure: This PR was co-authored with Gemini (AGY).

### Checklist

#### General

- [x] Added the correct label: `bug`
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI
- [x] Removed the release notes section if the title is sufficient for the release notes description
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary.
- [ ] Ensured PII wasn't added to any new logs
- [x] Noted in the PR description which, if any, code in this PR was generated by AI.

#### User visible changes

- [x] Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
  - [x] No new messages added — reuses existing `title.confirmAddress` key
  - [x] Didn't use a message in applicant facing code that isn't translated yet
- [x] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method — existing tests already call `validateAccessibility(page)` on the address correction page
- [ ] Tested on mobile view
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order
- [ ] Performed manual accessibility tests for any applicant-facing changes
- [ ] Manually tested with a right-to-left language

### Instructions for manual testing

1. Start the dev server (`bin/run-dev`)
2. As an admin, create a program with an address question that has address correction enabled
3. As an applicant, fill in the address question with an address that triggers suggestions (e.g., "Legit Address" if using the fake Esri client)
4. On the "Confirm your address" page, use a screen reader (or browser dev tools accessibility inspector) to verify:
   - The radio button group is announced with the legend "Confirm your address"
   - Each radio button under "Address you entered:" is described by that heading
   - Each radio button under "Suggested address(es):" is described by that heading

### Issue(s) this completes

Fixes #13431
