### PR TITLE
fix: handle multiple applicants per account in UnusedAccountCleanupJob

### DIFF
--- a/server/app/repository/AccountRepository.java
+++ b/server/app/repository/AccountRepository.java
@@ -506,9 +506,12 @@ public final class AccountRepository {
 
   /** Delete guest accounts that have no data and were created before the provided maximum age. */
   public int deleteUnusedGuestAccounts(int minAgeInDays) {
-    // TODO(#12167): Handle that Accounts can have multiple Applicants.
+    // First, identify all unused guest applicants: those with no applications, on guest accounts
+    // (no authority_id), and older than the minimum age. Then delete those applicants. Finally,
+    // only delete accounts where ALL applicants have been removed — this handles the case where
+    // an Account has multiple Applicants and only some qualify for cleanup.
     String sql =
-        "WITH unused_accounts AS ( "
+        "WITH unused_applicants AS ( "
             + "  SELECT applicants.account_id AS account_id, applicants.id AS applicant_id "
             + "  FROM applicants"
             + "  LEFT JOIN applications ON applicants.id = applications.applicant_id "
@@ -521,10 +524,15 @@ public final class AccountRepository {
             + "), "
             + "applicants_deleted AS ("
             + "  DELETE FROM applicants"
-            + "  WHERE applicants.id IN (SELECT applicant_id FROM unused_accounts) "
+            + "  WHERE applicants.id IN (SELECT applicant_id FROM unused_applicants) "
             + ") "
             + "DELETE FROM accounts "
-            + "WHERE accounts.id IN (SELECT account_id FROM unused_accounts);";
+            + "WHERE accounts.id IN (SELECT account_id FROM unused_applicants) "
+            + "AND NOT EXISTS ( "
+            + "  SELECT 1 FROM applicants "
+            + "  WHERE applicants.account_id = accounts.id "
+            + "  AND applicants.id NOT IN (SELECT applicant_id FROM unused_applicants) "
+            + ");";
 
     return database.sqlUpdate(sql).execute();
   }

--- a/server/test/repository/AccountRepositoryTest.java
+++ b/server/test/repository/AccountRepositoryTest.java
@@ -462,6 +462,85 @@ public class AccountRepositoryTest extends ResetPostgres {
   }
 
   @Test
+  public void deleteUnusedGuestAccounts_multipleApplicants_onlyOneUnused() {
+    // When an account has two applicants and only one qualifies for cleanup,
+    // the unused applicant should be deleted but the account should be kept
+    // because the other applicant still references it.
+    var testProgram = resourceCreator.insertActiveProgram("test-program");
+    LocalDateTime now = LocalDateTime.now(Clock.systemUTC());
+    Instant timeInPast = now.minus(10, ChronoUnit.DAYS).toInstant(ZoneOffset.UTC);
+
+    // Create a guest account with two applicants
+    AccountModel sharedAccount = resourceCreator.insertAccount();
+    sharedAccount.save();
+
+    ApplicantModel unusedApplicant = resourceCreator.insertApplicant();
+    unusedApplicant.setAccount(sharedAccount);
+    unusedApplicant.setWhenCreated(timeInPast);
+    unusedApplicant.save();
+
+    ApplicantModel usedApplicant = resourceCreator.insertApplicant();
+    usedApplicant.setAccount(sharedAccount);
+    usedApplicant.setWhenCreated(timeInPast);
+    usedApplicant.save();
+
+    sharedAccount.setApplicants(ImmutableList.of(unusedApplicant, usedApplicant));
+    sharedAccount.save();
+
+    // Give the used applicant an application so it won't be cleaned up
+    resourceCreator.insertApplication(usedApplicant, testProgram, LifecycleStage.DRAFT);
+
+    var numberDeleted = repo.deleteUnusedGuestAccounts(5);
+    var remainingApplicants = repo.listApplicants().toCompletableFuture().join();
+    var remainingAccounts = repo.listAccounts();
+
+    // The unused applicant should be deleted
+    assertThat(remainingApplicants).doesNotContain(unusedApplicant);
+    // The used applicant should remain
+    assertThat(remainingApplicants).contains(usedApplicant);
+    // The account should NOT be deleted because the used applicant still references it
+    assertThat(remainingAccounts).contains(sharedAccount);
+    // No accounts deleted (only applicants were cleaned up)
+    assertThat(numberDeleted).isEqualTo(0);
+  }
+
+  @Test
+  public void deleteUnusedGuestAccounts_multipleApplicants_allUnused() {
+    // When an account has two applicants and both qualify for cleanup,
+    // both applicants and the account should be deleted.
+    LocalDateTime now = LocalDateTime.now(Clock.systemUTC());
+    Instant timeInPast = now.minus(10, ChronoUnit.DAYS).toInstant(ZoneOffset.UTC);
+
+    // Create a guest account with two applicants, both unused
+    AccountModel sharedAccount = resourceCreator.insertAccount();
+    sharedAccount.save();
+
+    ApplicantModel unusedApplicant1 = resourceCreator.insertApplicant();
+    unusedApplicant1.setAccount(sharedAccount);
+    unusedApplicant1.setWhenCreated(timeInPast);
+    unusedApplicant1.save();
+
+    ApplicantModel unusedApplicant2 = resourceCreator.insertApplicant();
+    unusedApplicant2.setAccount(sharedAccount);
+    unusedApplicant2.setWhenCreated(timeInPast);
+    unusedApplicant2.save();
+
+    sharedAccount.setApplicants(ImmutableList.of(unusedApplicant1, unusedApplicant2));
+    sharedAccount.save();
+
+    var numberDeleted = repo.deleteUnusedGuestAccounts(5);
+    var remainingApplicants = repo.listApplicants().toCompletableFuture().join();
+    var remainingAccounts = repo.listAccounts();
+
+    // Both applicants should be deleted
+    assertThat(remainingApplicants).doesNotContain(unusedApplicant1);
+    assertThat(remainingApplicants).doesNotContain(unusedApplicant2);
+    // The account should also be deleted since all applicants are gone
+    assertThat(remainingAccounts).doesNotContain(sharedAccount);
+    assertThat(numberDeleted).isEqualTo(1);
+  }
+
+  @Test
   public void addIdTokenAndPrune() {
     AccountModel account = new AccountModel();
     String fakeEmail = "fake email";

--- a/server/test/repository/AccountRepositoryTest.java
+++ b/server/test/repository/AccountRepositoryTest.java
@@ -490,7 +490,7 @@ public class AccountRepositoryTest extends ResetPostgres {
     // Give the used applicant an application so it won't be cleaned up
     resourceCreator.insertApplication(usedApplicant, testProgram, LifecycleStage.DRAFT);
 
-    var numberDeleted = repo.deleteUnusedGuestAccounts(5);
+    var numberDeleted = repo.deleteUnusedGuestAccounts(/* minAgeInDays= */ 5);
     var remainingApplicants = repo.listApplicants().toCompletableFuture().join();
     var remainingAccounts = repo.listAccounts();
 

--- a/server/test/repository/AccountRepositoryTest.java
+++ b/server/test/repository/AccountRepositoryTest.java
@@ -505,7 +505,7 @@ public class AccountRepositoryTest extends ResetPostgres {
   }
 
   @Test
-  public void deleteUnusedGuestAccounts_multipleApplicants_allUnused() {
+  public void deleteUnusedGuestAccounts_multipleApplicants_allUnused_allDeleted() {
     // When an account has two applicants and both qualify for cleanup,
     // both applicants and the account should be deleted.
     LocalDateTime now = LocalDateTime.now(Clock.systemUTC());
@@ -528,7 +528,7 @@ public class AccountRepositoryTest extends ResetPostgres {
     sharedAccount.setApplicants(ImmutableList.of(unusedApplicant1, unusedApplicant2));
     sharedAccount.save();
 
-    var numberDeleted = repo.deleteUnusedGuestAccounts(5);
+    var numberDeleted = repo.deleteUnusedGuestAccounts(/* minAgeInDays= */ 5);
     var remainingApplicants = repo.listApplicants().toCompletableFuture().join();
     var remainingAccounts = repo.listAccounts();
 

--- a/server/test/repository/AccountRepositoryTest.java
+++ b/server/test/repository/AccountRepositoryTest.java
@@ -462,7 +462,7 @@ public class AccountRepositoryTest extends ResetPostgres {
   }
 
   @Test
-  public void deleteUnusedGuestAccounts_multipleApplicants_onlyOneUnused() {
+  public void deleteUnusedGuestAccounts_multipleApplicants_onlyOneUnused_onlyDeletesUnusedOne() {
     // When an account has two applicants and only one qualifies for cleanup,
     // the unused applicant should be deleted but the account should be kept
     // because the other applicant still references it.


### PR DESCRIPTION
### Description

Fix the `UnusedAccountCleanupJob` to correctly handle Accounts that have multiple Applicants, resolving a foreign key violation that caused the job to fail on production deployments (e.g., Arkansas staging).

**Problem**: The cleanup SQL in `AccountRepository.deleteUnusedGuestAccounts()` assumed each Account had exactly one Applicant. When an Account had multiple Applicants and only some qualified for cleanup (no applications, guest account, older than 90 days), it tried to delete the Account while other Applicants still referenced it, causing:

```
io.ebean.DataIntegrityException: ERROR: update or delete on table "accounts"
violates foreign key constraint "applicants_account_id_fkey" on table "applicants"
Detail: Key (id)=(3156) is still referenced from table "applicants".
```

**Fix**: The SQL now only deletes an Account when ALL of its Applicants have been removed by the cleanup. If any Applicant on the Account still has applications or does not qualify for deletion, the Account is preserved.

AI-generated code: This change was written with AI assistance.

### Checklist

#### General

- [x] Added the correct label: bug
- [x] Assigned to a specific person, `civiform/developers`, or a more specific round-robin list
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI
- [ ] Added an additional reviewer as required if changes potentially affect the security of the application.
- [x] Removed the release notes section if the title is sufficient for the release notes description
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary.
- [x] Ensured PII was not added to any new logs, unless it was guarded by `isDevOrStaging`
- [x] Noted in the PR description which, if any, code in this PR was generated by AI.

### Instructions for manual testing

This is a backend durable job — no UI changes. Run the unit tests:

```bash
bin/sbt-test
# Inside sbt:
testOnly repository.AccountRepositoryTest
```

New test cases:
- `deleteUnusedGuestAccounts_multipleApplicants_onlyOneUnused` — Account with 2 applicants where only 1 is unused → deletes unused applicant, keeps account
- `deleteUnusedGuestAccounts_multipleApplicants_allUnused` — Account with 2 applicants where both are unused → deletes both applicants and the account

### Issue(s) this completes

Fixes #12167