### PR TITLE
Add max-value validation to NumberQuestion and CurrencyQuestion

### DIFF
--- a/server/app/services/applicant/question/CurrencyQuestion.java
+++ b/server/app/services/applicant/question/CurrencyQuestion.java
@@ -16,6 +16,8 @@ import services.question.types.CurrencyQuestionDefinition;
  * <p>See {@link ApplicantQuestion} for details.
  */
 public final class CurrencyQuestion extends AbstractQuestion {
+  // Values shouldn't exceed $1B
+  private static final long CURRENCY_MAX_DOLLARS = 1_000_000_000;
 
   // Stores the value, loading and caching it on first access.
   private Optional<Optional<Currency>> currencyCache;
@@ -40,7 +42,20 @@ public final class CurrencyQuestion extends AbstractQuestion {
           ImmutableSet.of(
               ValidationErrorMessage.create(MessageKey.CURRENCY_VALIDATION_MISFORMATTED)));
     }
-    return ImmutableMap.of();
+
+    return ImmutableMap.of(getCurrencyPath(), validateCurrencyValue());
+  }
+
+  public ImmutableSet<ValidationErrorMessage> validateCurrencyValue() {
+    ImmutableSet.Builder<ValidationErrorMessage> errors = ImmutableSet.builder();
+    if (getCurrencyValue().isPresent()
+        && getCurrencyValue().get().getCents() > CURRENCY_MAX_DOLLARS * 100) {
+      errors.add(
+          ValidationErrorMessage.create(
+              MessageKey.NUMBER_VALIDATION_TOO_BIG, CURRENCY_MAX_DOLLARS));
+    }
+
+    return errors.build();
   }
 
   public Optional<Currency> getCurrencyValue() {

--- a/server/app/services/applicant/question/NumberQuestion.java
+++ b/server/app/services/applicant/question/NumberQuestion.java
@@ -15,6 +15,7 @@ import services.question.types.NumberQuestionDefinition;
  * <p>See {@link ApplicantQuestion} for details.
  */
 public final class NumberQuestion extends AbstractQuestion {
+  private static final long NUMBER_MAX = 1_000_000_000;
 
   private Optional<Long> numberValue;
 
@@ -61,12 +62,14 @@ public final class NumberQuestion extends AbstractQuestion {
       }
     }
 
-    if (questionDefinition.getMax().isPresent()) {
-      long max = questionDefinition.getMax().getAsLong();
-      // If value is empty, don't test against max.
-      if (getNumberValue().isPresent() && getNumberValue().get() > max) {
-        errors.add(ValidationErrorMessage.create(MessageKey.NUMBER_VALIDATION_TOO_BIG, max));
-      }
+    // Fall back to global max if no max is set
+    long max =
+        questionDefinition.getMax().isPresent()
+            ? questionDefinition.getMax().getAsLong()
+            : NUMBER_MAX;
+    // If value is empty, don't test against max.
+    if (getNumberValue().isPresent() && getNumberValue().get() > max) {
+      errors.add(ValidationErrorMessage.create(MessageKey.NUMBER_VALIDATION_TOO_BIG, max));
     }
 
     return errors.build();

--- a/server/test/services/applicant/question/CurrencyQuestionTest.java
+++ b/server/test/services/applicant/question/CurrencyQuestionTest.java
@@ -106,4 +106,36 @@ public class CurrencyQuestionTest {
                     ValidationErrorMessage.create(MessageKey.CURRENCY_VALIDATION_MISFORMATTED))));
     assertThat(currencyQuestion.getCurrencyValue().isPresent()).isFalse();
   }
