### PR TITLE
Add legacy question type fragments with thtests

### DIFF
--- a/server/app/views/admin/questions/YesNoConfig.java
+++ b/server/app/views/admin/questions/YesNoConfig.java
@@ -1,0 +1,23 @@
+package views.admin.questions;
+
+import com.google.common.collect.ImmutableList;
+
+/**
+ * YES_NO question settings. {@code showLabel} is true when rendering the default option set for a
+ * question with no saved options.
+ */
+public record YesNoConfig(boolean showLabel, ImmutableList<YesNoOptionRow> options) {
+
+  /**
+   * A single YES_NO option row: hidden form-binding inputs plus a display checkbox. Required
+   * options ("yes"/"no") render checked and disabled, with an extra hidden input so the value still
+   * posts.
+   */
+  public record YesNoOptionRow(
+      String optionId,
+      String adminName,
+      String optionText,
+      boolean required,
+      boolean checked,
+      String ariaLabel) {}
+}

--- a/server/app/views/admin/questions/fragments/AddressFragment.html
+++ b/server/app/views/admin/questions/fragments/AddressFragment.html
@@ -1,0 +1,17 @@
+<!--/*@thymesVar id="questionForm" type="forms.questions.AddressQuestionForm"*/-->
+<th:block th:fragment="build(questionForm)" xmlns:th="http://www.thymeleaf.org">
+  <label
+    th:with="fieldId=${model.randomFieldId()}"
+    class="px-3 bg-white text-black text-lg py-2 block outline-none box-border m-auto border border-gray-500 rounded-lg w-full focus:border-civiform-blue align-middle flex flex-row mb-2 cf-radio-option"
+    th:for="${fieldId}"
+    ><input
+      type="checkbox"
+      value="true"
+      maxlength="10000"
+      th:id="${fieldId}"
+      name="disallowPoBox"
+      class="h-4 w-4 mr-4 align-middle self-center flex-none"
+      th:checked="${questionForm.getDisallowPoBox()}"
+    />Disallow post office boxes</label
+  >
+</th:block>

--- a/server/app/views/admin/questions/fragments/CheckboxFragment.html
+++ b/server/app/views/admin/questions/fragments/CheckboxFragment.html
@@ -1,0 +1,16 @@
+<!--/*@thymesVar id="questionForm" type="forms.questions.MultiOptionQuestionForm"*/-->
+<!--/*
+  Type-specific question config for CHECKBOX questions: the shared
+  multi-option markup plus the min/max choices validation fields.
+*/-->
+<th:block th:fragment="build(questionForm)" xmlns:th="http://www.thymeleaf.org">
+  <th:block
+    th:replace="~{admin/questions/fragments/MultiOptionContainerFragment :: build(${questionForm})}"
+  ></th:block>
+  <div
+    th:replace="~{admin/shared/LegacyFieldWithLabel/NumberField :: numberField(${model.randomFieldId()}, 'minChoicesRequired', 'Minimum number of choices required', ${questionForm.getMinChoicesRequired().isPresent() ? questionForm.getMinChoicesRequired().getAsInt() : null}, '0')}"
+  ></div>
+  <div
+    th:replace="~{admin/shared/LegacyFieldWithLabel/NumberField :: numberField(${model.randomFieldId()}, 'maxChoicesAllowed', 'Maximum number of choices allowed', ${questionForm.getMaxChoicesAllowed().isPresent() ? questionForm.getMaxChoicesAllowed().getAsInt() : null}, '1')}"
+  ></div>
+</th:block>

