### PR TITLE
Go to enumerator screen rather than repeated screen

### DIFF
--- a/browser-test/src/end_to_end_enumerators.test.ts
+++ b/browser-test/src/end_to_end_enumerators.test.ts
@@ -27,7 +27,7 @@ test.describe('End to end enumerator test with enumerators feature flag on', () 
         await adminPrograms.gotoEditDraftProgramPage(
           'Enumerator seeding program',
         )
-        await addRepeatedSetBlock(page, {selectParent: true})
+        await addRepeatedSetBlock(page)
         await fillAndSubmitEnumeratorQuestionForm(page, {
           listedEntity: 'household member',
           questionText: 'Household members',
@@ -62,11 +62,11 @@ test.describe('End to end enumerator test with enumerators feature flag on', () 
 
     test('can add an enumerator block and a repeated block to a program at once from the program block edit page', async ({
       page,
+      adminPrograms,
     }) => {
       const blockPanel = page.getByTestId('block-panel-edit')
       let initialBlockCount: number
       const screenLinks = page.getByRole('link', {name: /Screen /})
-      let enumeratorBlockLink: Locator
 
       await test.step('Record how many blocks are present in the block order panel', async () => {
         initialBlockCount = await screenLinks.count()
@@ -88,27 +88,22 @@ test.describe('End to end enumerator test with enumerators feature flag on', () 
         await expect(screenLinks).toHaveCount(initialBlockCount + 2)
       })
 
-      await test.step('Validate that the current block is the newly-created repeated block', async () => {
+      await test.step('Validate that the current block is the newly-created enumerator block', async () => {
         await expectCurrentBlockTitle(
-          /* isRepeatedBlock= */ true,
+          /* isRepeatedBlock= */ false,
           blockPanel,
-          /* expectedScreenNumber= */ 3,
-          /* repeatedFrom= */ 2,
+          /* expectedScreenNumber= */ 2,
         )
       })
 
       await test.step('Validate that the enumerator block says repeated set', async () => {
-        enumeratorBlockLink = page
+        const enumeratorBlockLink = page
           .getByRole('link', {name: /Screen /})
           .nth(initialBlockCount) // zero-indexed
 
         await expect(
           enumeratorBlockLink.getByText('Repeated set'),
         ).toBeVisible()
-      })
-
-      await test.step('Click on the enumerator block in the block order panel', async () => {
-        await enumeratorBlockLink.click()
       })
 
       await test.step('Validate that "Repeated set creation method" radio buttons are visible', async () => {
@@ -144,6 +139,15 @@ test.describe('End to end enumerator test with enumerators feature flag on', () 
           fullPage: false,
         })
       })
+
+      await test.step('Validate that leaving and returning to the program edit page lands on the enumerator screen', async () => {
+        await adminPrograms.gotoEditDraftProgramPage('Enumerator test program')
+        await expectCurrentBlockTitle(
+          /* isRepeatedBlock= */ false,
+          blockPanel,
+          /* expectedScreenNumber= */ 2,
+        )
+      })
     })
 
     test('can add an existing enumerator question without an initial question to an enumerator block', async ({
@@ -154,8 +158,8 @@ test.describe('End to end enumerator test with enumerators feature flag on', () 
         name: 'Add a question',
       })
 
-      await test.step('Add a new repeated set and select the parent block', async () => {
-        await addRepeatedSetBlock(page, {selectParent: true})
+      await test.step('Add a new repeated set', async () => {
+        await addRepeatedSetBlock(page)
       })
 
       await test.step('Click the "Choose existing" radio button', async () => {
@@ -237,8 +241,8 @@ test.describe('End to end enumerator test with enumerators feature flag on', () 
           )
         })
 
-        await test.step('Add a new repeated set and select the parent block', async () => {
-          await addRepeatedSetBlock(page, {selectParent: true})
+        await test.step('Add a new repeated set', async () => {
+          await addRepeatedSetBlock(page)
         })
 
         await test.step('Open the question bank by clicking the initial-question "Add question" button', async () => {
@@ -296,7 +300,7 @@ test.describe('End to end enumerator test with enumerators feature flag on', () 
         const initialQuestionSlot = blockPanel.locator('#initial-question-slot')
 
         await test.step('Add a new repeated set', async () => {
-          await addRepeatedSetBlock(page, {selectParent: true})
+          await addRepeatedSetBlock(page)
         })
 
         await test.step('Open the question bank', async () => {
@@ -357,7 +361,7 @@ test.describe('End to end enumerator test with enumerators feature flag on', () 
         const blockPanel = page.getByTestId('block-panel-edit')
         const initialQuestionSlot = blockPanel.locator('#initial-question-slot')
 
-        await addRepeatedSetBlock(page, {selectParent: true})
+        await addRepeatedSetBlock(page)
 
         await test.step('Open the question bank via the initial-question slot', async () => {
           await initialQuestionSlot
@@ -441,7 +445,7 @@ test.describe('End to end enumerator test with enumerators feature flag on', () 
         const newQuestionAdminId = 'household-member-name'
         const newQuestionText = 'What is the household member name?'
 
-        await addRepeatedSetBlock(page, {selectParent: true})
+        await addRepeatedSetBlock(page)
 
         await test.step('Fill out the enumerator form fields before leaving to create the initial question', async () => {
           await fillEnumeratorQuestionForm(page)
@@ -560,7 +564,7 @@ test.describe('End to end enumerator test with enumerators feature flag on', () 
         name: 'Add a question',
       })
 
-      await addRepeatedSetBlock(page, {selectParent: true})
+      await addRepeatedSetBlock(page)
 
       await test.step('create an enumerator with initial question', async () => {
         await initialQuestionSlot
@@ -629,8 +633,8 @@ test.describe('End to end enumerator test with enumerators feature flag on', () 
         name: 'Question text',
       })
 
-      await test.step('Add a new repeated set and select its block', async () => {
-        await addRepeatedSetBlock(page, {selectParent: true})
+      await test.step('Add a new repeated set', async () => {
+        await addRepeatedSetBlock(page)
       })
 
       await test.step('Auto-fill admin id and question text from listed entity', async () => {
@@ -676,7 +680,7 @@ test.describe('End to end enumerator test with enumerators feature flag on', () 
       })
       const initialQuestionSlot = blockPanel.locator('#initial-question-slot')
 
-      await addRepeatedSetBlock(page, {selectParent: true})
+      await addRepeatedSetBlock(page)
 
       await test.step('Submit the new enumerator question form without filling out all the required fields or selecting an initial question', async () => {
         await blockPanel
@@ -757,10 +761,6 @@ test.describe('End to end enumerator test with enumerators feature flag on', () 
         await addRepeatedSetBlock(page)
       })
 
-      await test.step('Select the new enumerator block from the block order panel', async () => {
-        await page.getByRole('link', {name: 'Screen 4'}).click()
-      })
-
       await test.step('Submit the new enumerator question form with a duplicate admin ID', async () => {
         await fillAndSubmitEnumeratorQuestionForm(page, {
           adminId: 'pets enumerator',
@@ -797,6 +797,12 @@ test.describe('End to end enumerator test with enumerators feature flag on', () 
       await test.step('Add a new repeated set', async () => {
         await addRepeatedSetBlock(page)
       })
+
+      await navigateToRepeatedScreen(
+        page,
+        /* screenNumber= */ 3,
+        /* repeatedFrom= */ 2,
+      )
 
       await test.step('Verify that the "Add repeated screen" button is not present on the repeated screen', async () => {
         await expect(addRepeatedScreenButton).toBeHidden()
@@ -847,7 +853,7 @@ test.describe('End to end enumerator test with enumerators feature flag on', () 
       })
 
       await test.step('Add a new repeated set and verify nested button is hidden before parent enumerator question is saved', async () => {
-        await addRepeatedSetBlock(page, {selectParent: true})
+        await addRepeatedSetBlock(page)
         await expect(addNestedRepeatedSetButton).toBeHidden()
       })
 
@@ -916,7 +922,7 @@ test.describe('End to end enumerator test with enumerators feature flag on', () 
       })
 
       await test.step('Add a new repeated set and save the enumerator question on the parent block', async () => {
-        await addRepeatedSetBlock(page, {selectParent: true})
+        await addRepeatedSetBlock(page)
         await fillAndSubmitEnumeratorQuestionForm(page, {
           initialQuestion: SAMPLE_QUESTIONS.number,
         })
@@ -957,8 +963,8 @@ test.describe('End to end enumerator test with enumerators feature flag on', () 
     }) => {
       const blockPanel = page.getByTestId('block-panel-edit')
 
-      await test.step('Add a new repeated set and select the parent block', async () => {
-        await addRepeatedSetBlock(page, {selectParent: true})
+      await test.step('Add a new repeated set', async () => {
+        await addRepeatedSetBlock(page)
       })
 
       await test.step('Fill out the enumerator form (auto-save captures the values)', async () => {
@@ -992,8 +998,8 @@ test.describe('End to end enumerator test with enumerators feature flag on', () 
         await page.locator('#delete-block-button').click()
       })
 
-      await test.step('Add another repeated set (block id is reused) and select the parent block', async () => {
-        await addRepeatedSetBlock(page, {selectParent: true})
+      await test.step('Add another repeated set (block id is reused)', async () => {
+        await addRepeatedSetBlock(page)
       })
 
       await test.step('Verify the enumerator form fields are empty — storage was cleared on delete', async () => {
@@ -1017,7 +1023,7 @@ test.describe('End to end enumerator test with enumerators feature flag on', () 
     }) => {
       const blockPanel = page.getByTestId('block-panel-edit')
 
-      await addRepeatedSetBlock(page, {selectParent: true})
+      await addRepeatedSetBlock(page)
 
       await fillAndSubmitEnumeratorQuestionForm(page, {
         initialQuestion: SAMPLE_QUESTIONS.number,
@@ -1059,8 +1065,13 @@ test.describe('End to end enumerator test with enumerators feature flag on', () 
           'A repeated set question must first be added before repeated questions can be. Please navigate to the parent screen to add a repeated set question.',
       })
 
-      await test.step('Add a new repeated set and verify repeated screen is selected', async () => {
+      await test.step('Add a new repeated set and go to the repeated screen', async () => {
         await addRepeatedSetBlock(page)
+        await navigateToRepeatedScreen(
+          page,
+          /* screenNumber= */ 3,
+          /* repeatedFrom= */ 2,
+        )
         await expectCurrentBlockTitle(
           /* isRepeatedBlock= */ true,
           blockPanel,
@@ -1121,8 +1132,8 @@ test.describe('End to end enumerator test with enumerators feature flag on', () 
         name: 'Add repeated screen',
       })
 
-      await test.step('Add a new repeated set and select the parent block', async () => {
-        await addRepeatedSetBlock(page, {selectParent: true})
+      await test.step('Add a new repeated set', async () => {
+        await addRepeatedSetBlock(page)
       })
 
       await fillAndSubmitEnumeratorQuestionForm(page, {
@@ -1317,8 +1328,8 @@ test.describe('End to end enumerator test with enumerators feature flag on', () 
         await adminPrograms.gotoEditDraftProgramPage('Enumerator test program')
       })
 
-      await test.step('Add a new repeated set and select the parent block', async () => {
-        await addRepeatedSetBlock(page, {selectParent: true})
+      await test.step('Add a new repeated set', async () => {
+        await addRepeatedSetBlock(page)
       })
 
       await test.step('Check that Create New is preselected and create new partial view is visible', async () => {
@@ -1392,7 +1403,7 @@ test.describe('End to end enumerator test with enumerators feature flag on', () 
       const blockPanel = page.getByTestId('block-panel-edit')
 
       await test.step('Add the existing enumerator question to a new repeated set', async () => {
-        await addRepeatedSetBlock(page, {selectParent: true})
+        await addRepeatedSetBlock(page)
         await blockPanel.getByTestId('choose-existing-radio-label').click()
         await blockPanel.getByRole('button', {name: 'Add question'}).click()
         await pickQuestionFromBank(page, 'enumerator-ete-householdmembers')
@@ -1451,8 +1462,8 @@ test.describe('End to end enumerator test with enumerators feature flag on', () 
       await adminPrograms.addProgram(programName)
       await adminPrograms.gotoEditDraftProgramPage(programName)
 
-      await test.step('Add a new repeated set and select the parent block', async () => {
-        await addRepeatedSetBlock(page, {selectParent: true})
+      await test.step('Add a new repeated set', async () => {
+        await addRepeatedSetBlock(page)
       })
 
       await fillAndSubmitEnumeratorQuestionForm(page, {
@@ -1888,20 +1899,12 @@ test.describe('End to end enumerator test with enumerators feature flag on', () 
     await entityNameInput(page, entityType, newIndex).fill(entityName)
   }
 
-  // Adds a new repeated-set block via the program block edit page. Clicks
-  // "Add screen", then "Add repeated set" — which creates a parent enumerator
-  // block (Screen 2) plus a repeated child block (Screen 3) and leaves focus
-  // on the repeated child. Pass {selectParent: true} to also click into the
-  // parent (Screen 2) afterward.
-  async function addRepeatedSetBlock(
-    page: Page,
-    options?: {selectParent?: boolean},
-  ) {
+  // Adds a new repeated-set block via the program block edit page. This creates
+  // a parent enumerator block (Screen 2) plus a repeated child block (Screen 3)
+  // and lands on the parent enumerator block.
+  async function addRepeatedSetBlock(page: Page) {
     await page.getByRole('button', {name: 'Add screen'}).first().click()
     await page.getByRole('button', {name: 'Add repeated set'}).click()
-    if (options?.selectParent) {
-      await page.getByRole('link', {name: 'Screen 2'}).click()
-    }
   }
 
   async function fillEnumeratorQuestionForm(

--- a/server/app/assets/javascripts/admin_predicate_edit.ts
+++ b/server/app/assets/javascripts/admin_predicate_edit.ts
@@ -878,9 +878,7 @@ export class AdminPredicateEdit {
    */
   private static getPredicateFormState(): string | undefined | null {
     const predicateForm = document.getElementById('predicate-form') as
-      | HTMLFormElement
-      | undefined
-      | null
+      HTMLFormElement | undefined | null
     if (!predicateForm) {
       return null
     }

--- a/server/app/controllers/admin/AdminProgramBlocksController.java
+++ b/server/app/controllers/admin/AdminProgramBlocksController.java
@@ -105,11 +105,23 @@ public final class AdminProgramBlocksController extends CiviFormController {
    *
    * <p>By default, the last program screen (block) is shown. Admins can navigate to other screens
    * (blocks) if applicable through links on the page.
+   *
+   * <p>When editing, if the last screen is a repeated screen whose enumerator screen does not yet
+   * have an enumerator question, the enumerator screen is shown instead, since setting up the
+   * enumerator question is the admin's next step.
    */
   private Result index(long programId, boolean readOnly) {
     try {
       ProgramDefinition program = programService.getFullProgramDefinition(programId);
-      long blockId = program.getLastBlockDefinition().id();
+      BlockDefinition block = program.getLastBlockDefinition();
+
+      if (!readOnly && block.isRepeated()) {
+        BlockDefinition enumeratorBlock = program.getBlockDefinition(block.enumeratorId().get());
+        if (!enumeratorBlock.hasEnumeratorQuestion()) {
+          block = enumeratorBlock;
+        }
+      }
+      long blockId = block.id();
 
       String redirectUrl =
           readOnly
@@ -117,7 +129,9 @@ public final class AdminProgramBlocksController extends CiviFormController {
               : routes.AdminProgramBlocksController.edit(programId, blockId).url();
 
       return redirect(redirectUrl);
-    } catch (ProgramNotFoundException | ProgramNeedsABlockException e) {
+    } catch (ProgramNotFoundException
+        | ProgramNeedsABlockException
+        | ProgramBlockDefinitionNotFoundException e) {
       return notFound();
     }
   }
@@ -187,7 +201,8 @@ public final class AdminProgramBlocksController extends CiviFormController {
 
       long addedBlockId = block.id();
 
-      // If it's an enumerator, also add the first repeated block.
+      // If it's an enumerator, also add the first repeated block, but land on the enumerator
+      // screen since setting up the enumerator question is the admin's next step.
       if (BlockType.ENUMERATOR.equals(blockType.orElse(null))) {
         result =
             programService.addRepeatedBlockToProgram(
@@ -199,7 +214,6 @@ public final class AdminProgramBlocksController extends CiviFormController {
           ToastMessage message = ToastMessage.errorNonLocalized(joinErrors(result.getErrors()));
           return renderEditViewWithMessage(request, program, block, Optional.of(message));
         }
-        addedBlockId++;
       }
       return redirect(routes.AdminProgramBlocksController.edit(programId, addedBlockId).url());
     } catch (ProgramNotFoundException | ProgramNeedsABlockException e) {

--- a/server/test/controllers/admin/AdminProgramBlocksControllerTest.java
+++ b/server/test/controllers/admin/AdminProgramBlocksControllerTest.java
@@ -344,7 +344,8 @@ public class AdminProgramBlocksControllerTest extends ResetPostgres {
   }
 
   @Test
-  public void edit_withEnumeratorImprovementsEnabled_showsNestedButtonOnlyOnAllowedNestingLevels() {
+  public void
+      edit_withEnumeratorImprovementsEnabled_showsNestedButtonOnParentEnumeratorAndDirectRepeatedScreens() {
     ProgramModel program =
         ProgramBuilder.newDraftProgram()
             .withBlock()
@@ -412,7 +413,7 @@ public class AdminProgramBlocksControllerTest extends ResetPostgres {
             program.id,
             /* blockId= */ parentEnumeratorId);
     String parentEnumeratorHtml = Helpers.contentAsString(parentEnumeratorResult);
-    assertThat(parentEnumeratorHtml).doesNotContain("id=\"create-nested-set-button\"");
+    assertThat(parentEnumeratorHtml).contains("id=\"create-nested-set-button\"");
 
     Result repeatedUnderParentResult =
         controller.edit(

--- a/server/test/controllers/admin/AdminProgramBlocksControllerTest.java
+++ b/server/test/controllers/admin/AdminProgramBlocksControllerTest.java
@@ -61,6 +61,39 @@ public class AdminProgramBlocksControllerTest extends ResetPostgres {
   }
 
   @Test
+  public void index_withRepeatedLastBlockWithoutEnumeratorQuestion_redirectsToEnumeratorScreen() {
+    ProgramModel program =
+        ProgramBuilder.newDraftProgram().withEnumeratorBlock().withRepeatedBlock().build();
+
+    Result result = controller.index(program.id);
+
+    assertThat(result.status()).isEqualTo(SEE_OTHER);
+    assertThat(result.redirectLocation())
+        .hasValue(
+            routes.AdminProgramBlocksController.edit(program.id, /* blockDefinitionId= */ 1L)
+                .url());
+  }
+
+  @Test
+  public void index_withRepeatedLastBlockWithEnumeratorQuestion_redirectsToLastBlock() {
+    ProgramModel program =
+        ProgramBuilder.newDraftProgram()
+            .withBlock()
+            .withRequiredQuestion(testQuestionBank.enumeratorApplicantHouseholdMembers())
+            .withRepeatedBlock()
+            .withRequiredQuestion(testQuestionBank.textApplicantFavoriteColor())
+            .build();
+
+    Result result = controller.index(program.id);
+
+    assertThat(result.status()).isEqualTo(SEE_OTHER);
+    assertThat(result.redirectLocation())
+        .hasValue(
+            routes.AdminProgramBlocksController.edit(program.id, /* blockDefinitionId= */ 2L)
+                .url());
+  }
+
+  @Test
   public void readOnlyIndex_readOnly_redirectsToShow() {
     ProgramModel program = ProgramBuilder.newActiveProgram().build();
 
@@ -128,11 +161,11 @@ public class AdminProgramBlocksControllerTest extends ResetPostgres {
     Result result = controller.create(request, program.id);
 
     assertThat(result.status()).isEqualTo(SEE_OTHER);
-    // Ensures we're redirected to the newly created repeated block rather than the last
-    // block in the program (see issue #1885).
+    // Ensures we're redirected to the newly-created enumerator block rather than the repeated
+    // block.
     assertThat(result.redirectLocation())
         .hasValue(
-            routes.AdminProgramBlocksController.edit(program.id, /* blockDefinitionId= */ 3L)
+            routes.AdminProgramBlocksController.edit(program.id, /* blockDefinitionId= */ 2L)
                 .url());
 
     program.refresh();
@@ -182,23 +215,24 @@ public class AdminProgramBlocksControllerTest extends ResetPostgres {
             .findFirst()
             .orElseThrow()
             .id();
-    long repeatedUnderNestedId =
-        blockDefinitions.stream()
-            .filter(
-                block ->
-                    block.isRepeated()
-                        && block
-                            .enumeratorId()
-                            .map(id -> id.equals(nestedEnumeratorId))
-                            .orElse(false))
-            .findFirst()
-            .orElseThrow()
-            .id();
+    // The repeated block under the nested enumerator was also created.
+    assertThat(
+            blockDefinitions.stream()
+                .anyMatch(
+                    block ->
+                        block.isRepeated()
+                            && block
+                                .enumeratorId()
+                                .map(id -> id.equals(nestedEnumeratorId))
+                                .orElse(false)))
+        .isTrue();
 
+    // We're redirected to the nested enumerator block rather than its repeated block, since
+    // setting up the enumerator question is the admin's next step.
     assertThat(result.redirectLocation())
         .hasValue(
             routes.AdminProgramBlocksController.edit(
-                    program.id, /* blockDefinitionId= */ repeatedUnderNestedId)
+                    program.id, /* blockDefinitionId= */ nestedEnumeratorId)
                 .url());
   }
 

--- a/server/test/services/ProgramBlockValidationTest.java
+++ b/server/test/services/ProgramBlockValidationTest.java
@@ -258,25 +258,6 @@ public class ProgramBlockValidationTest extends ResetPostgres {
   }
 
   @Test
-  public void canAddQuestion_canAddRepeatedQuestionToEnumeratorBlock_IfEnumeratorIdMatches()
-      throws Exception {
-    ProgramDefinition program =
-        ProgramBuilder.newDraftProgram("program1")
-            .withBlock()
-            .withRequiredQuestionDefinition(householdMemberQuestion.getQuestionDefinition())
-            .buildDefinition();
-    assertThat(
-            programBlockValidation.canAddQuestion(
-                program,
-                program.getLastBlockDefinition(),
-                repeatedHouseholdMemberNameQuestion.getQuestionDefinition(),
-                /* enumeratorImprovementsEnabled= */ true,
-                /* fileUploadQuestionImprovementsEnabled= */ false,
-                /* isInitialQuestion= */ false))
-        .isEqualTo(AddQuestionResult.ELIGIBLE);
-  }
-
-  @Test
   public void
       canAddQuestion_canAddNonRepeatedQuestionToRepeatedBlock_whenEnumeratorImprovementsEnabled()
           throws Exception {
@@ -295,33 +276,6 @@ public class ProgramBlockValidationTest extends ResetPostgres {
                 /* fileUploadQuestionImprovementsEnabled= */ false,
                 /* isInitialQuestion= */ false))
         .isEqualTo(AddQuestionResult.ELIGIBLE);
-  }
-
-  @Test
-  public void
-      canAddQuestion_cannotAddRepeatedQuestionToWrongEnumeratorBlock_whenEnumeratorImprovementsEnabled()
-          throws Exception {
-    QuestionModel otherEnumerator = resourceCreator.insertEnum("otherEnumerator");
-    QuestionModel otherRepeatedQuestion =
-        resourceCreator.insertRepeatedTextQuestion("otherRepeated", otherEnumerator);
-    version.addQuestion(otherEnumerator);
-    version.addQuestion(otherRepeatedQuestion);
-    version.save();
-
-    ProgramDefinition program =
-        ProgramBuilder.newDraftProgram("program1")
-            .withBlock()
-            .withRequiredQuestionDefinition(householdMemberQuestion.getQuestionDefinition())
-            .buildDefinition();
-    assertThat(
-            programBlockValidation.canAddQuestion(
-                program,
-                program.getLastBlockDefinition(),
-                otherRepeatedQuestion.getQuestionDefinition(),
-                /* enumeratorImprovementsEnabled= */ true,
-                /* fileUploadQuestionImprovementsEnabled= */ false,
-                /* isInitialQuestion= */ false))
-        .isEqualTo(AddQuestionResult.ENUMERATOR_MISMATCH);
   }
 
   @Test

--- a/server/test/support/ProgramBuilder.java
+++ b/server/test/support/ProgramBuilder.java
@@ -24,6 +24,7 @@ import services.program.BlockDefinition;
 import services.program.EligibilityDefinition;
 import services.program.ProgramDefinition;
 import services.program.ProgramQuestionDefinition;
+import services.program.ProgramService;
 import services.program.ProgramType;
 import services.program.predicate.PredicateDefinition;
 import services.question.types.AddressQuestionDefinition;
@@ -533,10 +534,22 @@ public class ProgramBuilder {
       return this;
     }
 
+    /**
+     * Adds a question to the block, marking the block as an enumerator when the question is an
+     * enumerator question. Mirrors {@link ProgramService.addQuestionsToBlock}, which sets
+     * isEnumerator whenever an enumerator question is added to a block.
+     */
+    private void addQuestion(ProgramQuestionDefinition pqd) {
+      blockDefBuilder.addQuestion(pqd);
+      if (pqd.getQuestionDefinition().isEnumerator()) {
+        blockDefBuilder.setIsEnumerator(Optional.of(true));
+      }
+    }
+
     /** Add a required question to the block. */
     public BlockBuilder withRequiredQuestion(QuestionModel question) {
       QuestionRepository questionRepository = injector.instanceOf(QuestionRepository.class);
-      blockDefBuilder.addQuestion(
+      addQuestion(
           ProgramQuestionDefinition.create(
               questionRepository.getQuestionDefinition(question),
               Optional.of(programBuilder.programDefinitionId)));
@@ -551,7 +564,7 @@ public class ProgramBuilder {
         throw new IllegalArgumentException("Only address questions can be address corrected.");
       }
 
-      blockDefBuilder.addQuestion(
+      addQuestion(
           ProgramQuestionDefinition.create(
               questionRepository.getQuestionDefinition(question),
               Optional.of(programBuilder.programDefinitionId),
@@ -566,7 +579,7 @@ public class ProgramBuilder {
     }
 
     public BlockBuilder withOptionalQuestion(QuestionDefinition question) {
-      blockDefBuilder.addQuestion(
+      addQuestion(
           ProgramQuestionDefinition.create(
                   question, Optional.of(programBuilder.programDefinitionId))
               .setOptional(true));
@@ -579,7 +592,7 @@ public class ProgramBuilder {
     }
 
     public BlockBuilder withQuestionDefinition(QuestionDefinition question, boolean optional) {
-      blockDefBuilder.addQuestion(
+      addQuestion(
           ProgramQuestionDefinition.create(
                   question, Optional.of(programBuilder.programDefinitionId))
               .setOptional(optional));
@@ -608,6 +621,13 @@ public class ProgramBuilder {
                           questionDefinition, Optional.of(programBuilder.programDefinitionId)))
               .collect(ImmutableList.toImmutableList());
       blockDefBuilder.setProgramQuestionDefinitions(pqds);
+      // Mark the block as an enumerator when any question is an enumerator question, mirroring
+      // {@link ProgramService}.
+      if (pqds.stream()
+          .map(ProgramQuestionDefinition::getQuestionDefinition)
+          .anyMatch(QuestionDefinition::isEnumerator)) {
+        blockDefBuilder.setIsEnumerator(Optional.of(true));
+      }
       return this;
     }
 

--- a/server/test/support/ProgramBuilder.java
+++ b/server/test/support/ProgramBuilder.java
@@ -668,7 +668,7 @@ public class ProgramBuilder {
      */
     public BlockBuilder withRepeatedBlock(String name, String description) {
       BlockDefinition thisBlock = blockDefBuilder.build();
-      if (!thisBlock.hasEnumeratorQuestion()) {
+      if (!thisBlock.hasEnumeratorQuestion() && !thisBlock.getIsEnumerator()) {
         throw new RuntimeException(
             "Cannot create a repeated block if this block is not an enumerator.");
       }

--- a/server/test/support/ProgramBuilder.java
+++ b/server/test/support/ProgramBuilder.java
@@ -668,7 +668,7 @@ public class ProgramBuilder {
      */
     public BlockBuilder withRepeatedBlock(String name, String description) {
       BlockDefinition thisBlock = blockDefBuilder.build();
-      if (!thisBlock.hasEnumeratorQuestion() && !thisBlock.getIsEnumerator()) {
+      if (!thisBlock.getIsEnumerator()) {
         throw new RuntimeException(
             "Cannot create a repeated block if this block is not an enumerator.");
       }


### PR DESCRIPTION
### Description

On the Admin Program Block Edit page, in the block order panel on the left, if the repeated set is the last thing in the program and the repeated set doesn't yet have an enumerator question, land on the enumerator screen rather than the last repeated screen.  This also applies to nested repeated sets.  We land on the nested enumerator block rather than its child screen.  

I didn't gate this behind the feature flag because it isn't possible to create an empty enumerator block with the feature flag off.  The only time where this new behavior would apply to the legacy flow is after an admin has turned the feature flag on, created a new empty repeated set and switched the flag off.  In that case, we still want to land on the empty enumerator.  

AI usage:  Claude Code (Fable 5) assisted by proposing the needed changes and updating the tests.  All AI suggestions were carefully reviewed and edited.

### Checklist

#### General

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [ ] Added an additional reviewer as required if changes potentially affect the security of the application.
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [x] Noted in the PR description which, if any, code in this PR was generated by AI.

#### User visible changes

- [ ] Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
  - [ ] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [ ] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order
- [ ] Performed manual accessibility tests for any applicant-facing changes or any new admin-facing features. See [manual-accessibility-testing](https://github.com/civiform/civiform/wiki/Accessibility#manual-accessibility-testing)
- [ ] Manually tested with a right-to-left language

### Instructions for manual testing

1. Turn the feature flag on.
2. Click "Edit" on a program.
3. Click "Add screen", then "Add repeated set".
4. Notice that the enumerator block is highlighted in the block order panel on the left and the enumerator block is shown on the right.
5. Click on the "Programs" tab.
6. Click "Edit" again on that same program.
7. Note that you land on the enumerator block again rather than the repeated screen.

### Issue(s) this completes

Fixes #13460 
