### PR TITLE
Add optional score to QuestionOption model

### DIFF
--- a/server/app/services/question/QuestionOption.java
+++ b/server/app/services/question/QuestionOption.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableMap;
+import java.math.BigDecimal;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.OptionalLong;
@@ -39,6 +40,13 @@ public abstract class QuestionOption {
   public abstract Optional<Boolean> displayInAnswerOptions();
 
   /**
+   * The score this option contributes to a submitted application, for programs that use scoring.
+   * Never shown to applicants. Absent means unscored, which is distinct from a score of 0.
+   */
+  @JsonProperty("score")
+  public abstract Optional<Double> score();
+
+  /**
    * Create a QuestionOption, used for JSON mapping to account for the legacy `optionText`.
    *
    * <p>Legacy QuestionOptions from before early May 2021 will not have `localizedOptionText`.
@@ -50,16 +58,20 @@ public abstract class QuestionOption {
       @JsonProperty("adminName") String adminName,
       @JsonProperty("localizedOptionText") LocalizedStrings localizedOptionText,
       @JsonProperty("optionText") ImmutableMap<Locale, String> legacyOptionText,
-      @JsonProperty("displayInAnswerOptions") Optional<Boolean> displayInAnswerOptions) {
+      @JsonProperty("displayInAnswerOptions") Optional<Boolean> displayInAnswerOptions,
+      @JsonProperty("score") Optional<Double> score) {
     if (displayOrder == -1) {
       displayOrder = id;
     }
     if (localizedOptionText != null) {
       return QuestionOption.create(
-          id, displayOrder, adminName, localizedOptionText, displayInAnswerOptions);
+          id, displayOrder, adminName, localizedOptionText, displayInAnswerOptions, score);
     }
     return QuestionOption.create(
-        id, displayOrder, adminName, LocalizedStrings.create(legacyOptionText));
+            id, displayOrder, adminName, LocalizedStrings.create(legacyOptionText))
+        .toBuilder()
+        .setScore(score)
+        .build();
   }
 
   /**
@@ -123,6 +135,44 @@ public abstract class QuestionOption {
         .build();
   }
 
+  /**
+   * Create a {@link QuestionOption}.
+   *
+   * @param id the option id
+   * @param displayOrder the option display
+   * @param adminName the option's immutable admin name, exposed via the API
+   * @param optionText the option's user-facing text
+   * @param displayInAnswerOptions whether to show the option to the applicant
+   * @param score the score the option contributes to a scored application, absent if unscored
+   * @return the {@link QuestionOption}
+   */
+  public static QuestionOption create(
+      long id,
+      long displayOrder,
+      String adminName,
+      LocalizedStrings optionText,
+      Optional<Boolean> displayInAnswerOptions,
+      Optional<Double> score) {
+    return QuestionOption.builder()
+        .setId(id)
+        .setAdminName(adminName)
+        .setOptionText(optionText)
+        .setDisplayOrder(OptionalLong.of(displayOrder))
+        .setDisplayInAnswerOptions(displayInAnswerOptions)
+        .setScore(score)
+        .build();
+  }
+
+  /**
+   * Canonical admin-facing rendering of a score value: plain decimal notation with trailing
+   * zeros stripped, so {@code 2.0} renders as {@code 2} and {@code 1.50} as {@code 1.5}. Used
+   * everywhere a score is displayed (question form inputs, PDFs, CSV cells); JSON output emits
+   * raw numbers instead.
+   */
+  public static String formatScore(double score) {
+    return BigDecimal.valueOf(score).stripTrailingZeros().toPlainString();
+  }
+
   public LocalizedQuestionOption localize(Locale locale) {
     if (!optionText().hasTranslationFor(locale)) {
       throw new RuntimeException(
@@ -180,6 +230,13 @@ public abstract class QuestionOption {
 
     @JsonProperty("displayInAnswerOptions")
     public abstract Builder setDisplayInAnswerOptions(Optional<Boolean> displayInAnswerOptions);
+
+    @JsonProperty("score")
+    public abstract Builder setScore(Optional<Double> score);
+
+    public Builder setScore(double score) {
+      return setScore(Optional.of(score));
+    }
 
     public abstract QuestionOption build();
   }

--- a/server/app/services/question/types/QuestionType.java
+++ b/server/app/services/question/types/QuestionType.java
@@ -1,5 +1,6 @@
 package services.question.types;
 
+import com.google.common.collect.ImmutableSet;
 import java.util.List;
 import java.util.Locale;
 import services.applicant.question.AbstractQuestion;
@@ -48,6 +49,9 @@ public enum QuestionType {
   private static final List<QuestionType> QUESTION_TYPES_SUPPORTING_SETTINGS =
       List.of(QuestionType.MAP);
 
+  private static final ImmutableSet<QuestionType> QUESTION_TYPES_SUPPORTING_OPTION_SCORES =
+      ImmutableSet.of(QuestionType.CHECKBOX, QuestionType.DROPDOWN, QuestionType.RADIO_BUTTON);
+
   QuestionType(String label, Class<? extends AbstractQuestion> supportedQuestion) {
     this.label = label;
     this.supportedQuestion = supportedQuestion;
@@ -61,6 +65,19 @@ public enum QuestionType {
    */
   public static boolean supportsQuestionSettings(QuestionType questionType) {
     return QUESTION_TYPES_SUPPORTING_SETTINGS.contains(questionType);
+  }
+
+  /**
+   * Determines if a {@link QuestionType} supports optional scores on its answer options.
+   *
+   * <p>This is deliberately narrower than {@link #isMultiOptionType()}: Yes/No questions are
+   * multi-option but must never carry scores.
+   *
+   * @param questionType a {@link QuestionType}
+   * @return boolean to indicate whether the question type supports option scores
+   */
+  public static boolean supportsOptionScores(QuestionType questionType) {
+    return QUESTION_TYPES_SUPPORTING_OPTION_SCORES.contains(questionType);
   }
 
   /**

--- a/server/test/services/question/types/QuestionOptionTest.java
+++ b/server/test/services/question/types/QuestionOptionTest.java
@@ -3,15 +3,21 @@ package services.question.types;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.collect.ImmutableMap;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.OptionalLong;
 import org.junit.Test;
 import services.LocalizedStrings;
+import services.ObjectMapperSingleton;
 import services.question.LocalizedQuestionOption;
 import services.question.QuestionOption;
 
 public class QuestionOptionTest {
+
+  private static final ObjectMapper mapper = ObjectMapperSingleton.instance();
 
   @Test
   public void localize_unsupportedLocale_throws() {
@@ -113,5 +119,149 @@ public class QuestionOptionTest {
     assertThat(localizedNo.order()).isEqualTo(1L); // displayOrder=1, not id=0
     assertThat(localizedNotSure.order()).isEqualTo(2L); // displayOrder=2, same as id=2
     assertThat(localizedMaybe.order()).isEqualTo(3L); // displayOrder=3, same as id=3
+  }
+
+  @Test
+  public void serde_roundTrip_preservesScore() throws Exception {
+    QuestionOption option =
+        QuestionOption.create(
+            /* id= */ 1L,
+            /* displayOrder= */ 0L,
+            /* adminName= */ "scored",
+            /* optionText= */ LocalizedStrings.of(Locale.US, "scored option"),
+            /* displayInAnswerOptions= */ Optional.of(true),
+            /* score= */ Optional.of(5.0));
+
+    QuestionOption deserialized =
+        mapper.readValue(mapper.writeValueAsString(option), QuestionOption.class);
+
+    assertThat(deserialized).isEqualTo(option);
+    assertThat(deserialized.score()).isEqualTo(Optional.of(5.0));
+  }
+
+  @Test
+  public void serde_roundTrip_preservesNegativeScore() throws Exception {
+    QuestionOption option =
+        QuestionOption.create(
+            /* id= */ 1L,
+            /* displayOrder= */ 0L,
+            /* adminName= */ "negative",
+            /* optionText= */ LocalizedStrings.of(Locale.US, "negative option"),
+            /* displayInAnswerOptions= */ Optional.of(true),
+            /* score= */ Optional.of(-3.5));
+
+    QuestionOption deserialized =
+        mapper.readValue(mapper.writeValueAsString(option), QuestionOption.class);
+
+    assertThat(deserialized.score()).isEqualTo(Optional.of(-3.5));
+  }
+
+  @Test
+  public void deserialize_integralScoreJson_readsEquivalentDouble() throws Exception {
+    // Stored rows written while scores were whole numbers hold integral JSON values; they
+    // deserialize to the equivalent double.
+    QuestionOption option =
+        QuestionOption.create(
+            /* id= */ 1L,
+            /* displayOrder= */ 0L,
+            /* adminName= */ "integral",
+            /* optionText= */ LocalizedStrings.of(Locale.US, "integral option"),
+            /* displayInAnswerOptions= */ Optional.of(true));
+    ObjectNode node = (ObjectNode) mapper.readTree(mapper.writeValueAsString(option));
+    node.put("score", 6);
+
+    QuestionOption deserialized = mapper.readValue(node.toString(), QuestionOption.class);
+
+    assertThat(deserialized.score()).isEqualTo(Optional.of(6.0));
+  }
+
+  @Test
+  public void formatScore_stripsTrailingZerosAndUsesPlainNotation() {
+    assertThat(QuestionOption.formatScore(2.0)).isEqualTo("2");
+    assertThat(QuestionOption.formatScore(1.5)).isEqualTo("1.5");
+    assertThat(QuestionOption.formatScore(-0.5)).isEqualTo("-0.5");
+    assertThat(QuestionOption.formatScore(0.0)).isEqualTo("0");
+    assertThat(QuestionOption.formatScore(1234567.25)).isEqualTo("1234567.25");
+  }
+
+  @Test
+  public void serde_roundTrip_absentScore() throws Exception {
+    QuestionOption option =
+        QuestionOption.create(
+            /* id= */ 1L,
+            /* displayOrder= */ 0L,
+            /* adminName= */ "unscored",
+            /* optionText= */ LocalizedStrings.of(Locale.US, "unscored option"),
+            /* displayInAnswerOptions= */ Optional.of(true));
+
+    QuestionOption deserialized =
+        mapper.readValue(mapper.writeValueAsString(option), QuestionOption.class);
+
+    assertThat(deserialized).isEqualTo(option);
+    assertThat(deserialized.score()).isEmpty();
+  }
+
+  @Test
+  public void deserialize_storedJsonWithoutScoreField_readsEmptyScore() throws Exception {
+    // Simulates a pre-feature stored row: no `score` property at all.
+    QuestionOption option =
+        QuestionOption.create(
+            /* id= */ 1L,
+            /* displayOrder= */ 0L,
+            /* adminName= */ "pre-feature",
+            /* optionText= */ LocalizedStrings.of(Locale.US, "pre-feature option"),
+            /* displayInAnswerOptions= */ Optional.of(true));
+    ObjectNode node = (ObjectNode) mapper.readTree(mapper.writeValueAsString(option));
+    node.remove("score");
+
+    QuestionOption deserialized = mapper.readValue(node.toString(), QuestionOption.class);
+
+    assertThat(deserialized).isEqualTo(option);
+    assertThat(deserialized.score()).isEmpty();
+  }
+
+  @Test
+  public void deserialize_explicitNullScore_readsEmptyScore() throws Exception {
+    QuestionOption option =
+        QuestionOption.create(
+            /* id= */ 1L,
+            /* displayOrder= */ 0L,
+            /* adminName= */ "null-score",
+            /* optionText= */ LocalizedStrings.of(Locale.US, "null score option"),
+            /* displayInAnswerOptions= */ Optional.of(true));
+    ObjectNode node = (ObjectNode) mapper.readTree(mapper.writeValueAsString(option));
+    node.putNull("score");
+
+    QuestionOption deserialized = mapper.readValue(node.toString(), QuestionOption.class);
+
+    assertThat(deserialized.score()).isEmpty();
+  }
+
+  @Test
+  public void deserialize_legacyOptionTextJson_preservesScore() throws Exception {
+    // Legacy rows (pre-May 2021) have `optionText` instead of `localizedOptionText`.
+    String legacyJson =
+        "{\"id\": 1, \"displayOrder\": 2, \"adminName\": \"legacy\","
+            + " \"optionText\": {\"en_US\": \"legacy option\"}, \"score\": 7.5}";
+
+    QuestionOption deserialized = mapper.readValue(legacyJson, QuestionOption.class);
+
+    assertThat(deserialized.optionText().get(Locale.US)).isEqualTo("legacy option");
+    assertThat(deserialized.score()).isEqualTo(Optional.of(7.5));
+  }
+
+  @Test
+  public void jsonCreator_legacyBranch_preservesScore() {
+    QuestionOption option =
+        QuestionOption.jsonCreator(
+            /* id= */ 1L,
+            /* displayOrder= */ 2L,
+            /* adminName= */ "legacy",
+            /* localizedOptionText= */ null,
+            /* legacyOptionText= */ ImmutableMap.of(Locale.US, "legacy option"),
+            /* displayInAnswerOptions= */ Optional.empty(),
+            /* score= */ Optional.of(4.5));
+
+    assertThat(option.score()).isEqualTo(Optional.of(4.5));
   }
 }

--- a/server/test/services/question/types/QuestionTypeTest.java
+++ b/server/test/services/question/types/QuestionTypeTest.java
@@ -41,4 +41,30 @@ public class QuestionTypeTest {
   public void of_lowercase() throws InvalidQuestionTypeException {
     assertThat(QuestionType.of("text")).isEqualTo(QuestionType.TEXT);
   }
+
+  @Test
+  public void supportsOptionScores_trueForCheckboxDropdownRadio() {
+    assertThat(QuestionType.supportsOptionScores(QuestionType.CHECKBOX)).isTrue();
+    assertThat(QuestionType.supportsOptionScores(QuestionType.DROPDOWN)).isTrue();
+    assertThat(QuestionType.supportsOptionScores(QuestionType.RADIO_BUTTON)).isTrue();
+  }
+
+  @Test
+  public void supportsOptionScores_falseForYesNo() {
+    // Yes/No is a multi-option type but must never support scoring.
+    assertThat(QuestionType.YES_NO.isMultiOptionType()).isTrue();
+    assertThat(QuestionType.supportsOptionScores(QuestionType.YES_NO)).isFalse();
+  }
+
+  @Test
+  public void supportsOptionScores_falseForAllOtherTypes() {
+    for (QuestionType type : QuestionType.values()) {
+      if (type == QuestionType.CHECKBOX
+          || type == QuestionType.DROPDOWN
+          || type == QuestionType.RADIO_BUTTON) {
+        continue;
+      }
+      assertThat(QuestionType.supportsOptionScores(type)).isFalse();
+    }
+  }
 }


### PR DESCRIPTION
QuestionOption gains an additive Optional<Integer> score JSON property,
threaded through both jsonCreator branches (including the legacy
optionText branch) so stored rows round-trip. Existing factory overloads
are unchanged; pre-feature JSON without the property deserializes to
empty. QuestionType.supportsOptionScores defines the supported set
(checkbox, dropdown, radio) - deliberately excluding Yes/No, which
isMultiOptionType() includes. LocalizedQuestionOption intentionally does
not carry the score so applicant-facing rendering can never see it.

Assisted-by: Claude Code:claude-fable-5

---

Part 2 of 12 in the option-scores stack. Merge in order, top to bottom:

1. https://github.com/civiform/civiform/pull/13796
2. https://github.com/civiform/civiform/pull/13797
3. https://github.com/civiform/civiform/pull/13798
4. https://github.com/civiform/civiform/pull/13799
5. https://github.com/civiform/civiform/pull/13800
6. https://github.com/civiform/civiform/pull/13801
7. https://github.com/civiform/civiform/pull/13802
8. https://github.com/civiform/civiform/pull/13803
9. https://github.com/civiform/civiform/pull/13804
10. https://github.com/civiform/civiform/pull/13805
11. https://github.com/civiform/civiform/pull/13806
12. https://github.com/civiform/civiform/pull/13807