+
+  @Test
+  public void withValueExceedingMax_failsValidation() {
+    ApplicantQuestion applicantQuestion =
+        new ApplicantQuestion(
+            currencyQuestionDefinition, applicant, applicantData, Optional.empty());
+    QuestionAnswerer.answerCurrencyQuestion(
+        applicantData, applicantQuestion.getContextualizedPath(), "1000000001");
+
+    CurrencyQuestion currencyQuestion = applicantQuestion.createCurrencyQuestion();
+
+    assertThat(currencyQuestion.getValidationErrors())
+        .isEqualTo(
+            ImmutableMap.of(
+                currencyQuestion.getCurrencyPath(),
+                ImmutableSet.of(
+                    ValidationErrorMessage.create(
+                        MessageKey.NUMBER_VALIDATION_TOO_BIG, 1_000_000_000L))));
+  }
+
+  @Test
+  public void withMaxValue_passesValidation() {
+    ApplicantQuestion applicantQuestion =
+        new ApplicantQuestion(
+            currencyQuestionDefinition, applicant, applicantData, Optional.empty());
+    QuestionAnswerer.answerCurrencyQuestion(
+        applicantData, applicantQuestion.getContextualizedPath(), "1000000000");
+
+    CurrencyQuestion currencyQuestion = applicantQuestion.createCurrencyQuestion();
+
+    assertThat(currencyQuestion.getValidationErrors()).isEmpty();
+  }
 }

--- a/server/test/services/applicant/question/NumberQuestionTest.java
+++ b/server/test/services/applicant/question/NumberQuestionTest.java
@@ -170,4 +170,34 @@ public class NumberQuestionTest extends ResetPostgres {
                     ValidationErrorMessage.create(MessageKey.NUMBER_VALIDATION_NON_INTEGER))));
     assertThat(numberQuestion.getNumberValue().isPresent()).isFalse();
   }
+
+  @Test
+  public void withNoMaxConfigured_withValueExceedingGlobalMax_failsValidation() {
+    ApplicantQuestion applicantQuestion =
+        new ApplicantQuestion(numberQuestionDefinition, applicant, applicantData, Optional.empty());
+    QuestionAnswerer.answerNumberQuestion(
+        applicantData, applicantQuestion.getContextualizedPath(), 1_000_000_001L);
+
+    NumberQuestion numberQuestion = applicantQuestion.createNumberQuestion();
+
+    assertThat(numberQuestion.getValidationErrors())
+        .isEqualTo(
+            ImmutableMap.of(
+                numberQuestion.getNumberPath(),
+                ImmutableSet.of(
+                    ValidationErrorMessage.create(
+                        MessageKey.NUMBER_VALIDATION_TOO_BIG, 1_000_000_000L))));
+  }
+
+  @Test
+  public void withNoMaxConfigured_withValueAtGlobalMax_passesValidation() {
+    ApplicantQuestion applicantQuestion =
+        new ApplicantQuestion(numberQuestionDefinition, applicant, applicantData, Optional.empty());
+    QuestionAnswerer.answerNumberQuestion(
+        applicantData, applicantQuestion.getContextualizedPath(), 1_000_000_000L);
+
+    NumberQuestion numberQuestion = applicantQuestion.createNumberQuestion();
+
+    assertThat(numberQuestion.getValidationErrors()).isEmpty();
+  }
 }


### PR DESCRIPTION
### Description

Creates a default max-value boundary for both number and currency inputs in applicant questions. Used claude to help write the new test cases.

### Checklist

Remove any sections below that do not apply to your PR. For sections that do apply, complete all of the appropriate checklist items and check them off. If a checklist item doesn't apply to your PR, leave it unchecked but do not delete it.

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [ ] Added an additional reviewer as required if changes potentially affect the security of the application.
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [x] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [x] Noted in the PR description which, if any, code in this PR was generated by AI.

#### User visible changes

- [ ] Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
  - [ ] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [x] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order
- [ ] Performed manual accessibility tests for any applicant-facing changes or any new admin-facing features. See [manual-accessibility-testing](https://github.com/civiform/civiform/wiki/Accessibility#manual-accessibility-testing)
- [ ] Manually tested with a right-to-left language

### Instructions for manual testing

* Ensure you have a number question available in an application locally which doesn't have maximum values set up already, and a currency question.
* Input 1,000,000,001 in one of the number fields and currency fields as answers and submit, ensuring they are not accepted.

### Issue(s) this completes

Fixes #815

Assisted-by: Claude code:claude-sonnet-4-6