--- a/server/app/views/admin/questions/fragments/DateFragment.html
+++ b/server/app/views/admin/questions/fragments/DateFragment.html
@@ -1,0 +1,33 @@
+<!--/*@thymesVar id="questionForm" type="forms.questions.DateQuestionForm"*/-->
+<!--/*
+  Type-specific question config for DATE questions: validation parameters
+  legend, the start/end date type selects, and the min/max USWDS memorable
+  date pickers (hidden unless the corresponding type is CUSTOM).
+*/-->
+<th:block
+  th:fragment="build(questionForm)"
+  xmlns:th="http://www.thymeleaf.org"
+  th:with="minDateType=${questionForm.getMinDateType().isPresent() ? questionForm.getMinDateType().get().name() : 'ANY'},
+           maxDateType=${questionForm.getMaxDateType().isPresent() ? questionForm.getMaxDateType().get().name() : 'ANY'}"
+>
+  <legend class="pointer-events-none text-gray-600 text-base px-1 py-2">
+    Validation parameters
+  </legend>
+  <p class="px-1 pb-2 text-sm text-gray-600">
+    <span
+      th:text="'Set the parameters for allowable values for this date question below.'"
+    ></span>
+  </p>
+  <div
+    th:replace="~{admin/questions/fragments/DateTypeSelect :: dateTypeSelect('min-date-type', 'minDateType', 'Start date', 'Any past date', ${minDateType})}"
+  ></div>
+  <fieldset
+    th:replace="~{admin/questions/fragments/MemorableDate :: memorableDate('min-custom-date', ${minDateType != 'CUSTOM'}, 'minCustomMonth', ${questionForm.getMinCustomMonth().orElse('')}, 'minCustomDay', ${questionForm.getMinCustomDay().orElse('')}, 'minCustomYear', ${questionForm.getMinCustomYear().orElse('')})}"
+  ></fieldset>
+  <div
+    th:replace="~{admin/questions/fragments/DateTypeSelect :: dateTypeSelect('max-date-type', 'maxDateType', 'End date', 'Any future date', ${maxDateType})}"
+  ></div>
+  <fieldset
+    th:replace="~{admin/questions/fragments/MemorableDate :: memorableDate('max-custom-date', ${maxDateType != 'CUSTOM'}, 'maxCustomMonth', ${questionForm.getMaxCustomMonth().orElse('')}, 'maxCustomDay', ${questionForm.getMaxCustomDay().orElse('')}, 'maxCustomYear', ${questionForm.getMaxCustomYear().orElse('')})}"
+  ></fieldset>
+</th:block>

--- a/server/app/views/admin/questions/fragments/EnumeratorFragment.html
+++ b/server/app/views/admin/questions/fragments/EnumeratorFragment.html
@@ -1,0 +1,35 @@
+<!--/*@thymesVar id="questionForm" type="forms.questions.EnumeratorQuestionForm"*/-->
+<!--/* Type-specific question config for ENUMERATOR questions: required
+     entity type input plus min/max entity count fields. */-->
+<th:block th:fragment="build(questionForm)" xmlns:th="http://www.thymeleaf.org">
+  <div class="mb-2">
+    <label
+      for="enumerator-question-entity-type-input"
+      class="pointer-events-none text-gray-600 text-base px-1 py-2"
+      >Repeated entity type (What are we enumerating?)<span
+        th:replace="~{admin/shared/LegacyFieldWithLabel/RequiredIndicator :: requiredIndicator(true)}"
+      ></span
+    ></label>
+    <div class="flex flex-col">
+      <input
+        type="text"
+        th:value="${questionForm.getEntityType()}"
+        maxlength="10000"
+        aria-required="true"
+        id="enumerator-question-entity-type-input"
+        name="entityType"
+        class="px-3 bg-white text-black text-lg py-2 block outline-none box-border m-auto border border-gray-500 rounded-lg w-full focus:border-civiform-blue placeholder-gray-500"
+      />
+      <div
+        id="enumerator-question-entity-type-input-errors"
+        class="text-red-600 text-xs p-1 hidden"
+      ></div>
+    </div>
+  </div>
+  <div
+    th:replace="~{admin/shared/LegacyFieldWithLabel/NumberField :: numberField(${model.randomFieldId()}, 'minEntities', 'Minimum entity count', ${questionForm.getMinEntities().isPresent() ? questionForm.getMinEntities().getAsInt() : null}, '0')}"
+  ></div>
+  <div
+    th:replace="~{admin/shared/LegacyFieldWithLabel/NumberField :: numberField(${model.randomFieldId()}, 'maxEntities', 'Maximum entity count', ${questionForm.getMaxEntities().isPresent() ? questionForm.getMaxEntities().getAsInt() : null}, '1')}"
+  ></div>
+</th:block>

--- a/server/app/views/admin/questions/fragments/FileUploadFragment.html
+++ b/server/app/views/admin/questions/fragments/FileUploadFragment.html
@@ -1,0 +1,8 @@
+<!--/*@thymesVar id="questionForm" type="forms.questions.FileUploadQuestionForm"*/-->
+<!--/* Type-specific question config for FILEUPLOAD questions: the max files
+     field. */-->
+<th:block th:fragment="build(questionForm)" xmlns:th="http://www.thymeleaf.org">
+  <div
+    th:replace="~{admin/shared/LegacyFieldWithLabel/NumberField :: numberField(${model.randomFieldId()}, 'maxFiles', 'Maximum number of file uploads', ${questionForm.getMaxFiles().isPresent() ? questionForm.getMaxFiles().getAsInt() : null}, '1')}"
+  ></div>
+</th:block>

