### PR TITLE
[Enumerators] Add Initial Question when pre-exising enumerator is added to a block.

### DIFF
--- a/browser-test/src/end_to_end_enumerators.test.ts
+++ b/browser-test/src/end_to_end_enumerators.test.ts
@@ -395,10 +395,14 @@ test.describe('End to end enumerator test with enumerators feature flag on', () 
 
       test('creates the enumerator and attaches a copy of the selected initial question when the form is submitted', async ({
         page,
+        adminPrograms,
         adminQuestions,
       }) => {
         const blockPanel = page.getByTestId('block-panel-edit')
         const initialQuestionSlot = blockPanel.locator('#initial-question-slot')
+        const questionBankSidebar = page.getByRole('form', {
+          name: 'Add a question',
+        })
 
         await addRepeatedSetBlock(page, {selectParent: true})
 
@@ -421,6 +425,49 @@ test.describe('End to end enumerator test with enumerators feature flag on', () 
         })
 
         await test.step('Verify the initial question line shows the newly-created copy (" -_- a" suffix)', async () => {
+          await expect(
+            blockPanel.getByText(
+              'Initial question: income-non-repeated-question -_- a',
+            ),
+          ).toBeVisible()
+        })
+
+        await test.step('Delete the entire repeated set block', async () => {
+          await adminPrograms.removeCurrentBlock()
+        })
+
+        await test.step('Add a fresh repeated set block and select the parent enumerator screen', async () => {
+          await addRepeatedSetBlock(page, {selectParent: true})
+
+          // The fresh enumerator block starts empty: no enumerator question and no
+          // initial question line.
+          await expect(
+            blockPanel.getByTestId('question-admin-name-pets enumerator'),
+          ).toBeHidden()
+          await expect(
+            blockPanel.getByTestId('repeated-set-initial-question'),
+          ).toBeHidden()
+        })
+
+        await test.step('Open the question bank via the "Choose existing" flow', async () => {
+          // Unfortunately, we have to click the label to select the radio button, because
+          // USWDS places the radio button itself outside the viewport.
+          await blockPanel.getByTestId('choose-existing-radio-label').click()
+        })
+
+        await test.step('Click the "Add question" button', async () => {
+          await blockPanel.getByRole('button', {name: 'Add question'}).click()
+          await expect(questionBankSidebar).toBeVisible()
+        })
+
+        await test.step('Add the existing enumerator question back to the block', async () => {
+          await pickQuestionFromBank(page, 'pets enumerator')
+          await expect(
+            blockPanel.getByTestId('question-admin-name-pets enumerator'),
+          ).toBeVisible()
+        })
+
+        await test.step('Verify the initial question is added along with the enumerator and is visible again', async () => {
           await expect(
             blockPanel.getByText(
               'Initial question: income-non-repeated-question -_- a',

--- a/browser-test/src/end_to_end_enumerators.test.ts
+++ b/browser-test/src/end_to_end_enumerators.test.ts
@@ -395,14 +395,10 @@ test.describe('End to end enumerator test with enumerators feature flag on', () 
 
       test('creates the enumerator and attaches a copy of the selected initial question when the form is submitted', async ({
         page,
-        adminPrograms,
         adminQuestions,
       }) => {
         const blockPanel = page.getByTestId('block-panel-edit')
         const initialQuestionSlot = blockPanel.locator('#initial-question-slot')
-        const questionBankSidebar = page.getByRole('form', {
-          name: 'Add a question',
-        })
 
         await addRepeatedSetBlock(page, {selectParent: true})
 
@@ -425,49 +421,6 @@ test.describe('End to end enumerator test with enumerators feature flag on', () 
         })
 
         await test.step('Verify the initial question line shows the newly-created copy (" -_- a" suffix)', async () => {
-          await expect(
-            blockPanel.getByText(
-              'Initial question: income-non-repeated-question -_- a',
-            ),
-          ).toBeVisible()
-        })
-
-        await test.step('Delete the entire repeated set block', async () => {
-          await adminPrograms.removeCurrentBlock()
-        })
-
-        await test.step('Add a fresh repeated set block and select the parent enumerator screen', async () => {
-          await addRepeatedSetBlock(page, {selectParent: true})
-
-          // The fresh enumerator block starts empty: no enumerator question and no
-          // initial question line.
-          await expect(
-            blockPanel.getByTestId('question-admin-name-pets enumerator'),
-          ).toBeHidden()
-          await expect(
-            blockPanel.getByTestId('repeated-set-initial-question'),
-          ).toBeHidden()
-        })
-
-        await test.step('Open the question bank via the "Choose existing" flow', async () => {
-          // Unfortunately, we have to click the label to select the radio button, because
-          // USWDS places the radio button itself outside the viewport.
-          await blockPanel.getByTestId('choose-existing-radio-label').click()
-        })
-
-        await test.step('Click the "Add question" button', async () => {
-          await blockPanel.getByRole('button', {name: 'Add question'}).click()
-          await expect(questionBankSidebar).toBeVisible()
-        })
-
-        await test.step('Add the existing enumerator question back to the block', async () => {
-          await pickQuestionFromBank(page, 'pets enumerator')
-          await expect(
-            blockPanel.getByTestId('question-admin-name-pets enumerator'),
-          ).toBeVisible()
-        })
-
-        await test.step('Verify the initial question is added along with the enumerator and is visible again', async () => {
           await expect(
             blockPanel.getByText(
               'Initial question: income-non-repeated-question -_- a',
@@ -595,6 +548,72 @@ test.describe('End to end enumerator test with enumerators feature flag on', () 
             page.getByLabel('Question enumerator').locator('option[selected]'),
           ).toHaveText('pets enumerator')
         })
+      })
+    })
+
+    test('reuses an enumerator with initial question and attaches the initial question', async ({
+      page,
+      adminPrograms,
+    }) => {
+      const blockPanel = page.getByTestId('block-panel-edit')
+      const initialQuestionSlot = blockPanel.locator('#initial-question-slot')
+      const questionBankSidebar = page.getByRole('form', {
+        name: 'Add a question',
+      })
+
+      await addRepeatedSetBlock(page, {selectParent: true})
+
+      await test.step('create an enumerator with initial question', async () => {
+        await initialQuestionSlot
+          .getByRole('button', {name: 'Add question'})
+          .click()
+
+        await pickQuestionFromBank(page, 'income-non-repeated-question')
+
+        await fillAndSubmitEnumeratorQuestionForm(page)
+      })
+
+      await test.step('Delete the entire repeated set block', async () => {
+        await adminPrograms.removeCurrentBlock()
+      })
+
+      await test.step('Add a fresh repeated set block and select the parent enumerator screen', async () => {
+        await addRepeatedSetBlock(page, {selectParent: true})
+
+        // The fresh enumerator block starts empty: no enumerator question and no
+        // initial question line.
+        await expect(
+          blockPanel.getByTestId('question-admin-name-pets enumerator'),
+        ).toBeHidden()
+        await expect(
+          blockPanel.getByTestId('repeated-set-initial-question'),
+        ).toBeHidden()
+      })
+
+      await test.step('Open the question bank via the "Choose existing" flow', async () => {
+        // Unfortunately, we have to click the label to select the radio button, because
+        // USWDS places the radio button itself outside the viewport.
+        await blockPanel.getByTestId('choose-existing-radio-label').click()
+      })
+
+      await test.step('Click the "Add question" button', async () => {
+        await blockPanel.getByRole('button', {name: 'Add question'}).click()
+        await expect(questionBankSidebar).toBeVisible()
+      })
+
+      await test.step('Add the existing enumerator question back to the block', async () => {
+        await pickQuestionFromBank(page, 'pets enumerator')
+        await expect(
+          blockPanel.getByTestId('question-admin-name-pets enumerator'),
+        ).toBeVisible()
+      })
+
+      await test.step('Verify the initial question is added along with the enumerator and is visible again', async () => {
+        await expect(
+          blockPanel.getByText(
+            'Initial question: income-non-repeated-question -_- a',
+          ),
+        ).toBeVisible()
       })
     })
 

--- a/server/app/controllers/admin/AdminProgramBlockQuestionsController.java
+++ b/server/app/controllers/admin/AdminProgramBlockQuestionsController.java
@@ -86,6 +86,8 @@ public class AdminProgramBlockQuestionsController extends Controller {
   @Secure(authorizers = Labels.CIVIFORM_ADMIN)
   public Result create(Request request, long programId, long blockId) {
     requestChecker.throwIfProgramNotDraft(programId);
+    boolean enumeratorImprovementsEnabled =
+        settingsManifest.getEnumeratorImprovementsEnabled(request);
 
     DynamicForm requestData = formFactory.form().bindFromRequest(request);
     ImmutableList<Long> questionIds =
@@ -95,7 +97,7 @@ public class AdminProgramBlockQuestionsController extends Controller {
             .map(Long::valueOf)
             .collect(ImmutableList.toImmutableList());
 
-    // The users' browser may be out of date. Find the last revision of each question.
+    // The user's browser may be out of date. Find the last revision of each question.
     ImmutableList.Builder<Long> idBuilder = new ImmutableList.Builder<Long>();
     boolean addedEnumeratorQuestion = false;
     for (Long qId : questionIds) {
@@ -103,7 +105,12 @@ public class AdminProgramBlockQuestionsController extends Controller {
       if (latestQuestion.isEmpty()) {
         return notFound(String.format("Question ID %s not found", qId));
       }
-      idBuilder.add(latestQuestion.get().id);
+      QuestionModel question = latestQuestion.get();
+      idBuilder.add(question.id);
+      // If adding a new-flow enumerator, also add its initial question.
+      if (enumeratorImprovementsEnabled) {
+        question.getQuestionDefinition().getEnumeratorInitialQuestionId().ifPresent(idBuilder::add);
+      }
       if (latestQuestion.get().getQuestionDefinition().isEnumerator()) {
         addedEnumeratorQuestion = true;
       }
@@ -117,7 +124,7 @@ public class AdminProgramBlockQuestionsController extends Controller {
           programId,
           blockId,
           latestQuestionIds,
-          settingsManifest.getEnumeratorImprovementsEnabled(request),
+          enumeratorImprovementsEnabled,
           settingsManifest.getFileUploadQuestionImprovementsEnabled(request));
     } catch (ProgramNotFoundException e) {
       return notFound(String.format("Program ID %d not found.", programId));
@@ -217,20 +224,23 @@ public class AdminProgramBlockQuestionsController extends Controller {
 
     try {
       // TODO (#13548): Remove this condition once initialQuestionId is required
-      programDefinition =
+      ImmutableList<Long> questionIds =
           optionalEnumAndInitialQuestion.isPresent()
-              ? programService.addQuestionsToBlock(
-                  programId,
-                  blockId,
-                  optionalEnumAndInitialQuestion.get(),
-                  settingsManifest.getEnumeratorImprovementsEnabled(request),
-                  settingsManifest.getFileUploadQuestionImprovementsEnabled(request))
-              : programService.addQuestionsToBlock(
-                  programId,
-                  blockId,
-                  ImmutableList.of(persistedEnumeratorQuestion.getId()),
-                  settingsManifest.getEnumeratorImprovementsEnabled(request),
-                  settingsManifest.getFileUploadQuestionImprovementsEnabled(request));
+              ?
+              // The enum must come before the initial question as the validation
+              // will require the enum to be present for the initial question.
+              ImmutableList.of(
+                  optionalEnumAndInitialQuestion.get().enumeratorQuestion().getId(),
+                  optionalEnumAndInitialQuestion.get().initialQuestion().getId())
+              : ImmutableList.of(persistedEnumeratorQuestion.getId());
+
+      programDefinition =
+          programService.addQuestionsToBlock(
+              programId,
+              blockId,
+              questionIds,
+              settingsManifest.getEnumeratorImprovementsEnabled(request),
+              settingsManifest.getFileUploadQuestionImprovementsEnabled(request));
       blockDefinition = programDefinition.getBlockDefinition(blockId);
       programQuestionDefinition =
           blockDefinition.programQuestionDefinitions().stream()

--- a/server/app/services/ProgramBlockValidation.java
+++ b/server/app/services/ProgramBlockValidation.java
@@ -97,7 +97,7 @@ public final class ProgramBlockValidation {
       QuestionDefinition question,
       boolean enumeratorImprovementsEnabled,
       boolean fileUploadQuestionImprovementsEnabled,
-      boolean isInitialQuestionSelection) {
+      boolean isInitialQuestion) {
     if (version.getTombstonedQuestionNames().contains(question.getName())) {
       return AddQuestionResult.QUESTION_TOMBSTONED;
     }
@@ -111,7 +111,7 @@ public final class ProgramBlockValidation {
     if (enumeratorImprovementsEnabled && question.isEnumerator() && !block.getIsEnumerator()) {
       return AddQuestionResult.ENUMERATOR_ON_NON_ENUMERATOR_BLOCK;
     }
-    if (isInitialQuestionSelection
+    if (isInitialQuestion
         && !VALID_INITIAL_QUESTION_TYPES.contains(question.getQuestionType())) {
       return AddQuestionResult.INVALID_INITIAL_QUESTION_TYPE;
     }

--- a/server/app/services/ProgramBlockValidation.java
+++ b/server/app/services/ProgramBlockValidation.java
@@ -111,8 +111,7 @@ public final class ProgramBlockValidation {
     if (enumeratorImprovementsEnabled && question.isEnumerator() && !block.getIsEnumerator()) {
       return AddQuestionResult.ENUMERATOR_ON_NON_ENUMERATOR_BLOCK;
     }
-    if (isInitialQuestion
-        && !VALID_INITIAL_QUESTION_TYPES.contains(question.getQuestionType())) {
+    if (isInitialQuestion && !VALID_INITIAL_QUESTION_TYPES.contains(question.getQuestionType())) {
       return AddQuestionResult.INVALID_INITIAL_QUESTION_TYPE;
     }
     if (block.getQuestionCount() > 0

--- a/server/app/services/program/ProgramService.java
+++ b/server/app/services/program/ProgramService.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
@@ -58,7 +59,6 @@ import services.pagination.BasePaginationSpec;
 import services.pagination.PaginationResult;
 import services.program.predicate.PredicateDefinition;
 import services.question.QuestionService;
-import services.question.QuestionService.EnumAndInitialQuestion;
 import services.question.ReadOnlyQuestionService;
 import services.question.exceptions.QuestionNotFoundException;
 import services.question.exceptions.UnsupportedQuestionTypeException;
@@ -1605,9 +1605,14 @@ public final class ProgramService {
   /**
    * Update a {@link BlockDefinition} to include additional questions.
    *
+   * <p>Questions in {@code questionIds} are added in the specified order.
+   *
+   * <p>Enforces that the block is correctly configured and will not allow incorrect configurations,
+   * such as tombstoned questions, multiple enumerators, other questions with enumerators.
+   *
    * @param programId the ID of the program to update
    * @param blockDefinitionId the ID of the block to update
-   * @param questionIds an {@link ImmutableList} of question IDs for the block
+   * @param questionIds the questions to add
    * @return the updated {@link ProgramDefinition}
    * @throws ProgramNotFoundException when programId does not correspond to a real Program.
    * @throws ProgramBlockDefinitionNotFoundException when blockDefinitionId does not correspond to a
@@ -1618,50 +1623,6 @@ public final class ProgramService {
       long programId,
       long blockDefinitionId,
       ImmutableList<Long> questionIds,
-      boolean enumeratorImprovementsEnabled,
-      boolean fileUploadQuestionImprovementsEnabled)
-      throws CantAddQuestionToBlockException,
-          ProgramNotFoundException,
-          ProgramBlockDefinitionNotFoundException {
-    return addQuestionsToBlockInternal(
-        programId,
-        blockDefinitionId,
-        questionIds,
-        /* initialQuestionId= */ Optional.empty(),
-        enumeratorImprovementsEnabled,
-        fileUploadQuestionImprovementsEnabled);
-  }
-
-  /**
-   * Adds an enumerator question and its initial question to a block in one call. The pair type
-   * enforces the ordering that the block validation depends on (enumerator added first so the
-   * initial question's enumeratorId match sees it).
-   */
-  public ProgramDefinition addQuestionsToBlock(
-      long programId,
-      long blockDefinitionId,
-      EnumAndInitialQuestion enumAndInitialQuestion,
-      boolean enumeratorImprovementsEnabled,
-      boolean fileUploadQuestionImprovementsEnabled)
-      throws CantAddQuestionToBlockException,
-          ProgramNotFoundException,
-          ProgramBlockDefinitionNotFoundException {
-    return addQuestionsToBlockInternal(
-        programId,
-        blockDefinitionId,
-        ImmutableList.of(
-            enumAndInitialQuestion.enumeratorQuestion().getId(),
-            enumAndInitialQuestion.initialQuestion().getId()),
-        Optional.of(enumAndInitialQuestion.initialQuestion().getId()),
-        enumeratorImprovementsEnabled,
-        fileUploadQuestionImprovementsEnabled);
-  }
-
-  private ProgramDefinition addQuestionsToBlockInternal(
-      long programId,
-      long blockDefinitionId,
-      ImmutableList<Long> questionIds,
-      Optional<Long> initialQuestionId,
       boolean enumeratorImprovementsEnabled,
       boolean fileUploadQuestionImprovementsEnabled)
       throws CantAddQuestionToBlockException,
@@ -1679,8 +1640,13 @@ public final class ProgramService {
     ReadOnlyQuestionService roQuestionService =
         questionService.getReadOnlyQuestionService().toCompletableFuture().join();
 
+    Set<Long> newFlowEnumIds = new HashSet<>();
     for (long questionId : questionIds) {
       QuestionDefinition questionDefinition = roQuestionService.getQuestionDefinition(questionId);
+      if (questionDefinition.isEnumerator()
+          && questionDefinition.getEnumeratorInitialQuestionId().isPresent()) {
+        newFlowEnumIds.add(questionId);
+      }
 
       // If this is a repeated block and the question is not repeated
       // Create a new question that is a copy and save that question before adding it to the block.
@@ -1694,6 +1660,8 @@ public final class ProgramService {
 
       ProgramQuestionDefinition question =
           ProgramQuestionDefinition.create(questionDefinition, Optional.of(programId));
+      boolean isInitialQuestion =
+          questionDefinition.getEnumeratorId().map(newFlowEnumIds::contains).orElse(false);
       AddQuestionResult canAddQuestion =
           programBlockValidationFactory
               .create()
@@ -1703,8 +1671,7 @@ public final class ProgramService {
                   question.getQuestionDefinition(),
                   enumeratorImprovementsEnabled,
                   fileUploadQuestionImprovementsEnabled,
-                  /* isInitialQuestionSelection= */ initialQuestionId.isPresent()
-                      && initialQuestionId.get() == questionId);
+                  isInitialQuestion);
       if (canAddQuestion != AddQuestionResult.ELIGIBLE) {
         throw new CantAddQuestionToBlockException(
             programDefinition, blockDefinition, question.getQuestionDefinition(), canAddQuestion);

--- a/server/app/views/components/ProgramQuestionBank.java
+++ b/server/app/views/components/ProgramQuestionBank.java
@@ -429,7 +429,7 @@ public final class ProgramQuestionBank {
                         q,
                         settingsManifest.getEnumeratorImprovementsEnabled(request),
                         settingsManifest.getFileUploadQuestionImprovementsEnabled(request),
-                        /* isInitialQuestionSelection= */ params.mode() == Mode.INITIAL_QUESTION)
+                        /* isInitialQuestion= */ params.mode() == Mode.INITIAL_QUESTION)
                     == AddQuestionResult.ELIGIBLE);
   }
 

--- a/server/test/controllers/admin/AdminProgramBlockQuestionsControllerTest.java
+++ b/server/test/controllers/admin/AdminProgramBlockQuestionsControllerTest.java
@@ -80,10 +80,9 @@ public class AdminProgramBlockQuestionsControllerTest extends ResetPostgres {
 
   @Test
   public void create_addEnumeratorWithInitialQuestion_addsInitialQuestionToBlock()
-      throws ProgramBlockDefinitionNotFoundException,
-          ProgramNotFoundException,
-          UnsupportedQuestionTypeException {
-    var enumeratorQuestionModel = testQuestionBank.enumeratorWithInitialQuestionNotCached();
+      throws ProgramBlockDefinitionNotFoundException, ProgramNotFoundException {
+    var enumeratorQuestionModel =
+        testQuestionBank.enumeratorWithInitialQuestionApplicantHouseholdPlantNames();
     long enumeratorId = enumeratorQuestionModel.id;
     long initialQuestionId =
         enumeratorQuestionModel

--- a/server/test/controllers/admin/AdminProgramBlockQuestionsControllerTest.java
+++ b/server/test/controllers/admin/AdminProgramBlockQuestionsControllerTest.java
@@ -79,6 +79,39 @@ public class AdminProgramBlockQuestionsControllerTest extends ResetPostgres {
   }
 
   @Test
+  public void create_addEnumeratorWithInitialQuestion_addsInitialQuestionToBlock()
+      throws ProgramBlockDefinitionNotFoundException,
+          ProgramNotFoundException,
+          UnsupportedQuestionTypeException {
+    var enumeratorQuestionModel = testQuestionBank.enumeratorWithInitialQuestionNotCached();
+    long enumeratorId = enumeratorQuestionModel.id;
+    long initialQuestionId =
+        enumeratorQuestionModel
+            .getQuestionDefinition()
+            .getEnumeratorInitialQuestionId()
+            .orElseThrow();
+
+    ProgramModel program = ProgramBuilder.newDraftProgram().withEnumeratorBlock().build();
+
+    // Execute. Submit only the enumerator question to the block.
+    Request request =
+        fakeRequestBuilder()
+            .call(
+                controllers.admin.routes.AdminProgramBlockQuestionsController.create(program.id, 1))
+            .addCiviFormSetting("ENUMERATOR_IMPROVEMENTS_ENABLED", "true")
+            .bodyForm(ImmutableMap.of("question-", String.valueOf(enumeratorId)))
+            .build();
+    Result result = controller.create(request, program.id, 1);
+
+    // Verify.
+    assertThat(result.status()).withFailMessage(contentAsString(result)).isEqualTo(SEE_OTHER);
+    BlockDefinition blockAfter =
+        programService.getFullProgramDefinition(program.id).getBlockDefinition(1L);
+    assertThat(blockAfter.programQuestionDefinitions().stream().map(ProgramQuestionDefinition::id))
+        .containsExactly(enumeratorId, initialQuestionId);
+  }
+
+  @Test
   public void hxCreateEnumerator_addsNewEnumeratorQuestionToBlock()
       throws ProgramBlockDefinitionNotFoundException {
 

--- a/server/test/services/ProgramBlockValidationTest.java
+++ b/server/test/services/ProgramBlockValidationTest.java
@@ -70,7 +70,7 @@ public class ProgramBlockValidationTest extends ResetPostgres {
                 questionForTombstone.getQuestionDefinition(),
                 /* enumeratorImprovementsEnabled= */ false,
                 /* fileUploadQuestionImprovementsEnabled= */ false,
-                /* isInitialQuestionSelection= */ false))
+                /* isInitialQuestion= */ false))
         .isEqualTo(services.ProgramBlockValidation.AddQuestionResult.QUESTION_TOMBSTONED);
   }
 
@@ -93,7 +93,7 @@ public class ProgramBlockValidationTest extends ResetPostgres {
                 householdMemberNameQuestion,
                 /* enumeratorImprovementsEnabled= */ false,
                 /* fileUploadQuestionImprovementsEnabled= */ false,
-                /* isInitialQuestionSelection= */ false))
+                /* isInitialQuestion= */ false))
         .isEqualTo(
             services.ProgramBlockValidation.AddQuestionResult
                 .QUESTION_NOT_IN_ACTIVE_OR_DRAFT_STATE);
@@ -111,7 +111,7 @@ public class ProgramBlockValidationTest extends ResetPostgres {
                 question,
                 /* enumeratorImprovementsEnabled= */ false,
                 /* fileUploadQuestionImprovementsEnabled= */ false,
-                /* isInitialQuestionSelection= */ false))
+                /* isInitialQuestion= */ false))
         .isEqualTo(AddQuestionResult.ELIGIBLE);
   }
 
@@ -130,7 +130,7 @@ public class ProgramBlockValidationTest extends ResetPostgres {
                 question,
                 /* enumeratorImprovementsEnabled= */ false,
                 /* fileUploadQuestionImprovementsEnabled= */ false,
-                /* isInitialQuestionSelection= */ false))
+                /* isInitialQuestion= */ false))
         .isEqualTo(AddQuestionResult.DUPLICATE);
   }
 
@@ -151,7 +151,7 @@ public class ProgramBlockValidationTest extends ResetPostgres {
                 nameQuestion,
                 /* enumeratorImprovementsEnabled= */ false,
                 /* fileUploadQuestionImprovementsEnabled= */ false,
-                /* isInitialQuestionSelection= */ false))
+                /* isInitialQuestion= */ false))
         .isEqualTo(AddQuestionResult.BLOCK_IS_SINGLE_QUESTION);
   }
 
@@ -172,7 +172,7 @@ public class ProgramBlockValidationTest extends ResetPostgres {
                 fileQuestion,
                 /* enumeratorImprovementsEnabled= */ false,
                 /* fileUploadQuestionImprovementsEnabled= */ false,
-                /* isInitialQuestionSelection= */ false))
+                /* isInitialQuestion= */ false))
         .isEqualTo(AddQuestionResult.CANT_ADD_SINGLE_BLOCK_QUESTION_TO_NON_EMPTY_BLOCK);
   }
 
