### PR TITLE
[Enumerators] Only allow enumerator or initial questions on an enumerator block

### DIFF
--- a/server/app/services/ProgramBlockValidation.java
+++ b/server/app/services/ProgramBlockValidation.java
@@ -156,6 +156,9 @@ public final class ProgramBlockValidation {
    */
   private boolean isAllowedOnEnumeratorBlock(
       BlockDefinition block, QuestionDefinition question, boolean isInitialQuestion) {
+    if (!block.getIsEnumerator()) {
+      return true;
+    }
     if (!block.hasEnumeratorQuestion()) {
       return question.isEnumerator() || isInitialQuestion;
     }

--- a/server/app/services/ProgramBlockValidation.java
+++ b/server/app/services/ProgramBlockValidation.java
@@ -79,7 +79,11 @@ public final class ProgramBlockValidation {
 
     // Cannot use this question as the initial question on an enumerator block because its
     // type is not in {@link #VALID_INITIAL_QUESTION_TYPES}.
-    INVALID_INITIAL_QUESTION_TYPE
+    INVALID_INITIAL_QUESTION_TYPE,
+
+    // Cannot use this question on an enumerator block because it is not an enumerator question
+    // or an initial question.
+    NOT_ENUMERATOR_OR_INITIAL_ON_ENUMERATOR_BLOCK
   }
 
   /**
@@ -111,6 +115,11 @@ public final class ProgramBlockValidation {
     if (enumeratorImprovementsEnabled && question.isEnumerator() && !block.getIsEnumerator()) {
       return AddQuestionResult.ENUMERATOR_ON_NON_ENUMERATOR_BLOCK;
     }
+    if (enumeratorImprovementsEnabled
+        && block.getIsEnumerator()
+        && !isAllowedOnEnumeratorBlock(block, question, isInitialQuestion)) {
+      return AddQuestionResult.NOT_ENUMERATOR_OR_INITIAL_ON_ENUMERATOR_BLOCK;
+    }
     if (isInitialQuestion && !VALID_INITIAL_QUESTION_TYPES.contains(question.getQuestionType())) {
       return AddQuestionResult.INVALID_INITIAL_QUESTION_TYPE;
     }
@@ -136,6 +145,26 @@ public final class ProgramBlockValidation {
       case FILEUPLOAD -> !fileUploadQuestionImprovementsEnabled;
       default -> false;
     };
+  }
+
+  /**
+   * The only questions a new-flow enumerator block should ever hold are the enumerator itself and
+   * its associated initial question. An empty enumerator block accepts the enumerator or an
+   * initial-question candidate (the question bank filter path marks candidates with {@code
+   * isInitialQuestion=true}); a populated enumerator block accepts only the specific question the
+   * enumerator points to via {@code enumeratorInitialQuestionId}.
+   */
+  private boolean isAllowedOnEnumeratorBlock(
+      BlockDefinition block, QuestionDefinition question, boolean isInitialQuestion) {
+    if (!block.hasEnumeratorQuestion()) {
+      return question.isEnumerator() || isInitialQuestion;
+    }
+    return isInitialQuestion
+        && block
+            .getEnumeratorQuestionDefinition()
+            .getEnumeratorInitialQuestionId()
+            .map(id -> id.equals(question.getId()))
+            .orElse(false);
   }
 
   /**

--- a/server/test/services/ProgramBlockValidationTest.java
+++ b/server/test/services/ProgramBlockValidationTest.java
@@ -2,6 +2,7 @@ package services;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Optional;
 import models.QuestionModel;
 import models.VersionModel;
 import org.junit.Before;
@@ -13,6 +14,7 @@ import services.program.ProgramDefinition;
 import services.program.ProgramNeedsABlockException;
 import services.question.QuestionService;
 import services.question.types.QuestionDefinition;
+import services.question.types.QuestionDefinitionBuilder;
 import services.question.types.QuestionType;
 import support.ProgramBuilder;
 
@@ -393,6 +395,105 @@ public class ProgramBlockValidationTest extends ResetPostgres {
                 /* enumeratorImprovementsEnabled= */ true,
                 /* fileUploadQuestionImprovementsEnabled= */ false,
                 /* isInitialQuestion= */ false))