--- a/server/app/views/admin/questions/fragments/IdFragment.html
+++ b/server/app/views/admin/questions/fragments/IdFragment.html
@@ -1,0 +1,11 @@
+<!--/*@thymesVar id="questionForm" type="forms.questions.IdQuestionForm"*/-->
+<!--/* Type-specific question config for ID questions: min/max length
+     fields. */-->
+<th:block th:fragment="build(questionForm)" xmlns:th="http://www.thymeleaf.org">
+  <div
+    th:replace="~{admin/shared/LegacyFieldWithLabel/NumberField :: numberField(${model.randomFieldId()}, 'minLength', 'Minimum length', ${questionForm.getMinLength().isPresent() ? questionForm.getMinLength().getAsInt() : null}, '0')}"
+  ></div>
+  <div
+    th:replace="~{admin/shared/LegacyFieldWithLabel/NumberField :: numberField(${model.randomFieldId()}, 'maxLength', 'Maximum length', ${questionForm.getMaxLength().isPresent() ? questionForm.getMaxLength().getAsInt() : null}, '1')}"
+  ></div>
+</th:block>

--- a/server/app/views/admin/questions/fragments/MapFragment.html
+++ b/server/app/views/admin/questions/fragments/MapFragment.html
@@ -1,0 +1,13 @@
+<!--/*@thymesVar id="mapSettings" type="views.admin.questions.MapQuestionSettingsPartialViewModel"*/-->
+<!--/* Type-specific question config for MAP questions. Reuses the shared
+       MapQuestionSettingsPartial template (the same markup the GeoJSON hx
+       endpoint swaps into #geoJsonOutput) by rebinding `model` to the map
+       settings view model, so this page and the dynamic refresh stay in
+       sync. */-->
+<th:block th:fragment="build(mapSettings)" xmlns:th="http://www.thymeleaf.org">
+  <th:block th:with="model=${mapSettings}">
+    <th:block
+      th:replace="~{admin/questions/MapQuestionSettingsPartial}"
+    ></th:block>
+  </th:block>
+</th:block>

--- a/server/app/views/admin/questions/fragments/MultiOptionContainerFragment.html
+++ b/server/app/views/admin/questions/fragments/MultiOptionContainerFragment.html
@@ -1,0 +1,54 @@
+<!--/*@thymesVar id="questionForm" type="forms.questions.MultiOptionQuestionForm"*/-->
+<!--/*
+  Type-specific question config for CHECKBOX, RADIO_BUTTON and DROPDOWN questions:
+  the editable option rows, the "Add answer option" button, and the hidden
+  nextAvailableId field.
+*/-->
+<th:block th:fragment="build(questionForm)" xmlns:th="http://www.thymeleaf.org">
+  <div id="multi-option-container">
+    <th:block th:each="optionText, stat : ${questionForm.getOptions()}">
+      <div
+        th:replace="~{admin/questions/fragments/MultiOptionRow :: multiOptionRow(false, ${questionForm.getOptionIds().get(stat.index)}, ${questionForm.getOptionAdminNames().get(stat.index)}, ${optionText}, ${model.randomFieldId()}, ${model.randomFieldId()}, ${model.randomFieldId()})}"
+      ></div>
+    </th:block>
+    <th:block th:each="newOptionText, stat : ${questionForm.getNewOptions()}">
+      <div
+        th:replace="~{admin/questions/fragments/MultiOptionRow :: multiOptionRow(true, '', ${questionForm.getNewOptionAdminNames().get(stat.index)}, ${newOptionText}, ${model.randomFieldId()}, ${model.randomFieldId()}, ${model.randomFieldId()})}"
+      ></div>
+    </th:block>
+  </div>
+  <button
+    type="button"
+    id="add-new-option"
+    class="m-2 font-semibold block py-2 text-center rounded-full border text-civiform-blue border-civiform-blue hover:bg-blue-100 flex items-center font-medium space-x-2 bg-white hover:bg-gray-200"
+  >
+    <svg
+      th:replace="~{admin/shared/LegacySvgFragments :: iconPlus('inline-block h-4.5 w-4.5')}"
+    ></svg>
+    <span class="text-left">Add answer option</span>
+  </button>
+  <!--/* Hidden number field carrying nextAvailableId. */-->
+  <div class="hidden" th:with="nextAvailableIdFieldId=${model.randomFieldId()}">
+    <label th:for="${nextAvailableIdFieldId}" class="sr-only"
+      ><span
+        th:replace="~{admin/shared/LegacyFieldWithLabel/RequiredIndicator :: requiredIndicator(false)}"
+      ></span
+    ></label>
+    <div class="flex flex-col">
+      <input
+        type="number"
+        inputmode="decimal"
+        step="any"
+        th:value="${questionForm.getNextAvailableId().isPresent() ? questionForm.getNextAvailableId().getAsLong() : null}"
+        maxlength="10000"
+        th:id="${nextAvailableIdFieldId}"
+        name="nextAvailableId"
+        class="px-3 bg-white text-black text-lg py-2 block outline-none box-border m-auto border border-gray-500 rounded-lg w-full focus:border-civiform-blue placeholder-gray-500"
+      />
+      <div
+        th:id="|${nextAvailableIdFieldId}-errors|"
+        class="text-red-600 text-xs p-1 hidden"
+      ></div>
+    </div>
+  </div>
+</th:block>

