### PR TITLE
Remove unnecessary trailing logoffs in tests

### DIFF
--- a/browser-test/src/admin/admin_application_download.test.ts
+++ b/browser-test/src/admin/admin_application_download.test.ts
@@ -116,7 +116,6 @@ test.describe('Program admin download button visibility and endpoint access', ()
         await enableFeatureFlag(page, downloadFlag)
         await loginAsCiviformAndProgramAdmin(page)
         await expectDownloadButtonsAndEndpoints(true)
-        await logout(page)
       })
     },
   )

--- a/browser-test/src/admin/admin_program_login_only.test.ts
+++ b/browser-test/src/admin/admin_program_login_only.test.ts
@@ -1,5 +1,5 @@
 import {expect, test} from '../support/civiform_fixtures'
-import {loginAsAdmin, logout} from '../support'
+import {loginAsAdmin} from '../support'
 import {ProgramLifecycle, ProgramVisibility} from '../support/admin_programs'
 
 test.describe('login only program', () => {
@@ -40,8 +40,6 @@ test.describe('login only program', () => {
         }),
       ).toBeDisabled()
     })
-
-    await logout(page)
   })
 
   test('login only persists through publish', async ({page, adminPrograms}) => {

--- a/browser-test/src/admin/admin_program_viewing.test.ts
+++ b/browser-test/src/admin/admin_program_viewing.test.ts
@@ -273,7 +273,6 @@ test.describe('admin program view page', () => {
       ProgramHeaderButton.DOWNLOAD_PDF_PREVIEW,
     )
     await adminPrograms.expectBlockPanelHidden()
-    await logout(page)
   })
 
   test('admin views application with long text answer', async ({

--- a/browser-test/src/applicant/application_address_correction.test.ts
+++ b/browser-test/src/applicant/application_address_correction.test.ts
@@ -114,7 +114,6 @@ test.describe('address correction single-block, single-address program', () => {
           'Address In Area',
         )
         await applicantQuestions.clickSubmitApplication()
-        await logout(page)
       })
     })
 
@@ -184,7 +183,6 @@ test.describe('address correction single-block, single-address program', () => {
       await test.step('Confirm user can confirm address and submit', async () => {
         await applicantQuestions.clickConfirmAddress()
         await applicantQuestions.clickSubmitApplication()
-        await logout(page)
       })
     })
 
@@ -228,8 +226,6 @@ test.describe('address correction single-block, single-address program', () => {
         await applicantQuestions.clickConfirmAddress()
         await applicantQuestions.clickSubmitApplication()
       })
-
-      await logout(page)
     })
 
     test('prompts user to edit if an Esri error response object is returned from the Esri service', async ({
@@ -257,7 +253,6 @@ test.describe('address correction single-block, single-address program', () => {
     })
 
     test('skips address correction screen if address exactly matches suggestions', async ({
-      page,
       applicantQuestions,
     }) => {
       await test.step('Answer address question', async () => {
@@ -275,8 +270,6 @@ test.describe('address correction single-block, single-address program', () => {
       await test.step('Validate review page is shown', async () => {
         await applicantQuestions.expectReviewPage()
       })
-
-      await logout(page)
     })
   }
 
@@ -308,8 +301,6 @@ test.describe('address correction single-block, single-address program', () => {
       )
       await applicantQuestions.clickSubmitApplication()
     })
-
-    await logout(page)
   })
 })
 
@@ -381,8 +372,6 @@ test.describe('require address correction when address is pre-filled', () => {
         await applicantQuestions.clickContinue()
         await applicantQuestions.expectVerifyAddressPage(true)
       })
-
-      await logout(page)
     })
   }
 })
@@ -443,7 +432,6 @@ if (isLocalDevEnvironment()) {
     })
 
     test('skips address correction if optional address question is not answered', async ({
-      page,
       applicantQuestions,
     }) => {
       await test.step('Answer address question', async () => {
@@ -457,8 +445,6 @@ if (isLocalDevEnvironment()) {
 
         await applicantQuestions.clickSubmitApplication()
       })
-
-      await logout(page)
     })
   })
 