@@ -190,7 +190,7 @@ public class ProgramBlockValidationTest extends ResetPostgres {
                 repeatedQuestion,
                 /* enumeratorImprovementsEnabled= */ false,
                 /* fileUploadQuestionImprovementsEnabled= */ false,
-                /* isInitialQuestionSelection= */ false))
+                /* isInitialQuestion= */ false))
         .isEqualTo(AddQuestionResult.ENUMERATOR_MISMATCH);
   }
 
@@ -209,7 +209,7 @@ public class ProgramBlockValidationTest extends ResetPostgres {
                 question,
                 /* enumeratorImprovementsEnabled= */ true,
                 /* fileUploadQuestionImprovementsEnabled= */ false,
-                /* isInitialQuestionSelection= */ false))
+                /* isInitialQuestion= */ false))
         .isEqualTo(AddQuestionResult.ENUMERATOR_ON_NON_ENUMERATOR_BLOCK);
   }
 
@@ -232,7 +232,7 @@ public class ProgramBlockValidationTest extends ResetPostgres {
                 nameQuestion,
                 /* enumeratorImprovementsEnabled= */ false,
                 /* fileUploadQuestionImprovementsEnabled= */ false,
-                /* isInitialQuestionSelection= */ false))
+                /* isInitialQuestion= */ false))
         .isEqualTo(AddQuestionResult.ENUMERATOR_MISMATCH);
   }
 
