### PR TITLE
Add @JsonInclude(NON_EMPTY) to Optional fields in BlockDefinition

### DIFF
--- a/server/app/services/program/BlockDefinition.java
+++ b/server/app/services/program/BlockDefinition.java
@@ -72,6 +72,7 @@ public abstract class BlockDefinition {
   @JsonProperty("localizedDescription")
   public abstract LocalizedStrings localizedDescription();
 
+  @JsonInclude(Include.NON_EMPTY)
   @JsonProperty("localizedEligibilityMessage")
   public abstract Optional<LocalizedStrings> localizedEligibilityMessage();
 
@@ -111,6 +112,7 @@ public abstract class BlockDefinition {
    *
    * @return the BlockDefinition ID for this block definitions enumerator, if it exists
    */
+  @JsonInclude(Include.NON_EMPTY)
   @JsonProperty("repeaterId")
   public abstract Optional<Long> enumeratorId();
 
@@ -182,6 +184,7 @@ public abstract class BlockDefinition {
   }
 
   /** A {@link PredicateDefinition} that determines whether this block is hidden or shown. */
+  @JsonInclude(Include.NON_EMPTY)
   @JsonProperty("hidePredicate")
   public abstract Optional<PredicateDefinition> visibilityPredicate();
 
@@ -234,6 +237,7 @@ public abstract class BlockDefinition {
    * required if shown. Instead, individual questions can be optional or required. This field is
    * kept for serialization consistency.
    */
+  @JsonInclude(Include.NON_EMPTY)
   @JsonProperty("optionalPredicate")
   public abstract Optional<PredicateDefinition> optionalPredicate();
 


### PR DESCRIPTION
### Description

`BlockDefinition` has several `Optional` fields that were missing the `@JsonInclude(Include.NON_EMPTY)` annotation, causing them to be written as `null` in the database JSON even when absent. This wastes storage space and adds noise to the serialized program data.

This PR adds the annotation to the 4 fields that were missing it:

| JSON key | Java method |
|---|---|
| `repeaterId` | `enumeratorId()` |
| `hidePredicate` | `visibilityPredicate()` |
| `optionalPredicate` | `optionalPredicate()` |
| `localizedEligibilityMessage` | `localizedEligibilityMessage()` |

`eligibilityDefinition`, `namePrefix`, and `isEnumerator` already had this annotation — this change makes the rest consistent.

**Before:**
```json
{
  "id": 1,
  "name": "Screen 1",
  "repeaterId": null,
  "hidePredicate": null,
  "optionalPredicate": null,
  "localizedEligibilityMessage": null,
  ...
}
```

**After:**
```json
{
  "id": 1,
  "name": "Screen 1",
  ...
}
```

### Checklist

#### General

- [x] Added the correct label: `enhancement`
- [x] Assigned to `civiform/developers`
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [ ] Added an additional reviewer as required if changes potentially affect the security of the application.
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible) — no new tests needed; `@JsonInclude` only affects serialization and existing deserialization tests remain valid
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes) — backend-only change, no front-end impact
- [ ] Ensured PII wasn't added to any new logs
- [x] Noted in the PR description which, if any, code in this PR was generated by AI. — Code in this PR was written with AI assistance.

### Issue(s) this completes

Related to [#12055](https://github.com/civiform/civiform/issues/12055)