@@ -532,7 +518,6 @@ if (isLocalDevEnvironment()) {
     })
 
     test('can correct address multi-block, multi-address program', async ({
-      page,
       applicantQuestions,
     }) => {
       await test.step('Answer address question', async () => {
@@ -569,8 +554,6 @@ if (isLocalDevEnvironment()) {
         )
         await applicantQuestions.clickSubmitApplication()
       })
-
-      await logout(page)
     })
   })
 
@@ -634,7 +617,6 @@ if (isLocalDevEnvironment()) {
     })
 
     test('can correct address single-block, multi-address program', async ({
-      page,
       applicantQuestions,
     }) => {
       await test.step('Answer address question', async () => {
@@ -675,8 +657,6 @@ if (isLocalDevEnvironment()) {
         )
         await applicantQuestions.clickSubmitApplication()
       })
-
-      await logout(page)
     })
   })
 
@@ -916,7 +896,6 @@ if (isLocalDevEnvironment()) {
       })
 
       test('clicking back saves address and goes to previous block if the user enters an address that exactly matches suggestions', async ({
-        page,
         applicantQuestions,
       }) => {
         await test.step('Answer address question', async () => {
@@ -949,8 +928,6 @@ if (isLocalDevEnvironment()) {
             'Address In Area',
           )
         })
-
-        await logout(page)
       })
     })
 
@@ -1008,7 +985,6 @@ if (isLocalDevEnvironment()) {
       })
 
       test('address correction page saves original address when selected and redirects to review', async ({
-        page,
         applicantQuestions,
       }) => {
         await test.step('Answer address question', async () => {
@@ -1045,12 +1021,9 @@ if (isLocalDevEnvironment()) {
             'Legit Address',
           )
         })
-
-        await logout(page)
       })
 
       test('address correction page saves suggested address when selected and redirects to review', async ({
-        page,
         applicantQuestions,
       }) => {
         await test.step('Answer address question', async () => {
@@ -1086,12 +1059,9 @@ if (isLocalDevEnvironment()) {
             'Address With No Service Area Features',
           )
         })
-
-        await logout(page)
       })
 
       test('address correction page saves original address when no suggestions offered and redirects to review', async ({
-        page,
         applicantQuestions,
       }) => {
         await test.step('Answer address question', async () => {
@@ -1125,12 +1095,9 @@ if (isLocalDevEnvironment()) {
             'Bogus Address',
           )
         })
-
-        await logout(page)
       })
 
       test('clicking review saves address and goes to review page if the user enters an address that exactly matches suggestions', async ({
-        page,
         applicantQuestions,
       }) => {
         await test.step('Answer address question', async () => {
@@ -1160,8 +1127,6 @@ if (isLocalDevEnvironment()) {
             'Address In Area',
           )
         })
-
-        await logout(page)
       })
     })
 
@@ -1340,7 +1305,6 @@ if (isLocalDevEnvironment()) {
       })
 
       test('clicking next saves address and goes to next block if the user enters an address that exactly matches suggestions', async ({
-        page,
         applicantQuestions,
       }) => {
         await test.step('Answer address question', async () => {
@@ -1373,8 +1337,6 @@ if (isLocalDevEnvironment()) {
             'Address In Area',
           )
         })
-
-        await logout(page)
       })
     })
 