--- a/server/app/views/admin/questions/fragments/NumberFragment.html
+++ b/server/app/views/admin/questions/fragments/NumberFragment.html
@@ -1,0 +1,11 @@
+<!--/*@thymesVar id="questionForm" type="forms.questions.NumberQuestionForm"*/-->
+<!--/* Type-specific question config for NUMBER questions: min/max value
+     fields. */-->
+<th:block th:fragment="build(questionForm)" xmlns:th="http://www.thymeleaf.org">
+  <div
+    th:replace="~{admin/shared/LegacyFieldWithLabel/NumberField :: numberField(${model.randomFieldId()}, 'min', 'Minimum value', ${questionForm.getMin().isPresent() ? questionForm.getMin().getAsLong() : null}, '0')}"
+  ></div>
+  <div
+    th:replace="~{admin/shared/LegacyFieldWithLabel/NumberField :: numberField(${model.randomFieldId()}, 'max', 'Maximum value', ${questionForm.getMax().isPresent() ? questionForm.getMax().getAsLong() : null}, '0')}"
+  ></div>
+</th:block>

--- a/server/app/views/admin/questions/fragments/PhoneFragment.html
+++ b/server/app/views/admin/questions/fragments/PhoneFragment.html
@@ -1,0 +1,7 @@
+<!--/*@thymesVar id="questionForm" type="forms.questions.QuestionForm"*/-->
+<!--/* Type-specific question config for PHONE questions. */-->
+<th:block th:fragment="build(questionForm)" xmlns:th="http://www.thymeleaf.org">
+  <div
+    th:text="'This supports only US and CA phone numbers. If you need other international numbers, please use a Text question.'"
+  ></div>
+</th:block>

--- a/server/app/views/admin/questions/fragments/TextFragment.html
+++ b/server/app/views/admin/questions/fragments/TextFragment.html
@@ -1,0 +1,11 @@
+<!--/*@thymesVar id="questionForm" type="forms.questions.TextQuestionForm"*/-->
+<!--/* Type-specific question config for TEXT questions: min/max length
+     fields. */-->
+<th:block th:fragment="build(questionForm)" xmlns:th="http://www.thymeleaf.org">
+  <div
+    th:replace="~{admin/shared/LegacyFieldWithLabel/NumberField :: numberField(${model.randomFieldId()}, 'minLength', 'Minimum length', ${questionForm.getMinLength().isPresent() ? questionForm.getMinLength().getAsInt() : null}, '0')}"
+  ></div>
+  <div
+    th:replace="~{admin/shared/LegacyFieldWithLabel/NumberField :: numberField(${model.randomFieldId()}, 'maxLength', 'Maximum length', ${questionForm.getMaxLength().isPresent() ? questionForm.getMaxLength().getAsInt() : null}, '1')}"
+  ></div>
+</th:block>

