### PR TITLE
Remove obsolete question page j2html for thymeleaf migration

### DIFF
--- a/browser-test/src/applicant/application_review.test.ts
+++ b/browser-test/src/applicant/application_review.test.ts
@@ -147,8 +147,6 @@ test.describe('Program admin review of submitted applications', () => {
       await adminQuestions.expectActiveQuestionExist('monthly-income-q')
     })
 
-    await adminQuestions.goToViewQuestionPage('date-q')
-
     await test.step('Log in as test user', async () => {
       await logout(page)
       await loginAsTestUser(page)

--- a/browser-test/src/support/admin_questions.ts
+++ b/browser-test/src/support/admin_questions.ts
@@ -124,12 +124,6 @@ export class AdminQuestions {
     await this.expectAdminQuestionsPage()
   }
 
-  async goToViewQuestionPage(questionName: string) {
-    await this.gotoAdminQuestionsPage()
-    await this.page.click(this.selectQuestionTableRow(questionName))
-    await waitForPageJsLoad(this.page)
-  }
-
   async clickSubmitButtonAndNavigate(buttonText: string) {
     await this.page.click(`button:text-is("${buttonText}")`)
     await waitForPageJsLoad(this.page)

--- a/server/app/controllers/admin/AdminQuestionController.java
+++ b/server/app/controllers/admin/AdminQuestionController.java
@@ -157,32 +157,6 @@ public final class AdminQuestionController extends CiviFormController {
         .as(Http.MimeTypes.HTML);
   }
 
-  /**
-   * Return a HTML page displaying all configurations of a question without the ability to update
-   * it.
-   */
-  @Secure(authorizers = Authorizers.Labels.CIVIFORM_ADMIN)
-  public CompletionStage<Result> show(Request request, long id) {
-    return service
-        .getReadOnlyQuestionService()
-        .thenApplyAsync(
-            readOnlyService -> {
-              QuestionDefinition questionDefinition = readOnlyService.getQuestionDefinition(id);
-
-              Optional<QuestionDefinition> maybeEnumerationQuestion =
-                  maybeGetEnumerationQuestion(readOnlyService, questionDefinition);
-              try {
-                return ok(
-                    editView.renderViewQuestionForm(
-                        request, questionDefinition, maybeEnumerationQuestion));
-              } catch (InvalidQuestionTypeException e) {
-                return badRequest(
-                    invalidQuestionTypeMessage(questionDefinition.getQuestionType().toString()));
-              }
-            },
-            classLoaderExecutionContext.current());
-  }
-
   /** Return a HTML page containing a form to create a new question in the draft version. */
   @Secure(authorizers = Authorizers.Labels.CIVIFORM_ADMIN)
   public Result newOne(

--- a/server/app/views/admin/questions/QuestionEditView.java
+++ b/server/app/views/admin/questions/QuestionEditView.java
@@ -81,8 +81,7 @@ public final class QuestionEditView extends BaseHtmlView {
 
   private enum FormMode {
     CREATE,
-    EDIT,
-    VIEW
+    EDIT
   }
 
   @Inject
@@ -241,30 +240,6 @@ public final class QuestionEditView extends BaseHtmlView {
         request, formContent, questionType, title, Optional.of(unsetUniversalModal));
   }
 
-  /** Render a read-only non-submittable question form. */
-  public Content renderViewQuestionForm(
-      Request request,
-      QuestionDefinition questionDefinition,
-      Optional<QuestionDefinition> maybeEnumerationQuestionDefinition)
-      throws InvalidQuestionTypeException {
-    QuestionForm questionForm = QuestionFormBuilder.create(questionDefinition);
-    QuestionType questionType = questionForm.getQuestionType();
-    String title =
-        String.format("View %s question", questionType.toString().toLowerCase(Locale.ROOT));
-
-    SelectWithLabel enumeratorOption =
-        enumeratorOptionsFromMaybeEnumerationQuestionDefinition(
-            maybeEnumerationQuestionDefinition,
-            questionForm.getEnumeratorSelectEnabled(),
-            FormMode.VIEW);
-    DivTag formContent =
-        buildQuestionContainer(title)
-            .with(buildReadOnlyQuestionForm(questionForm, enumeratorOption, request));
-
-    return renderWithPreview(
-        request, formContent, questionType, title, /* modal= */ Optional.empty());
-  }
-
   private Content renderWithPreview(
       Request request, DivTag formContent, QuestionType type, String title, Optional<Modal> modal) {
     DivTag previewContent;
@@ -295,12 +270,6 @@ public final class QuestionEditView extends BaseHtmlView {
       Request request) {
     return buildQuestionForm(
         questionForm, enumeratorOptions, /* submittable= */ true, forCreate, request);
-  }
-
-  private FormTag buildReadOnlyQuestionForm(
-      QuestionForm questionForm, SelectWithLabel enumeratorOptions, Request request) {
-    return buildQuestionForm(
-        questionForm, enumeratorOptions, /* submittable= */ false, /* forCreate= */ false, request);
   }
 
   private DivTag buildQuestionContainer(String title) {

--- a/server/app/views/admin/questions/QuestionsListView.java
+++ b/server/app/views/admin/questions/QuestionsListView.java
@@ -380,9 +380,6 @@ public final class QuestionsListView extends BaseHtmlView {
                         generateTranslationCompleteText(question).orElse(div())))
             .with(actionsCellAndModal.getLeft());
 
-    asRedirectElement(
-        row, controllers.admin.routes.AdminQuestionController.show(question.getId()).url());
-
     return Pair.of(row, actionsCellAndModal.getRight());
   }
 

--- a/server/conf/routes
+++ b/server/conf/routes
@@ -93,7 +93,6 @@ GET     /admin/questions                                                       c
 # Should have a `type` query param, like: /admin/questions/new?type=name. Defaults to text.
 GET     /admin/questions/new                                                   controllers.admin.AdminQuestionController.newOne(request: Request, type: String ?= "text", redirectUrl: String, enumeratorQuestion: java.util.Optional[String], isRepeatingBlock: java.util.Optional[String])
 GET     /admin/questions/:id/edit                                              controllers.admin.AdminQuestionController.edit(request: Request, id: Long, redirectUrl: String ?= "")
-GET     /admin/questions/:id                                                   controllers.admin.AdminQuestionController.show(request: Request, id: Long)
 POST    /admin/questions/:id                                                   controllers.admin.AdminQuestionController.update(request: Request, id: Long, type: String)
 POST    /admin/questions                                                       controllers.admin.AdminQuestionController.create(request: Request, type: String)
 POST    /admin/questions/:id/discard                                           controllers.admin.AdminQuestionController.discardDraft(request: Request, id: Long)


### PR DESCRIPTION
Removing code to the obsolete question page. This will make it easier to migrate the question list from j2html to thymeleaf.


Scanned the code with opus and sol. I didn't see any vestiges left over after that.

Assisted-by: Claude Code:claude-opus-4-8
Assisted-by: OpenCode:gpt-5.6-sol

Related to: #12427