@@ -251,7 +251,7 @@ public class ProgramBlockValidationTest extends ResetPostgres {
                 nestedHouseholdMemberWageQuestion.getQuestionDefinition(),
                 /* enumeratorImprovementsEnabled= */ false,
                 /* fileUploadQuestionImprovementsEnabled= */ false,
-                /* isInitialQuestionSelection= */ false))
+                /* isInitialQuestion= */ false))
         .isEqualTo(AddQuestionResult.ELIGIBLE);
   }
 
@@ -270,7 +270,7 @@ public class ProgramBlockValidationTest extends ResetPostgres {
                 repeatedHouseholdMemberNameQuestion.getQuestionDefinition(),
                 /* enumeratorImprovementsEnabled= */ true,
                 /* fileUploadQuestionImprovementsEnabled= */ false,
-                /* isInitialQuestionSelection= */ false))
+                /* isInitialQuestion= */ false))
         .isEqualTo(AddQuestionResult.ELIGIBLE);
   }
 
@@ -291,7 +291,7 @@ public class ProgramBlockValidationTest extends ResetPostgres {
                 questionForEligible.getQuestionDefinition(),
                 /* enumeratorImprovementsEnabled= */ true,
                 /* fileUploadQuestionImprovementsEnabled= */ false,
-                /* isInitialQuestionSelection= */ false))
+                /* isInitialQuestion= */ false))
         .isEqualTo(AddQuestionResult.ELIGIBLE);
   }
 