--- a/server/app/views/admin/questions/fragments/YesNoFragment.html
+++ b/server/app/views/admin/questions/fragments/YesNoFragment.html
@@ -1,0 +1,68 @@
+<!--/*@thymesVar id="yesNoConfig" type="views.admin.questions.YesNoConfig"*/-->
+<!--/*
+  Type-specific question config for YES_NO questions. New questions (no
+  saved options) show the "Select answer options" label and the default
+  option set; existing questions render their saved options. Required
+  options ("yes"/"no") are checked and disabled, with an extra hidden input
+  so their value still posts.
+*/-->
+<th:block th:fragment="build(yesNoConfig)" xmlns:th="http://www.thymeleaf.org">
+  <div th:if="${yesNoConfig.showLabel()}">
+    <label
+      data-testId="yes-no-options-label"
+      class="text-sm font-medium text-gray-700"
+      >Select answer options<span
+        th:replace="~{admin/shared/LegacyFieldWithLabel/RequiredIndicator :: requiredIndicator(true)}"
+      ></span
+    ></label>
+  </div>
+  <div
+    th:each="row : ${yesNoConfig.options()}"
+    class="cf-multi-option-question-option grid items-center"
+  >
+    <input
+      name="optionIds[]"
+      th:value="${row.optionId()}"
+      class="display-none"
+    />
+    <input
+      name="optionAdminNames[]"
+      th:value="${row.adminName()}"
+      class="display-none"
+    />
+    <input
+      name="options[]"
+      th:value="${row.optionText()}"
+      class="display-none"
+    />
+    <div
+      class="usa-checkbox flex-align-center border-width-1px border-base radius-md grid-row items-center padding-1 margin-1"
+    >
+      <input
+        th:id="${row.adminName()}"
+        type="checkbox"
+        name="displayedOptionIds[]"
+        th:value="${row.optionId()}"
+        class="usa-checkbox__input"
+        th:checked="${row.checked()}"
+        th:disabled="${row.required()}"
+      />
+      <label
+        th:for="${row.adminName()}"
+        th:aria-label="${row.ariaLabel()}"
+        class="usa-checkbox__label margin-top-0 flex flex-align-center"
+      >
+        <div class="flex-column">
+          <div><strong>Admin ID: </strong>[[${row.adminName()}]]</div>
+          <div><strong>Option text: </strong>[[${row.optionText()}]]</div>
+        </div>
+      </label>
+    </div>
+    <input
+      th:if="${row.required()}"
+      type="hidden"
+      name="displayedOptionIds[]"
+      th:value="${row.optionId()}"
+    />
+  </div>
+</th:block>