+        .isEqualTo(AddQuestionResult.ELIGIBLE);
+  }
+
+  @Test
+  public void
+      canAddQuestion_whenEnumeratorImprovementsEnabled_whenNonEnumeratorOnEmptyEnumeratorBlock_invalid()
+          throws ProgramNeedsABlockException {
+    ProgramDefinition program =
+        ProgramBuilder.newDraftProgram("program1").withEnumeratorBlock().buildDefinition();
+
+    assertThat(
+            programBlockValidation.canAddQuestion(
+                program,
+                program.getLastBlockDefinition(),
+                questionForEligible.getQuestionDefinition(),
+                /* enumeratorImprovementsEnabled= */ true,
+                /* fileUploadQuestionImprovementsEnabled= */ false,
+                /* isInitialQuestion= */ false))
+        .isEqualTo(AddQuestionResult.NOT_ENUMERATOR_OR_INITIAL_ON_ENUMERATOR_BLOCK);
+  }
+
+  @Test
+  public void
+      canAddQuestion_whenEnumeratorImprovementsEnabled_whenNonInitialOnPopulatedEnumeratorBlock_invalid()
+          throws ProgramNeedsABlockException {
+    ProgramDefinition program =
+        ProgramBuilder.newDraftProgram("program1")
+            .withEnumeratorBlock()
+            .withRequiredQuestionDefinition(householdMemberQuestion.getQuestionDefinition())
+            .buildDefinition();
+
+    assertThat(
+            programBlockValidation.canAddQuestion(
+                program,
+                program.getLastBlockDefinition(),
+                questionForEligible.getQuestionDefinition(),
+                /* enumeratorImprovementsEnabled= */ true,
+                /* fileUploadQuestionImprovementsEnabled= */ false,
+                /* isInitialQuestion= */ false))
+        .isEqualTo(AddQuestionResult.NOT_ENUMERATOR_OR_INITIAL_ON_ENUMERATOR_BLOCK);
+  }
+
+  @Test
+  public void
+      canAddQuestion_whenEnumeratorImprovementsEnabled_whenMismatchedInitialOnEnumeratorBlock_invalid()
+          throws Exception {
+    QuestionModel intendedInitial = resourceCreator.insertQuestion("intended-initial");
+    QuestionModel wrongCandidate = resourceCreator.insertQuestion("wrong-candidate");
+    version.addQuestion(intendedInitial);
+    version.addQuestion(wrongCandidate);
+    version.save();
+
+    QuestionDefinition linkedEnumerator =
+        new QuestionDefinitionBuilder(householdMemberQuestion.getQuestionDefinition())
+            .setEnumeratorInitialQuestionId(Optional.of(intendedInitial.id))
+            .build();
+
+    ProgramDefinition program =
+        ProgramBuilder.newDraftProgram("program1")
+            .withEnumeratorBlock()
+            .withRequiredQuestionDefinition(linkedEnumerator)
+            .buildDefinition();
+
+    assertThat(
+            programBlockValidation.canAddQuestion(
+                program,
+                program.getLastBlockDefinition(),
+                wrongCandidate.getQuestionDefinition(),
+                /* enumeratorImprovementsEnabled= */ true,
+                /* fileUploadQuestionImprovementsEnabled= */ false,
+                /* isInitialQuestion= */ true))
+        .isEqualTo(AddQuestionResult.NOT_ENUMERATOR_OR_INITIAL_ON_ENUMERATOR_BLOCK);
+  }
+
+  @Test
+  public void
+      canAddQuestion_whenEnumeratorImprovementsEnabled_whenExpectedInitialOnEnumeratorBlock_eligible()
+          throws Exception {
+    // Use questionForEligible (added to the version in setUp) so it lives in
+    // activeAndDraftQuestions, which was captured when programBlockValidation was created.
+    QuestionDefinition linkedEnumerator =
+        new QuestionDefinitionBuilder(householdMemberQuestion.getQuestionDefinition())
+            .setEnumeratorInitialQuestionId(Optional.of(questionForEligible.id))
+            .build();
+
+    ProgramDefinition program =
+        ProgramBuilder.newDraftProgram("program1")
+            .withEnumeratorBlock()
+            .withRequiredQuestionDefinition(linkedEnumerator)
+            .buildDefinition();
+
+    assertThat(
+            programBlockValidation.canAddQuestion(
+                program,
+                program.getLastBlockDefinition(),
+                questionForEligible.getQuestionDefinition(),
+                /* enumeratorImprovementsEnabled= */ true,
+                /* fileUploadQuestionImprovementsEnabled= */ false,
+                /* isInitialQuestion= */ true))
         .isEqualTo(AddQuestionResult.ELIGIBLE);
   }
 }

