### PR TITLE
fix: add lang and aria-label to language selector buttons for a11y

### DIFF
--- a/server/app/views/applicant/shared/NavigationFragment.html
+++ b/server/app/views/applicant/shared/NavigationFragment.html
@@ -403,8 +403,9 @@
                 th:text="${language.value}"
               ></span
               ><span
+                lang="en"
                 class="usa-sr-only"
-                th:text="', ' + ${language.key.toLocale().getDisplayLanguage(#locale)}"
+                th:text="', ' + ${language.key.toLocale().getDisplayLanguage(@java.util.Locale@ENGLISH)}"
               ></span>
             </button>
           </li>

--- a/server/app/views/applicant/shared/NavigationFragment.html
+++ b/server/app/views/applicant/shared/NavigationFragment.html
@@ -397,8 +397,16 @@
               name="locale"
               type="submit"
               th:value="${language.key.code()}"
-              th:text="${language.value}"
-            ></button>
+            >
+              <span
+                th:lang="${language.key.code()}"
+                th:text="${language.value}"
+              ></span
+              ><span
+                class="usa-sr-only"
+                th:text="', ' + ${language.key.toLocale().getDisplayLanguage(#locale)}"
+              ></span>
+            </button>
           </li>
         </ul>
       </li>

--- a/server/app/views/applicant/shared/NavigationFragment.html
+++ b/server/app/views/applicant/shared/NavigationFragment.html
@@ -402,6 +402,12 @@
               <span
                 th:lang="${language.key.code()}"
                 th:text="${language.value}"
+              ></span
+              ><span
+                lang="en"
+                class="usa-sr-only"
+                th:if="${language.value.chars().anyMatch(c -> c > 0x024F)}"
+                th:text="', ' + ${language.key.toLocale().getDisplayLanguage(@java.util.Locale@ENGLISH)}"
               ></span>
             </button>
           </li>

--- a/server/app/views/applicant/shared/NavigationFragment.html
+++ b/server/app/views/applicant/shared/NavigationFragment.html
@@ -397,6 +397,7 @@
               name="locale"
               type="submit"
               th:value="${language.key.code()}"
+              th:lang="${language.key.code()}"
             >
               <span
                 th:lang="${language.key.code()}"
@@ -405,6 +406,7 @@
               ><span
                 lang="en"
                 class="usa-sr-only"
+                th:if="${!language.value.equals(language.key.toLocale().getDisplayLanguage(@java.util.Locale@ENGLISH))}"
                 th:text="', ' + ${language.key.toLocale().getDisplayLanguage(@java.util.Locale@ENGLISH)}"
               ></span>
             </button>

--- a/server/app/views/applicant/shared/NavigationFragment.html
+++ b/server/app/views/applicant/shared/NavigationFragment.html
@@ -403,12 +403,7 @@
                 th:lang="${language.key.code()}"
                 th:text="${language.value}"
               ></span
-              ><span
-                lang="en"
-                class="usa-sr-only"
-                th:if="${!language.value.equals(language.key.toLocale().getDisplayLanguage(@java.util.Locale@ENGLISH))}"
-                th:text="', ' + ${language.key.toLocale().getDisplayLanguage(@java.util.Locale@ENGLISH)}"
-              ></span>
+              >
             </button>
           </li>
         </ul>

--- a/server/app/views/applicant/shared/NavigationFragment.html
+++ b/server/app/views/applicant/shared/NavigationFragment.html
@@ -407,7 +407,7 @@
                 lang="en"
                 class="usa-sr-only"
                 th:if="${language.value.matches('.*[^\u0000-\u024F].*')}"
-                th:text="', ' + ${language.key.toLocale().getDisplayLanguage(T(java.util.Locale).ENGLISH)}"
+                th:text="', ' + ${language.key.toLocale().getDisplayLanguage(@java.util.Locale@ENGLISH)}"
               ></span>
             </button>
           </li>

--- a/server/app/views/applicant/shared/NavigationFragment.html
+++ b/server/app/views/applicant/shared/NavigationFragment.html
@@ -402,8 +402,7 @@
               <span
                 th:lang="${language.key.code()}"
                 th:text="${language.value}"
-              ></span
-              >
+              ></span>
             </button>
           </li>
         </ul>

