### PR TITLE
Require npm v12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,10 +23,9 @@ RUN set -o pipefail && \
   apk update && \
   apk add --upgrade apk-tools && \
   apk upgrade --available && \
-  apk add --no-cache --update bash wget npm git
-
-# Install npm (node)
-RUN npm install -g npm
+  apk add --no-cache --update bash wget npm git && \
+  # npm >= 12 required by engines/engine-strict
+  npm install -g npm@^12
 
 # Download sbt
 RUN set -o pipefail && \

--- a/browser-test/.npmrc
+++ b/browser-test/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/browser-test/package.json
+++ b/browser-test/package.json
@@ -2,6 +2,10 @@
   "name": "civiform-browser-test",
   "main": "index.js",
   "license": "Apache-2.0",
+  "engines": {
+    "node": ">=24.0.0",
+    "npm": ">=12.0.0"
+  },
   "scripts": {
     "test": "npx playwright test",
     "probe": "npx playwright test"

--- a/browser-test/playwright.Dockerfile
+++ b/browser-test/playwright.Dockerfile
@@ -5,11 +5,13 @@ RUN apt-get update -y && \
     apt-get install -y ca-certificates curl gnupg && \
     # Add nodejs to repo
     curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
-    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list && \
+    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_24.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list && \
     # Cleanup packages and update the repos
     apt-get update && \
     # Install the packages
     apt-get install -y nodejs fonts-ubuntu && \
+    # node 24 bundles npm 11; engines/engine-strict require npm >= 12
+    npm install -g npm@^12 && \
     # Smoke tests
     node --version && \
     npm --version && \

--- a/formatter/.npmrc
+++ b/formatter/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/formatter/formatter.Dockerfile
+++ b/formatter/formatter.Dockerfile
@@ -6,6 +6,8 @@ ENV JAVA_FORMATTER_URL="https://github.com/google/google-java-format/releases/do
 RUN wget $JAVA_FORMATTER_URL -O /fmt.jar && \
     apk update && \
     apk add --no-cache --update bash wget npm shfmt git py3-pip py3-yapf && \
+    # npm >= 12 required by engines/engine-strict
+    npm install -g npm@^12 && \
     apk cache clean
 
 # Below we pre-install nodejs depdendencies for various

--- a/formatter/package.json
+++ b/formatter/package.json
@@ -1,5 +1,9 @@
 {
   "name": "civiform-formatter",
+  "engines": {
+    "node": ">=24.0.0",
+    "npm": ">=12.0.0"
+  },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "8.65.0",
     "@typescript-eslint/parser": "8.65.0",

--- a/mock-web-services/.npmrc
+++ b/mock-web-services/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/mock-web-services/mock-web-services.Dockerfile
+++ b/mock-web-services/mock-web-services.Dockerfile
@@ -1,7 +1,9 @@
 # syntax=docker/dockerfile:1@sha256:87999aa3d42bdc6bea60565083ee17e86d1f3339802f543c0d03998580f9cb89
 FROM node:24-slim@sha256:235600a8101ab264e117b1768e925532262668dc9b581ef1dd7d96ced463b8e7
 
-RUN useradd --create-home appuser --no-log-init
+# node:24 bundles npm 11; engines/engine-strict require npm >= 12
+RUN npm install -g npm@^12 && \
+    useradd --create-home appuser --no-log-init
 
 USER appuser
 

--- a/mock-web-services/package.json
+++ b/mock-web-services/package.json
@@ -30,6 +30,10 @@
     "typescript": "^6.0.0"
   },
   "license": "Apache-2.0",
+  "engines": {
+    "node": ">=24.0.0",
+    "npm": ">=12.0.0"
+  },
   "allowScripts": {
     "msw": false
   }

--- a/prod.Dockerfile
+++ b/prod.Dockerfile
@@ -14,6 +14,8 @@ RUN set -o pipefail && \
     apk add --upgrade apk-tools && \
     apk upgrade --available && \
     apk add --no-cache --update bash wget npm git && \
+    # npm >= 12 required by engines/engine-strict
+    npm install -g npm@^12 && \
     mkdir -p "$SBT_HOME" && \
     wget -qO - "${SBT_URL}" | tar xz -C "${INSTALL_DIR}" && \
     echo -ne "- with sbt $SBT_VERSION\n" >> /root/.built
@@ -24,7 +26,6 @@ ENV PROJECT_LOC="${PROJECT_HOME}/${PROJECT_NAME}"
 
 COPY "${PROJECT_NAME}" "${PROJECT_LOC}"
 RUN cd "${PROJECT_LOC}" && \
-    npm install -g npm && \
     npm ci && \
     npm run build && \
     sbt update && \

--- a/server/.npmrc
+++ b/server/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/server/package.json
+++ b/server/package.json
@@ -15,6 +15,10 @@
     "test:coverage": "vitest run --coverage"
   },
   "license": "CC0-1.0",
+  "engines": {
+    "node": ">=24.0.0",
+    "npm": ">=12.0.0"
+  },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@tsconfig/recommended": "1.0.13",

--- a/test-support/.npmrc
+++ b/test-support/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/test-support/oidc.Dockerfile
+++ b/test-support/oidc.Dockerfile
@@ -1,6 +1,9 @@
 # syntax=docker/dockerfile:1@sha256:87999aa3d42bdc6bea60565083ee17e86d1f3339802f543c0d03998580f9cb89
 FROM node:24-alpine@sha256:f70403e87646dc51b45295f4b8b70cdad0b63d2297c4c9899119b03f7af7a6b3
 
+# node:24 bundles npm 11; engines/engine-strict require npm >= 12
+RUN npm install -g npm@^12
+
 WORKDIR /usr/app
 ADD test_oidc_provider.js oidc.js
 ADD package.json package.json

--- a/test-support/package.json
+++ b/test-support/package.json
@@ -1,5 +1,9 @@
 {
   "type": "module",
+  "engines": {
+    "node": ">=24.0.0",
+    "npm": ">=12.0.0"
+  },
   "dependencies": {
     "oidc-provider": "9.11.1"
   },


### PR DESCRIPTION
The Node Package Manger (npm) v12 adds [new security features](https://github.blog/changelog/2026-06-09-upcoming-breaking-changes-for-npm-v12/), particularly of importance it no longer runs install scripts by default. This change will require npm v12 when running npm against our package.json scripts.

The `.npmrc` files make the v12 a requirement, without it is just a warning. This _reduces_ the attack surface for things like the Shai Hulud worm.


Developers that need to run npm directly on their computers will need to make sure they are running nodejs `v24.15.0` or later. and update their npm version `npm install -g npm@">=12"`. If running in docker or devcontainers, no manual steps should be needed.

Users that attempt to use older versions of npm v12 will see this error:

```
npm error code EBADENGINE
npm error engine Unsupported engine
npm error engine Not compatible with your version of node/npm: undefined
npm error notsup Not compatible with your version of node/npm: undefined
npm error notsup Required: {"node":">=24.0.0","npm":">=12.0.0"}
npm error notsup Actual:   {"node":"v22.20.0","npm":"11.17.0"}
npm error A complete log of this run can be found in: /home/USERNAME/.npm/_logs/2026-08-04T16_27_16_743Z-debug-0.log
```

### LLM Tooling

I directed claude to add the node settings and let it figure out the necessary dockerfile changes.

Assisted-by: Claude Code:claude-opus-5
