### PR TITLE
Thymeleaf FieldWithLabel Analogues and Tests

### DIFF
--- a/server/app/views/admin/questions/fragments/DateTypeSelect.html
+++ b/server/app/views/admin/questions/fragments/DateTypeSelect.html
@@ -1,0 +1,47 @@
+<!--/* Date validation type select shared by the question new/edit pages. */-->
+<div
+  th:fragment="dateTypeSelect(id, name, label, anyLabel, value)"
+  class="mb-2"
+>
+  <label
+    th:for="${id}"
+    class="pointer-events-none text-gray-600 text-base px-1 py-2"
+    >[[${label}]]<span
+      th:replace="~{admin/shared/LegacyFieldWithLabel/RequiredIndicator :: requiredIndicator(true)}"
+    ></span
+  ></label>
+  <div class="flex flex-col">
+    <select
+      maxlength="10000"
+      aria-required="true"
+      th:id="${id}"
+      th:name="${name}"
+      class="px-3 bg-white text-black text-lg py-2 block outline-none box-border m-auto border border-gray-500 rounded-lg w-full focus:border-civiform-blue placeholder-gray-500 h-11.5"
+    >
+      <option value="" hidden th:selected="${#strings.isEmpty(value)}"></option>
+      <optgroup label="">
+        <option
+          class="cf-multi-option-question-option cf-multi-option-value"
+          value="ANY"
+          th:selected="${value == 'ANY'}"
+          th:text="${anyLabel}"
+        ></option>
+        <option
+          class="cf-multi-option-question-option cf-multi-option-value"
+          value="APPLICATION_DATE"
+          th:selected="${value == 'APPLICATION_DATE'}"
+        >
+          Current date of application
+        </option>
+        <option
+          class="cf-multi-option-question-option cf-multi-option-value"
+          value="CUSTOM"
+          th:selected="${value == 'CUSTOM'}"
+        >
+          Custom date
+        </option>
+      </optgroup>
+    </select>
+    <div th:id="|${id}-errors|" class="text-red-600 text-xs p-1 hidden"></div>
+  </div>
+</div>

