### PR TITLE
Api Keys Creation Thymeleaf Migration

### DIFF
--- a/server/app/controllers/admin/AdminApiKeysController.java
+++ b/server/app/controllers/admin/AdminApiKeysController.java
@@ -10,7 +10,9 @@ import com.google.common.collect.ImmutableSet;
 import controllers.CiviFormController;
 import java.util.Optional;
 import javax.inject.Inject;
+import mapping.admin.apikeys.ApiKeyCredentialsPageMapper;
 import mapping.admin.apikeys.ApiKeyIndexPageMapper;
+import mapping.admin.apikeys.ApiKeyNewOnePageMapper;
 import mapping.admin.apikeys.ApiKeyStatus;
 import models.ApiKeyModel;
 import org.pac4j.play.java.Secure;
@@ -25,10 +27,14 @@ import services.apikey.ApiKeyCreationResult;
 import services.apikey.ApiKeyService;
 import services.program.ProgramService;
 import services.settings.SettingsManifest;
+import views.admin.apikeys.ApiKeyCredentialsPageView;
+import views.admin.apikeys.ApiKeyCredentialsPageViewModel;
 import views.admin.apikeys.ApiKeyCredentialsView;
 import views.admin.apikeys.ApiKeyIndexPageView;
 import views.admin.apikeys.ApiKeyIndexPageViewModel;
 import views.admin.apikeys.ApiKeyIndexView;
+import views.admin.apikeys.ApiKeyNewOnePageView;
+import views.admin.apikeys.ApiKeyNewOnePageViewModel;
 import views.admin.apikeys.ApiKeyNewOneView;
 
 /** Controller for admins managing ApiKeys. */
