### PR TITLE
Add load test for /admin/programs and /admin/questions

### DIFF
--- a/load-test/k6/admin_programs.js
+++ b/load-test/k6/admin_programs.js
@@ -52,19 +52,20 @@ export default async function () {
       page.getByRole("link", { name: "Questions", exact: true }).click(),
     ]);
 
+    // Run both handlers a second time just to get a little more from the
+    // cost of logging in without throwing off the utility of the scenario
+    // run configs too much.
     await Promise.all([
       page.waitForNavigation(),
       page.getByRole("link", { name: "Programs", exact: true }).click(),
     ]);
 	  
-    // Run both handlers a second time just to get a little more from the
-    // cost of logging in without throwing off the utility of the scenario
-    // run configs.
     await Promise.all([
       page.waitForNavigation(),
       page.getByRole("link", { name: "Questions", exact: true }).click(),
     ]);
 
+    // Ensure the page loaded.
     await expect(
       page.getByRole("heading", { name: "All questions", exact: true }),
     ).toBeVisible();

--- a/load-test/k6/admin_programs.js
+++ b/load-test/k6/admin_programs.js
@@ -1,0 +1,75 @@
+// Use Case: An admin loading the question and program lists.
+
+import { browser } from "k6/browser";
+import { expect } from "https://jslib.k6.io/k6-testing/0.5.0/index.js";
+
+export const options = {
+  scenarios: {
+    default: {
+      executor: "shared-iterations",
+      options: { browser: { type: "chromium" } },
+      // Simultaneous users
+      vus: 1,
+      // Total runs across all users
+      iterations: 20,
+      // max duration of the test, defaults to 10m
+      maxDuration: "30m",
+    },
+  },
+
+  thresholds: {
+    // These are not based on realistic expectations as we currently are addressing
+    // latency issues with these handlers.
+    "browser_http_req_duration{name:admin_questions}": ['avg < 75', 'p(95) < 100']
+    "browser_http_req_duration{name:admin_programs}": ['avg < 200', 'p(95) < 200'],
+  }
+};
+
+export default async function () {
+  const page = await browser.newPage();
+
+  // Connect urls with metric tags to use in the thresholds.
+  page.on("metric", (metric) => {
+    metric.tag({
+      name: "admin_questions", matches: [{ url: /\/admin\/questions$/ }],
+    });
+    metric.tag({
+      name: "admin_programs", matches: [{ url: /\/admin\/programs$/ }],
+    });
+  });
+
+  try {
+    await page.goto("http://civiform:9000/");
+    await page.getByRole("button", { name: "DevTools", exact: true }).click();
+
+    await Promise.all([
+      page.waitForNavigation(),
+      page.getByRole("link", { name: "Civiform Admin", exact: true }).click(),
+    ]);
+
+    await Promise.all([
+      page.waitForNavigation(),
+      page.getByRole("link", { name: "Questions", exact: true }).click(),
+    ]);
+
+    await Promise.all([
+      page.waitForNavigation(),
+      page.getByRole("link", { name: "Programs", exact: true }).click(),
+    ]);
+	  
+    // Run both handlers a second time just to get a little more from the
+    // cost of logging in without throwing off the utility of the scenario
+    // run configs.
+    await Promise.all([
+      page.waitForNavigation(),
+      page.getByRole("link", { name: "Questions", exact: true }).click(),
+    ]);
+
+    await expect(
+      page.getByRole("heading", { name: "All questions", exact: true }),
+    ).toBeVisible();
+
+  } finally {
+    await page?.close();
+  }
+}


### PR DESCRIPTION
### Description

Add load tests for /admin/programs and /admin/questions

Note: When sizeable programs are loaded in CF this is able to induce thread exhaustion at time.


### Checklist

Remove any sections below that do not apply to your PR. For sections that do apply, complete all of the appropriate checklist items and check them off. If a checklist item doesn't apply to your PR, leave it unchecked but do not delete it.

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [ ] Added an additional reviewer as required if changes potentially affect the security of the application.
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.


### Issue(s) this completes

Supports: #13707 