--- a/server/app/views/admin/questions/fragments/MemorableDate.html
+++ b/server/app/views/admin/questions/fragments/MemorableDate.html
@@ -1,0 +1,126 @@
+<!--/* USWDS memorable date (month/day/year) picker with required
+     indicators. Shared by the question new/edit pages. */-->
+<fieldset
+  th:fragment="memorableDate(idPrefix, hidden, monthName, monthValue, dayName, dayValue, yearName, yearValue)"
+  th:id="|${idPrefix}-fieldset|"
+  class="pb-2"
+  th:hidden="${hidden}"
+>
+  <div class="text-red-600 text-xs" id="memorable_date_error"></div>
+  <div class="usa-memorable-date">
+    <div class="usa-form-group usa-form-group--month usa-form-group--select">
+      <label class="usa-label" th:for="|${idPrefix}-month|"
+        >[[#{label.month}]]<span
+          th:replace="~{admin/shared/LegacyFieldWithLabel/RequiredIndicator :: requiredIndicator(true)}"
+        ></span
+      ></label>
+      <select
+        class="usa-select"
+        th:id="|${idPrefix}-month|"
+        th:name="${monthName}"
+        aria-describedby="mdHint"
+      >
+        <option
+          value=""
+          th:selected="${monthValue == ''}"
+          th:text="'- ' + #{placeholder.memorableDate} + ' -'"
+        ></option>
+        <option
+          value="1"
+          th:selected='${monthValue == "1"}'
+          th:text="#{option.memorableDate.January}"
+        ></option>
+        <option
+          value="2"
+          th:selected='${monthValue == "2"}'
+          th:text="#{option.memorableDate.February}"
+        ></option>
+        <option
+          value="3"
+          th:selected='${monthValue == "3"}'
+          th:text="#{option.memorableDate.March}"
+        ></option>
+        <option
+          value="4"
+          th:selected='${monthValue == "4"}'
+          th:text="#{option.memorableDate.April}"
+        ></option>
+        <option
+          value="5"
+          th:selected='${monthValue == "5"}'
+          th:text="#{option.memorableDate.May}"
+        ></option>
+        <option
+          value="6"
+          th:selected='${monthValue == "6"}'
+          th:text="#{option.memorableDate.June}"
+        ></option>
+        <option
+          value="7"
+          th:selected='${monthValue == "7"}'
+          th:text="#{option.memorableDate.July}"
+        ></option>
+        <option
+          value="8"
+          th:selected='${monthValue == "8"}'
+          th:text="#{option.memorableDate.August}"
+        ></option>
+        <option
+          value="9"
+          th:selected='${monthValue == "9"}'
+          th:text="#{option.memorableDate.September}"
+        ></option>
+        <option
+          value="10"
+          th:selected='${monthValue == "10"}'
+          th:text="#{option.memorableDate.October}"
+        ></option>
+        <option
+          value="11"
+          th:selected='${monthValue == "11"}'
+          th:text="#{option.memorableDate.November}"
+        ></option>
+        <option
+          value="12"
+          th:selected='${monthValue == "12"}'
+          th:text="#{option.memorableDate.December}"
+        ></option>
+      </select>
+    </div>
+    <div class="usa-form-group usa-form-group--day">
+      <label class="usa-label" th:for="|${idPrefix}-day|"
+        >[[#{label.day}]]<span
+          th:replace="~{admin/shared/LegacyFieldWithLabel/RequiredIndicator :: requiredIndicator(true)}"
+        ></span
+      ></label>
+      <input
+        class="usa-input"
+        th:id="|${idPrefix}-day|"
+        th:name="${dayName}"
+        aria-describedby="mdHint"
+        inputmode="numeric"
+        maxlength="2"
+        pattern="[0-9]*"
+        th:value="${dayValue}"
+      />
+    </div>
+    <div class="usa-form-group usa-form-group--year">
+      <label class="usa-label" th:for="|${idPrefix}-year|"
+        >[[#{label.year}]]<span
+          th:replace="~{admin/shared/LegacyFieldWithLabel/RequiredIndicator :: requiredIndicator(true)}"
+        ></span
+      ></label>
+      <input
+        class="usa-input"
+        th:id="|${idPrefix}-year|"
+        th:name="${yearName}"
+        aria-describedby="mdHint"
+        minlength="4"
+        inputmode="numeric"
+        maxlength="4"
+        pattern="[0-9]*"
+        th:value="${yearValue}"
+      />
+    </div>
+  </div>
+</fieldset>

--- a/server/app/views/admin/questions/fragments/MultiOptionRow.html
+++ b/server/app/views/admin/questions/fragments/MultiOptionRow.html
@@ -1,0 +1,126 @@
+<!--/*
+  One editable answer option row for CHECKBOX / DROPDOWN / RADIO_BUTTON
+  questions. New (unsaved) options post to newOptions[] /
+  newOptionAdminNames[] and have no hidden optionIds[] field; existing
+  options are also readonly on the Admin ID.
+
+  Callers pass the label/input ids in (optionIdFieldId, adminNameFieldId,
+  optionTextFieldId), generating them with ${model.randomFieldId()} so
+  labels stay associated with inputs. Icons live in LegacySvgFragments.html.
+*/-->
+<div
+  th:fragment="multiOptionRow(isForNewOption, optionId, adminName, optionText, optionIdFieldId, adminNameFieldId, optionTextFieldId)"
+  class="cf-multi-option-question-option cf-multi-option-question-option-editable grid grid-cols-8 grid-rows-4 items-center mb-4"
+>
+  <div th:if="${isForNewOption}"></div>
+  <div th:unless="${isForNewOption}" class="hidden">
+    <label th:for="${optionIdFieldId}" class="sr-only"
+      >option ids<span
+        th:replace="~{admin/shared/LegacyFieldWithLabel/RequiredIndicator :: requiredIndicator(false)}"
+      ></span
+    ></label>
+    <div class="flex flex-col">
+      <input
+        type="text"
+        th:value="${optionId}"
+        maxlength="10000"
+        th:id="${optionIdFieldId}"
+        name="optionIds[]"
+        class="px-3 bg-white text-black text-lg py-2 block outline-none box-border m-auto border border-gray-500 rounded-lg w-full focus:border-civiform-blue placeholder-gray-500"
+      />
+      <div
+        th:id="|${optionIdFieldId}-errors|"
+        class="text-red-600 text-xs p-1 hidden"
+      ></div>
+    </div>
+  </div>
+  <div
+    class="cf-multi-option-admin-input col-start-1 col-span-5 mb-2 ml-2 row-start-1 row-span-2"
+  >
+    <label
+      th:for="${adminNameFieldId}"
+      class="pointer-events-none text-gray-600 text-base px-1 py-2"
+      >Admin ID<span
+        th:replace="~{admin/shared/LegacyFieldWithLabel/RequiredIndicator :: requiredIndicator(true)}"
+      ></span
+    ></label>
+    <div class="flex flex-col">
+      <input
+        type="text"
+        th:value="${adminName}"
+        maxlength="10000"
+        aria-required="true"
+        th:id="${adminNameFieldId}"
+        th:name="${isForNewOption} ? 'newOptionAdminNames[]' : 'optionAdminNames[]'"
+        th:readonly="${!isForNewOption}"
+        class="px-3 bg-white text-black text-lg py-2 block outline-none box-border m-auto border border-gray-500 rounded-lg w-full focus:border-civiform-blue placeholder-gray-500"
+        th:classappend="${!isForNewOption} ? 'read-only:text-gray-500 read-only:bg-gray-100'"
+      />
+      <div
+        th:id="|${adminNameFieldId}-errors|"
+        class="cf-multi-option-admin-input-error text-red-600 text-xs p-1 hidden"
+      >
+        <div
+          th:text="#{toast.errorMessageOutline(#{adminValidation.multiOptionAdminError})}"
+        ></div>
+      </div>
+    </div>
+  </div>
+  <button
+    class="bg-transparent p-0 w-6 text-center text-gray-500 hover:bg-gray-200 hover:text-gray-900 col-start-8 multi-option-question-field-move-up-button row-start-1"
+    aria-label="move up"
+  >
+    <svg
+      th:replace="~{admin/shared/LegacySvgFragments :: iconKeyboardArrowUp('w-6 h-6')}"
+    ></svg>
+  </button>
+  <button
+    class="bg-transparent p-0 w-6 text-center text-gray-500 hover:bg-gray-200 hover:text-gray-900 col-start-8 multi-option-question-field-move-down-button row-start-2"
+    aria-label="move down"
+  >
+    <svg
+      th:replace="~{admin/shared/LegacySvgFragments :: iconKeyboardArrowDown('w-6 h-6')}"
+    ></svg>
+  </button>
+  <div
+    class="cf-multi-option-input col-start-1 col-span-5 mb-2 ml-2 row-start-3 row-span-2"
+  >
+    <label
+      th:for="${optionTextFieldId}"
+      class="pointer-events-none text-gray-600 text-base px-1 py-2"
+      >Option Text<span
+        th:replace="~{admin/shared/LegacyFieldWithLabel/RequiredIndicator :: requiredIndicator(true)}"
+      ></span
+    ></label>
+    <div class="flex flex-col">
+      <input
+        type="text"
+        th:value="${optionText}"
+        maxlength="10000"
+        aria-required="true"
+        th:id="${optionTextFieldId}"
+        th:name="${isForNewOption} ? 'newOptions[]' : 'options[]'"
+        class="px-3 bg-white text-black text-lg py-2 block outline-none box-border m-auto border border-gray-500 rounded-lg w-full focus:border-civiform-blue placeholder-gray-500"
+      />
+      <div
+        th:id="|${optionTextFieldId}-errors|"
+        class="cf-multi-option-input-error text-red-600 text-xs p-1 hidden"
+      >
+        <div
+          th:text="#{toast.errorMessageOutline(#{adminValidation.multiOptionEmpty})}"
+        ></div>
+      </div>
+    </div>
+    <span
+      th:replace="~{admin/shared/LegacyFieldWithLabel/MarkdownIndicator :: markdownIndicator('Some markdown is supported, ')}"
+    ></span>
+  </div>
+  <button
+    class="bg-transparent p-0 w-6 text-center text-blue-900 hover:bg-gray-200 hover:text-gray-900 multi-option-question-field-remove-button col-start-8 row-span-2"
+    aria-label="delete"
+  >
+    <svg
+      th:replace="~{admin/shared/LegacySvgFragments :: iconDelete('w-6 h-6')}"
+    ></svg>
+  </button>
+</div>

--- a/server/app/views/admin/shared/LegacyFieldWithLabel/MarkdownIndicator.html
+++ b/server/app/views/admin/shared/LegacyFieldWithLabel/MarkdownIndicator.html
@@ -1,0 +1,19 @@
+<!--/*
+  "Markdown is supported" indicator with a docs link. Icons live in
+  LegacySvgFragments.html.
+*/-->
+<span
+  th:fragment="markdownIndicator(text)"
+  class="flex flex-row mt-2 items-center"
+>
+  <svg th:replace="~{admin/shared/LegacySvgFragments :: iconMarkdown}"></svg>
+  <span class="text-gray-600 text-sm"
+    >[[${text}]]<a
+      href="https://docs.civiform.us/user-manual/civiform-admin-guide/using-markdown"
+      target="_blank"
+      rel="noopener noreferrer"
+      class="text-blue-600 hover:text-blue-500 inline-flex items-center"
+      >see how it works</a
+    ></span
+  >
+</span>

--- a/server/app/views/admin/shared/LegacyFieldWithLabel/NumberField.html
+++ b/server/app/views/admin/shared/LegacyFieldWithLabel/NumberField.html
@@ -1,0 +1,27 @@
+<!--/* Number field for optional settings fields (never
+     marked required). Pass value as a String or null; null omits the value
+     attribute entirely (th:attr, unlike th:value, drops null attributes),
+     matching the legacy FieldWithLabel output. */-->
+<div th:fragment="numberField(id, name, label, value, min)" class="mb-2">
+  <label
+    th:for="${id}"
+    class="pointer-events-none text-gray-600 text-base px-1 py-2"
+    >[[${label}]]<span
+      th:replace="~{admin/shared/LegacyFieldWithLabel/RequiredIndicator :: requiredIndicator(false)}"
+    ></span
+  ></label>
+  <div class="flex flex-col">
+    <input
+      type="number"
+      inputmode="decimal"
+      step="any"
+      th:min="${min}"
+      th:attr="value=${value}"
+      maxlength="10000"
+      th:id="${id}"
+      th:name="${name}"
+      class="px-3 bg-white text-black text-lg py-2 block outline-none box-border m-auto border border-gray-500 rounded-lg w-full focus:border-civiform-blue placeholder-gray-500"
+    />
+    <div th:id="|${id}-errors|" class="text-red-600 text-xs p-1 hidden"></div>
+  </div>
+</div>

--- a/server/app/views/admin/shared/LegacyFieldWithLabel/RadioOption.html
+++ b/server/app/views/admin/shared/LegacyFieldWithLabel/RadioOption.html
@@ -1,0 +1,16 @@
+<!--/* Label-wrapped radio option, legacy FieldWithLabel-parity markup for migrated admin pages. */-->
+<label
+  th:fragment="radioOption(id, name, label, value, checked)"
+  class="px-3 bg-white text-black text-lg py-2 block outline-none box-border m-auto border border-gray-500 rounded-lg w-full focus:border-civiform-blue align-middle flex flex-row mb-2 cf-radio-option"
+  th:for="${id}"
+  ><input
+    type="radio"
+    th:value="${value}"
+    maxlength="10000"
+    aria-required="true"
+    th:id="${id}"
+    th:name="${name}"
+    class="h-4 w-4 mr-4 align-middle self-center flex-none"
+    th:checked="${checked}"
+  />[[${label}]]</label
+>

--- a/server/app/views/admin/shared/LegacyFieldWithLabel/RequiredIndicator.html
+++ b/server/app/views/admin/shared/LegacyFieldWithLabel/RequiredIndicator.html
@@ -1,0 +1,10 @@
+<!--/*
+  Required-field indicator (*), legacy FieldWithLabel-parity markup for migrated admin pages.
+*/-->
+<span
+  th:fragment="requiredIndicator(visible)"
+  class="usa-hint--required"
+  th:classappend="${visible} ? '' : 'hidden'"
+  aria-hidden="true"
+  >&nbsp;*</span
+>

--- a/server/app/views/admin/shared/LegacyFieldWithLabel/SlimInfoAlert.html
+++ b/server/app/views/admin/shared/LegacyFieldWithLabel/SlimInfoAlert.html
@@ -1,0 +1,15 @@
+<!--/*
+  Slim USWDS info alert, legacy-parity markup for migrated admin pages.
+*/-->
+<div
+  th:fragment="slimInfoAlert(text, hidden, extraClasses)"
+  th:hidden="${hidden}"
+  class="usa-alert usa-alert--info usa-alert--slim"
+  th:classappend="${extraClasses}"
+  aria-live="polite"
+  role="alert"
+>
+  <div class="usa-alert__body">
+    <p class="usa-alert__text" th:text="${text}"></p>
+  </div>
+</div>

--- a/server/app/views/admin/shared/LegacyFieldWithLabel/TextareaField.html
+++ b/server/app/views/admin/shared/LegacyFieldWithLabel/TextareaField.html
@@ -1,0 +1,35 @@
+<!--/*
+  Labeled textarea field, legacy FieldWithLabel-parity markup for migrated admin pages.
+
+  Field ids: callers pass a fixed id, or generate a random 8-character
+  alphabetic id with ${model.randomFieldId()} so labels stay associated
+  with inputs.
+*/-->
+<div
+  th:fragment="textareaField(id, name, label, value, required, markdown)"
+  class="mb-2"
+>
+  <label
+    th:for="${id}"
+    class="pointer-events-none text-gray-600 text-base px-1 py-2"
+    >[[${label}]]<span
+      th:replace="~{admin/shared/LegacyFieldWithLabel/RequiredIndicator :: requiredIndicator(${required})}"
+    ></span
+  ></label>
+  <div class="flex flex-col">
+    <textarea
+      maxlength="10000"
+      th:attr="aria-required=${required} ? 'true'"
+      th:id="${id}"
+      th:name="${name}"
+      class="px-3 bg-white text-black text-lg py-2 block outline-none box-border m-auto border border-gray-500 rounded-lg w-full focus:border-civiform-blue placeholder-gray-500"
+      th:text="${value}"
+    ></textarea>
+    <div th:id="|${id}-errors|" class="text-red-600 text-xs p-1 hidden"></div>
+  </div>
+  <th:block th:if="${markdown}">
+    <span
+      th:replace="~{admin/shared/LegacyFieldWithLabel/MarkdownIndicator :: markdownIndicator('Markdown is supported, ')}"
+    ></span>
+  </th:block>
+</div>

--- a/server/app/views/admin/shared/LegacyFieldWithLabel/Toggle.html
+++ b/server/app/views/admin/shared/LegacyFieldWithLabel/Toggle.html
@@ -1,0 +1,23 @@
+<!--/* A CSS-only toggle. The hidden companion field MUST come after the
+     checkbox: when the box is unchecked only `false` posts; when checked
+     both post and Play form binding takes the first value. */-->
+<div
+  th:fragment="toggle(name, idPrefix, checked, hidden, text)"
+  class="cf-toggle mt-2"
+  th:hidden="${hidden}"
+>
+  <label class="cf-toggle__label" th:id="|${idPrefix}-toggle|">
+    <input
+      type="checkbox"
+      role="switch"
+      class="cf-toggle__input"
+      th:name="${name}"
+      value="true"
+      th:checked="${checked}"
+      th:id="|${idPrefix}-toggle-input|"
+    />
+    <input type="hidden" th:name="${name}" value="false" />
+    <span class="cf-toggle__track" aria-hidden="true"></span>
+    <span th:text="${text}"></span>
+  </label>
+</div>

--- a/server/test/resources/thymeleaf/admin/questions/legacyQuestionFragments/dateTypeSelectCustom.thtest
+++ b/server/test/resources/thymeleaf/admin/questions/legacyQuestionFragments/dateTypeSelectCustom.thtest
@@ -1,0 +1,45 @@
+%NAME dateTypeSelect - CUSTOM value selects the custom date option
+%TEMPLATE_MODE HTML
+# ----------------------------------------------------------------------
+%INPUT
+<div th:replace="~{admin/questions/fragments/DateTypeSelect :: dateTypeSelect('max-date-type', 'maxDateType', 'End date', 'Any future date', 'CUSTOM')}"></div>
+# ----------------------------------------------------------------------
+%OUTPUT
+<div class="mb-2">
+  <label
+    for="max-date-type"
+    class="pointer-events-none text-gray-600 text-base px-1 py-2"
+    >End date<span class="usa-hint--required" aria-hidden="true">&nbsp;*</span></label
+  >
+  <div class="flex flex-col">
+    <select
+      maxlength="10000"
+      aria-required="true"
+      id="max-date-type"
+      name="maxDateType"
+      class="px-3 bg-white text-black text-lg py-2 block outline-none box-border m-auto border border-gray-500 rounded-lg w-full focus:border-civiform-blue placeholder-gray-500 h-11.5"
+    >
+      <option value="" hidden></option>
+      <optgroup label="">
+        <option
+          class="cf-multi-option-question-option cf-multi-option-value"
+          value="ANY"
+        >Any future date</option>
+        <option
+          class="cf-multi-option-question-option cf-multi-option-value"
+          value="APPLICATION_DATE"
+        >
+          Current date of application
+        </option>
+        <option
+          class="cf-multi-option-question-option cf-multi-option-value"
+          value="CUSTOM"
+          selected="selected"
+        >
+          Custom date
+        </option>
+      </optgroup>
+    </select>
+    <div id="max-date-type-errors" class="text-red-600 text-xs p-1 hidden"></div>
+  </div>
+</div>

--- a/server/test/resources/thymeleaf/admin/questions/legacyQuestionFragments/dateTypeSelectNoValue.thtest
+++ b/server/test/resources/thymeleaf/admin/questions/legacyQuestionFragments/dateTypeSelectNoValue.thtest
@@ -1,0 +1,44 @@
+%NAME dateTypeSelect - no value selects the empty placeholder option
+%TEMPLATE_MODE HTML
+# ----------------------------------------------------------------------
+%INPUT
+<div th:replace="~{admin/questions/fragments/DateTypeSelect :: dateTypeSelect('min-date-type', 'minDateType', 'Start date', 'Any past date', '')}"></div>
+# ----------------------------------------------------------------------
+%OUTPUT
+<div class="mb-2">
+  <label
+    for="min-date-type"
+    class="pointer-events-none text-gray-600 text-base px-1 py-2"
+    >Start date<span class="usa-hint--required" aria-hidden="true">&nbsp;*</span></label
+  >
+  <div class="flex flex-col">
+    <select
+      maxlength="10000"
+      aria-required="true"
+      id="min-date-type"
+      name="minDateType"
+      class="px-3 bg-white text-black text-lg py-2 block outline-none box-border m-auto border border-gray-500 rounded-lg w-full focus:border-civiform-blue placeholder-gray-500 h-11.5"
+    >
+      <option value="" hidden selected="selected"></option>
+      <optgroup label="">
+        <option
+          class="cf-multi-option-question-option cf-multi-option-value"
+          value="ANY"
+        >Any past date</option>
+        <option
+          class="cf-multi-option-question-option cf-multi-option-value"
+          value="APPLICATION_DATE"
+        >
+          Current date of application
+        </option>
+        <option
+          class="cf-multi-option-question-option cf-multi-option-value"
+          value="CUSTOM"
+        >
+          Custom date
+        </option>
+      </optgroup>
+    </select>
+    <div id="min-date-type-errors" class="text-red-600 text-xs p-1 hidden"></div>
+  </div>
+</div>

--- a/server/test/resources/thymeleaf/admin/questions/legacyQuestionFragments/memorableDate.thtest
+++ b/server/test/resources/thymeleaf/admin/questions/legacyQuestionFragments/memorableDate.thtest
@@ -1,0 +1,86 @@
+%NAME memorableDate - month/day/year with the stored values selected
+%TEMPLATE_MODE HTML
+# A two-digit month is used here on purpose. See memorableDateSingleDigitMonth.thtest.
+%MESSAGES
+label.month=Month
+label.day=Day
+label.year=Year
+placeholder.memorableDate=Select
+option.memorableDate.January=01 - January
+option.memorableDate.February=02 - February
+option.memorableDate.March=03 - March
+option.memorableDate.April=04 - April
+option.memorableDate.May=05 - May
+option.memorableDate.June=06 - June
+option.memorableDate.July=07 - July
+option.memorableDate.August=08 - August
+option.memorableDate.September=09 - September
+option.memorableDate.October=10 - October
+option.memorableDate.November=11 - November
+option.memorableDate.December=12 - December
+# ----------------------------------------------------------------------
+%INPUT
+<fieldset th:replace="~{admin/questions/fragments/MemorableDate :: memorableDate('min-custom-date', false, 'minCustomMonth', '11', 'minCustomDay', '15', 'minCustomYear', '2026')}"></fieldset>
+# ----------------------------------------------------------------------
+%OUTPUT
+<fieldset id="min-custom-date-fieldset" class="pb-2">
+  <div class="text-red-600 text-xs" id="memorable_date_error"></div>
+  <div class="usa-memorable-date">
+    <div class="usa-form-group usa-form-group--month usa-form-group--select">
+      <label class="usa-label" for="min-custom-date-month"
+        >Month<span class="usa-hint--required" aria-hidden="true">&nbsp;*</span></label
+      >
+      <select
+        class="usa-select"
+        id="min-custom-date-month"
+        name="minCustomMonth"
+        aria-describedby="mdHint"
+      >
+        <option value="">- Select -</option>
+        <option value="1">01 - January</option>
+        <option value="2">02 - February</option>
+        <option value="3">03 - March</option>
+        <option value="4">04 - April</option>
+        <option value="5">05 - May</option>
+        <option value="6">06 - June</option>
+        <option value="7">07 - July</option>
+        <option value="8">08 - August</option>
+        <option value="9">09 - September</option>
+        <option value="10">10 - October</option>
+        <option value="11" selected="selected">11 - November</option>
+        <option value="12">12 - December</option>
+      </select>
+    </div>
+    <div class="usa-form-group usa-form-group--day">
+      <label class="usa-label" for="min-custom-date-day"
+        >Day<span class="usa-hint--required" aria-hidden="true">&nbsp;*</span></label
+      >
+      <input
+        class="usa-input"
+        id="min-custom-date-day"
+        name="minCustomDay"
+        aria-describedby="mdHint"
+        inputmode="numeric"
+        maxlength="2"
+        pattern="[0-9]*"
+        value="15"
+      />
+    </div>
+    <div class="usa-form-group usa-form-group--year">
+      <label class="usa-label" for="min-custom-date-year"
+        >Year<span class="usa-hint--required" aria-hidden="true">&nbsp;*</span></label
+      >
+      <input
+        class="usa-input"
+        id="min-custom-date-year"
+        name="minCustomYear"
+        aria-describedby="mdHint"
+        minlength="4"
+        inputmode="numeric"
+        maxlength="4"
+        pattern="[0-9]*"
+        value="2026"
+      />
+    </div>
+  </div>
+</fieldset>

--- a/server/test/resources/thymeleaf/admin/questions/legacyQuestionFragments/memorableDateSingleDigitMonth.thtest
+++ b/server/test/resources/thymeleaf/admin/questions/legacyQuestionFragments/memorableDateSingleDigitMonth.thtest
@@ -1,0 +1,89 @@
+%NAME memorableDate - a single-digit month is selected, matching legacy j2html
+%TEMPLATE_MODE HTML
+# Guards an OGNL pitfall: inside ${...}, a single-quoted single character ('3') is a char
+# literal that never equals a String month value, so months 1-9 would silently render
+# unselected. The fragment compares against double-quoted literals to avoid this; legacy
+# j2html (ViewUtils.makeMemorableDate) selects single-digit months.
+%MESSAGES
+label.month=Month
+label.day=Day
+label.year=Year
+placeholder.memorableDate=Select
+option.memorableDate.January=01 - January
+option.memorableDate.February=02 - February
+option.memorableDate.March=03 - March
+option.memorableDate.April=04 - April
+option.memorableDate.May=05 - May
+option.memorableDate.June=06 - June
+option.memorableDate.July=07 - July
+option.memorableDate.August=08 - August
+option.memorableDate.September=09 - September
+option.memorableDate.October=10 - October
+option.memorableDate.November=11 - November
+option.memorableDate.December=12 - December
+# ----------------------------------------------------------------------
+%INPUT
+<fieldset th:replace="~{admin/questions/fragments/MemorableDate :: memorableDate('min-custom-date', false, 'minCustomMonth', '3', 'minCustomDay', '15', 'minCustomYear', '2026')}"></fieldset>
+# ----------------------------------------------------------------------
+%OUTPUT
+<fieldset id="min-custom-date-fieldset" class="pb-2">
+  <div class="text-red-600 text-xs" id="memorable_date_error"></div>
+  <div class="usa-memorable-date">
+    <div class="usa-form-group usa-form-group--month usa-form-group--select">
+      <label class="usa-label" for="min-custom-date-month"
+        >Month<span class="usa-hint--required" aria-hidden="true">&nbsp;*</span></label
+      >
+      <select
+        class="usa-select"
+        id="min-custom-date-month"
+        name="minCustomMonth"
+        aria-describedby="mdHint"
+      >
+        <option value="">- Select -</option>
+        <option value="1">01 - January</option>
+        <option value="2">02 - February</option>
+        <option value="3" selected="selected">03 - March</option>
+        <option value="4">04 - April</option>
+        <option value="5">05 - May</option>
+        <option value="6">06 - June</option>
+        <option value="7">07 - July</option>
+        <option value="8">08 - August</option>
+        <option value="9">09 - September</option>
+        <option value="10">10 - October</option>
+        <option value="11">11 - November</option>
+        <option value="12">12 - December</option>
+      </select>
+    </div>
+    <div class="usa-form-group usa-form-group--day">
+      <label class="usa-label" for="min-custom-date-day"
+        >Day<span class="usa-hint--required" aria-hidden="true">&nbsp;*</span></label
+      >
+      <input
+        class="usa-input"
+        id="min-custom-date-day"
+        name="minCustomDay"
+        aria-describedby="mdHint"
+        inputmode="numeric"
+        maxlength="2"
+        pattern="[0-9]*"
+        value="15"
+      />
+    </div>
+    <div class="usa-form-group usa-form-group--year">
+      <label class="usa-label" for="min-custom-date-year"
+        >Year<span class="usa-hint--required" aria-hidden="true">&nbsp;*</span></label
+      >
+      <input
+        class="usa-input"
+        id="min-custom-date-year"
+        name="minCustomYear"
+        aria-describedby="mdHint"
+        minlength="4"
+        inputmode="numeric"
+        maxlength="4"
+        pattern="[0-9]*"
+        value="2026"
+      />
+    </div>
+  </div>
+</fieldset>

--- a/server/test/resources/thymeleaf/admin/questions/legacyQuestionFragments/multiOptionRowExisting.thtest
+++ b/server/test/resources/thymeleaf/admin/questions/legacyQuestionFragments/multiOptionRowExisting.thtest
@@ -1,0 +1,158 @@
+%NAME multiOptionRow - existing option keeps its id and locks the Admin ID
+%TEMPLATE_MODE HTML
+%MESSAGES
+toast.errorMessageOutline=Error: {0}
+adminValidation.multiOptionAdminError=Admin names can only contain lowercase letters, numbers, underscores, and dashes.
+adminValidation.multiOptionEmpty=Multi option questions cannot have blank options.
+# ----------------------------------------------------------------------
+%INPUT
+<div th:replace="~{admin/questions/fragments/MultiOptionRow :: multiOptionRow(false, '42', 'option_one', 'Option one', 'field-1', 'field-2', 'field-3')}"></div>
+# ----------------------------------------------------------------------
+%OUTPUT
+<div
+  class="cf-multi-option-question-option cf-multi-option-question-option-editable grid grid-cols-8 grid-rows-4 items-center mb-4"
+>
+  <div class="hidden">
+    <label for="field-1" class="sr-only"
+      >option ids<span class="usa-hint--required hidden" aria-hidden="true">&nbsp;*</span></label
+    >
+    <div class="flex flex-col">
+      <input
+        type="text"
+        value="42"
+        maxlength="10000"
+        id="field-1"
+        name="optionIds[]"
+        class="px-3 bg-white text-black text-lg py-2 block outline-none box-border m-auto border border-gray-500 rounded-lg w-full focus:border-civiform-blue placeholder-gray-500"
+      />
+      <div id="field-1-errors" class="text-red-600 text-xs p-1 hidden"></div>
+    </div>
+  </div>
+  <div
+    class="cf-multi-option-admin-input col-start-1 col-span-5 mb-2 ml-2 row-start-1 row-span-2"
+  >
+    <label
+      for="field-2"
+      class="pointer-events-none text-gray-600 text-base px-1 py-2"
+      >Admin ID<span class="usa-hint--required" aria-hidden="true">&nbsp;*</span></label
+    >
+    <div class="flex flex-col">
+      <input
+        type="text"
+        value="option_one"
+        maxlength="10000"
+        aria-required="true"
+        id="field-2"
+        name="optionAdminNames[]"
+        readonly="readonly"
+        class="px-3 bg-white text-black text-lg py-2 block outline-none box-border m-auto border border-gray-500 rounded-lg w-full focus:border-civiform-blue placeholder-gray-500 read-only:text-gray-500 read-only:bg-gray-100"
+      />
+      <div
+        id="field-2-errors"
+        class="cf-multi-option-admin-input-error text-red-600 text-xs p-1 hidden"
+      >
+        <div>Error: Admin names can only contain lowercase letters, numbers, underscores, and dashes.</div>
+      </div>
+    </div>
+  </div>
+  <button
+    class="bg-transparent p-0 w-6 text-center text-gray-500 hover:bg-gray-200 hover:text-gray-900 col-start-8 multi-option-question-field-move-up-button row-start-1"
+    aria-label="move up"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="currentColor"
+      stroke="currentColor"
+      stroke-width="1%"
+      aria-hidden="true"
+      viewBox="0 -960 960 960"
+      class="w-6 h-6"
+    >
+      <path d="M480-528 296-344l-56-56 240-240 240 240-56 56-184-184Z"></path>
+    </svg>
+  </button>
+  <button
+    class="bg-transparent p-0 w-6 text-center text-gray-500 hover:bg-gray-200 hover:text-gray-900 col-start-8 multi-option-question-field-move-down-button row-start-2"
+    aria-label="move down"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="currentColor"
+      stroke="currentColor"
+      stroke-width="1%"
+      aria-hidden="true"
+      viewBox="0 -960 960 960"
+      class="w-6 h-6"
+    >
+      <path d="M480-344 240-584l56-56 184 184 184-184 56 56-240 240Z"></path>
+    </svg>
+  </button>
+  <div
+    class="cf-multi-option-input col-start-1 col-span-5 mb-2 ml-2 row-start-3 row-span-2"
+  >
+    <label
+      for="field-3"
+      class="pointer-events-none text-gray-600 text-base px-1 py-2"
+      >Option Text<span class="usa-hint--required" aria-hidden="true">&nbsp;*</span></label
+    >
+    <div class="flex flex-col">
+      <input
+        type="text"
+        value="Option one"
+        maxlength="10000"
+        aria-required="true"
+        id="field-3"
+        name="options[]"
+        class="px-3 bg-white text-black text-lg py-2 block outline-none box-border m-auto border border-gray-500 rounded-lg w-full focus:border-civiform-blue placeholder-gray-500"
+      />
+      <div
+        id="field-3-errors"
+        class="cf-multi-option-input-error text-red-600 text-xs p-1 hidden"
+      >
+        <div>Error: Multi option questions cannot have blank options.</div>
+      </div>
+    </div>
+    <span class="flex flex-row mt-2 items-center">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        fill="text-gray-600"
+        stroke="text-gray-600"
+        stroke-width="1%"
+        aria-hidden="true"
+        viewBox="0 -960 960 960"
+        class="h-6 w-6 mr-1"
+      >
+        <path
+          d="m640-360 120-120-42-43-48 48v-125h-60v125l-48-48-42 43 120 120ZM140-160q-24 0-42-18t-18-42v-520q0-24 18-42t42-18h680q24 0 42 18t18 42v520q0 24-18 42t-42 18H140Zm0-60h680v-520H140v520Zm0 0v-520 520Zm79-140h50v-190h53v127h50v-127h60v190h50v-200q0-14-13-27t-27-13H259q-14 0-27 13t-13 27v200Z"
+        ></path>
+      </svg>
+      <span class="text-gray-600 text-sm"
+        >Some markdown is supported, <a
+          href="https://docs.civiform.us/user-manual/civiform-admin-guide/using-markdown"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="text-blue-600 hover:text-blue-500 inline-flex items-center"
+          >see how it works</a
+        ></span
+      >
+    </span>
+  </div>
+  <button
+    class="bg-transparent p-0 w-6 text-center text-blue-900 hover:bg-gray-200 hover:text-gray-900 multi-option-question-field-remove-button col-start-8 row-span-2"
+    aria-label="delete"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="currentColor"
+      stroke="currentColor"
+      stroke-width="1%"
+      aria-hidden="true"
+      viewBox="0 0 20 20"
+      class="w-6 h-6"
+    >
+      <path
+        d="M5.896 17.5Q5.167 17.5 4.656 16.99Q4.146 16.479 4.146 15.75V5.125H3.333V3.375H7.542V2.5H12.458V3.375H16.667V5.125H15.833V15.75Q15.833 16.479 15.323 16.99Q14.812 17.5 14.083 17.5ZM14.083 5.125H5.896V15.75Q5.896 15.75 5.896 15.75Q5.896 15.75 5.896 15.75H14.083Q14.083 15.75 14.083 15.75Q14.083 15.75 14.083 15.75ZM7.458 14H9.208V6.875H7.458ZM10.771 14H12.521V6.875H10.771ZM5.896 5.125V15.75Q5.896 15.75 5.896 15.75Q5.896 15.75 5.896 15.75Q5.896 15.75 5.896 15.75Q5.896 15.75 5.896 15.75Z"
+      ></path>
+    </svg>
+  </button>
+</div>

--- a/server/test/resources/thymeleaf/admin/questions/legacyQuestionFragments/multiOptionRowNew.thtest
+++ b/server/test/resources/thymeleaf/admin/questions/legacyQuestionFragments/multiOptionRowNew.thtest
@@ -1,0 +1,142 @@
+%NAME multiOptionRow - new option posts to the newOptions fields and has no optionIds field
+%TEMPLATE_MODE HTML
+%MESSAGES
+toast.errorMessageOutline=Error: {0}
+adminValidation.multiOptionAdminError=Admin names can only contain lowercase letters, numbers, underscores, and dashes.
+adminValidation.multiOptionEmpty=Multi option questions cannot have blank options.
+# ----------------------------------------------------------------------
+%INPUT
+<div th:replace="~{admin/questions/fragments/MultiOptionRow :: multiOptionRow(true, null, '', '', 'field-1', 'field-2', 'field-3')}"></div>
+# ----------------------------------------------------------------------
+%OUTPUT
+<div
+  class="cf-multi-option-question-option cf-multi-option-question-option-editable grid grid-cols-8 grid-rows-4 items-center mb-4"
+>
+  <div></div>
+  <div
+    class="cf-multi-option-admin-input col-start-1 col-span-5 mb-2 ml-2 row-start-1 row-span-2"
+  >
+    <label
+      for="field-2"
+      class="pointer-events-none text-gray-600 text-base px-1 py-2"
+      >Admin ID<span class="usa-hint--required" aria-hidden="true">&nbsp;*</span></label
+    >
+    <div class="flex flex-col">
+      <input
+        type="text"
+        value=""
+        maxlength="10000"
+        aria-required="true"
+        id="field-2"
+        name="newOptionAdminNames[]"
+        class="px-3 bg-white text-black text-lg py-2 block outline-none box-border m-auto border border-gray-500 rounded-lg w-full focus:border-civiform-blue placeholder-gray-500"
+      />
+      <div
+        id="field-2-errors"
+        class="cf-multi-option-admin-input-error text-red-600 text-xs p-1 hidden"
+      >
+        <div>Error: Admin names can only contain lowercase letters, numbers, underscores, and dashes.</div>
+      </div>
+    </div>
+  </div>
+  <button
+    class="bg-transparent p-0 w-6 text-center text-gray-500 hover:bg-gray-200 hover:text-gray-900 col-start-8 multi-option-question-field-move-up-button row-start-1"
+    aria-label="move up"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="currentColor"
+      stroke="currentColor"
+      stroke-width="1%"
+      aria-hidden="true"
+      viewBox="0 -960 960 960"
+      class="w-6 h-6"
+    >
+      <path d="M480-528 296-344l-56-56 240-240 240 240-56 56-184-184Z"></path>
+    </svg>
+  </button>
+  <button
+    class="bg-transparent p-0 w-6 text-center text-gray-500 hover:bg-gray-200 hover:text-gray-900 col-start-8 multi-option-question-field-move-down-button row-start-2"
+    aria-label="move down"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="currentColor"
+      stroke="currentColor"
+      stroke-width="1%"
+      aria-hidden="true"
+      viewBox="0 -960 960 960"
+      class="w-6 h-6"
+    >
+      <path d="M480-344 240-584l56-56 184 184 184-184 56 56-240 240Z"></path>
+    </svg>
+  </button>
+  <div
+    class="cf-multi-option-input col-start-1 col-span-5 mb-2 ml-2 row-start-3 row-span-2"
+  >
+    <label
+      for="field-3"
+      class="pointer-events-none text-gray-600 text-base px-1 py-2"
+      >Option Text<span class="usa-hint--required" aria-hidden="true">&nbsp;*</span></label
+    >
+    <div class="flex flex-col">
+      <input
+        type="text"
+        value=""
+        maxlength="10000"
+        aria-required="true"
+        id="field-3"
+        name="newOptions[]"
+        class="px-3 bg-white text-black text-lg py-2 block outline-none box-border m-auto border border-gray-500 rounded-lg w-full focus:border-civiform-blue placeholder-gray-500"
+      />
+      <div
+        id="field-3-errors"
+        class="cf-multi-option-input-error text-red-600 text-xs p-1 hidden"
+      >
+        <div>Error: Multi option questions cannot have blank options.</div>
+      </div>
+    </div>
+    <span class="flex flex-row mt-2 items-center">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        fill="text-gray-600"
+        stroke="text-gray-600"
+        stroke-width="1%"
+        aria-hidden="true"
+        viewBox="0 -960 960 960"
+        class="h-6 w-6 mr-1"
+      >
+        <path
+          d="m640-360 120-120-42-43-48 48v-125h-60v125l-48-48-42 43 120 120ZM140-160q-24 0-42-18t-18-42v-520q0-24 18-42t42-18h680q24 0 42 18t18 42v520q0 24-18 42t-42 18H140Zm0-60h680v-520H140v520Zm0 0v-520 520Zm79-140h50v-190h53v127h50v-127h60v190h50v-200q0-14-13-27t-27-13H259q-14 0-27 13t-13 27v200Z"
+        ></path>
+      </svg>
+      <span class="text-gray-600 text-sm"
+        >Some markdown is supported, <a
+          href="https://docs.civiform.us/user-manual/civiform-admin-guide/using-markdown"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="text-blue-600 hover:text-blue-500 inline-flex items-center"
+          >see how it works</a
+        ></span
+      >
+    </span>
+  </div>
+  <button
+    class="bg-transparent p-0 w-6 text-center text-blue-900 hover:bg-gray-200 hover:text-gray-900 multi-option-question-field-remove-button col-start-8 row-span-2"
+    aria-label="delete"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="currentColor"
+      stroke="currentColor"
+      stroke-width="1%"
+      aria-hidden="true"
+      viewBox="0 0 20 20"
+      class="w-6 h-6"
+    >
+      <path
+        d="M5.896 17.5Q5.167 17.5 4.656 16.99Q4.146 16.479 4.146 15.75V5.125H3.333V3.375H7.542V2.5H12.458V3.375H16.667V5.125H15.833V15.75Q15.833 16.479 15.323 16.99Q14.812 17.5 14.083 17.5ZM14.083 5.125H5.896V15.75Q5.896 15.75 5.896 15.75Q5.896 15.75 5.896 15.75H14.083Q14.083 15.75 14.083 15.75Q14.083 15.75 14.083 15.75ZM7.458 14H9.208V6.875H7.458ZM10.771 14H12.521V6.875H10.771ZM5.896 5.125V15.75Q5.896 15.75 5.896 15.75Q5.896 15.75 5.896 15.75Q5.896 15.75 5.896 15.75Q5.896 15.75 5.896 15.75Z"
+      ></path>
+    </svg>
+  </button>
+</div>

--- a/server/test/resources/thymeleaf/admin/shared/legacyFieldFragments/markdownIndicator.thtest
+++ b/server/test/resources/thymeleaf/admin/shared/legacyFieldFragments/markdownIndicator.thtest
@@ -1,0 +1,31 @@
+%NAME markdownIndicator - renders the icon, the given text, and the docs link
+%TEMPLATE_MODE HTML
+# ----------------------------------------------------------------------
+%INPUT
+<span th:replace="~{admin/shared/LegacyFieldWithLabel/MarkdownIndicator :: markdownIndicator('Markdown is supported, ')}"></span>
+# ----------------------------------------------------------------------
+%OUTPUT
+<span class="flex flex-row mt-2 items-center">
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="text-gray-600"
+    stroke="text-gray-600"
+    stroke-width="1%"
+    aria-hidden="true"
+    viewBox="0 -960 960 960"
+    class="h-6 w-6 mr-1"
+  >
+    <path
+      d="m640-360 120-120-42-43-48 48v-125h-60v125l-48-48-42 43 120 120ZM140-160q-24 0-42-18t-18-42v-520q0-24 18-42t42-18h680q24 0 42 18t18 42v520q0 24-18 42t-42 18H140Zm0-60h680v-520H140v520Zm0 0v-520 520Zm79-140h50v-190h53v127h50v-127h60v190h50v-200q0-14-13-27t-27-13H259q-14 0-27 13t-13 27v200Z"
+    ></path>
+  </svg>
+  <span class="text-gray-600 text-sm"
+    >Markdown is supported, <a
+      href="https://docs.civiform.us/user-manual/civiform-admin-guide/using-markdown"
+      target="_blank"
+      rel="noopener noreferrer"
+      class="text-blue-600 hover:text-blue-500 inline-flex items-center"
+      >see how it works</a
+    ></span
+  >
+</span>

--- a/server/test/resources/thymeleaf/admin/shared/legacyFieldFragments/numberField.thtest
+++ b/server/test/resources/thymeleaf/admin/shared/legacyFieldFragments/numberField.thtest
@@ -1,0 +1,28 @@
+%NAME numberField - never marked required, renders min and value
+%TEMPLATE_MODE HTML
+# ----------------------------------------------------------------------
+%INPUT
+<div th:replace="~{admin/shared/LegacyFieldWithLabel/NumberField :: numberField('min-length', 'minLength', 'Minimum length', '5', '0')}"></div>
+# ----------------------------------------------------------------------
+%OUTPUT
+<div class="mb-2">
+  <label
+    for="min-length"
+    class="pointer-events-none text-gray-600 text-base px-1 py-2"
+    >Minimum length<span class="usa-hint--required hidden" aria-hidden="true">&nbsp;*</span></label
+  >
+  <div class="flex flex-col">
+    <input
+      type="number"
+      inputmode="decimal"
+      step="any"
+      min="0"
+      value="5"
+      maxlength="10000"
+      id="min-length"
+      name="minLength"
+      class="px-3 bg-white text-black text-lg py-2 block outline-none box-border m-auto border border-gray-500 rounded-lg w-full focus:border-civiform-blue placeholder-gray-500"
+    />
+    <div id="min-length-errors" class="text-red-600 text-xs p-1 hidden"></div>
+  </div>
+</div>

--- a/server/test/resources/thymeleaf/admin/shared/legacyFieldFragments/numberFieldEmpty.thtest
+++ b/server/test/resources/thymeleaf/admin/shared/legacyFieldFragments/numberFieldEmpty.thtest
@@ -1,0 +1,26 @@
+%NAME numberField - null min and value drop those attributes, matching legacy j2html
+%TEMPLATE_MODE HTML
+# ----------------------------------------------------------------------
+%INPUT
+<div th:replace="~{admin/shared/LegacyFieldWithLabel/NumberField :: numberField('max-length', 'maxLength', 'Maximum length', null, null)}"></div>
+# ----------------------------------------------------------------------
+%OUTPUT
+<div class="mb-2">
+  <label
+    for="max-length"
+    class="pointer-events-none text-gray-600 text-base px-1 py-2"
+    >Maximum length<span class="usa-hint--required hidden" aria-hidden="true">&nbsp;*</span></label
+  >
+  <div class="flex flex-col">
+    <input
+      type="number"
+      inputmode="decimal"
+      step="any"
+      maxlength="10000"
+      id="max-length"
+      name="maxLength"
+      class="px-3 bg-white text-black text-lg py-2 block outline-none box-border m-auto border border-gray-500 rounded-lg w-full focus:border-civiform-blue placeholder-gray-500"
+    />
+    <div id="max-length-errors" class="text-red-600 text-xs p-1 hidden"></div>
+  </div>
+</div>

--- a/server/test/resources/thymeleaf/admin/shared/legacyFieldFragments/radioOptionChecked.thtest
+++ b/server/test/resources/thymeleaf/admin/shared/legacyFieldFragments/radioOptionChecked.thtest
@@ -1,0 +1,21 @@
+%NAME radioOption - checked
+%TEMPLATE_MODE HTML
+# ----------------------------------------------------------------------
+%INPUT
+<label th:replace="~{admin/shared/LegacyFieldWithLabel/RadioOption :: radioOption('date-any', 'dateValidationOption', 'Any date', 'ANY', true)}"></label>
+# ----------------------------------------------------------------------
+%OUTPUT
+<label
+  class="px-3 bg-white text-black text-lg py-2 block outline-none box-border m-auto border border-gray-500 rounded-lg w-full focus:border-civiform-blue align-middle flex flex-row mb-2 cf-radio-option"
+  for="date-any"
+  ><input
+    type="radio"
+    value="ANY"
+    maxlength="10000"
+    aria-required="true"
+    id="date-any"
+    name="dateValidationOption"
+    class="h-4 w-4 mr-4 align-middle self-center flex-none"
+    checked="checked"
+  />Any date</label
+>

--- a/server/test/resources/thymeleaf/admin/shared/legacyFieldFragments/radioOptionUnchecked.thtest
+++ b/server/test/resources/thymeleaf/admin/shared/legacyFieldFragments/radioOptionUnchecked.thtest
@@ -1,0 +1,20 @@
+%NAME radioOption - unchecked
+%TEMPLATE_MODE HTML
+# ----------------------------------------------------------------------
+%INPUT
+<label th:replace="~{admin/shared/LegacyFieldWithLabel/RadioOption :: radioOption('date-custom', 'dateValidationOption', 'Custom date', 'CUSTOM', false)}"></label>
+# ----------------------------------------------------------------------
+%OUTPUT
+<label
+  class="px-3 bg-white text-black text-lg py-2 block outline-none box-border m-auto border border-gray-500 rounded-lg w-full focus:border-civiform-blue align-middle flex flex-row mb-2 cf-radio-option"
+  for="date-custom"
+  ><input
+    type="radio"
+    value="CUSTOM"
+    maxlength="10000"
+    aria-required="true"
+    id="date-custom"
+    name="dateValidationOption"
+    class="h-4 w-4 mr-4 align-middle self-center flex-none"
+  />Custom date</label
+>

--- a/server/test/resources/thymeleaf/admin/shared/legacyFieldFragments/requiredIndicatorHidden.thtest
+++ b/server/test/resources/thymeleaf/admin/shared/legacyFieldFragments/requiredIndicatorHidden.thtest
@@ -1,0 +1,8 @@
+%NAME requiredIndicator - not visible
+%TEMPLATE_MODE HTML
+# ----------------------------------------------------------------------
+%INPUT
+<span th:replace="~{admin/shared/LegacyFieldWithLabel/RequiredIndicator :: requiredIndicator(false)}"></span>
+# ----------------------------------------------------------------------
+%OUTPUT
+<span class="usa-hint--required hidden" aria-hidden="true">&nbsp;*</span>

--- a/server/test/resources/thymeleaf/admin/shared/legacyFieldFragments/requiredIndicatorVisible.thtest
+++ b/server/test/resources/thymeleaf/admin/shared/legacyFieldFragments/requiredIndicatorVisible.thtest
@@ -1,0 +1,8 @@
+%NAME requiredIndicator - visible
+%TEMPLATE_MODE HTML
+# ----------------------------------------------------------------------
+%INPUT
+<span th:replace="~{admin/shared/LegacyFieldWithLabel/RequiredIndicator :: requiredIndicator(true)}"></span>
+# ----------------------------------------------------------------------
+%OUTPUT
+<span class="usa-hint--required" aria-hidden="true">&nbsp;*</span>

--- a/server/test/resources/thymeleaf/admin/shared/legacyFieldFragments/slimInfoAlertHidden.thtest
+++ b/server/test/resources/thymeleaf/admin/shared/legacyFieldFragments/slimInfoAlertHidden.thtest
@@ -1,0 +1,17 @@
+%NAME slimInfoAlert - hidden, no extra classes
+%TEMPLATE_MODE HTML
+# ----------------------------------------------------------------------
+%INPUT
+<div th:replace="~{admin/shared/LegacyFieldWithLabel/SlimInfoAlert :: slimInfoAlert('Admins can see this.', true, null)}"></div>
+# ----------------------------------------------------------------------
+%OUTPUT
+<div
+  hidden="hidden"
+  class="usa-alert usa-alert--info usa-alert--slim"
+  aria-live="polite"
+  role="alert"
+>
+  <div class="usa-alert__body">
+    <p class="usa-alert__text">Admins can see this.</p>
+  </div>
+</div>

--- a/server/test/resources/thymeleaf/admin/shared/legacyFieldFragments/slimInfoAlertVisible.thtest
+++ b/server/test/resources/thymeleaf/admin/shared/legacyFieldFragments/slimInfoAlertVisible.thtest
@@ -1,0 +1,16 @@
+%NAME slimInfoAlert - visible, with extra classes
+%TEMPLATE_MODE HTML
+# ----------------------------------------------------------------------
+%INPUT
+<div th:replace="~{admin/shared/LegacyFieldWithLabel/SlimInfoAlert :: slimInfoAlert('Admins can see this.', false, 'mt-4')}"></div>
+# ----------------------------------------------------------------------
+%OUTPUT
+<div
+  class="usa-alert usa-alert--info usa-alert--slim mt-4"
+  aria-live="polite"
+  role="alert"
+>
+  <div class="usa-alert__body">
+    <p class="usa-alert__text">Admins can see this.</p>
+  </div>
+</div>

--- a/server/test/resources/thymeleaf/admin/shared/legacyFieldFragments/textareaFieldOptionalEmpty.thtest
+++ b/server/test/resources/thymeleaf/admin/shared/legacyFieldFragments/textareaFieldOptionalEmpty.thtest
@@ -1,0 +1,23 @@
+%NAME textareaField - not required, no value, no markdown indicator
+%TEMPLATE_MODE HTML
+# ----------------------------------------------------------------------
+%INPUT
+<div th:replace="~{admin/shared/LegacyFieldWithLabel/TextareaField :: textareaField('help-text', 'questionHelpText', 'Question help text', null, false, false)}"></div>
+# ----------------------------------------------------------------------
+%OUTPUT
+<div class="mb-2">
+  <label
+    for="help-text"
+    class="pointer-events-none text-gray-600 text-base px-1 py-2"
+    >Question help text<span class="usa-hint--required hidden" aria-hidden="true">&nbsp;*</span></label
+  >
+  <div class="flex flex-col">
+    <textarea
+      maxlength="10000"
+      id="help-text"
+      name="questionHelpText"
+      class="px-3 bg-white text-black text-lg py-2 block outline-none box-border m-auto border border-gray-500 rounded-lg w-full focus:border-civiform-blue placeholder-gray-500"
+    ></textarea>
+    <div id="help-text-errors" class="text-red-600 text-xs p-1 hidden"></div>
+  </div>
+</div>

--- a/server/test/resources/thymeleaf/admin/shared/legacyFieldFragments/textareaFieldRequiredWithMarkdown.thtest
+++ b/server/test/resources/thymeleaf/admin/shared/legacyFieldFragments/textareaFieldRequiredWithMarkdown.thtest
@@ -1,0 +1,48 @@
+%NAME textareaField - required, markdown indicator shown
+%TEMPLATE_MODE HTML
+# ----------------------------------------------------------------------
+%INPUT
+<div th:replace="~{admin/shared/LegacyFieldWithLabel/TextareaField :: textareaField('question-text', 'questionText', 'Question text', 'What is your name?', true, true)}"></div>
+# ----------------------------------------------------------------------
+%OUTPUT
+<div class="mb-2">
+  <label
+    for="question-text"
+    class="pointer-events-none text-gray-600 text-base px-1 py-2"
+    >Question text<span class="usa-hint--required" aria-hidden="true">&nbsp;*</span></label
+  >
+  <div class="flex flex-col">
+    <textarea
+      maxlength="10000"
+      aria-required="true"
+      id="question-text"
+      name="questionText"
+      class="px-3 bg-white text-black text-lg py-2 block outline-none box-border m-auto border border-gray-500 rounded-lg w-full focus:border-civiform-blue placeholder-gray-500"
+    >What is your name?</textarea>
+    <div id="question-text-errors" class="text-red-600 text-xs p-1 hidden"></div>
+  </div>
+  <span class="flex flex-row mt-2 items-center">
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="text-gray-600"
+      stroke="text-gray-600"
+      stroke-width="1%"
+      aria-hidden="true"
+      viewBox="0 -960 960 960"
+      class="h-6 w-6 mr-1"
+    >
+      <path
+        d="m640-360 120-120-42-43-48 48v-125h-60v125l-48-48-42 43 120 120ZM140-160q-24 0-42-18t-18-42v-520q0-24 18-42t42-18h680q24 0 42 18t18 42v520q0 24-18 42t-42 18H140Zm0-60h680v-520H140v520Zm0 0v-520 520Zm79-140h50v-190h53v127h50v-127h60v190h50v-200q0-14-13-27t-27-13H259q-14 0-27 13t-13 27v200Z"
+      ></path>
+    </svg>
+    <span class="text-gray-600 text-sm"
+      >Markdown is supported, <a
+        href="https://docs.civiform.us/user-manual/civiform-admin-guide/using-markdown"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="text-blue-600 hover:text-blue-500 inline-flex items-center"
+        >see how it works</a
+      ></span
+    >
+  </span>
+</div>

--- a/server/test/resources/thymeleaf/admin/shared/legacyFieldFragments/toggleChecked.thtest
+++ b/server/test/resources/thymeleaf/admin/shared/legacyFieldFragments/toggleChecked.thtest
@@ -1,0 +1,23 @@
+%NAME toggle - checked
+%TEMPLATE_MODE HTML
+# ----------------------------------------------------------------------
+%INPUT
+<div th:replace="~{admin/shared/LegacyFieldWithLabel/Toggle :: toggle('validationEnabled', 'validation', true, false, 'Require an answer')}"></div>
+# ----------------------------------------------------------------------
+%OUTPUT
+<div class="cf-toggle mt-2">
+  <label class="cf-toggle__label" id="validation-toggle">
+    <input
+      type="checkbox"
+      role="switch"
+      class="cf-toggle__input"
+      name="validationEnabled"
+      value="true"
+      checked="checked"
+      id="validation-toggle-input"
+    />
+    <input type="hidden" name="validationEnabled" value="false" />
+    <span class="cf-toggle__track" aria-hidden="true"></span>
+    <span>Require an answer</span>
+  </label>
+</div>

--- a/server/test/resources/thymeleaf/admin/shared/legacyFieldFragments/toggleUncheckedAndHidden.thtest
+++ b/server/test/resources/thymeleaf/admin/shared/legacyFieldFragments/toggleUncheckedAndHidden.thtest
@@ -1,0 +1,22 @@
+%NAME toggle - unchecked and hidden; the false companion field still posts
+%TEMPLATE_MODE HTML
+# ----------------------------------------------------------------------
+%INPUT
+<div th:replace="~{admin/shared/LegacyFieldWithLabel/Toggle :: toggle('validationEnabled', 'validation', false, true, 'Require an answer')}"></div>
+# ----------------------------------------------------------------------
+%OUTPUT
+<div class="cf-toggle mt-2" hidden="hidden">
+  <label class="cf-toggle__label" id="validation-toggle">
+    <input
+      type="checkbox"
+      role="switch"
+      class="cf-toggle__input"
+      name="validationEnabled"
+      value="true"
+      id="validation-toggle-input"
+    />
+    <input type="hidden" name="validationEnabled" value="false" />
+    <span class="cf-toggle__track" aria-hidden="true"></span>
+    <span>Require an answer</span>
+  </label>
+</div>

--- a/server/test/views/admin/questions/LegacyQuestionFragmentsTest.java
+++ b/server/test/views/admin/questions/LegacyQuestionFragmentsTest.java
@@ -1,0 +1,55 @@
+package views.admin.questions;
+
+import org.junit.Test;
+import support.thymeleaf.ThymeleafFragmentTester;
+
+/**
+ * Renders the question-specific field fragments under {@code admin/questions/fragments/} (one file
+ * per fragment, e.g. {@code MultiOptionRow.html}) with thymeleaf-testing and compares the result
+ * against the expected markup. The generic field fragments these build on live under {@code
+ * admin/shared/LegacyFieldWithLabel/} and are covered by {@code
+ * views.admin.shared.LegacyFieldFragmentsTest}.
+ *
+ * <p>Each case is a {@code .thtest} file under {@code
+ * test/resources/thymeleaf/admin/questions/legacyQuestionFragments/}: it declares the fragment
+ * call, the context/messages it needs, and the markup the fragment is expected to produce.
+ */
+public class LegacyQuestionFragmentsTest {
+
+  private static final String DIR = "admin/questions/legacyQuestionFragments/";
+
+  @Test
+  public void dateTypeSelect_noValue() {
+    ThymeleafFragmentTester.run(DIR + "dateTypeSelectNoValue.thtest");
+  }
+
+  @Test
+  public void dateTypeSelect_custom() {
+    ThymeleafFragmentTester.run(DIR + "dateTypeSelectCustom.thtest");
+  }
+
+  @Test
+  public void memorableDate() {
+    ThymeleafFragmentTester.run(DIR + "memorableDate.thtest");
+  }
+
+  /**
+   * Guards an OGNL pitfall: single-quoted single-character literals ('3') are chars, which never
+   * equal a String month value. The fragment must compare against double-quoted literals so months
+   * 1-9 render as selected, like the legacy j2html did.
+   */
+  @Test
+  public void memorableDate_singleDigitMonthIsSelected() {
+    ThymeleafFragmentTester.run(DIR + "memorableDateSingleDigitMonth.thtest");
+  }
+
+  @Test
+  public void multiOptionRow_newOption() {
+    ThymeleafFragmentTester.run(DIR + "multiOptionRowNew.thtest");
+  }
+
+  @Test
+  public void multiOptionRow_existingOption() {
+    ThymeleafFragmentTester.run(DIR + "multiOptionRowExisting.thtest");
+  }
+}

--- a/server/test/views/admin/shared/LegacyFieldFragmentsTest.java
+++ b/server/test/views/admin/shared/LegacyFieldFragmentsTest.java
@@ -1,0 +1,83 @@
+package views.admin.shared;
+
+import org.junit.Test;
+import support.thymeleaf.ThymeleafFragmentTester;
+
+/**
+ * Renders the shared legacy-parity field fragments under {@code admin/shared/LegacyFieldWithLabel/}
+ * (one file per fragment, e.g. {@code RequiredIndicator.html}, {@code TextareaField.html}) with
+ * thymeleaf-testing and compares the result against the expected markup.
+ *
+ * <p>Each case is a {@code .thtest} file under {@code
+ * test/resources/thymeleaf/admin/shared/legacyFieldFragments/}: it declares the fragment call, the
+ * context/messages it needs, and the markup the fragment is expected to produce.
+ */
+public class LegacyFieldFragmentsTest {
+
+  private static final String DIR = "admin/shared/legacyFieldFragments/";
+
+  @Test
+  public void requiredIndicator_visible() {
+    ThymeleafFragmentTester.run(DIR + "requiredIndicatorVisible.thtest");
+  }
+
+  @Test
+  public void requiredIndicator_hidden() {
+    ThymeleafFragmentTester.run(DIR + "requiredIndicatorHidden.thtest");
+  }
+
+  @Test
+  public void markdownIndicator() {
+    ThymeleafFragmentTester.run(DIR + "markdownIndicator.thtest");
+  }
+
+  @Test
+  public void slimInfoAlert_visible() {
+    ThymeleafFragmentTester.run(DIR + "slimInfoAlertVisible.thtest");
+  }
+
+  @Test
+  public void slimInfoAlert_hidden() {
+    ThymeleafFragmentTester.run(DIR + "slimInfoAlertHidden.thtest");
+  }
+
+  @Test
+  public void toggle_checked() {
+    ThymeleafFragmentTester.run(DIR + "toggleChecked.thtest");
+  }
+
+  @Test
+  public void toggle_uncheckedAndHidden() {
+    ThymeleafFragmentTester.run(DIR + "toggleUncheckedAndHidden.thtest");
+  }
+
+  @Test
+  public void textareaField_requiredWithMarkdown() {
+    ThymeleafFragmentTester.run(DIR + "textareaFieldRequiredWithMarkdown.thtest");
+  }
+
+  @Test
+  public void textareaField_optionalEmpty() {
+    ThymeleafFragmentTester.run(DIR + "textareaFieldOptionalEmpty.thtest");
+  }
+
+  @Test
+  public void numberField() {
+    ThymeleafFragmentTester.run(DIR + "numberField.thtest");
+  }
+
+  @Test
+  public void numberField_empty() {
+    ThymeleafFragmentTester.run(DIR + "numberFieldEmpty.thtest");
+  }
+
+  @Test
+  public void radioOption_checked() {
+    ThymeleafFragmentTester.run(DIR + "radioOptionChecked.thtest");
+  }
+
+  @Test
+  public void radioOption_unchecked() {
+    ThymeleafFragmentTester.run(DIR + "radioOptionUnchecked.thtest");
+  }
+}


### PR DESCRIPTION
- Adds Thymeleaf fragments that contain reusable components used similarly to how the old `FieldWithLabel` existed to keep things uniform.
  - There are two places these are put `admin/questions` and `admin/shared`. depends on if it is used by more than just that question new/edit pages.
  - These are pull out of the next PRs that have the question new/edit pages so they are all used. Nothing is migrated that won't be used.
- Adds Thymeleaf unit tests based on the old j2html unit tests to assert compatibility.

Supporting work for: #12428 and #12429

### LLM Tooling

Claude did most of the migration with some manual assistance. I've cleaned things up and made sure it looks good. Built using this custom skill: [SKILL.md](https://github.com/user-attachments/files/30205592/SKILL.md) | [REFERENCE.md](https://github.com/user-attachments/files/30205591/REFERENCE.md)

Assisted-by: Claude Code:claude-fable-5