--- a/browser-test/src/applicant/navigation/application_navigation_address_visibility_eligibility.test.ts
+++ b/browser-test/src/applicant/navigation/application_navigation_address_visibility_eligibility.test.ts
@@ -121,7 +121,6 @@ test.describe('Applicant navigation flow', () => {
       )
 
       test('when address is eligible show hidden screen', async ({
-        page,
         applicantQuestions,
       }) => {
         await test.step('Fill out application with an eligible address', async () => {
@@ -156,12 +155,10 @@ test.describe('Applicant navigation flow', () => {
           )
 
           await applicantQuestions.clickSubmitApplication()
-          await logout(page)
         })
       })
 
       test('when address is not eligible do not show hidden screen', async ({
-        page,
         applicantQuestions,
       }) => {
         await test.step('Fill out application with an eligible address', async () => {
@@ -193,12 +190,10 @@ test.describe('Applicant navigation flow', () => {
           )
 
           await applicantQuestions.clickSubmitApplication()
-          await logout(page)
         })
       })
 
       test('hide screen when address changes from eligible to not eligible', async ({
-        page,
         applicantQuestions,
       }) => {
         await test.step('Fill out application with an eligible address', async () => {
@@ -249,7 +244,6 @@ test.describe('Applicant navigation flow', () => {
           )
 
           await applicantQuestions.clickSubmitApplication()
-          await logout(page)
         })
       })
     })

--- a/browser-test/src/applicant/navigation/navigation_address_visibility_condition.test.ts
+++ b/browser-test/src/applicant/navigation/navigation_address_visibility_condition.test.ts
@@ -122,7 +122,6 @@ test.describe('Applicant navigation flow', () => {
       )
 
       test('when address is eligible show hidden screen', async ({
-        page,
         applicantQuestions,
       }) => {
         await applicantQuestions.applyProgram(programName)
@@ -151,11 +150,9 @@ test.describe('Applicant navigation flow', () => {
         )
 
         await applicantQuestions.clickSubmitApplication()
-        await logout(page)
       })
 
       test('when address is not eligible do not show hidden screen', async ({
-        page,
         applicantQuestions,
       }) => {
         await applicantQuestions.applyProgram(programName)
@@ -182,7 +179,6 @@ test.describe('Applicant navigation flow', () => {
         )
 
         await applicantQuestions.clickSubmitApplication()
-        await logout(page)
       })
     })
   }

--- a/browser-test/src/end_to_end_enumerators.test.ts
+++ b/browser-test/src/end_to_end_enumerators.test.ts
@@ -1718,8 +1718,6 @@ test.describe('End to end enumerator test with enumerators feature flag on', () 
         await expect(applicationSummary).not.toContainText('Cartoon Character')
         await expect(applicationSummary).not.toContainText('100')
       })
-
-      await logout(page)
     })
 
     test('applicant repeated entity add button is enabled/disabled correctly', async ({
@@ -1827,8 +1825,6 @@ test.describe('End to end enumerator test with enumerators feature flag on', () 
         await expect(entityNameInput(page, 'Pets', 1)).toHaveValue('Bugs')
         await expect(entityNameInput(page, 'Pets', 2)).toHaveValue('Daffy')
       })
-
-      await logout(page)
     })
   })
 

--- a/browser-test/src/legacy_enumerators.test.ts
+++ b/browser-test/src/legacy_enumerators.test.ts
@@ -278,8 +278,6 @@ test.describe('End to end enumerator test', () => {
       await expect(page.locator('.application-summary')).not.toContainText(
         '100',
       )
-
-      await logout(page)
     })
 
     test('Enumerator add button is enabled/disabled correctly', async ({
@@ -363,7 +361,6 @@ test.describe('End to end enumerator test', () => {
     })
 
     test('Applicant can navigate to previous blocks', async ({
-      page,
       applicantQuestions,
     }) => {
       await applicantQuestions.applyProgram(programName)
@@ -414,8 +411,6 @@ test.describe('End to end enumerator test', () => {
       // Click previous and see name question
       await applicantQuestions.clickBack()
       await applicantQuestions.checkNameQuestionValue('Porky', 'Pig')
-
-      await logout(page)
     })
 
     test('Create new version of enumerator and update repeated questions and programs', async ({
@@ -445,8 +440,6 @@ test.describe('End to end enumerator test', () => {
       await test.step('Publish program', async () => {
         await adminPrograms.publishProgram(programName)
       })
-
-      await logout(page)
     })
   })
 


### PR DESCRIPTION
Removes unnecessary logoff calls that are at the end of some browser tests. Nothing is asserted after them so they are just wasting runtime as it logs off, does some redirects, and then waits for the `/programs` page to load.

### LLM Tooling

LLM did the work; I reviewed it.

Assisted-by: Claude Code:claude-opus-4-8