@@ -39,6 +45,8 @@ public class AdminApiKeysController extends CiviFormController {
   private final ApiKeyNewOneView newOneView;
   private final ApiKeyCredentialsView apiKeyCredentialsView;
   private final ApiKeyIndexPageView indexPageView;
+  private final ApiKeyNewOnePageView newOnePageView;
+  private final ApiKeyCredentialsPageView credentialsPageView;
   private final ProgramService programService;
   private final FormFactory formFactory;
   private final ProgramRepository programRepository;
@@ -52,6 +60,8 @@ public class AdminApiKeysController extends CiviFormController {
       ApiKeyNewOneView newOneView,
       ApiKeyCredentialsView apiKeyCredentialsView,
       ApiKeyIndexPageView indexPageView,
+      ApiKeyNewOnePageView newOnePageView,
+      ApiKeyCredentialsPageView credentialsPageView,
       ProgramService programService,
       FormFactory formFactory,
       ProfileUtils profileUtils,
@@ -65,6 +75,8 @@ public class AdminApiKeysController extends CiviFormController {
     this.newOneView = checkNotNull(newOneView);
     this.apiKeyCredentialsView = checkNotNull(apiKeyCredentialsView);
     this.indexPageView = checkNotNull(indexPageView);
+    this.newOnePageView = checkNotNull(newOnePageView);
+    this.credentialsPageView = checkNotNull(credentialsPageView);
     this.programService = checkNotNull(programService);
     this.formFactory = checkNotNull(formFactory);
     this.programRepository = checkNotNull(programRepository);
@@ -100,6 +112,12 @@ public class AdminApiKeysController extends CiviFormController {
   public Result newOne(Http.Request request) {
     ImmutableSet<String> programNames = programRepository.getAllNonExternalProgramNames();
 
+    if (settingsManifest.getAdminUiMigrationJ2htmlToThymeleafScEnabled(request)) {
+      ApiKeyNewOnePageViewModel model =
+          new ApiKeyNewOnePageMapper().map(programNames, /* maybeForm= */ Optional.empty());
+      return ok(newOnePageView.render(request, model)).as(Http.MimeTypes.HTML);
+    }
+
     if (programNames.isEmpty()) {
       return ok(newOneView.renderNoPrograms(request));
     } else {
@@ -115,6 +133,17 @@ public class AdminApiKeysController extends CiviFormController {
     ApiKeyCreationResult result = apiKeyService.createApiKey(form, profile);
 
     if (result.isSuccessful()) {
+      if (settingsManifest.getAdminUiMigrationJ2htmlToThymeleafScEnabled(request)) {
+        ApiKeyCredentialsPageViewModel model =
+            new ApiKeyCredentialsPageMapper()
+                .map(
+                    result.getApiKey(),
+                    result.getEncodedCredentials(),
+                    result.getKeyId(),
+                    result.getKeySecret());
+        return created(credentialsPageView.render(request, model)).as(Http.MimeTypes.HTML);
+      }
+
       return created(
           apiKeyCredentialsView.render(
               request,
@@ -122,6 +151,13 @@ public class AdminApiKeysController extends CiviFormController {
               result.getEncodedCredentials(),
               result.getKeyId(),
               result.getKeySecret()));
+    }
+
+    if (settingsManifest.getAdminUiMigrationJ2htmlToThymeleafScEnabled(request)) {
+      ApiKeyNewOnePageViewModel model =
+          new ApiKeyNewOnePageMapper()
+              .map(programService.getAllNonExternalProgramNames(), Optional.of(result.getForm()));
+      return badRequest(newOnePageView.render(request, model)).as(Http.MimeTypes.HTML);
     }
 
     return badRequest(

--- a/server/app/mapping/admin/apikeys/ApiKeyCredentialsPageMapper.java
+++ b/server/app/mapping/admin/apikeys/ApiKeyCredentialsPageMapper.java
@@ -1,0 +1,26 @@
+package mapping.admin.apikeys;
+
+import models.ApiKeyModel;
+import views.admin.apikeys.ApiKeyCredentialsPageViewModel;
+
+/** Maps data to the ApiKeyCredentialsPageViewModel for the API key credentials page. */
+public final class ApiKeyCredentialsPageMapper {
+
+  /**
+   * Maps a newly created API key and its credentials to the view model.
+   *
+   * @param apiKey the key that was just created
+   * @param encodedCredentials the base64 encoded credentials used as a single API token
+   * @param keyId the API username
+   * @param keySecret the API password, only available at creation time
+   */
+  public ApiKeyCredentialsPageViewModel map(
+      ApiKeyModel apiKey, String encodedCredentials, String keyId, String keySecret) {
+    return ApiKeyCredentialsPageViewModel.builder()
+        .title("Created API key: " + apiKey.getName())
+        .encodedCredentials(encodedCredentials)
+        .keyId(keyId)
+        .keySecret(keySecret)
+        .build();
+  }
+}

--- a/server/app/mapping/admin/apikeys/ApiKeyNewOnePageMapper.java
+++ b/server/app/mapping/admin/apikeys/ApiKeyNewOnePageMapper.java
@@ -1,0 +1,77 @@
+package mapping.admin.apikeys;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import java.util.Optional;
+import modules.MainModule;
+import play.data.DynamicForm;
+import services.apikey.ApiKeyService;
+import views.admin.apikeys.ApiKeyNewOnePageViewModel;
+import views.admin.apikeys.ApiKeyNewOnePageViewModel.ProgramCheckbox;
+
+/** Maps data to the ApiKeyNewOnePageViewModel for the new API key page. */
+public final class ApiKeyNewOnePageMapper {
+
+  /**
+   * Maps the programs a key can be granted access to, and any previously submitted form, to the
+   * view model.
+   *
+   * @param programNames the programs a new key may be granted read access to
+   * @param maybeForm the submitted form, present only when creation failed validation
+   */
+  public ApiKeyNewOnePageViewModel map(
+      ImmutableSet<String> programNames, Optional<DynamicForm> maybeForm) {
+    return ApiKeyNewOnePageViewModel.builder()
+        .title("Create a new API key")
+        // On first load with no program to grant access to, the page shows the
+        // "create a program first" notice instead of the form. A rejected submission
+        // always re-renders the form, as the legacy view did.
+        .showForm(maybeForm.isPresent() || !programNames.isEmpty())
+        .formActionUrl(controllers.admin.routes.AdminApiKeysController.create().url())
+        .keyNameValue(fieldValue(maybeForm, ApiKeyService.FORM_FIELD_NAME_KEY_NAME))
+        .expirationValue(fieldValue(maybeForm, ApiKeyService.FORM_FIELD_NAME_EXPIRATION))
+        .subnetValue(fieldValue(maybeForm, ApiKeyService.FORM_FIELD_NAME_SUBNET))
+        .keyNameError(fieldError(maybeForm, ApiKeyService.FORM_FIELD_NAME_KEY_NAME))
+        .expirationError(fieldError(maybeForm, ApiKeyService.FORM_FIELD_NAME_EXPIRATION))
+        .subnetError(fieldError(maybeForm, ApiKeyService.FORM_FIELD_NAME_SUBNET))
+        .showProgramsError(
+            maybeForm
+                .map(form -> form.error(ApiKeyService.PROGRAMS_FIELD_GROUP_NAME).isPresent())
+                .orElse(false))
+        .programCheckboxes(buildProgramCheckboxes(programNames, maybeForm))
+        .build();
+  }
+
+  private String fieldValue(Optional<DynamicForm> maybeForm, String key) {
+    return maybeForm.flatMap(form -> form.value(key)).map(String::valueOf).orElse("");
+  }
+
+  // ApiKeyService adds these errors as literal English, and this page is English only,
+  // so the outline the legacy view took from toast.errorMessageOutline is just a
+  // prefix here.
+  private String fieldError(Optional<DynamicForm> maybeForm, String key) {
+    return maybeForm
+        .flatMap(form -> form.error(key))
+        .map(error -> "Error: " + error.message())
+        .orElse(null);
+  }
+
+  private ImmutableList<ProgramCheckbox> buildProgramCheckboxes(
+      ImmutableSet<String> programNames, Optional<DynamicForm> maybeForm) {
+    return programNames.stream()
+        .sorted(String::compareToIgnoreCase)
+        .map(
+            name -> {
+              String slug = MainModule.SLUGIFIER.slugify(name);
+              String fieldName = "grant-program-read[" + slug + "]";
+
+              return ProgramCheckbox.builder()
+                  .id(slug)
+                  .name(fieldName)
+                  .label(name)
+                  .checked(maybeForm.map(form -> form.value(fieldName).isPresent()).orElse(false))
+                  .build();
+            })
+        .collect(ImmutableList.toImmutableList());
+  }
+}

--- a/server/app/views/admin/apikeys/ApiKeyCredentialsPage.html
+++ b/server/app/views/admin/apikeys/ApiKeyCredentialsPage.html
@@ -1,0 +1,46 @@
+<!--/*@thymesVar id="templateGlobals" type="views.shared.TemplateGlobals"*/-->
+<!--/*@thymesVar id="model" type="views.admin.apikeys.ApiKeyCredentialsPageViewModel"*/-->
+<th:block th:fragment="content">
+  <!--/* The layout's <main> supplies the legacy centered wrapper, so this div is
+         the direct child of <main> in the legacy j2html DOM. */-->
+  <div class="px-20">
+    <h1 class="my-4" th:text="${model.title}"></h1>
+    <h2>Credentials</h2>
+    <p class="my-4">
+      Please copy your API credentials and store them somewhere secure. This is
+      your only opportunity to copy the secret from CiviForm, if you refresh the
+      page or navigate away you will not be able to recover the secret value and
+      will need to create a new key instead.
+    </p>
+    <!--/* The legacy view put no space between the link and "for details.", so
+           neither does this. */-->
+    <p class="my-4">
+      The API credentials are available as both a single token (the "API Secret
+      Token") or a username/password combination, depending on the needs of your
+      API client. See the
+      <a
+        href="https://docs.civiform.us/it-manual/api/authentication"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="text-blue-600 hover:text-blue-500 inline-flex items-center"
+        >API documentation<svg
+          th:replace="~{admin/shared/LegacySvgFragments :: iconOpenInNew('mr-2 w-5 h-5')}"
+        ></svg></a
+      >for details.
+    </p>
+    <p class="my-4">
+      API secret token:
+      <span
+        id="api-key-credentials"
+        class="font-mono"
+        th:text="${model.encodedCredentials}"
+      ></span>
+    </p>
+    <p>
+      API username: <span class="font-mono" th:text="${model.keyId}"></span>
+    </p>
+    <p>
+      API password: <span class="font-mono" th:text="${model.keySecret}"></span>
+    </p>
+  </div>
+</th:block>

--- a/server/app/views/admin/apikeys/ApiKeyCredentialsPageView.java
+++ b/server/app/views/admin/apikeys/ApiKeyCredentialsPageView.java
@@ -1,0 +1,32 @@
+package views.admin.apikeys;
+
+import com.google.inject.Inject;
+import play.i18n.Messages;
+import views.admin.AdminLayout;
+import views.admin.LegacyTailwindLayoutBaseView;
+import views.shared.LayoutDeps;
+
+/** Thymeleaf view for the API key credentials page, rendering ApiKeyCredentialsPage.html. */
+public final class ApiKeyCredentialsPageView
+    extends LegacyTailwindLayoutBaseView<ApiKeyCredentialsPageViewModel> {
+
+  @Inject
+  public ApiKeyCredentialsPageView(LayoutDeps layoutDeps) {
+    super(layoutDeps);
+  }
+
+  @Override
+  protected String pageTitle(ApiKeyCredentialsPageViewModel model, Messages messages) {
+    return model.getTitle();
+  }
+
+  @Override
+  protected AdminLayout.NavPage activeNavigationPage() {
+    return AdminLayout.NavPage.API_KEYS;
+  }
+
+  @Override
+  protected String pageTemplate() {
+    return "admin/apikeys/ApiKeyCredentialsPage.html";
+  }
+}

--- a/server/app/views/admin/apikeys/ApiKeyCredentialsPageViewModel.java
+++ b/server/app/views/admin/apikeys/ApiKeyCredentialsPageViewModel.java
@@ -1,0 +1,19 @@
+package views.admin.apikeys;
+
+import lombok.Builder;
+import lombok.Data;
+import views.BaseViewModel;
+
+/** ViewModel for the page shown once, right after an API key is created (Thymeleaf). */
+@Data
+@Builder
+public final class ApiKeyCredentialsPageViewModel implements BaseViewModel {
+
+  // Page heading, e.g. "Created API key: my-key"
+  private final String title;
+
+  // The base64 encoded "<key id>:<key secret>" token
+  private final String encodedCredentials;
+  private final String keyId;
+  private final String keySecret;
+}

--- a/server/app/views/admin/apikeys/ApiKeyNewOnePage.html
+++ b/server/app/views/admin/apikeys/ApiKeyNewOnePage.html
@@ -1,0 +1,90 @@
+<!--/*@thymesVar id="templateGlobals" type="views.shared.TemplateGlobals"*/-->
+<!--/*@thymesVar id="model" type="views.admin.apikeys.ApiKeyNewOnePageViewModel"*/-->
+<th:block th:fragment="content">
+  <!--/* The layout's <main> supplies the legacy centered wrapper, so this div is
+         the direct child of <main> in the legacy j2html DOM. */-->
+  <div class="px-20">
+    <h1 class="my-4" th:text="${model.title}"></h1>
+
+    <!--/* Empty state: the legacy view rendered this from renderNoPrograms. */-->
+    <div th:unless="${model.showForm}">
+      You must create and publish a program before creating an API Key.
+    </div>
+
+    <form
+      th:if="${model.showForm}"
+      method="POST"
+      th:action="${model.formActionUrl}"
+    >
+      <input
+        hidden
+        th:value="${templateGlobals.csrfToken()}"
+        name="csrfToken"
+      />
+
+      <h2>Name</h2>
+      <p>A human-readable name for identifying this API key in the UI.</p>
+      <div
+        th:replace="~{admin/apikeys/fragments/ApiKeyFormFields :: inputField('keyName', 'API key name', 'text', ${model.keyNameValue}, ${model.keyNameError})}"
+      ></div>
+
+      <h2>Expiration date</h2>
+      <p>
+        Specify a date when this API key will no longer be valid. The expiration
+        date may be edited after the API key is created. It is strongly
+        recommended to allow API keys to expire and create new ones to ensure
+        that if a key has been stolen, malicious users will eventually lose
+        access. For highly sensitive data, expiring keys once a week or once a
+        month is recommended. Once a year is acceptable in most situations.
+      </p>
+      <div
+        th:replace="~{admin/apikeys/fragments/ApiKeyFormFields :: inputField('expiration', 'Expiration date', 'date', ${model.expirationValue}, ${model.expirationError})}"
+      ></div>
+
+      <h2>Allowed IP addresses</h2>
+      <p>
+        Specify one or more comma-separated subnets using
+        <a
+          href="https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="text-blue-600 hover:text-blue-500 inline-flex items-center"
+          >CIDR notation</a
+        >
+        that is allowed to call the API. The subnet may not be edited after the
+        API key is created. A single IP address can be specified with a mask of
+        /32. For example, "8.8.8.8/32" allows only the IP 8.8.8.8 to use the API
+        key. All IP addresses can be allowed, but this is strongly discouraged
+        for security reasons because it would allow any computer connected to
+        the internet to use the key if they obtain it. All IP addresses can be
+        allowed with a value of 0.0.0.0/0, though this is not recommended.
+      </p>
+      <div
+        th:replace="~{admin/apikeys/fragments/ApiKeyFormFields :: inputField('subnet', 'API key subnet', 'text', ${model.subnetValue}, ${model.subnetError})}"
+      ></div>
+
+      <h2>Allowed programs</h2>
+      <p>Select the programs this key grants read access to.</p>
+      <p
+        th:if="${model.showProgramsError}"
+        class="text-red-600 text-xs mt-2 mb-2"
+      >
+        Error: You must select at least one program.
+      </p>
+
+      <th:block th:each="program : ${model.programCheckboxes}">
+        <label
+          th:replace="~{admin/apikeys/fragments/ApiKeyFormFields :: programCheckbox(${program})}"
+        ></label>
+      </th:block>
+
+      <button
+        type="submit"
+        class="block py-2 text-center rounded-full border bg-civiform-blue border-transparent text-white rounded-full font-semibold px-8 hover:bg-blue-700 disabled:bg-gray-200 disabled:text-gray-400 text-base"
+        id="apikey-submit-button"
+      >
+        Save
+      </button>
+    </form>
+  </div>
+</th:block>

--- a/server/app/views/admin/apikeys/ApiKeyNewOnePageView.java
+++ b/server/app/views/admin/apikeys/ApiKeyNewOnePageView.java
@@ -1,0 +1,32 @@
+package views.admin.apikeys;
+
+import com.google.inject.Inject;
+import play.i18n.Messages;
+import views.admin.AdminLayout;
+import views.admin.LegacyTailwindLayoutBaseView;
+import views.shared.LayoutDeps;
+
+/** Thymeleaf view for the new API key page, rendering ApiKeyNewOnePage.html. */
+public final class ApiKeyNewOnePageView
+    extends LegacyTailwindLayoutBaseView<ApiKeyNewOnePageViewModel> {
+
+  @Inject
+  public ApiKeyNewOnePageView(LayoutDeps layoutDeps) {
+    super(layoutDeps);
+  }
+
+  @Override
+  protected String pageTitle(ApiKeyNewOnePageViewModel model, Messages messages) {
+    return model.getTitle();
+  }
+
+  @Override
+  protected AdminLayout.NavPage activeNavigationPage() {
+    return AdminLayout.NavPage.API_KEYS;
+  }
+
+  @Override
+  protected String pageTemplate() {
+    return "admin/apikeys/ApiKeyNewOnePage.html";
+  }
+}

--- a/server/app/views/admin/apikeys/ApiKeyNewOnePageViewModel.java
+++ b/server/app/views/admin/apikeys/ApiKeyNewOnePageViewModel.java
@@ -1,0 +1,47 @@
+package views.admin.apikeys;
+
+import com.google.common.collect.ImmutableList;
+import lombok.Builder;
+import lombok.Data;
+import views.BaseViewModel;
+
+/** ViewModel for the new API key page (Thymeleaf). */
+@Data
+@Builder
+public final class ApiKeyNewOnePageViewModel implements BaseViewModel {
+
+  // Page heading, always "Create a new API key"
+  private final String title;
+
+  // False when there is no program to grant access to yet. The legacy view had a
+  // separate render method for that case, but it is the empty state of this same
+  // page: same route, same title, only the form is swapped for a notice.
+  private final boolean showForm;
+
+  private final String formActionUrl;
+
+  // Submitted field values, empty when creation has not failed validation.
+  private final String keyNameValue;
+  private final String expirationValue;
+  private final String subnetValue;
+
+  // Field errors, null when the field has none. Already prefixed with "Error: ".
+  private final String keyNameError;
+  private final String expirationError;
+  private final String subnetError;
+
+  // Set when the submitted form granted access to no program at all.
+  private final boolean showProgramsError;
+  private final ImmutableList<ProgramCheckbox> programCheckboxes;
+
+  /** A checkbox granting the key read access to one program. */
+  @Data
+  @Builder
+  public static final class ProgramCheckbox {
+    // The slugified program name, which the browser tests select on.
+    private final String id;
+    private final String name;
+    private final String label;
+    private final boolean checked;
+  }
+}

--- a/server/app/views/admin/apikeys/fragments/ApiKeyFormFields.html
+++ b/server/app/views/admin/apikeys/fragments/ApiKeyFormFields.html
@@ -1,0 +1,66 @@
+<!--/*
+  Form fields for the new API key page.
+
+  These are not the shared admin/shared/LegacyFieldWithLabel fragments because
+  those render neither an input type nor the field errors a rejected form
+  carries, both of which this page needs.
+
+  Legacy counterpart: FieldWithLabel.input()/date()/checkbox() as used by
+  ApiKeyNewOneView.
+*/-->
+
+<!--/*
+  id: the form key, used as both the input id and name, as in the legacy view.
+  errorMessage: null when the field has no error, already prefixed "Error: ".
+*/-->
+<div
+  th:fragment="inputField(id, label, type, value, errorMessage)"
+  class="mb-2"
+  th:with="hasError=${errorMessage != null}"
+>
+  <label
+    th:for="${id}"
+    class="pointer-events-none text-gray-600 text-base px-1 py-2"
+    >[[${label}]]<span
+      th:replace="~{admin/shared/LegacyFieldWithLabel/RequiredIndicator :: requiredIndicator(false)}"
+    ></span
+  ></label>
+  <div class="flex flex-col">
+    <!--/* The a11y attributes only appear when the field has an error, matching
+           FieldWithLabel, and the error border replaces the gray one. */-->
+    <input
+      th:type="${type}"
+      th:value="${value}"
+      th:attr="aria-describedby=${hasError} ? |${id}-errors|, aria-invalid=${hasError} ? 'true'"
+      maxlength="10000"
+      th:id="${id}"
+      th:name="${id}"
+      th:class="${hasError} ? 'px-3 bg-white text-black text-lg py-2 block outline-none box-border m-auto border rounded-lg w-full focus:border-civiform-blue placeholder-gray-500 border-red-600' : 'px-3 bg-white text-black text-lg py-2 block outline-none box-border m-auto border border-gray-500 rounded-lg w-full focus:border-civiform-blue placeholder-gray-500'"
+    />
+    <div
+      th:id="|${id}-errors|"
+      class="text-red-600 text-xs p-1"
+      th:classappend="${hasError} ? '' : 'hidden'"
+    >
+      <div th:if="${hasError}" th:text="${errorMessage}"></div>
+    </div>
+  </div>
+</div>
+
+<!--/*@thymesVar id="program" type="views.admin.apikeys.ApiKeyNewOnePageViewModel.ProgramCheckbox"*/-->
+<!--/* The label wraps the checkbox, so no whitespace may creep in between the
+       input and the program name. */-->
+<label
+  th:fragment="programCheckbox(program)"
+  class="px-3 bg-white text-black text-lg py-2 block outline-none box-border m-auto border border-gray-500 rounded-lg w-full focus:border-civiform-blue align-middle flex flex-row mb-2 cf-radio-option"
+  th:for="${program.id}"
+  ><input
+    type="checkbox"
+    value="true"
+    maxlength="10000"
+    th:id="${program.id}"
+    th:name="${program.name}"
+    class="h-4 w-4 mr-4 align-middle self-center flex-none"
+    th:checked="${program.checked}"
+  />[[${program.label}]]</label
+>

--- a/server/app/views/admin/shared/LegacySvgFragments.html
+++ b/server/app/views/admin/shared/LegacySvgFragments.html
@@ -89,6 +89,21 @@
   ></path>
 </svg>
 
+<svg
+  th:fragment="iconOpenInNew(classes)"
+  xmlns="http://www.w3.org/2000/svg"
+  fill="currentColor"
+  stroke="currentColor"
+  stroke-width="1%"
+  aria-hidden="true"
+  viewBox="0 0 24 24"
+  th:class="${classes}"
+>
+  <path
+    d="M19 19H5V5H12V3H5C3.89 3 3 3.9 3 5V19C3 20.1 3.89 21 5 21H19C20.1 21 21 20.1 21 19V12H19V19ZM14 3V5H17.59L7.76 14.83L9.17 16.24L19 6.41V10H21V3H14Z"
+  ></path>
+</svg>
+
 <!--/* fill/stroke carry the label text color class. */-->
 <svg
   th:fragment="iconMarkdown"

--- a/server/test/controllers/admin/AdminApiKeysControllerTest.java
+++ b/server/test/controllers/admin/AdminApiKeysControllerTest.java
@@ -26,9 +26,11 @@ import services.program.ProgramService;
 import services.program.ProgramType;
 import services.settings.SettingsManifest;
 import support.ProgramBuilder;
+import views.admin.apikeys.ApiKeyCredentialsPageView;
 import views.admin.apikeys.ApiKeyCredentialsView;
 import views.admin.apikeys.ApiKeyIndexPageView;
 import views.admin.apikeys.ApiKeyIndexView;
+import views.admin.apikeys.ApiKeyNewOnePageView;
 import views.admin.apikeys.ApiKeyNewOneView;
 
 public class AdminApiKeysControllerTest extends ResetPostgres {
@@ -62,6 +64,8 @@ public class AdminApiKeysControllerTest extends ResetPostgres {
             apiKeyNewOneView,
             instanceOf(ApiKeyCredentialsView.class),
             instanceOf(ApiKeyIndexPageView.class),
+            instanceOf(ApiKeyNewOnePageView.class),
+            instanceOf(ApiKeyCredentialsPageView.class),
             instanceOf(ProgramService.class),
             instanceOf(play.data.FormFactory.class),
             profileUtils,

--- a/server/test/mapping/admin/apikeys/ApiKeyCredentialsPageMapperTest.java
+++ b/server/test/mapping/admin/apikeys/ApiKeyCredentialsPageMapperTest.java
@@ -1,0 +1,38 @@
+package mapping.admin.apikeys;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import models.ApiKeyModel;
+import org.junit.Before;
+import org.junit.Test;
+import views.admin.apikeys.ApiKeyCredentialsPageViewModel;
+
+public final class ApiKeyCredentialsPageMapperTest {
+
+  private ApiKeyCredentialsPageMapper mapper;
+
+  @Before
+  public void setup() {
+    mapper = new ApiKeyCredentialsPageMapper();
+  }
+
+  private ApiKeyCredentialsPageViewModel map() {
+    ApiKeyModel apiKey = new ApiKeyModel().setName("Test API key");
+
+    return mapper.map(apiKey, "encoded-credentials", "key-id", "key-secret");
+  }
+
+  @Test
+  public void map_setsTitleFromKeyName() {
+    assertThat(map().getTitle()).isEqualTo("Created API key: Test API key");
+  }
+
+  @Test
+  public void map_setsCredentials() {
+    ApiKeyCredentialsPageViewModel result = map();
+
+    assertThat(result.getEncodedCredentials()).isEqualTo("encoded-credentials");
+    assertThat(result.getKeyId()).isEqualTo("key-id");
+    assertThat(result.getKeySecret()).isEqualTo("key-secret");
+  }
+}

--- a/server/test/mapping/admin/apikeys/ApiKeyNewOnePageMapperTest.java
+++ b/server/test/mapping/admin/apikeys/ApiKeyNewOnePageMapperTest.java
@@ -1,0 +1,148 @@
+package mapping.admin.apikeys;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+import com.google.common.collect.ImmutableSet;
+import java.util.Optional;
+import org.junit.Before;
+import org.junit.Test;
+import play.data.DynamicForm;
+import play.data.validation.ValidationError;
+import views.admin.apikeys.ApiKeyNewOnePageViewModel;
+import views.admin.apikeys.ApiKeyNewOnePageViewModel.ProgramCheckbox;
+
+public final class ApiKeyNewOnePageMapperTest {
+
+  private static final ImmutableSet<String> PROGRAM_NAMES =
+      ImmutableSet.of("Utility Discount", "Housing Voucher");
+
+  private ApiKeyNewOnePageMapper mapper;
+
+  @Before
+  public void setup() {
+    mapper = new ApiKeyNewOnePageMapper();
+  }
+
+  private ApiKeyNewOnePageViewModel mapWithoutForm() {
+    return mapper.map(PROGRAM_NAMES, /* maybeForm= */ Optional.empty());
+  }
+
+  private ApiKeyNewOnePageViewModel mapWithForm(DynamicForm form) {
+    return mapper.map(PROGRAM_NAMES, Optional.of(form));
+  }
+
+  @Test
+  public void map_setsTitle() {
+    ApiKeyNewOnePageViewModel result = mapWithoutForm();
+
+    assertThat(result.getTitle()).isEqualTo("Create a new API key");
+  }
+
+  @Test
+  public void map_setsFormActionUrl() {
+    ApiKeyNewOnePageViewModel result = mapWithoutForm();
+
+    assertThat(result.getFormActionUrl()).isEqualTo("/admin/apiKeys");
+  }
+
+  @Test
+  public void map_noForm_leavesFieldsEmptyAndErrorFree() {
+    ApiKeyNewOnePageViewModel result = mapWithoutForm();
+
+    assertThat(result.getKeyNameValue()).isEmpty();
+    assertThat(result.getExpirationValue()).isEmpty();
+    assertThat(result.getSubnetValue()).isEmpty();
+    assertThat(result.getKeyNameError()).isNull();
+    assertThat(result.getExpirationError()).isNull();
+    assertThat(result.getSubnetError()).isNull();
+  }
+
+  @Test
+  public void map_withForm_setsSubmittedValues() {
+    DynamicForm form = mock(DynamicForm.class);
+    doReturn(Optional.of("my key")).when(form).value("keyName");
+    doReturn(Optional.of("2030-01-01")).when(form).value("expiration");
+
+    ApiKeyNewOnePageViewModel result = mapWithForm(form);
+
+    assertThat(result.getKeyNameValue()).isEqualTo("my key");
+    assertThat(result.getExpirationValue()).isEqualTo("2030-01-01");
+    assertThat(result.getSubnetValue()).isEmpty();
+  }
+
+  @Test
+  public void map_withFieldError_setsOutlinedErrorMessage() {
+    DynamicForm form = mock(DynamicForm.class);
+    doReturn(Optional.of(new ValidationError("subnet", "Subnet cannot be blank.")))
+        .when(form)
+        .error("subnet");
+
+    ApiKeyNewOnePageViewModel result = mapWithForm(form);
+
+    assertThat(result.getSubnetError()).isEqualTo("Error: Subnet cannot be blank.");
+    assertThat(result.getKeyNameError()).isNull();
+  }
+
+  @Test
+  public void map_withProgramsError_setsShowProgramsError() {
+    DynamicForm form = mock(DynamicForm.class);
+    doReturn(Optional.of(new ValidationError("programs", ""))).when(form).error("programs");
+
+    assertThat(mapWithForm(form).isShowProgramsError()).isTrue();
+  }
+
+  @Test
+  public void map_noForm_doesNotShowProgramsError() {
+    assertThat(mapWithoutForm().isShowProgramsError()).isFalse();
+  }
+
+  @Test
+  public void map_sortsProgramCheckboxesCaseInsensitively() {
+    ApiKeyNewOnePageViewModel result = mapWithoutForm();
+
+    assertThat(result.getProgramCheckboxes())
+        .extracting(ProgramCheckbox::getLabel)
+        .containsExactly("Housing Voucher", "Utility Discount");
+  }
+
+  @Test
+  public void map_setsProgramCheckboxIdAndFieldName() {
+    ProgramCheckbox result = mapWithoutForm().getProgramCheckboxes().get(0);
+
+    assertThat(result.getId()).isEqualTo("housing-voucher");
+    assertThat(result.getName()).isEqualTo("grant-program-read[housing-voucher]");
+    assertThat(result.isChecked()).isFalse();
+  }
+
+  @Test
+  public void map_withGrantedProgram_checksThatProgram() {
+    DynamicForm form = mock(DynamicForm.class);
+    doReturn(Optional.of("true")).when(form).value("grant-program-read[housing-voucher]");
+
+    ApiKeyNewOnePageViewModel result = mapWithForm(form);
+
+    assertThat(result.getProgramCheckboxes().get(0).isChecked()).isTrue();
+    assertThat(result.getProgramCheckboxes().get(1).isChecked()).isFalse();
+  }
+
+  @Test
+  public void map_withoutPrograms_hidesForm() {
+    ApiKeyNewOnePageViewModel result =
+        mapper.map(ImmutableSet.of(), /* maybeForm= */ Optional.empty());
+
+    assertThat(result.isShowForm()).isFalse();
+    assertThat(result.getProgramCheckboxes()).isEmpty();
+  }
+
+  @Test
+  public void map_withFormAndWithoutPrograms_showsForm() {
+    // A rejected submission re-renders the form even with no program left to grant
+    // access to, as the legacy view did.
+    ApiKeyNewOnePageViewModel result =
+        mapper.map(ImmutableSet.of(), Optional.of(mock(DynamicForm.class)));
+
+    assertThat(result.isShowForm()).isTrue();
+  }
+}

--- a/server/test/resources/thymeleaf/admin/apikeys/apiKeyFragments/inputFieldDateWithError.thtest
+++ b/server/test/resources/thymeleaf/admin/apikeys/apiKeyFragments/inputFieldDateWithError.thtest
@@ -1,0 +1,30 @@
+%NAME inputField - date field carrying a validation error
+%TEMPLATE_MODE HTML
+%INPUT
+<div th:replace="~{admin/apikeys/fragments/ApiKeyFormFields :: inputField('expiration', 'Expiration date', 'date', '', 'Error: Expiration cannot be blank.')}"></div>
+# ----------------------------------------------------------------------
+# An error adds the a11y attributes ahead of maxlength, swaps the gray border
+# for the red one and unhides the error container, as FieldWithLabel did.
+%OUTPUT
+<div class="mb-2">
+  <label
+    for="expiration"
+    class="pointer-events-none text-gray-600 text-base px-1 py-2"
+    >Expiration date<span class="usa-hint--required hidden" aria-hidden="true">&nbsp;*</span></label
+  >
+  <div class="flex flex-col">
+    <input
+      type="date"
+      value=""
+      aria-describedby="expiration-errors"
+      aria-invalid="true"
+      maxlength="10000"
+      id="expiration"
+      name="expiration"
+      class="px-3 bg-white text-black text-lg py-2 block outline-none box-border m-auto border rounded-lg w-full focus:border-civiform-blue placeholder-gray-500 border-red-600"
+    />
+    <div id="expiration-errors" class="text-red-600 text-xs p-1">
+      <div>Error: Expiration cannot be blank.</div>
+    </div>
+  </div>
+</div>

--- a/server/test/resources/thymeleaf/admin/apikeys/apiKeyFragments/inputFieldText.thtest
+++ b/server/test/resources/thymeleaf/admin/apikeys/apiKeyFragments/inputFieldText.thtest
@@ -1,0 +1,27 @@
+%NAME inputField - text field with a submitted value and no error
+%TEMPLATE_MODE HTML
+%INPUT
+<div th:replace="~{admin/apikeys/fragments/ApiKeyFormFields :: inputField('keyName', 'API key name', 'text', 'my key', null)}"></div>
+# ----------------------------------------------------------------------
+# No error means no a11y attributes and a hidden, empty error container, as
+# FieldWithLabel rendered it.
+%OUTPUT
+<div class="mb-2">
+  <label
+    for="keyName"
+    class="pointer-events-none text-gray-600 text-base px-1 py-2"
+    >API key name<span class="usa-hint--required hidden" aria-hidden="true">&nbsp;*</span></label
+  >
+  <div class="flex flex-col">
+    <input
+      type="text"
+      value="my key"
+      maxlength="10000"
+      id="keyName"
+      name="keyName"
+      class="px-3 bg-white text-black text-lg py-2 block outline-none box-border m-auto border border-gray-500 rounded-lg w-full focus:border-civiform-blue placeholder-gray-500"
+    />
+    <div id="keyName-errors" class="text-red-600 text-xs p-1 hidden">
+    </div>
+  </div>
+</div>

--- a/server/test/resources/thymeleaf/admin/apikeys/apiKeyFragments/programCheckboxChecked.thtest
+++ b/server/test/resources/thymeleaf/admin/apikeys/apiKeyFragments/programCheckboxChecked.thtest
@@ -1,0 +1,25 @@
+%NAME programCheckbox - previously granted, so the box stays checked
+%TEMPLATE_MODE HTML
+%CONTEXT
+# ProgramCheckbox(id, name, label, checked)
+program = @views.admin.apikeys.ApiKeyNewOnePageViewModel$ProgramCheckbox@builder() \
+    .id("utility-discount").name("grant-program-read[utility-discount]") \
+    .label("Utility Discount").checked(true).build()
+# ----------------------------------------------------------------------
+%INPUT
+<label th:replace="~{admin/apikeys/fragments/ApiKeyFormFields :: programCheckbox(${program})}"></label>
+# ----------------------------------------------------------------------
+%OUTPUT
+<label
+  class="px-3 bg-white text-black text-lg py-2 block outline-none box-border m-auto border border-gray-500 rounded-lg w-full focus:border-civiform-blue align-middle flex flex-row mb-2 cf-radio-option"
+  for="utility-discount"
+  ><input
+    type="checkbox"
+    value="true"
+    maxlength="10000"
+    id="utility-discount"
+    name="grant-program-read[utility-discount]"
+    class="h-4 w-4 mr-4 align-middle self-center flex-none"
+    checked="checked"
+  />Utility Discount</label
+>

--- a/server/test/resources/thymeleaf/admin/apikeys/apiKeyFragments/programCheckboxUnchecked.thtest
+++ b/server/test/resources/thymeleaf/admin/apikeys/apiKeyFragments/programCheckboxUnchecked.thtest
@@ -1,0 +1,24 @@
+%NAME programCheckbox - not granted, so the box is unchecked
+%TEMPLATE_MODE HTML
+%CONTEXT
+# ProgramCheckbox(id, name, label, checked)
+program = @views.admin.apikeys.ApiKeyNewOnePageViewModel$ProgramCheckbox@builder() \
+    .id("housing-voucher").name("grant-program-read[housing-voucher]") \
+    .label("Housing Voucher").checked(false).build()
+# ----------------------------------------------------------------------
+%INPUT
+<label th:replace="~{admin/apikeys/fragments/ApiKeyFormFields :: programCheckbox(${program})}"></label>
+# ----------------------------------------------------------------------
+%OUTPUT
+<label
+  class="px-3 bg-white text-black text-lg py-2 block outline-none box-border m-auto border border-gray-500 rounded-lg w-full focus:border-civiform-blue align-middle flex flex-row mb-2 cf-radio-option"
+  for="housing-voucher"
+  ><input
+    type="checkbox"
+    value="true"
+    maxlength="10000"
+    id="housing-voucher"
+    name="grant-program-read[housing-voucher]"
+    class="h-4 w-4 mr-4 align-middle self-center flex-none"
+  />Housing Voucher</label
+>

--- a/server/test/resources/thymeleaf/admin/shared/legacySvgFragments/iconOpenInNewLink.thtest
+++ b/server/test/resources/thymeleaf/admin/shared/legacySvgFragments/iconOpenInNewLink.thtest
@@ -1,0 +1,20 @@
+%NAME iconOpenInNew - trailing link icon sizing (legacy LinkElement.setIcon)
+%TEMPLATE_MODE HTML
+# ----------------------------------------------------------------------
+%INPUT
+<svg th:replace="~{admin/shared/LegacySvgFragments :: iconOpenInNew('mr-2 w-5 h-5')}"></svg>
+# ----------------------------------------------------------------------
+%OUTPUT
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  fill="currentColor"
+  stroke="currentColor"
+  stroke-width="1%"
+  aria-hidden="true"
+  viewBox="0 0 24 24"
+  class="mr-2 w-5 h-5"
+>
+  <path
+    d="M19 19H5V5H12V3H5C3.89 3 3 3.9 3 5V19C3 20.1 3.89 21 5 21H19C20.1 21 21 20.1 21 19V12H19V19ZM14 3V5H17.59L7.76 14.83L9.17 16.24L19 6.41V10H21V3H14Z"
+  ></path>
+</svg>

--- a/server/test/views/admin/apikeys/ApiKeyFragmentsTest.java
+++ b/server/test/views/admin/apikeys/ApiKeyFragmentsTest.java
@@ -24,4 +24,24 @@ public class ApiKeyFragmentsTest {
   public void apiKeyCard_retired() {
     ThymeleafFragmentTester.run(DIR + "apiKeyCardRetired.thtest");
   }
+
+  @Test
+  public void inputField_textWithValue() {
+    ThymeleafFragmentTester.run(DIR + "inputFieldText.thtest");
+  }
+
+  @Test
+  public void inputField_dateWithError() {
+    ThymeleafFragmentTester.run(DIR + "inputFieldDateWithError.thtest");
+  }
+
+  @Test
+  public void programCheckbox_unchecked() {
+    ThymeleafFragmentTester.run(DIR + "programCheckboxUnchecked.thtest");
+  }
+
+  @Test
+  public void programCheckbox_checked() {
+    ThymeleafFragmentTester.run(DIR + "programCheckboxChecked.thtest");
+  }
 }

--- a/server/test/views/admin/shared/LegacySvgFragmentsTest.java
+++ b/server/test/views/admin/shared/LegacySvgFragmentsTest.java
@@ -101,6 +101,12 @@ public class LegacySvgFragmentsTest {
     ThymeleafFragmentTester.run(DIR + "iconCloseModal.thtest");
   }
 
+  /** Legacy source: ApiKeyCredentialsView API documentation link (LinkElement.setIcon). */
+  @Test
+  public void iconOpenInNew_link() {
+    ThymeleafFragmentTester.run(DIR + "iconOpenInNewLink.thtest");
+  }
+
   /** Legacy source: ViewUtils.makeSvgTextButton ("Edit"). */
   @Test
   public void iconEdit_svgTextButton() {


### PR DESCRIPTION
Migrate the Api Keys Creation and Api Keys output pages from j2html to thymeleaf.

There are no browser tests in this PR. They were already brought over with the Api Keys List screen.

As noted in [ApiKeyFormFields.html](https://github.com/civiform/civiform/pull/13775/files#diff-a0fc22d96daa5f8b25ac54f2d3ca714ac7fd1b092ce2d316eb9940c7c0bd14c9) the form fields are not fully reusing the form fields already brought over in LegacyFieldWithLabel fragments. This is _purposeful_ on my part. Trying to make a generic fragment just adds on a lot of additional optional fields. For the short term it is cleaner to accept a little bit of duplication for this stage of the migration. During the next stage of removing the tailwind and swapping in USWDS the fields should get swapped over to using the `cf:*` custom Thymeleaf components.




### LLM Tooling

Claude did most of the migration with some manual assistance. Built using this custom skill: [SKILL.md](https://github.com/user-attachments/files/30719902/SKILL.md) | [REFERENCE.md](https://github.com/user-attachments/files/30719901/REFERENCE.md).

Assisted-by: Claude Code:claude-opus-5[1m]

### Issue(s) this completes

Related to: #12441