@@ -318,7 +318,7 @@ public class ProgramBlockValidationTest extends ResetPostgres {
                 otherRepeatedQuestion.getQuestionDefinition(),
                 /* enumeratorImprovementsEnabled= */ true,
                 /* fileUploadQuestionImprovementsEnabled= */ false,
-                /* isInitialQuestionSelection= */ false))
+                /* isInitialQuestion= */ false))
         .isEqualTo(AddQuestionResult.ENUMERATOR_MISMATCH);
   }
 
@@ -336,7 +336,7 @@ public class ProgramBlockValidationTest extends ResetPostgres {
                 questionForEligible.getQuestionDefinition(), // text question type
                 /* enumeratorImprovementsEnabled= */ true,
                 /* fileUploadQuestionImprovementsEnabled= */ false,
-                /* isInitialQuestionSelection= */ true))
+                /* isInitialQuestion= */ true))
         .isEqualTo(AddQuestionResult.ELIGIBLE);
   }
 
@@ -356,7 +356,7 @@ public class ProgramBlockValidationTest extends ResetPostgres {
                 checkboxQuestion,
                 /* enumeratorImprovementsEnabled= */ true,
                 /* fileUploadQuestionImprovementsEnabled= */ false,
-                /* isInitialQuestionSelection= */ true))
+                /* isInitialQuestion= */ true))
         .isEqualTo(AddQuestionResult.INVALID_INITIAL_QUESTION_TYPE);
   }
 
