### PR TITLE
Remove CUSTOM_THEME_COLORS_ENABLED feature flag

### DIFF
--- a/server/app/services/settings/SettingsManifest.java
+++ b/server/app/services/settings/SettingsManifest.java
@@ -1062,11 +1062,6 @@ public final class SettingsManifest extends AbstractSettingsManifest {
     return getBool("CUSTOMIZED_ELIGIBILITY_MESSAGE_ENABLED", request);
   }
 
-  /** Enable using custom theme colors in the applicant UI. */
-  public boolean getCustomThemeColorsEnabled() {
-    return getBool("CUSTOM_THEME_COLORS_ENABLED");
-  }
-
   /** Enables suffix dropdown field in name question. */
   public boolean getNameSuffixDropdownEnabled(RequestHeader request) {
     return getBool("NAME_SUFFIX_DROPDOWN_ENABLED", request);
@@ -2343,12 +2338,6 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                           /* isRequired= */ false,
                           SettingType.BOOLEAN,
                           SettingMode.ADMIN_WRITEABLE),
-                      SettingDescription.create(
-                          "CUSTOM_THEME_COLORS_ENABLED",
-                          "Enable using custom theme colors in the applicant UI.",
-                          /* isRequired= */ false,
-                          SettingType.BOOLEAN,
-                          SettingMode.ADMIN_READABLE),
                       SettingDescription.create(
                           "NAME_SUFFIX_DROPDOWN_ENABLED",
                           "Enables suffix dropdown field in name question.",

--- a/server/app/views/applicant/ApplicantBaseView.java
+++ b/server/app/views/applicant/ApplicantBaseView.java
@@ -135,17 +135,15 @@ public abstract class ApplicantBaseView {
     // Set branding theme colors.
     context.setVariable("themeColorPrimary", THEME_PRIMARY_HEX);
     context.setVariable("themeColorPrimaryDark", THEME_PRIMARY_DARKER_HEX);
-    if (settingsManifest.getCustomThemeColorsEnabled()) {
-      settingsManifest
-          .getThemeColorPrimary(request)
-          .filter(setting -> !setting.isEmpty())
-          .ifPresent(colorPrimary -> context.setVariable("themeColorPrimary", colorPrimary));
-      settingsManifest
-          .getThemeColorPrimaryDark(request)
-          .filter(setting -> !setting.isEmpty())
-          .ifPresent(
-              colorPrimaryDark -> context.setVariable("themeColorPrimaryDark", colorPrimaryDark));
-    }
+    settingsManifest
+        .getThemeColorPrimary(request)
+        .filter(setting -> !setting.isEmpty())
+        .ifPresent(colorPrimary -> context.setVariable("themeColorPrimary", colorPrimary));
+    settingsManifest
+        .getThemeColorPrimaryDark(request)
+        .filter(setting -> !setting.isEmpty())
+        .ifPresent(
+            colorPrimaryDark -> context.setVariable("themeColorPrimaryDark", colorPrimaryDark));
 
     // In Thymeleaf, it's impossible to add escaped text inside unescaped text, which makes it
     // difficult to add HTML within a message. So we have to manually build the html for a link

--- a/server/conf/env-var-docs.json
+++ b/server/conf/env-var-docs.json
@@ -917,12 +917,6 @@
         "description": "Enables civiform admins to set up a customized eligibility message per screen.",
         "type": "bool"
       },
-      "CUSTOM_THEME_COLORS_ENABLED": {
-        "mode": "ADMIN_READABLE",
-        "description": "Enable using custom theme colors in the applicant UI.",
-        "type": "bool",
-        "required": false
-      },
       "NAME_SUFFIX_DROPDOWN_ENABLED": {
         "mode": "ADMIN_WRITEABLE",
         "description": "Enables suffix dropdown field in name question.",

--- a/server/conf/helper/feature-flags.conf
+++ b/server/conf/helper/feature-flags.conf
@@ -47,10 +47,6 @@ name_suffix_dropdown_enabled = ${?NAME_SUFFIX_DROPDOWN_ENABLED}
 customized_eligibility_message_enabled = true
 customized_eligibility_message_enabled = ${?CUSTOMIZED_ELIGIBILITY_MESSAGE_ENABLED}
 
-# Custom theme colors
-custom_theme_colors_enabled = true
-custom_theme_colors_enabled = ${?CUSTOM_THEME_COLORS_ENABLED}
-
 # External program cards
 external_program_cards_enabled = true
 external_program_cards_enabled = ${?EXTERNAL_PROGRAM_CARDS_ENABLED}


### PR DESCRIPTION
### Description

Removing the `CUSTOM_THEME_COLORS_ENABLED` feature flag which will allow govs to set two custom theme colors (one primary, one dark) in their environment if they so choose. If the custom theme colors are left blank, the default blue colors are used.

## Release notes
Optional custom theme colors are now fully integrated into the application and are not toggleable by feature flag. This feature allows governments to set two custom theme colors (one light, one dark) in your environment if you so choose via the THEME_COLOR_PRIMARY and THEME_COLOR_PRIMARY_DARK settings in the Admin Settings Panel. If the custom theme colors are left blank, the default blue colors are used. Please remove the CUSTOM_THEME_COLORS_ENABLED feature flag from your deployment configs if it is still present. 

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [ ] Added an additional reviewer as required if changes potentially affect the security of the application.
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

### Issue(s) this completes

Fixes #9882;