--- a/server/test/services/ProgramBlockValidationTest.java
+++ b/server/test/services/ProgramBlockValidationTest.java
@@ -442,9 +442,9 @@ public class ProgramBlockValidationTest extends ResetPostgres {
       canAddQuestion_whenEnumeratorImprovementsEnabled_whenMismatchedInitialOnEnumeratorBlock_invalid()
           throws Exception {
     QuestionModel intendedInitial = resourceCreator.insertQuestion("intended-initial");
-    QuestionModel wrongCandidate = resourceCreator.insertQuestion("wrong-candidate");
+    QuestionModel wrongInitial = resourceCreator.insertQuestion("wrong-candidate");
     version.addQuestion(intendedInitial);
-    version.addQuestion(wrongCandidate);
+    version.addQuestion(wrongInitial);
     version.save();
 
     QuestionDefinition linkedEnumerator =
@@ -462,7 +462,7 @@ public class ProgramBlockValidationTest extends ResetPostgres {
             programBlockValidation.canAddQuestion(
                 program,
                 program.getLastBlockDefinition(),
-                wrongCandidate.getQuestionDefinition(),
+                wrongInitial.getQuestionDefinition(),
                 /* enumeratorImprovementsEnabled= */ true,
                 /* fileUploadQuestionImprovementsEnabled= */ false,
                 /* isInitialQuestion= */ true))
@@ -473,8 +473,6 @@ public class ProgramBlockValidationTest extends ResetPostgres {
   public void
       canAddQuestion_whenEnumeratorImprovementsEnabled_whenExpectedInitialOnEnumeratorBlock_eligible()
           throws Exception {
-    // Use questionForEligible (added to the version in setUp) so it lives in
-    // activeAndDraftQuestions, which was captured when programBlockValidation was created.
     QuestionDefinition linkedEnumerator =
         new QuestionDefinitionBuilder(householdMemberQuestion.getQuestionDefinition())
             .setEnumeratorInitialQuestionId(Optional.of(questionForEligible.id))

--- a/server/test/support/TestQuestionBank.java
+++ b/server/test/support/TestQuestionBank.java
@@ -632,10 +632,12 @@ public class TestQuestionBank {
     var enumeratorQuestionModel = maybeSave(enumeratorQuestion);
 
     try {
-      new QuestionModel(
-          new QuestionDefinitionBuilder(initialQuestionModel.getQuestionDefinition())
-              .setEnumeratorId(Optional.of(enumeratorQuestionModel.id))
-              .build());
+      QuestionModel updatedInitial =
+          new QuestionModel(
+              new QuestionDefinitionBuilder(initialQuestionModel.getQuestionDefinition())
+                  .setEnumeratorId(Optional.of(enumeratorQuestionModel.id))
+                  .build());
+      updatedInitial.update();
     } catch (UnsupportedQuestionTypeException e) {
       throw new RuntimeException(e);
     }


### PR DESCRIPTION
### Description

This adds server-side validation that only allows an enumerator question and its associated initial question to be added to an enumerator block when the feature flag is on.  The UI already restricts the questions that can be added to an enumerator block, but this will enforce that server-side so that a direct API call can't circumvent the rules and so that future development doesn't accidentally introduce unwanted behavior.

AI usage:  Used Claude Code Opus 4.7 to assist with tests and to double-check my logic.

### Checklist

#### General

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [ ] Added an additional reviewer as required if changes potentially affect the security of the application.
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [x] Noted in the PR description which, if any, code in this PR was generated by AI.

### Instructions for manual testing

Although we could test this manually with an API call, it's a bit of a pain and I think the unit tests are sufficient.

### Issue(s) this completes

Fixes #13667 