@@ -374,7 +374,7 @@ public class ProgramBlockValidationTest extends ResetPostgres {
                 householdMemberQuestion.getQuestionDefinition(),
                 /* enumeratorImprovementsEnabled= */ true,
                 /* fileUploadQuestionImprovementsEnabled= */ false,
-                /* isInitialQuestionSelection= */ true))
+                /* isInitialQuestion= */ true))
         .isEqualTo(AddQuestionResult.INVALID_INITIAL_QUESTION_TYPE);
   }
 
@@ -392,7 +392,7 @@ public class ProgramBlockValidationTest extends ResetPostgres {
                 householdMemberQuestion.getQuestionDefinition(),
                 /* enumeratorImprovementsEnabled= */ true,
                 /* fileUploadQuestionImprovementsEnabled= */ false,
-                /* isInitialQuestionSelection= */ false))
+                /* isInitialQuestion= */ false))
         .isEqualTo(AddQuestionResult.ELIGIBLE);
   }
 }

--- a/server/test/support/TestQuestionBank.java
+++ b/server/test/support/TestQuestionBank.java
@@ -212,6 +212,43 @@ public class TestQuestionBank {
         this::enumeratorNestedApplicantHouseholdMemberJobs);
   }
 
+  /**
+   * Creates an new-flow enumerator and an initial question that each reference the other.
+   *
+   * <p>Because this is a transitional new alternative to the ENUMERATOR type it can't be cached as
+   * the cache is keyed by question type.
+   */
+  public QuestionModel enumeratorWithInitialQuestionNotCached()
+      throws UnsupportedQuestionTypeException {
+    QuestionDefinition initialQuestion =
+        new TextQuestionDefinition(
+            QuestionDefinitionConfig.builder()
+                .setName("plant species")
+                .setDescription("The species of the plant")
+                .setQuestionText(LocalizedStrings.of(Locale.US, "What species is this plant?"))
+                .build());
+    var initialQuestionModel = maybeSave(initialQuestion);
+
+    QuestionDefinition enumeratorQuestion =
+        new EnumeratorQuestionDefinition(
+            QuestionDefinitionConfig.builder()
+                .setName("household plants")
+                .setDescription("The names of the plants in the household")
+                .setQuestionText(LocalizedStrings.of(Locale.US, "List your household plants"))
+                .setEnumeratorInitialQuestionId(initialQuestionModel.id)
+                .build(),
+            LocalizedStrings.empty());
+    var enumeratorQuestionModel = maybeSave(enumeratorQuestion);
+
+    var updatedEnumeratorQuestionModel =
+        new QuestionModel(
+            new QuestionDefinitionBuilder(enumeratorQuestionModel.getQuestionDefinition())
+                .setEnumeratorInitialQuestionId(Optional.of(initialQuestionModel.id))
+                .build());
+    updatedEnumeratorQuestionModel.update();
+    return updatedEnumeratorQuestionModel;
+  }
+
   /** Returns a sample FILE_UPLOAD question. */
   public QuestionModel fileUploadApplicantFile() {
     return questionCache.computeIfAbsent(

--- a/server/test/support/TestQuestionBank.java
+++ b/server/test/support/TestQuestionBank.java
@@ -213,40 +213,13 @@ public class TestQuestionBank {
   }
 
   /**
-   * Creates an new-flow enumerator and an initial question that each reference the other.
-   *
-   * <p>Because this is a transitional new alternative to the ENUMERATOR type it can't be cached as
-   * the cache is keyed by question type.
+   * Returns a sample ENUMERATOR question with an initial question listing the applicant's household
+   * members.
    */
-  public QuestionModel enumeratorWithInitialQuestionNotCached()
-      throws UnsupportedQuestionTypeException {
-    QuestionDefinition initialQuestion =
-        new TextQuestionDefinition(
-            QuestionDefinitionConfig.builder()
-                .setName("plant species")
-                .setDescription("The species of the plant")
-                .setQuestionText(LocalizedStrings.of(Locale.US, "What species is this plant?"))
-                .build());
-    var initialQuestionModel = maybeSave(initialQuestion);
-
-    QuestionDefinition enumeratorQuestion =
-        new EnumeratorQuestionDefinition(
-            QuestionDefinitionConfig.builder()
-                .setName("household plants")
-                .setDescription("The names of the plants in the household")
-                .setQuestionText(LocalizedStrings.of(Locale.US, "List your household plants"))
-                .setEnumeratorInitialQuestionId(initialQuestionModel.id)
-                .build(),
-            LocalizedStrings.empty());
-    var enumeratorQuestionModel = maybeSave(enumeratorQuestion);
-
-    var updatedEnumeratorQuestionModel =
-        new QuestionModel(
-            new QuestionDefinitionBuilder(enumeratorQuestionModel.getQuestionDefinition())
-                .setEnumeratorInitialQuestionId(Optional.of(initialQuestionModel.id))
-                .build());
-    updatedEnumeratorQuestionModel.update();
-    return updatedEnumeratorQuestionModel;
+  public QuestionModel enumeratorWithInitialQuestionApplicantHouseholdPlantNames() {
+    return questionCache.computeIfAbsent(
+        QuestionEnum.ENUMERATOR_NEW_FLOW_APPLICANT_HOUSEHOLD_MEMBERS,
+        this::enumeratorNewFlowApplicantHouseholdMembers);
   }
 
   /** Returns a sample FILE_UPLOAD question. */
@@ -634,6 +607,44 @@ public class TestQuestionBank {
     return maybeSave(definition);
   }
 
+  /** Creates an new-flow enumerator and an initial question that each reference the other. */
+  private QuestionModel enumeratorNewFlowApplicantHouseholdMembers(QuestionEnum ignore) {
+    QuestionDefinition initialQuestion =
+        new TextQuestionDefinition(
+            QuestionDefinitionConfig.builder()
+                .setName("applicant's household member's name")
+                .setDescription("The household member's name")
+                .setQuestionText(LocalizedStrings.of(Locale.US, "What is your name?"))
+                .setQuestionHelpText(LocalizedStrings.of(Locale.US, "This is sample help text."))
+                .build());
+    var initialQuestionModel = maybeSave(initialQuestion);
+
+    QuestionDefinition enumeratorQuestion =
+        new EnumeratorQuestionDefinition(
+            QuestionDefinitionConfig.builder()
+                .setName("applicant household members")
+                .setDescription("The applicant's household members")
+                .setQuestionText(LocalizedStrings.of(Locale.US, "Who are your household members?"))
+                .setQuestionHelpText(LocalizedStrings.of(Locale.US, "This is sample help text."))
+                .setEnumeratorInitialQuestionId(initialQuestionModel.id)
+                .build(),
+            LocalizedStrings.empty());
+    var enumeratorQuestionModel = maybeSave(enumeratorQuestion);
+
+    final QuestionModel updatedEnumeratorQuestionModel;
+    try {
+      updatedEnumeratorQuestionModel =
+          new QuestionModel(
+              new QuestionDefinitionBuilder(enumeratorQuestionModel.getQuestionDefinition())
+                  .setEnumeratorInitialQuestionId(Optional.of(initialQuestionModel.id))
+                  .build());
+    } catch (UnsupportedQuestionTypeException e) {
+      throw new RuntimeException(e);
+    }
+    updatedEnumeratorQuestionModel.update();
+    return updatedEnumeratorQuestionModel;
+  }
+
   // File upload
   private QuestionModel fileUploadApplicantFile(QuestionEnum ignore) {
     QuestionDefinition definition =
@@ -981,6 +992,7 @@ public class TestQuestionBank {
     EMAIL_REPEATED_HOUSEHOLD_MEMBER_EMAIL,
     ENUMERATOR_APPLICANT_HOUSEHOLD_MEMBERS,
     ENUMERATOR_NESTED_APPLICANT_HOUSEHOLD_MEMBER_JOBS,
+    ENUMERATOR_NEW_FLOW_APPLICANT_HOUSEHOLD_MEMBERS,
     FILE_UPLOAD_APPLICANT_FILE,
     FILE_UPLOAD_REPEATED_HOUSEHOLD_MEMBER_FILE,
     ID_APPLICANT_ID,

--- a/server/test/support/TestQuestionBank.java
+++ b/server/test/support/TestQuestionBank.java
@@ -218,7 +218,7 @@ public class TestQuestionBank {
    */
   public QuestionModel enumeratorWithInitialQuestionApplicantHouseholdPlantNames() {
     return questionCache.computeIfAbsent(
-        QuestionEnum.ENUMERATOR_NEW_FLOW_APPLICANT_HOUSEHOLD_MEMBERS,
+        QuestionEnum.ENUMERATOR_APPLICANT_HOUSEHOLD_MEMBERS_WITH_INITIAL,
         this::enumeratorNewFlowApplicantHouseholdMembers);
   }
 
@@ -607,7 +607,7 @@ public class TestQuestionBank {
     return maybeSave(definition);
   }
 
-  /** Creates an new-flow enumerator and an initial question that each reference the other. */
+  /** Creates a new-flow enumerator and an initial question that each reference the other. */
   private QuestionModel enumeratorNewFlowApplicantHouseholdMembers(QuestionEnum ignore) {
     QuestionDefinition initialQuestion =
         new TextQuestionDefinition(
@@ -631,18 +631,15 @@ public class TestQuestionBank {
             LocalizedStrings.empty());
     var enumeratorQuestionModel = maybeSave(enumeratorQuestion);
 
-    final QuestionModel updatedEnumeratorQuestionModel;
     try {
-      updatedEnumeratorQuestionModel =
-          new QuestionModel(
-              new QuestionDefinitionBuilder(enumeratorQuestionModel.getQuestionDefinition())
-                  .setEnumeratorInitialQuestionId(Optional.of(initialQuestionModel.id))
-                  .build());
+      new QuestionModel(
+          new QuestionDefinitionBuilder(initialQuestionModel.getQuestionDefinition())
+              .setEnumeratorId(Optional.of(enumeratorQuestionModel.id))
+              .build());
     } catch (UnsupportedQuestionTypeException e) {
       throw new RuntimeException(e);
     }
-    updatedEnumeratorQuestionModel.update();
-    return updatedEnumeratorQuestionModel;
+    return enumeratorQuestionModel;
   }
 
   // File upload
@@ -992,7 +989,7 @@ public class TestQuestionBank {
     EMAIL_REPEATED_HOUSEHOLD_MEMBER_EMAIL,
     ENUMERATOR_APPLICANT_HOUSEHOLD_MEMBERS,
     ENUMERATOR_NESTED_APPLICANT_HOUSEHOLD_MEMBER_JOBS,
-    ENUMERATOR_NEW_FLOW_APPLICANT_HOUSEHOLD_MEMBERS,
+    ENUMERATOR_APPLICANT_HOUSEHOLD_MEMBERS_WITH_INITIAL,
     FILE_UPLOAD_APPLICANT_FILE,
     FILE_UPLOAD_REPEATED_HOUSEHOLD_MEMBER_FILE,
     ID_APPLICANT_ID,


### PR DESCRIPTION
### Description

When configuring a Repeated Screen and selecting a pre-existing enum, if the enumerator has an Initial Question set also add it to the Screen.

Note on validation: The pre-existing methods, as designed, defer validation of the added data through `ProgramService.addQuestionsToBlock()` to `ProgramBlockValidation.canAddQuestion()`.  Keeping with that style the new code continues to allow for and doesn't not enforce that there aren't multiple enumerators, initial questions, etc.

### Checklist

Remove any sections below that do not apply to your PR. For sections that do apply, complete all of the appropriate checklist items and check them off. If a checklist item doesn't apply to your PR, leave it unchecked but do not delete it.

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [ ] Added an additional reviewer as required if changes potentially affect the security of the application.
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

### Instructions for manual testing

1. Enable the ENUMERATOR_IMPROVEMENTS_ENABLED feature
2. Add a new repeated screen to a program
3. Select an existing enumerator
Notice: The initial question is also added to the block. It will be shown immediately below the enumerator question in the resulting view debug line.

### Issue(s) this completes

Fixes #13391
