### PR TITLE
Avoid clearing date questions on validation failure

### DIFF
--- a/server/app/services/applicant/question/DateQuestion.java
+++ b/server/app/services/applicant/question/DateQuestion.java
@@ -28,6 +28,9 @@ import services.question.types.DateQuestionDefinition.DateValidationOption;
 public final class DateQuestion extends AbstractQuestion {
 
   private Optional<LocalDate> dateValue;
+  private Optional<Integer> yearValue;
+  private Optional<Integer> monthValue;
+  private Optional<Integer> dayValue;
   private ApplicantData applicantData;
 
   DateQuestion(ApplicantQuestion applicantQuestion) {
@@ -188,27 +191,39 @@ public final class DateQuestion extends AbstractQuestion {
   }
 
   public Optional<Integer> getMonthValue() {
-    if (getDateValue().isPresent()) {
-      return Optional.of(getDateValue().get().getMonthValue());
-    } else {
-      return getDatePartFromFailedUpdates(1);
+    if (monthValue != null) {
+      return monthValue;
     }
+    if (getDateValue().isPresent()) {
+      monthValue = Optional.of(getDateValue().get().getMonthValue());
+    } else {
+      monthValue = getDatePartFromFailedUpdates(1);
+    }
+    return monthValue;
   }
 
   public Optional<Integer> getYearValue() {
-    if (getDateValue().isPresent()) {
-      return Optional.of(getDateValue().get().getYear());
-    } else {
-      return getDatePartFromFailedUpdates(0);
+    if (yearValue != null) {
+      return yearValue;
     }
+    if (getDateValue().isPresent()) {
+      yearValue = Optional.of(getDateValue().get().getYear());
+    } else {
+      yearValue = getDatePartFromFailedUpdates(0);
+    }
+    return yearValue;
   }
 
   public Optional<Integer> getDayValue() {
-    if (getDateValue().isPresent()) {
-      return Optional.of(getDateValue().get().getDayOfMonth());
-    } else {
-      return getDatePartFromFailedUpdates(2);
+    if (dayValue != null) {
+      return dayValue;
     }
+    if (getDateValue().isPresent()) {
+      dayValue = Optional.of(getDateValue().get().getDayOfMonth());
+    } else {
+      dayValue = getDatePartFromFailedUpdates(2);
+    }
+    return dayValue;
   }
 
   public boolean isYearEmpty() {

--- a/server/app/services/applicant/question/DateQuestion.java
+++ b/server/app/services/applicant/question/DateQuestion.java
@@ -227,7 +227,6 @@ public final class DateQuestion extends AbstractQuestion {
     return getYearValue().isPresent() && getMonthValue().isPresent() && getDayValue().isPresent();
   }
 
-
   /**
    * Returns a part of the date that the user entered and failed to parse. Used to re-populate the
    * date fields in the UI after a failed update attempt.

--- a/server/app/services/applicant/question/DateQuestion.java
+++ b/server/app/services/applicant/question/DateQuestion.java
@@ -28,9 +28,11 @@ import services.question.types.DateQuestionDefinition.DateValidationOption;
 public final class DateQuestion extends AbstractQuestion {
 
   private Optional<LocalDate> dateValue;
+  private ApplicantData applicantData;
 
   DateQuestion(ApplicantQuestion applicantQuestion) {
     super(applicantQuestion);
+    this.applicantData = applicantQuestion.getApplicantData();
   }
 
   // Since we cannot inject Config class here to check the zone, we take the systemDefaultZone as
@@ -43,7 +45,6 @@ public final class DateQuestion extends AbstractQuestion {
 
   @Override
   protected ImmutableMap<Path, ImmutableSet<ValidationErrorMessage>> getValidationErrorsInternal() {
-    ApplicantData applicantData = applicantQuestion.getApplicantData();
     // When staging updates, the attempt to update ApplicantData would have failed to
     // convert to a date and been noted as a failed update. We check for that here.
     if (applicantData.updateDidFailAt(getDatePath())) {
@@ -178,7 +179,6 @@ public final class DateQuestion extends AbstractQuestion {
       return dateValue;
     }
 
-    ApplicantData applicantData = applicantQuestion.getApplicantData();
     dateValue = applicantData.readDate(getDatePath());
 
     if (dateValue.isEmpty() && isPaiQuestion()) {
@@ -225,17 +225,12 @@ public final class DateQuestion extends AbstractQuestion {
       return Optional.empty();
     }
 
-    ApplicantData applicantData = getApplicantQuestion().getApplicantData();
     if (!applicantData.updateDidFailAt(getDatePath())) {
       return Optional.empty();
     }
 
     // This contains the raw user input for the date, formatted as "YYYY-MM-DD".
     String failedDate = applicantData.getFailedUpdates().get(getDatePath());
-
-    if (failedDate == null) {
-      return Optional.empty();
-    }
 
     String[] parts = failedDate.split("-", -1);
     if (parts.length != 3) {
@@ -247,7 +242,11 @@ public final class DateQuestion extends AbstractQuestion {
     }
 
     try {
-      return Optional.of(Integer.parseInt(parts[index]));
+      int parsedValue = Integer.parseInt(parts[index]);
+      if (parsedValue == 0) {
+        return Optional.empty();
+      }
+      return Optional.of(parsedValue);
     } catch (NumberFormatException e) {
       return Optional.empty();
     }

--- a/server/app/services/applicant/question/DateQuestion.java
+++ b/server/app/services/applicant/question/DateQuestion.java
@@ -211,6 +211,23 @@ public final class DateQuestion extends AbstractQuestion {
     }
   }
 
+  public boolean isYearEmpty() {
+    return getYearValue().isEmpty();
+  }
+
+  public boolean isMonthEmpty() {
+    return getMonthValue().isEmpty();
+  }
+
+  public boolean isDayEmpty() {
+    return getDayValue().isEmpty();
+  }
+
+  public boolean allFieldsPresent() {
+    return getYearValue().isPresent() && getMonthValue().isPresent() && getDayValue().isPresent();
+  }
+
+
   /**
    * Returns a part of the date that the user entered and failed to parse. Used to re-populate the
    * date fields in the UI after a failed update attempt.

--- a/server/app/services/applicant/question/DateQuestion.java
+++ b/server/app/services/applicant/question/DateQuestion.java
@@ -188,22 +188,69 @@ public final class DateQuestion extends AbstractQuestion {
   }
 
   public Optional<Integer> getMonthValue() {
-    return getDateValue()
-        .map(localDate -> Optional.of(localDate.getMonthValue()))
-        .orElse(Optional.empty());
+    if(getDateValue().isPresent()){
+      return Optional.of(getDateValue().get().getMonthValue());
+    }else{
+      return getDatePartFromFailedUpdates(1);
+    }
   }
 
   public Optional<Integer> getYearValue() {
-    return getDateValue()
-        .map(localDate -> Optional.of(localDate.getYear()))
-        .orElse(Optional.empty());
+    if(getDateValue().isPresent()){
+      return Optional.of(getDateValue().get().getYear());
+    }else{
+      return getDatePartFromFailedUpdates(0);
+    }
   }
 
   public Optional<Integer> getDayValue() {
-    return getDateValue()
-        .map(localDate -> Optional.of(localDate.getDayOfMonth()))
-        .orElse(Optional.empty());
+    if(getDateValue().isPresent()){
+      return Optional.of(getDateValue().get().getDayOfMonth());
+    }else{
+      return getDatePartFromFailedUpdates(2);
+    }
   }
+
+  /**
+   * Returns a part of the date that the user entered and failed to parse.
+   * Used to re-populate the date fields in the UI after a failed update attempt.
+   *
+   * @param index 0 for year, 1 for month, 2 for day.
+   * @return Optional<Integer> containing the requested part of the date that the user entered and failed to parse. 
+   *         Returns empty if the index is out of bounds, the date part couldn't be parsed or if the update did not fail.
+   */
+  private Optional<Integer> getDatePartFromFailedUpdates(int index) {
+    if (index < 0 || index > 2) {
+      return Optional.empty();
+    }
+
+  ApplicantData applicantData = getApplicantQuestion().getApplicantData();
+    if (!applicantData.updateDidFailAt(getDatePath())) {
+      return Optional.empty();
+    }
+  
+  // This contains the raw user input for the date, formatted as "YYYY-MM-DD".
+  String failedDate = applicantData.getFailedUpdates().get(getDatePath());
+
+  if(failedDate == null){
+    return Optional.empty();
+  }
+
+  String[] parts = failedDate.split("-", -1);
+  if(parts.length != 3){
+    return Optional.empty();
+  }
+
+  if(parts[index].isEmpty()){
+    return Optional.empty();
+  }
+
+  try{
+    return Optional.of(Integer.parseInt(parts[index]));
+  }catch(NumberFormatException e){
+    return Optional.empty();
+  }
+}
 
   public DateQuestionDefinition getQuestionDefinition() {
     return (DateQuestionDefinition) applicantQuestion.getQuestionDefinition();

--- a/server/app/services/applicant/question/DateQuestion.java
+++ b/server/app/services/applicant/question/DateQuestion.java
@@ -188,69 +188,70 @@ public final class DateQuestion extends AbstractQuestion {
   }
 
   public Optional<Integer> getMonthValue() {
-    if(getDateValue().isPresent()){
+    if (getDateValue().isPresent()) {
       return Optional.of(getDateValue().get().getMonthValue());
-    }else{
+    } else {
       return getDatePartFromFailedUpdates(1);
     }
   }
 
   public Optional<Integer> getYearValue() {
-    if(getDateValue().isPresent()){
+    if (getDateValue().isPresent()) {
       return Optional.of(getDateValue().get().getYear());
-    }else{
+    } else {
       return getDatePartFromFailedUpdates(0);
     }
   }
 
   public Optional<Integer> getDayValue() {
-    if(getDateValue().isPresent()){
+    if (getDateValue().isPresent()) {
       return Optional.of(getDateValue().get().getDayOfMonth());
-    }else{
+    } else {
       return getDatePartFromFailedUpdates(2);
     }
   }
 
   /**
-   * Returns a part of the date that the user entered and failed to parse.
-   * Used to re-populate the date fields in the UI after a failed update attempt.
+   * Returns a part of the date that the user entered and failed to parse. Used to re-populate the
+   * date fields in the UI after a failed update attempt.
    *
    * @param index 0 for year, 1 for month, 2 for day.
-   * @return Optional<Integer> containing the requested part of the date that the user entered and failed to parse. 
-   *         Returns empty if the index is out of bounds, the date part couldn't be parsed or if the update did not fail.
+   * @return Optional<Integer> containing the requested part of the date that the user entered and
+   *     failed to parse. Returns empty if the index is out of bounds, the date part couldn't be
+   *     parsed or if the update did not fail.
    */
   private Optional<Integer> getDatePartFromFailedUpdates(int index) {
     if (index < 0 || index > 2) {
       return Optional.empty();
     }
 
-  ApplicantData applicantData = getApplicantQuestion().getApplicantData();
+    ApplicantData applicantData = getApplicantQuestion().getApplicantData();
     if (!applicantData.updateDidFailAt(getDatePath())) {
       return Optional.empty();
     }
-  
-  // This contains the raw user input for the date, formatted as "YYYY-MM-DD".
-  String failedDate = applicantData.getFailedUpdates().get(getDatePath());
 
-  if(failedDate == null){
-    return Optional.empty();
-  }
+    // This contains the raw user input for the date, formatted as "YYYY-MM-DD".
+    String failedDate = applicantData.getFailedUpdates().get(getDatePath());
 
-  String[] parts = failedDate.split("-", -1);
-  if(parts.length != 3){
-    return Optional.empty();
-  }
+    if (failedDate == null) {
+      return Optional.empty();
+    }
 
-  if(parts[index].isEmpty()){
-    return Optional.empty();
-  }
+    String[] parts = failedDate.split("-", -1);
+    if (parts.length != 3) {
+      return Optional.empty();
+    }
 
-  try{
-    return Optional.of(Integer.parseInt(parts[index]));
-  }catch(NumberFormatException e){
-    return Optional.empty();
+    if (parts[index].isEmpty()) {
+      return Optional.empty();
+    }
+
+    try {
+      return Optional.of(Integer.parseInt(parts[index]));
+    } catch (NumberFormatException e) {
+      return Optional.empty();
+    }
   }
-}
 
   public DateQuestionDefinition getQuestionDefinition() {
     return (DateQuestionDefinition) applicantQuestion.getQuestionDefinition();

--- a/server/app/views/questiontypes/DateQuestionFragment.html
+++ b/server/app/views/questiontypes/DateQuestionFragment.html
@@ -4,6 +4,9 @@
            fieldErrors=${dateQuestion.getValidationErrors().get(dateQuestion.getDatePath())},
            questionErrors=${dateQuestion.getValidationErrors().get(question.getContextualizedPath())},
            hasErrors=${questionRendererParams.shouldShowErrors() && !dateQuestion.getValidationErrors().isEmpty()},
+           monthHasError=${hasErrors && (dateQuestion.isMonthEmpty() || dateQuestion.allFieldsPresent())},
+           dayHasError=${hasErrors && (dateQuestion.isDayEmpty() || dateQuestion.allFieldsPresent())},
+           yearHasError=${hasErrors && (dateQuestion.isYearEmpty() || dateQuestion.allFieldsPresent())},
            questionId=${'id-' + #strings.randomAlphanumeric(8)}"
   class="cf-question-date cf-applicant-question-field"
   th:classappend="${hasErrors ? 'cf-question-field-with-error' : ''}"
@@ -46,7 +49,8 @@
         </label>
         <select
           class="usa-select"
-          th:classappend="${hasErrors ? 'usa-input--error' : ''}"
+          th:classappend="${monthHasError ? 'usa-input--error' : ''}"
+          th:aria-invalid="${monthHasError}"
           th:id="${monthId}"
           th:name="${dateQuestion.getMonthPath()}"
           th:with="value=${dateQuestion.getMonthValue().orElse('')}"
@@ -134,7 +138,8 @@
         </label>
         <input
           class="usa-input"
-          th:classappend="${hasErrors ? 'usa-input--error' : ''}"
+          th:classappend="${dayHasError ? 'usa-input--error' : ''}"
+          th:aria-invalid="${dayHasError}"
           th:aria-describedby="${questionId} + '-description' + (${hasErrors} ? ' ' + ${questionId} + '-error' : '')"
           th:id="${dayId}"
           th:name="${dateQuestion.getDayPath()}"
@@ -162,7 +167,8 @@
         </label>
         <input
           class="usa-input"
-          th:classappend="${hasErrors ? 'usa-input--error' : ''}"
+          th:classappend="${yearHasError ? 'usa-input--error' : ''}"
+          th:aria-invalid="${yearHasError}"
           th:aria-describedby="${questionId} + '-description' + (${hasErrors} ? ' ' + ${questionId} + '-error' : '')"
           th:id="${yearId}"
           th:name="${dateQuestion.getYearPath()}"

--- a/server/test/services/applicant/question/DateQuestionTest.java
+++ b/server/test/services/applicant/question/DateQuestionTest.java
@@ -142,25 +142,6 @@ public class DateQuestionTest extends ResetPostgres {
                         DateQuestion.ALLOWABLE_YEAR_FOR_DATE_VALIDATION))));
   }
 
-    @Test
-  public void withInvalidDateParts_retainsValuesOnFailedUpdate() {
-    ApplicantQuestion applicantQuestion =
-        new ApplicantQuestion(dateQuestionDefinition, applicant, applicantData, Optional.empty());
-    // Use a date without a year and an invalid month.
-    QuestionAnswerer.answerDateQuestion(
-        applicantData, applicantQuestion.getContextualizedPath(), "-13-10");
-
-    DateQuestion dateQuestion = new DateQuestion(applicantQuestion);
-
-    // Date should fail to parse.
-    assertThat(dateQuestion.getDateValue()).isEmpty();
-    assertThat(dateQuestion.getValidationErrors()).isNotEmpty();
-    // Previously entered values should be kept so the user doesn't lose their input.
-    assertThat(dateQuestion.getYearValue()).isEmpty();
-    assertThat(dateQuestion.getMonthValue()).hasValue(13);
-    assertThat(dateQuestion.getDayValue()).hasValue(10);
-  }
-
   @SuppressWarnings("unused")
   private Object[] passingDateValidationCases() {
     return new Object[] {
@@ -293,6 +274,28 @@ public class DateQuestionTest extends ResetPostgres {
                     ValidationErrorMessage.create(
                         MessageKey.DATE_VALIDATION_INVALID_DATE_FORMAT))));
     assertThat(dateQuestion.getDateValue().isPresent()).isFalse();
+  }
+
+  @Test
+  public void withMisformattedDate_retainsValuesOnFailedUpdate() {
+    Path datePath =
+        ApplicantData.APPLICANT_PATH
+            .join(dateQuestionDefinition.getQuestionPathSegment())
+            .join(Scalar.DATE);
+    // Use a date without a year and an invalid month.
+    applicantData.setFailedUpdates(ImmutableMap.of(datePath, "-13-10"));
+    ApplicantQuestion applicantQuestion =
+        new ApplicantQuestion(dateQuestionDefinition, applicant, applicantData, Optional.empty());
+
+    DateQuestion dateQuestion = applicantQuestion.createDateQuestion();
+
+    // Date should have validation errors.
+    assertThat(dateQuestion.getDateValue()).isEmpty();
+    assertThat(dateQuestion.getValidationErrors()).isNotEmpty();
+    // Previously entered values should be kept so the user doesn't lose their input.
+    assertThat(dateQuestion.getYearValue()).isEmpty();
+    assertThat(dateQuestion.getMonthValue()).hasValue(13);
+    assertThat(dateQuestion.getDayValue()).hasValue(10);
   }
 
   @Test

--- a/server/test/services/applicant/question/DateQuestionTest.java
+++ b/server/test/services/applicant/question/DateQuestionTest.java
@@ -142,6 +142,25 @@ public class DateQuestionTest extends ResetPostgres {
                         DateQuestion.ALLOWABLE_YEAR_FOR_DATE_VALIDATION))));
   }
 
+    @Test
+  public void withInvalidDateParts_retainsValuesOnFailedUpdate() {
+    ApplicantQuestion applicantQuestion =
+        new ApplicantQuestion(dateQuestionDefinition, applicant, applicantData, Optional.empty());
+    // Use a date without a year and an invalid month.
+    QuestionAnswerer.answerDateQuestion(
+        applicantData, applicantQuestion.getContextualizedPath(), "-13-10");
+
+    DateQuestion dateQuestion = new DateQuestion(applicantQuestion);
+
+    // Date should fail to parse.
+    assertThat(dateQuestion.getDateValue()).isEmpty();
+    assertThat(dateQuestion.getValidationErrors()).isNotEmpty();
+    // Previously entered values should be kept so the user doesn't lose their input.
+    assertThat(dateQuestion.getYearValue()).isEmpty();
+    assertThat(dateQuestion.getMonthValue()).hasValue(13);
+    assertThat(dateQuestion.getDayValue()).hasValue(10);
+  }
+
   @SuppressWarnings("unused")
   private Object[] passingDateValidationCases() {
     return new Object[] {

--- a/server/test/services/applicant/question/DateQuestionTest.java
+++ b/server/test/services/applicant/question/DateQuestionTest.java
@@ -325,6 +325,40 @@ public class DateQuestionTest extends ResetPostgres {
     assertThat(dateQuestion.getDateValue().get()).isEqualTo(applicant.getDateOfBirth().get());
   }
 
+  @Test
+  public void emptyFieldsDetection_withPartialDate() {
+    Path datePath =
+        ApplicantData.APPLICANT_PATH
+            .join(dateQuestionDefinition.getQuestionPathSegment())
+            .join(Scalar.DATE);
+    // Missing year, valid month (5), valid day (10)
+    applicantData.setFailedUpdates(ImmutableMap.of(datePath, "-5-10"));
+    ApplicantQuestion applicantQuestion =
+        new ApplicantQuestion(dateQuestionDefinition, applicant, applicantData, Optional.empty());
+
+    DateQuestion dateQuestion = applicantQuestion.createDateQuestion();
+
+    assertThat(dateQuestion.isYearEmpty()).isTrue();
+    assertThat(dateQuestion.isMonthEmpty()).isFalse();
+    assertThat(dateQuestion.isDayEmpty()).isFalse();
+    assertThat(dateQuestion.allFieldsPresent()).isFalse();
+  }
+
+  @Test
+  public void allFieldsPresent_withCompleteDate() {
+    ApplicantQuestion applicantQuestion =
+        new ApplicantQuestion(dateQuestionDefinition, applicant, applicantData, Optional.empty());
+    QuestionAnswerer.answerDateQuestion(
+        applicantData, applicantQuestion.getContextualizedPath(), "2021-05-10");
+
+    DateQuestion dateQuestion = applicantQuestion.createDateQuestion();
+
+    assertThat(dateQuestion.isYearEmpty()).isFalse();
+    assertThat(dateQuestion.isMonthEmpty()).isFalse();
+    assertThat(dateQuestion.isDayEmpty()).isFalse();
+    assertThat(dateQuestion.allFieldsPresent()).isTrue();
+  }
+
   private DateQuestionDefinition createDateQuestionDefinition(
       DateValidationOption minDate, DateValidationOption maxDate) {
     return new DateQuestionDefinition(

--- a/server/test/services/applicant/question/DateQuestionTest.java
+++ b/server/test/services/applicant/question/DateQuestionTest.java
@@ -282,8 +282,9 @@ public class DateQuestionTest extends ResetPostgres {
         ApplicantData.APPLICANT_PATH
             .join(dateQuestionDefinition.getQuestionPathSegment())
             .join(Scalar.DATE);
-    // Use a date without a year and an invalid month.
-    applicantData.setFailedUpdates(ImmutableMap.of(datePath, "-13-10"));
+    // User input from the 3 fields are concatenated in YYYY-MM-DD format.
+    // Test a date with no year and an invalid month.
+    applicantData.setFailedUpdates(ImmutableMap.of(datePath, "-invalid-10"));
     ApplicantQuestion applicantQuestion =
         new ApplicantQuestion(dateQuestionDefinition, applicant, applicantData, Optional.empty());
 
@@ -292,9 +293,9 @@ public class DateQuestionTest extends ResetPostgres {
     // Date should have validation errors.
     assertThat(dateQuestion.getDateValue()).isEmpty();
     assertThat(dateQuestion.getValidationErrors()).isNotEmpty();
-    // Previously entered values should be kept so the user doesn't lose their input.
+    // Previously entered integer values should be kept so the user doesn't lose their input.
     assertThat(dateQuestion.getYearValue()).isEmpty();
-    assertThat(dateQuestion.getMonthValue()).hasValue(13);
+    assertThat(dateQuestion.getMonthValue()).isEmpty();
     assertThat(dateQuestion.getDayValue()).hasValue(10);
   }
 


### PR DESCRIPTION
### Description

When a date question has validation errors (e.g. month not selected, invalid year entered) then the entire question is cleared, forcing users to reenter information again.

This change modifies DateQuestion.java to retrieve the previously entered values when there's a validation error. 

This change contains no AI generated code.

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [x] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [ ] Added an additional reviewer as required if changes potentially affect the security of the application.
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [x] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [x] Noted in the PR description which, if any, code in this PR was generated by AI.


### Instructions for manual testing

- Open a form with a date type question
- Fill one or two fields (e.g. year and month)
- Submit the form
- Form should show a validation error, and previously entered values should be present.

### Issue(s) this completes

Fixes #12892