--- a/server/app/views/applicant/shared/NavigationFragment.html
+++ b/server/app/views/applicant/shared/NavigationFragment.html
@@ -406,8 +406,8 @@
               ><span
                 lang="en"
                 class="usa-sr-only"
-                th:if="${language.value.chars().anyMatch(c -> c > 0x024F)}"
-                th:text="', ' + ${language.key.toLocale().getDisplayLanguage(@java.util.Locale@ENGLISH)}"
+                th:if="${language.value.matches('.*[^\u0000-\u024F].*')}"
+                th:text="', ' + ${language.key.toLocale().getDisplayLanguage(T(java.util.Locale).ENGLISH)}"
               ></span>
             </button>
           </li>


### PR DESCRIPTION
### Description

Add `lang` attribute and a screen-reader-only English fallback to each language button in the "Select Language" menu to fix a WCAG 4.1.2 (Name, Role, Value) violation.

**Problem**: Screen readers could not properly announce language names that use non-Latin scripts (Arabic, Chinese, Japanese, Korean, Amharic, etc.) because the `<button>` elements lacked a `lang` attribute. Without it, screen readers tried to read characters like العربية or 繁體中文 using English pronunciation rules, resulting in silence or garbled output.

**Fix**: Each language `<button>` in `NavigationFragment.html` now has:
- `th:lang` on the button and the text `<span>` — tells the screen reader which language the text is in so it switches pronunciation engine
- A `<span class="usa-sr-only" lang="en">` appended **only for non-Latin scripts** — provides the English name as an audio fallback for screen readers that cannot handle the script

**Non-Latin detection**: `language.value.matches(.*[^\u0000-\u024F].*)` — matches any character above U+024F (end of Latin Extended-B). Latin-script languages (Spanish, French, Vietnamese) get no English suffix; non-Latin scripts (Amharic, Arabic, Chinese) get `", English Name"` appended as sr-only text.

**English-locked fallback**: `T(java.util.Locale).ENGLISH` ensures the fallback English name is always in English regardless of the current page locale — prevents the Amharic screen reader from reading "kane" instead of "Amharic".

The J2HTML `LanguageSelector.java` (used by the TI layout `<select>` dropdown) already correctly applied `withLang()` on `<option>` tags — this brings the Thymeleaf template into parity.

AI-generated code: This change was written with AI assistance.

### Checklist

#### General

- [x] Added the correct label: bug
- [ ] Assigned to a specific person, `civiform/developers`, or a more specific round-robin list
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI
- [ ] Added an additional reviewer as required if changes potentially affect the security of the application.
- [x] Removed the release notes section if the title is sufficient for the release notes description
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary.
- [x] Ensured PII was not added to any new logs, unless it was guarded by `isDevOrStaging`
- [x] Noted in the PR description which, if any, code in this PR was generated by AI.

#### User visible changes

- [x] Followed steps to internationalize any new strings (no new strings — uses existing locale data)
- [ ] Wrote browser tests using the validateAccessibility method
- [ ] Tested on mobile view.
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order
- [ ] Performed manual accessibility tests for any applicant-facing changes
- [ ] Manually tested with a right-to-left language

### Instructions for manual testing

1. Start the dev server: `bin/run-dev`
2. Navigate to `http://localhost:9000`
3. Open the "Select Language" dropdown in the header navigation
4. **Inspect the language buttons** in DevTools — each should now have a `lang` attribute matching the language code (e.g., `lang="ar"`, `lang="zh-TW"`). Non-Latin-script buttons should have an additional `<span class="usa-sr-only" lang="en">` with the English name.
5. Example expected HTML for Arabic:
   ```html
   <button lang="ar" name="locale" type="submit" value="ar">
     <span lang="ar">العربية</span><span lang="en" class="usa-sr-only">, Arabic</span>
   </button>
   ```
6. Example expected HTML for Spanish (no English suffix):
   ```html
   <button lang="es" name="locale" type="submit" value="es">
     <span lang="es">Español</span>
   </button>
   ```
7. **Screen reader testing (if available)**:
   - Using JAWS (PC): Navigate to "Select Language" → open with Enter/Space → navigate menu items with arrow keys → verify non-Latin languages announce in English, Latin languages announce only in their native language
   - Using VoiceOver (Mac/iPhone): Same verification

### Issue(s) this completes

Fixes #12790