--- a/server/test/resources/thymeleaf/admin/questions/legacyQuestionFragments/dateFragmentCustomMax.thtest
+++ b/server/test/resources/thymeleaf/admin/questions/legacyQuestionFragments/dateFragmentCustomMax.thtest
@@ -1,0 +1,44 @@
+%NAME dateFragment - CUSTOM max shows its picker, unset min falls back to ANY and hides it
+%TEMPLATE_MODE HTML
+# Mirror of dateFragmentCustomMin.thtest, flipped so the max side runs
+# too — the min/max code in DateFragment is copy-paste symmetric.
+%CONTEXT
+questionForm = (#form = new forms.questions.DateQuestionForm(), \
+                #form.setMaxDateType("CUSTOM"), \
+                #form.setMaxCustomMonth("9"), \
+                #form.setMaxCustomDay("8"), \
+                #form.setMaxCustomYear("2027"), \
+                #form)
+# ----------------------------------------------------------------------
+%INPUT
+<th:block th:replace="~{admin/questions/fragments/DateFragment :: build(${questionForm})}"></th:block>
+# ----------------------------------------------------------------------
+# Swaps the real DateTypeSelect for a fake that just prints its arguments.
+# The output then shows exactly what DateFragment passed in; the real
+# dropdown markup has its own thtests.
+%INPUT[admin/questions/fragments/DateTypeSelect]
+<div
+  th:fragment="dateTypeSelect(id, fieldName, labelText, anyDateLabel, selectedValue)"
+  th:text="|dateTypeSelect(${id}, ${fieldName}, ${labelText}, ${anyDateLabel}, ${selectedValue})|"
+></div>
+# ----------------------------------------------------------------------
+# Same for MemorableDate: the printed arguments show whether each picker
+# is hidden and that min/max read their own form values, without copying
+# the picker markup tested in memorableDate*.thtest.
+%INPUT[admin/questions/fragments/MemorableDate]
+<fieldset
+  th:fragment="memorableDate(idPrefix, hidden, monthName, monthValue, dayName, dayValue, yearName, yearValue)"
+  th:text="|memorableDate(${idPrefix}, hidden=${hidden}, ${monthName}=${monthValue}, ${dayName}=${dayValue}, ${yearName}=${yearValue})|"
+></fieldset>
+# ----------------------------------------------------------------------
+%OUTPUT
+<legend class="pointer-events-none text-gray-600 text-base px-1 py-2">
+  Validation parameters
+</legend>
+<p class="px-1 pb-2 text-sm text-gray-600">
+  <span>Set the parameters for allowable values for this date question below.</span>
+</p>
+<div>dateTypeSelect(min-date-type, minDateType, Start date, Any past date, ANY)</div>
+<fieldset>memorableDate(min-custom-date, hidden=true, minCustomMonth=, minCustomDay=, minCustomYear=)</fieldset>
+<div>dateTypeSelect(max-date-type, maxDateType, End date, Any future date, CUSTOM)</div>
+<fieldset>memorableDate(max-custom-date, hidden=false, maxCustomMonth=9, maxCustomDay=8, maxCustomYear=2027)</fieldset>

--- a/server/test/resources/thymeleaf/admin/questions/legacyQuestionFragments/dateFragmentCustomMin.thtest
+++ b/server/test/resources/thymeleaf/admin/questions/legacyQuestionFragments/dateFragmentCustomMin.thtest
@@ -1,0 +1,45 @@
+%NAME dateFragment - CUSTOM min shows its picker, unset max falls back to ANY and hides it
+%TEMPLATE_MODE HTML
+# DateFragment just wires up DateTypeSelect and MemorableDate, so both are
+# faked here and only the wiring is checked: an unset date type becomes
+# ANY, and each picker is hidden unless its type is CUSTOM.
+%CONTEXT
+questionForm = (#form = new forms.questions.DateQuestionForm(), \
+                #form.setMinDateType("CUSTOM"), \
+                #form.setMinCustomMonth("1"), \
+                #form.setMinCustomDay("2"), \
+                #form.setMinCustomYear("2024"), \
+                #form)
+# ----------------------------------------------------------------------
+%INPUT
+<th:block th:replace="~{admin/questions/fragments/DateFragment :: build(${questionForm})}"></th:block>
+# ----------------------------------------------------------------------
+# Swaps the real DateTypeSelect for a fake that just prints its arguments.
+# The output then shows exactly what DateFragment passed in; the real
+# dropdown markup has its own thtests.
+%INPUT[admin/questions/fragments/DateTypeSelect]
+<div
+  th:fragment="dateTypeSelect(id, fieldName, labelText, anyDateLabel, selectedValue)"
+  th:text="|dateTypeSelect(${id}, ${fieldName}, ${labelText}, ${anyDateLabel}, ${selectedValue})|"
+></div>
+# ----------------------------------------------------------------------
+# Same for MemorableDate: the printed arguments show whether each picker
+# is hidden and that min/max read their own form values, without copying
+# the picker markup tested in memorableDate*.thtest.
+%INPUT[admin/questions/fragments/MemorableDate]
+<fieldset
+  th:fragment="memorableDate(idPrefix, hidden, monthName, monthValue, dayName, dayValue, yearName, yearValue)"
+  th:text="|memorableDate(${idPrefix}, hidden=${hidden}, ${monthName}=${monthValue}, ${dayName}=${dayValue}, ${yearName}=${yearValue})|"
+></fieldset>
+# ----------------------------------------------------------------------
+%OUTPUT
+<legend class="pointer-events-none text-gray-600 text-base px-1 py-2">
+  Validation parameters
+</legend>
+<p class="px-1 pb-2 text-sm text-gray-600">
+  <span>Set the parameters for allowable values for this date question below.</span>
+</p>
+<div>dateTypeSelect(min-date-type, minDateType, Start date, Any past date, CUSTOM)</div>
+<fieldset>memorableDate(min-custom-date, hidden=false, minCustomMonth=1, minCustomDay=2, minCustomYear=2024)</fieldset>
+<div>dateTypeSelect(max-date-type, maxDateType, End date, Any future date, ANY)</div>
+<fieldset>memorableDate(max-custom-date, hidden=true, maxCustomMonth=, maxCustomDay=, maxCustomYear=)</fieldset>

--- a/server/test/resources/thymeleaf/admin/questions/legacyQuestionFragments/yesNoRequiredHiddenInput.thtest
+++ b/server/test/resources/thymeleaf/admin/questions/legacyQuestionFragments/yesNoRequiredHiddenInput.thtest
@@ -1,0 +1,79 @@
+%NAME yesNo - new question shows the label; required option posts via hidden input
+%TEMPLATE_MODE HTML
+# New question: label shown, default options all checked. Required "yes"
+# is locked (disabled) — and a disabled checkbox doesn't post, so a hidden
+# input submits its value instead. Optional "maybe" gets neither.
+%CONTEXT
+# YesNoOptionRow(optionId, adminName, optionText, required, checked, ariaLabel)
+yesNoConfig = new views.admin.questions.YesNoConfig(true, \
+    @com.google.common.collect.ImmutableList@of( \
+        new views.admin.questions.YesNoConfig$YesNoOptionRow( \
+            "1", "yes", "Yes", true, true, "Admin ID: yes. Option text: Yes."), \
+        new views.admin.questions.YesNoConfig$YesNoOptionRow( \
+            "3", "maybe", "Maybe", false, true, "Admin ID: maybe. Option text: Maybe.")))
+# ----------------------------------------------------------------------
+%INPUT
+<th:block th:replace="~{admin/questions/fragments/YesNoFragment :: build(${yesNoConfig})}"></th:block>
+# ----------------------------------------------------------------------
+%OUTPUT
+<div>
+  <label data-testId="yes-no-options-label" class="text-sm font-medium text-gray-700"
+    >Select answer options<span class="usa-hint--required" aria-hidden="true">&nbsp;*</span></label
+  >
+</div>
+<div class="cf-multi-option-question-option grid items-center">
+  <input name="optionIds[]" value="1" class="display-none" />
+  <input name="optionAdminNames[]" value="yes" class="display-none" />
+  <input name="options[]" value="Yes" class="display-none" />
+  <div
+    class="usa-checkbox flex-align-center border-width-1px border-base radius-md grid-row items-center padding-1 margin-1"
+  >
+    <input
+      id="yes"
+      type="checkbox"
+      name="displayedOptionIds[]"
+      value="1"
+      class="usa-checkbox__input"
+      checked="checked"
+      disabled="disabled"
+    />
+    <label
+      for="yes"
+      aria-label="Admin ID: yes. Option text: Yes."
+      class="usa-checkbox__label margin-top-0 flex flex-align-center"
+    >
+      <div class="flex-column">
+        <div><strong>Admin ID: </strong>yes</div>
+        <div><strong>Option text: </strong>Yes</div>
+      </div>
+    </label>
+  </div>
+  <input type="hidden" name="displayedOptionIds[]" value="1" />
+</div>
+<div class="cf-multi-option-question-option grid items-center">
+  <input name="optionIds[]" value="3" class="display-none" />
+  <input name="optionAdminNames[]" value="maybe" class="display-none" />
+  <input name="options[]" value="Maybe" class="display-none" />
+  <div
+    class="usa-checkbox flex-align-center border-width-1px border-base radius-md grid-row items-center padding-1 margin-1"
+  >
+    <input
+      id="maybe"
+      type="checkbox"
+      name="displayedOptionIds[]"
+      value="3"
+      class="usa-checkbox__input"
+      checked="checked"
+    />
+    <label
+      for="maybe"
+      aria-label="Admin ID: maybe. Option text: Maybe."
+      class="usa-checkbox__label margin-top-0 flex flex-align-center"
+    >
+      <div class="flex-column">
+        <div><strong>Admin ID: </strong>maybe</div>
+        <div><strong>Option text: </strong>Maybe</div>
+      </div>
+    </label>
+  </div>
+</div>

--- a/server/test/resources/thymeleaf/admin/questions/legacyQuestionFragments/yesNoUndisplayedUnchecked.thtest
+++ b/server/test/resources/thymeleaf/admin/questions/legacyQuestionFragments/yesNoUndisplayedUnchecked.thtest
@@ -1,0 +1,73 @@
+%NAME yesNo - existing question hides the label; undisplayed option is unchecked
+%TEMPLATE_MODE HTML
+# Existing question: no label, saved options keep their saved state. The
+# admin hid "maybe", so it renders unchecked. Required "yes" is still
+# locked and checked, with its hidden posting input.
+%CONTEXT
+# YesNoOptionRow(optionId, adminName, optionText, required, checked, ariaLabel)
+yesNoConfig = new views.admin.questions.YesNoConfig(false, \
+    @com.google.common.collect.ImmutableList@of( \
+        new views.admin.questions.YesNoConfig$YesNoOptionRow( \
+            "1", "yes", "Yes", true, true, "Admin ID: yes. Option text: Yes."), \
+        new views.admin.questions.YesNoConfig$YesNoOptionRow( \
+            "3", "maybe", "Maybe", false, false, "Admin ID: maybe. Option text: Maybe.")))
+# ----------------------------------------------------------------------
+%INPUT
+<th:block th:replace="~{admin/questions/fragments/YesNoFragment :: build(${yesNoConfig})}"></th:block>
+# ----------------------------------------------------------------------
+%OUTPUT
+<div class="cf-multi-option-question-option grid items-center">
+  <input name="optionIds[]" value="1" class="display-none" />
+  <input name="optionAdminNames[]" value="yes" class="display-none" />
+  <input name="options[]" value="Yes" class="display-none" />
+  <div
+    class="usa-checkbox flex-align-center border-width-1px border-base radius-md grid-row items-center padding-1 margin-1"
+  >
+    <input
+      id="yes"
+      type="checkbox"
+      name="displayedOptionIds[]"
+      value="1"
+      class="usa-checkbox__input"
+      checked="checked"
+      disabled="disabled"
+    />
+    <label
+      for="yes"
+      aria-label="Admin ID: yes. Option text: Yes."
+      class="usa-checkbox__label margin-top-0 flex flex-align-center"
+    >
+      <div class="flex-column">
+        <div><strong>Admin ID: </strong>yes</div>
+        <div><strong>Option text: </strong>Yes</div>
+      </div>
+    </label>
+  </div>
+  <input type="hidden" name="displayedOptionIds[]" value="1" />
+</div>
+<div class="cf-multi-option-question-option grid items-center">
+  <input name="optionIds[]" value="3" class="display-none" />
+  <input name="optionAdminNames[]" value="maybe" class="display-none" />
+  <input name="options[]" value="Maybe" class="display-none" />
+  <div
+    class="usa-checkbox flex-align-center border-width-1px border-base radius-md grid-row items-center padding-1 margin-1"
+  >
+    <input
+      id="maybe"
+      type="checkbox"
+      name="displayedOptionIds[]"
+      value="3"
+      class="usa-checkbox__input"
+    />
+    <label
+      for="maybe"
+      aria-label="Admin ID: maybe. Option text: Maybe."
+      class="usa-checkbox__label margin-top-0 flex flex-align-center"
+    >
+      <div class="flex-column">
+        <div><strong>Admin ID: </strong>maybe</div>
+        <div><strong>Option text: </strong>Maybe</div>
+      </div>
+    </label>
+  </div>
+</div>

--- a/server/test/views/admin/questions/LegacyQuestionFragmentsTest.java
+++ b/server/test/views/admin/questions/LegacyQuestionFragmentsTest.java
@@ -43,6 +43,39 @@ public class LegacyQuestionFragmentsTest {
     ThymeleafFragmentTester.run(DIR + "memorableDateSingleDigitMonth.thtest");
   }
 
+  /**
+   * DateTypeSelect and MemorableDate internals are covered above; this stubs them out and asserts
+   * only DateFragment's wiring: the ANY fallback for an unset date type and the hidden flag pairing
+   * each memorable date picker with its type select.
+   */
+  @Test
+  public void dateFragment_customMinShowsPickerUnsetMaxHidesIt() {
+    ThymeleafFragmentTester.run(DIR + "dateFragmentCustomMin.thtest");
+  }
+
+  /**
+   * Mirror of the CUSTOM-min case: the min/max expressions are copy-paste symmetric, and only a
+   * CUSTOM max evaluates the max-present branch.
+   */
+  @Test
+  public void dateFragment_customMaxShowsPickerUnsetMinHidesIt() {
+    ThymeleafFragmentTester.run(DIR + "dateFragmentCustomMax.thtest");
+  }
+
+  /**
+   * Guards the required-option posting trick: a required option's checkbox is disabled (so it does
+   * not post) and must be duplicated by a hidden displayedOptionIds[] input.
+   */
+  @Test
+  public void yesNo_newQuestionShowsLabelAndRequiredOptionPostsViaHiddenInput() {
+    ThymeleafFragmentTester.run(DIR + "yesNoRequiredHiddenInput.thtest");
+  }
+
+  @Test
+  public void yesNo_existingQuestionHidesLabelAndUndisplayedOptionIsUnchecked() {
+    ThymeleafFragmentTester.run(DIR + "yesNoUndisplayedUnchecked.thtest");
+  }
+
   @Test
   public void multiOptionRow_newOption() {
     ThymeleafFragmentTester.run(DIR + "multiOptionRowNew.thtest");


### PR DESCRIPTION
Each fragment here represents the customized question settings aspect of the question new/edit page. This is mostly wrappers around the new thymeleaf versions of "fieldWithLabel" stuff so only a few things here have new thtests. 

The thtests are _mocking_ child fragments so it might look weird. If you want more info on that let me know.

<img width="90" height="220" alt="image" src="https://github.com/user-attachments/assets/ce5b2355-dad7-4850-842f-b71554dc5364" />



### LLM Tooling

Claude did most of the migration with some manual assistance. Built using this custom skill: [SKILL.md](https://github.com/user-attachments/files/30205592/SKILL.md) | [REFERENCE.md](https://github.com/user-attachments/files/30205591/REFERENCE.md). A lot of manually work making sure this was separated into decently sized PRs and manual testing.

Assisted-by: Claude Code:claude-fable-5
 

Related to: https://github.com/civiform/civiform/issues/12428, https://github.com/civiform/civiform/issues/12429