### PR TITLE
Fix expanded logic cancel button bug

### DIFF
--- a/browser-test/src/support/admin_predicates.ts
+++ b/browser-test/src/support/admin_predicates.ts
@@ -378,7 +378,7 @@ export class AdminPredicates {
   }
 
   async clickCancelButton() {
-    await this.page.getByRole('button', {name: 'Cancel'}).click()
+    await this.page.getByRole('link', {name: 'Cancel'}).click()
   }
 
   async clickSaveConditionButton() {

--- a/server/app/assets/javascripts/admin_predicate_edit.ts
+++ b/server/app/assets/javascripts/admin_predicate_edit.ts
@@ -134,9 +134,9 @@ export class AdminPredicateEdit {
       AdminPredicateEdit.updateRootNodeOperatorAriaLabel,
     )
     addEventListenerToElements(
-      '#predicate-form',
-      'submit',
-      AdminPredicateEdit.onPredicateFormSubmit.bind(this),
+      '#cancel-predicate-edit',
+      'click',
+      AdminPredicateEdit.onCancelClick.bind(this),
     )
 
     // Trigger change to update operators based on the current scalar selected.
@@ -297,46 +297,20 @@ export class AdminPredicateEdit {
     AdminPredicateEdit.updateRootNodeOperatorAriaLabel()
   }
 
-  private static onPredicateFormSubmit(event: SubmitEvent) {
-    // If this is a submit, do nothing and let it go through.
-    // If this is a cancel, handle submit manually.
-    if (event.submitter && event.submitter.id === 'cancel-predicate-edit') {
-      event.preventDefault()
-      AdminPredicateEdit.confirmExitWithoutSaving(
-        event.target as HTMLFormElement,
-        event.submitter as HTMLButtonElement,
-      )
-    }
-  }
+  private static onCancelClick(event: Event) {
+    const cancelLink = event.currentTarget as HTMLAnchorElement
 
-  private static confirmExitWithoutSaving(
-    predicateForm: HTMLFormElement,
-    cancelButton: HTMLButtonElement,
-  ) {
+    // If the form has unsaved changes, ask for confirmation before letting
+    // the link navigate away.
     const currentPredicateState = AdminPredicateEdit.getPredicateFormState()
-
-    // Check the initial form state against the current form state.
-    // If they're equal, do nothing and cancel.
-    // If there have been changes, show a confirmation dialog.
     if (
       currentPredicateState !== AdminPredicateEdit.INITIAL_PREDICATE_FORM_STATE
     ) {
-      const confirmationMessage =
-        cancelButton.getAttribute('data-cancel-dialog')
-      if (!confirmationMessage) {
-        return
-      }
-
-      if (window.confirm(confirmationMessage)) {
-        predicateForm.action = cancelButton.formAction
-        predicateForm.submit()
-      } else {
-        return
+      const confirmationMessage = cancelLink.getAttribute('data-cancel-dialog')
+      if (confirmationMessage && !window.confirm(confirmationMessage)) {
+        event.preventDefault()
       }
     }
-
-    predicateForm.action = cancelButton.formAction
-    predicateForm.submit()
   }
 
   /** Focus the root node operator select dropdown. Used on page load and on adding the first condition. */
@@ -878,9 +852,7 @@ export class AdminPredicateEdit {
    */
   private static getPredicateFormState(): string | undefined | null {
     const predicateForm = document.getElementById('predicate-form') as
-      | HTMLFormElement
-      | undefined
-      | null
+      HTMLFormElement | undefined | null
     if (!predicateForm) {
       return null
     }

--- a/server/app/views/admin/programs/predicates/EditPredicatePageView.html
+++ b/server/app/views/admin/programs/predicates/EditPredicatePageView.html
@@ -185,16 +185,13 @@
           th:text="#{button.saveAndExit}"
           th:disabled="${!model.hasAvailableQuestions}"
         ></button>
-        <button
+        <a
           id="cancel-predicate-edit"
-          type="submit"
           class="usa-button usa-button--outline tablet:grid-col-auto justify-center"
-          form="predicate-form"
-          th:formaction="${model.blockEditUrl()}"
-          formmethod="get"
+          th:href="${model.blockEditUrl()}"
           th:text="#{button.cancel}"
           th:data-cancel-dialog="#{confirm.leaveWithoutSaving} + '&#10;&#10;' + #{confirm.unsavedChanges}"
-        ></button>
+        ></a>
         <div
           id="delete-all-conditions-button"
           class="tablet:grid-col-auto padding-left-4 display-flex justify-center"


### PR DESCRIPTION
Description

There are two `cancel` buttons here. For clarity `cancel-a` is the cancel button on the html page next to the save button, and `cancel-b` is the cancel button on the confirmation dialog.

If you made changes on the expanded logic form and then clicked `cancel-a` you get a confirmation dialog. The confirmation dialog has `cancel-b` which was acting like a Save button. HTMX caught the original "click to post" action and swapped the full page *inside* a small element of the current page, making the screen look broken.

This change makes `cancel-a` just a link as it doesn't need to post anything. It still warns about unsaved changes, and if `cancel-b` is clicked the dialog closes and we've back as if we didn't do anything. If the dialog chooses ok it allows the navigation.

Steps to reproduce before the fix

1. Open a program and edit a block.
2. Open the block's visibility or eligibility conditions.
3. Change a condition without saving.
4. Click Cancel.
5. In the unsaved changes prompt, choose to stay on the page.
6. Notice the block edit page loads inside the conditions area, creating a broken page-within-a-page layout.

Assisted-by: Claude Code:claude-fable-5
