### PR TITLE
Add ANSWER_OPTION_SCORING_ENABLED feature flag

### DIFF
--- a/server/app/services/settings/SettingsManifest.java
+++ b/server/app/services/settings/SettingsManifest.java
@@ -1149,6 +1149,14 @@ public final class SettingsManifest extends AbstractSettingsManifest {
     return getBool("NEW_APPLICANT_GUEST_MERGING_STRATEGY_DRY_RUN_ENABLED");
   }
 
+  /**
+   * (NOT FOR PRODUCTION USE) Enables optional scores on multi-option question answer options and
+   * score output on submitted applications for programs that opt in.
+   */
+  public boolean getAnswerOptionScoringEnabled(RequestHeader request) {
+    return getBool("ANSWER_OPTION_SCORING_ENABLED", request);
+  }
+
   private static final ImmutableMap<String, SettingsSection> GENERATED_SECTIONS =
       ImmutableMap.<String, SettingsSection>builder()
           .put(
@@ -2441,7 +2449,15 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                               + " applicant-guest merging strategy.",
                           /* isRequired= */ false,
                           SettingType.BOOLEAN,
-                          SettingMode.ADMIN_READABLE))))
+                          SettingMode.ADMIN_READABLE),
+                      SettingDescription.create(
+                          "ANSWER_OPTION_SCORING_ENABLED",
+                          "(NOT FOR PRODUCTION USE) Enables optional scores on multi-option"
+                              + " question answer options and score output on submitted"
+                              + " applications for programs that opt in.",
+                          /* isRequired= */ false,
+                          SettingType.BOOLEAN,
+                          SettingMode.ADMIN_WRITEABLE))))
           .put(
               "Miscellaneous",
               SettingsSection.create(

--- a/server/conf/env-var-docs.json
+++ b/server/conf/env-var-docs.json
@@ -1010,6 +1010,12 @@
         "description": "(NOT FOR PRODUCTION USE) Enable dry run logging for the new applicant-guest merging strategy.",
         "type": "bool",
         "required": false
+      },
+      "ANSWER_OPTION_SCORING_ENABLED": {
+        "mode": "ADMIN_WRITEABLE",
+        "description": "(NOT FOR PRODUCTION USE) Enables optional scores on multi-option question answer options and score output on submitted applications for programs that opt in.",
+        "type": "bool",
+        "required": false
       }
     }
   }

--- a/server/conf/helper/feature-flags.conf
+++ b/server/conf/helper/feature-flags.conf
@@ -102,3 +102,7 @@ file_upload_question_improvements_enabled = ${?FILE_UPLOAD_QUESTION_IMPROVEMENTS
 # Session timeout based on inactivity and maximum session duration
 session_timeout_enabled = true
 session_timeout_enabled = ${?SESSION_TIMEOUT_ENABLED}
+
+# Enables optional scores on multi-option question answer options
+answer_option_scoring_enabled = false
+answer_option_scoring_enabled = ${?ANSWER_OPTION_SCORING_ENABLED}


### PR DESCRIPTION
Admin-writeable experimental flag gating optional answer-option scores
on multi-option questions. Off by default; no behavior change yet.

Assisted-by: Claude Code:claude-fable-5

---

Part 1 of 12 in the option-scores stack. Merge in order, top to bottom:

1. https://github.com/civiform/civiform/pull/13796
2. https://github.com/civiform/civiform/pull/13797
3. https://github.com/civiform/civiform/pull/13798
4. https://github.com/civiform/civiform/pull/13799
5. https://github.com/civiform/civiform/pull/13800
6. https://github.com/civiform/civiform/pull/13801
7. https://github.com/civiform/civiform/pull/13802
8. https://github.com/civiform/civiform/pull/13803
9. https://github.com/civiform/civiform/pull/13804
10. https://github.com/civiform/civiform/pull/13805
11. https://github.com/civiform/civiform/pull/13806
12. https://github.com/civiform/civiform/pull/13807
