### PR TITLE
Bind, validate, and persist option scores in question forms

### DIFF
--- a/server/app/controllers/admin/AdminQuestionController.java
+++ b/server/app/controllers/admin/AdminQuestionController.java
@@ -242,9 +242,27 @@ public final class AdminQuestionController extends CiviFormController {
       return badRequest(invalidQuestionTypeMessage(questionType));
     }
 
+    boolean scoringEnabled = settingsManifest.getAnswerOptionScoringEnabled(request);
+
+    // Invalid scores surface as form validation errors and re-render the form, rather than being
+    // silently dropped by the builder below.
+    ImmutableSet<CiviFormError> scoreErrors = getOptionScoreErrors(questionForm, scoringEnabled);
+    if (!scoreErrors.isEmpty()) {
+      ToastMessage errorMessage = ToastMessage.errorNonLocalized(joinErrors(scoreErrors));
+      ImmutableList<EnumeratorQuestionDefinition> enumeratorQuestionDefinitions =
+          service
+              .getReadOnlyQuestionService()
+              .toCompletableFuture()
+              .join()
+              .getUpToDateEnumeratorQuestions();
+      return ok(
+          editView.renderNewQuestionForm(
+              request, questionForm, enumeratorQuestionDefinitions, errorMessage));
+    }
+
     QuestionDefinition questionDefinition;
     try {
-      questionDefinition = questionForm.getBuilder().build();
+      questionDefinition = getBuilder(questionForm, scoringEnabled).build();
     } catch (UnsupportedQuestionTypeException e) {
       // Valid question type that is not yet fully supported.
       return badRequest(e.getMessage());
@@ -428,9 +446,25 @@ public final class AdminQuestionController extends CiviFormController {
 
     Optional<QuestionDefinition> maybeExisting = Optional.of(roService.getQuestionDefinition(id));
 
+    boolean scoringEnabled = settingsManifest.getAnswerOptionScoringEnabled(request);
+
+    // Invalid scores surface as form validation errors and re-render the form, rather than being
+    // silently dropped by the builder below.
+    ImmutableSet<CiviFormError> scoreErrors = getOptionScoreErrors(questionForm, scoringEnabled);
+    if (!scoreErrors.isEmpty()) {
+      return ok(
+          editView.renderEditQuestionForm(
+              request,
+              id,
+              questionForm,
+              maybeGetEnumerationQuestion(roService, maybeExisting.get()),
+              ToastMessage.errorNonLocalized(joinErrors(scoreErrors))));
+    }
+
     QuestionDefinition questionDefinition;
     try {
-      questionDefinition = getBuilder(maybeExisting, questionForm).setId(id).build();
+      questionDefinition =
+          getBuilder(maybeExisting, questionForm, scoringEnabled).setId(id).build();
     } catch (UnsupportedQuestionTypeException e) {
       // Failed while trying to update a question that was already created for the given question
       // type
@@ -496,12 +530,37 @@ public final class AdminQuestionController extends CiviFormController {
     return result;
   }
 
+  /**
+   * Builds the {@link QuestionDefinitionBuilder} for a form response, threading the scoring flag
+   * into multi-option forms. When the flag is off, submitted scores are discarded.
+   */
+  private QuestionDefinitionBuilder getBuilder(QuestionForm questionForm, boolean scoringEnabled) {
+    if (questionForm instanceof MultiOptionQuestionForm multiOptionQuestionForm) {
+      return multiOptionQuestionForm.getBuilder(scoringEnabled);
+    }
+    return questionForm.getBuilder();
+  }
+
+  /**
+   * Returns validation errors for submitted option scores. Only relevant when the scoring flag is
+   * on and the question type supports scores; crafted score fields on other requests are ignored.
+   */
+  private ImmutableSet<CiviFormError> getOptionScoreErrors(
+      QuestionForm questionForm, boolean scoringEnabled) {
+    if (!scoringEnabled
+        || !(questionForm instanceof MultiOptionQuestionForm multiOptionQuestionForm)
+        || !QuestionType.supportsOptionScores(questionForm.getQuestionType())) {
+      return ImmutableSet.of();
+    }
+    return multiOptionQuestionForm.getOptionScoreErrors();
+  }
+
   private QuestionDefinitionBuilder getBuilder(
-      Optional<QuestionDefinition> existing, QuestionForm questionForm) {
-    QuestionDefinitionBuilder updated = questionForm.getBuilder();
+      Optional<QuestionDefinition> existing, QuestionForm questionForm, boolean scoringEnabled) {
+    QuestionDefinitionBuilder updated = getBuilder(questionForm, scoringEnabled);
 
     if (existing.isPresent()) {
-      updateDefaultLocalizations(existing.get(), updated, questionForm);
+      updateDefaultLocalizations(existing.get(), updated, questionForm, scoringEnabled);
     }
 
     return updated;
@@ -514,7 +573,8 @@ public final class AdminQuestionController extends CiviFormController {
   private void updateDefaultLocalizations(
       QuestionDefinition currentQuestionDefinition,
       QuestionDefinitionBuilder updatedQuestionDefinitionBuilder,
-      QuestionForm questionForm) {
+      QuestionForm questionForm,
+      boolean scoringEnabled) {
     // Instead of overwriting all localizations, we just want to overwrite the one
     // for the default locale (the only one possible to change in the edit form).
     updatedQuestionDefinitionBuilder.setQuestionText(
@@ -553,7 +613,8 @@ public final class AdminQuestionController extends CiviFormController {
       updateDefaultLocalizationForOptions(
           updatedQuestionDefinitionBuilder,
           (MultiOptionQuestionDefinition) currentQuestionDefinition,
-          updatedQuestionOptions);
+          updatedQuestionOptions,
+          scoringEnabled);
     }
 
     if (questionForm instanceof MapQuestionForm) {
@@ -590,7 +651,15 @@ public final class AdminQuestionController extends CiviFormController {
   private void updateDefaultLocalizationForOptions(
       QuestionDefinitionBuilder updatedQuestionDefinitionBuilder,
       MultiOptionQuestionDefinition currentQuestionDefinition,
-      ImmutableList<QuestionOption> updatedQuestionOptions) {
+      ImmutableList<QuestionOption> updatedQuestionOptions,
+      boolean scoringEnabled) {
+
+    // When scores don't apply to this edit (flag off or unsupported type), existing options keep
+    // their stored score via toBuilder() below, so an edit made while the flag is off cannot drop
+    // a stored score, and crafted score fields are discarded.
+    boolean applyScores =
+        scoringEnabled
+            && QuestionType.supportsOptionScores(currentQuestionDefinition.getQuestionType());
 
     var existingOptions = currentQuestionDefinition.getOptions();
     ImmutableList.Builder<QuestionOption> newOptionsListBuilder = ImmutableList.builder();
@@ -610,24 +679,31 @@ public final class AdminQuestionController extends CiviFormController {
               .equals(updatedQuestionOptionText.getDefault())) {
         // If there's an existing option with the same ID and same default locale text, then use it
         // and only update the displayOrder, preserving the adminName and translations.
-        newOptionsListBuilder.add(
+        QuestionOption.Builder optionBuilder =
             maybeExistingOptionWithSameId.get().toBuilder()
                 .setDisplayOrder(updatedQuestionOption.displayOrder())
-                .setDisplayInAnswerOptions(updatedQuestionOption.displayInAnswerOptions())
-                .build());
+                .setDisplayInAnswerOptions(updatedQuestionOption.displayInAnswerOptions());
+        if (applyScores) {
+          optionBuilder.setScore(updatedQuestionOption.score());
+        }
+        newOptionsListBuilder.add(optionBuilder.build());
       } else if (maybeExistingOptionWithSameId.isPresent()) {
         // If there's an existing option with the same ID but different text, then use it
         // and update the displayOrder and default locale text, preserving the adminName but
         // clearing any existing translations.
-        newOptionsListBuilder.add(
+        QuestionOption.Builder optionBuilder =
             maybeExistingOptionWithSameId.get().toBuilder()
                 .setDisplayOrder(updatedQuestionOption.displayOrder())
                 .setOptionText(updatedQuestionOptionText)
-                .setDisplayInAnswerOptions(updatedQuestionOption.displayInAnswerOptions())
-                .build());
+                .setDisplayInAnswerOptions(updatedQuestionOption.displayInAnswerOptions());
+        if (applyScores) {
+          optionBuilder.setScore(updatedQuestionOption.score());
+        }
+        newOptionsListBuilder.add(optionBuilder.build());
       } else {
         // If there wasn't an option with the same ID, treat it as a new
-        // option with a new adminName, displayOrder, and text.
+        // option with a new adminName, displayOrder, and text. Its score is already stripped by
+        // the form builder when scores don't apply.
         newOptionsListBuilder.add(updatedQuestionOption);
       }
     }

--- a/server/app/forms/questions/MultiOptionQuestionForm.java
+++ b/server/app/forms/questions/MultiOptionQuestionForm.java
@@ -2,12 +2,16 @@ package forms.questions;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
+import services.CiviFormError;
 import services.LocalizedStrings;
 import services.TranslationNotFoundException;
 import services.question.LocalizedQuestionOption;
@@ -30,6 +34,10 @@ public abstract class MultiOptionQuestionForm extends QuestionForm {
   private List<Long> optionIds;
   private List<String> optionAdminNames;
   private List<String> newOptionAdminNames;
+  // Optional per-option scores, parallel to options/newOptions. Stored as strings so that blank
+  // (unscored), 0, and invalid input are distinguishable; see parseScore.
+  private List<String> optionScores;
+  private List<String> newOptionScores;
 
   // The IDs of option types which have been selected by the admin to be included in the question's
   // answer options.
@@ -50,6 +58,8 @@ public abstract class MultiOptionQuestionForm extends QuestionForm {
     this.optionIds = new ArrayList<>();
     this.optionAdminNames = new ArrayList<>();
     this.newOptionAdminNames = new ArrayList<>();
+    this.optionScores = new ArrayList<>();
+    this.newOptionScores = new ArrayList<>();
     this.displayedOptionIds = new ArrayList<>();
     this.minChoicesRequired = OptionalInt.empty();
     this.maxChoicesAllowed = OptionalInt.empty();
@@ -71,7 +81,16 @@ public abstract class MultiOptionQuestionForm extends QuestionForm {
     this.optionIds = new ArrayList<>();
     this.optionAdminNames = new ArrayList<>();
     this.newOptionAdminNames = new ArrayList<>();
+    this.optionScores = new ArrayList<>();
+    this.newOptionScores = new ArrayList<>();
     this.displayedOptionIds = new ArrayList<>();
+
+    // Scores live on QuestionOption only (never on the applicant-facing LocalizedQuestionOption),
+    // so resolve them by option id.
+    ImmutableMap<Long, QuestionOption> optionsById =
+        qd.getOptions().stream()
+            .collect(
+                ImmutableMap.toImmutableMap(QuestionOption::id, option -> option, (a, b) -> a));
 
     try {
       // The first time a question is created, we only create for the default locale. The admin can
@@ -84,6 +103,11 @@ public abstract class MultiOptionQuestionForm extends QuestionForm {
                   options.add(option.optionText());
                   optionIds.add(option.id());
                   optionAdminNames.add(option.adminName());
+                  optionScores.add(
+                      Optional.ofNullable(optionsById.get(option.id()))
+                          .flatMap(QuestionOption::score)
+                          .map(QuestionOption::formatScore)
+                          .orElse(""));
                   if (getQuestionType() == QuestionType.YES_NO) {
                     if (option.displayInAnswerOptions().isPresent()
                         && option.displayInAnswerOptions().get()) {
@@ -144,6 +168,22 @@ public abstract class MultiOptionQuestionForm extends QuestionForm {
     this.newOptionAdminNames = newOptionAdminNames;
   }
 
+  public List<String> getOptionScores() {
+    return this.optionScores;
+  }
+
+  public void setOptionScores(List<String> optionScores) {
+    this.optionScores = optionScores;
+  }
+
+  public List<String> getNewOptionScores() {
+    return this.newOptionScores;
+  }
+
+  public void setNewOptionScores(List<String> newOptionScores) {
+    this.newOptionScores = newOptionScores;
+  }
+
   public List<Long> getDisplayedOptionIds() {
     return this.displayedOptionIds;
   }
@@ -195,13 +235,93 @@ public abstract class MultiOptionQuestionForm extends QuestionForm {
   }
 
   /**
+   * Returns validation problems with the submitted option scores, as form errors rather than
+   * exceptions so the edit view can re-render with a message.
+   *
+   * <p>Each score list must be parallel to its option list, and every non-blank entry must parse
+   * as a finite decimal number. The cardinality check is unconditional: callers only validate
+   * scores when the score inputs were rendered, so a missing or short list is a crafted post (or
+   * a mid-edit flag flip) and must error rather than silently build unscored options — for an
+   * existing question that would wipe its stored scores.
+   */
+  public ImmutableSet<CiviFormError> getOptionScoreErrors() {
+    ImmutableSet.Builder<CiviFormError> errors = ImmutableSet.builder();
+    if (optionScores.size() != options.size()) {
+      errors.add(
+          CiviFormError.of("The number of option scores does not match the number of options"));
+    }
+    if (newOptionScores.size() != newOptions.size()) {
+      errors.add(
+          CiviFormError.of(
+              "The number of new option scores does not match the number of new options"));
+    }
+    for (String scoreAsString : optionScores) {
+      addParseErrorIfInvalid(errors, scoreAsString);
+    }
+    for (String scoreAsString : newOptionScores) {
+      addParseErrorIfInvalid(errors, scoreAsString);
+    }
+    return errors.build();
+  }
+
+  private static void addParseErrorIfInvalid(
+      ImmutableSet.Builder<CiviFormError> errors, String scoreAsString) {
+    if (!isBlank(scoreAsString) && parseScore(scoreAsString).isEmpty()) {
+      errors.add(
+          CiviFormError.of(
+              String.format("Option score '%s' must be a number", scoreAsString.trim())));
+    }
+  }
+
+  private static boolean isBlank(String scoreAsString) {
+    return scoreAsString == null || scoreAsString.isBlank();
+  }
+
+  /**
+   * Parses an admin-entered score. Blank means unscored. Parsing goes through {@link BigDecimal}
+   * rather than {@link Double#parseDouble} as a server-side backstop against crafted posts: it
+   * accepts plain and exponent decimal notation but rejects the NaN/Infinity/hex/suffix forms
+   * Double.parseDouble tolerates, and the finite check rejects double-overflowing exponents.
+   * Invalid input surfaces as empty here and as errors in {@link #getOptionScoreErrors}.
+   */
+  private static Optional<Double> parseScore(String scoreAsString) {
+    if (isBlank(scoreAsString)) {
+      return Optional.empty();
+    }
+    try {
+      double score = new BigDecimal(scoreAsString.trim()).doubleValue();
+      return Double.isFinite(score) ? Optional.of(score) : Optional.empty();
+    } catch (NumberFormatException e) {
+      return Optional.empty();
+    }
+  }
+
+  private static Optional<Double> scoreAt(List<String> scores, int index) {
+    return index < scores.size() ? parseScore(scores.get(index)) : Optional.empty();
+  }
+
+  /**
    * Build a {@link QuestionDefinitionBuilder} from this QuestionForm, for handling the form
-   * response.
+   * response. Option scores are never applied through this overload; callers with the scoring
+   * feature flag in hand use {@link #getBuilder(boolean)}.
    *
    * @return a {@link QuestionDefinitionBuilder} with the values from this QuestionForm
    */
   @Override
   public QuestionDefinitionBuilder getBuilder() {
+    return getBuilder(/* scoringEnabled= */ false);
+  }
+
+  /**
+   * Build a {@link QuestionDefinitionBuilder} from this QuestionForm, for handling the form
+   * response.
+   *
+   * @param scoringEnabled whether the answer-option-scoring feature flag is on for this request;
+   *     when false (or the question type does not support scores), submitted scores are discarded
+   *     and options are built unscored
+   * @return a {@link QuestionDefinitionBuilder} with the values from this QuestionForm
+   */
+  public QuestionDefinitionBuilder getBuilder(boolean scoringEnabled) {
     MultiOptionQuestionDefinition.MultiOptionValidationPredicates.Builder predicateBuilder =
         MultiOptionQuestionDefinition.MultiOptionValidationPredicates.builder();
 
@@ -222,6 +342,10 @@ public abstract class MultiOptionQuestionForm extends QuestionForm {
         this.optionAdminNames.size() == this.options.size(),
         "Option admin names and options are not the same size.");
 
+    // Scores only apply when the feature flag is on and the type supports them; this inherently
+    // excludes Yes/No questions.
+    boolean applyScores = scoringEnabled && QuestionType.supportsOptionScores(getQuestionType());
+
     // Note: the question edit form only sets or updates the default locale.
     for (int i = 0; i < options.size(); i++) {
       // Yes/No questions have optional question options; all other question types should write
@@ -236,7 +360,8 @@ public abstract class MultiOptionQuestionForm extends QuestionForm {
               /* displayOrder= */ i,
               /* adminName= */ optionAdminNames.get(i),
               /* optionText= */ LocalizedStrings.withDefaultValue(options.get(i)),
-              /* displayInAnswerOptions= */ Optional.of(displayInAnswerOptions)));
+              /* displayInAnswerOptions= */ Optional.of(displayInAnswerOptions),
+              /* score= */ applyScores ? scoreAt(optionScores, i) : Optional.empty()));
     }
 
     // Get the next available ID, from either the max of the option IDs in the response or the
@@ -251,7 +376,8 @@ public abstract class MultiOptionQuestionForm extends QuestionForm {
               /* displayOrder= */ options.size() + i,
               /* adminName= */ newOptionAdminNames.get(i),
               /* optionText= */ LocalizedStrings.withDefaultValue(newOptions.get(i)),
-              /* displayInAnswerOptions= */ Optional.of(true)));
+              /* displayInAnswerOptions= */ Optional.of(true),
+              /* score= */ applyScores ? scoreAt(newOptionScores, i) : Optional.empty()));
     }
     ImmutableList<QuestionOption> questionOptions = questionOptionsBuilder.build();
 

--- a/server/test/controllers/admin/AdminQuestionControllerTest.java
+++ b/server/test/controllers/admin/AdminQuestionControllerTest.java
@@ -935,6 +935,326 @@ public class AdminQuestionControllerTest extends ResetPostgres {
   }
 
   @Test
+  public void create_withOptionScores_flagEnabled_savesScores() {
+    ImmutableMap<String, String> formData =
+        ImmutableMap.<String, String>builder()
+            .put("questionName", "scored dropdown")
+            .put("questionDescription", "desc")
+            .put("questionType", "DROPDOWN")
+            .put("questionText", "Pick one")
+            .put("questionHelpText", "help")
+            .put("newOptions[0]", "first")
+            .put("newOptions[1]", "second")
+            .put("newOptionAdminNames[0]", "first_admin")
+            .put("newOptionAdminNames[1]", "second_admin")
+            .put("newOptionScores[0]", "5.5")
+            .put("newOptionScores[1]", "")
+            .build();
+    RequestBuilder requestBuilder =
+        fakeRequestBuilder()
+            .addCiviFormSetting("ANSWER_OPTION_SCORING_ENABLED", "true")
+            .bodyForm(formData);
+
+    ImmutableSet<Long> questionIdsBefore = retrieveAllQuestionIds();
+    Result result = controller.create(requestBuilder.build(), "dropdown");
+
+    assertThat(result.status()).isEqualTo(SEE_OTHER);
+    ImmutableSet<Long> questionIdsAfter = retrieveAllQuestionIds();
+    Long newQuestionId = Sets.difference(questionIdsAfter, questionIdsBefore).iterator().next();
+    MultiOptionQuestionDefinition definition =
+        (MultiOptionQuestionDefinition)
+            questionRepo
+                .lookupQuestion(newQuestionId)
+                .toCompletableFuture()
+                .join()
+                .get()
+                .getQuestionDefinition();
+    assertThat(definition.getOptions().stream().map(QuestionOption::score))
+        .containsExactly(Optional.of(5.5), Optional.empty());
+  }
+
+  @Test
+  public void create_withOptionScores_flagDisabled_ignoresCraftedScores() {
+    ImmutableMap<String, String> formData =
+        ImmutableMap.<String, String>builder()
+            .put("questionName", "crafted dropdown")
+            .put("questionDescription", "desc")
+            .put("questionType", "DROPDOWN")
+            .put("questionText", "Pick one")
+            .put("questionHelpText", "help")
+            .put("newOptions[0]", "first")
+            .put("newOptionAdminNames[0]", "first_admin")
+            .put("newOptionScores[0]", "5")
+            .build();
+    RequestBuilder requestBuilder = fakeRequestBuilder().bodyForm(formData);
+
+    ImmutableSet<Long> questionIdsBefore = retrieveAllQuestionIds();
+    Result result = controller.create(requestBuilder.build(), "dropdown");
+
+    assertThat(result.status()).isEqualTo(SEE_OTHER);
+    ImmutableSet<Long> questionIdsAfter = retrieveAllQuestionIds();
+    Long newQuestionId = Sets.difference(questionIdsAfter, questionIdsBefore).iterator().next();
+    MultiOptionQuestionDefinition definition =
+        (MultiOptionQuestionDefinition)
+            questionRepo
+                .lookupQuestion(newQuestionId)
+                .toCompletableFuture()
+                .join()
+                .get()
+                .getQuestionDefinition();
+    assertThat(definition.getOptions().stream().map(QuestionOption::score))
+        .containsExactly(Optional.empty());
+  }
+
+  @Test
+  public void create_withInvalidScore_flagEnabled_rendersErrorWithoutSaving() {
+    ImmutableMap<String, String> formData =
+        ImmutableMap.<String, String>builder()
+            .put("questionName", "invalid score dropdown")
+            .put("questionDescription", "desc")
+            .put("questionType", "DROPDOWN")
+            .put("questionText", "Pick one")
+            .put("questionHelpText", "help")
+            .put("newOptions[0]", "first")
+            .put("newOptionAdminNames[0]", "first_admin")
+            .put("newOptionScores[0]", "junk")
+            .build();
+    Request request =
+        fakeRequestBuilder()
+            .addCSRFToken()
+            .addCiviFormSetting("ANSWER_OPTION_SCORING_ENABLED", "true")
+            .bodyForm(formData)
+            .build();
+
+    ImmutableSet<Long> questionIdsBefore = retrieveAllQuestionIds();
+    Result result = controller.create(request, "dropdown");
+
+    assertThat(result.status()).isEqualTo(OK);
+    String unescaped = StringEscapeUtils.unescapeHtml4(contentAsString(result));
+    assertThat(unescaped).contains("Option score 'junk' must be a number");
+    assertThat(retrieveAllQuestionIds().size()).isEqualTo(questionIdsBefore.size());
+  }
+
+  @Test
+  public void update_withOptionScores_flagEnabled_savesScores() {
+    QuestionDefinition definition = createScoredDropdownDefinition();
+    QuestionModel question = testQuestionBank.maybeSave(definition, LifecycleStage.DRAFT);
+
+    ImmutableMap<String, String> formData =
+        ImmutableMap.<String, String>builder()
+            .put("questionName", definition.getName())
+            .put("questionDescription", definition.getDescription())
+            .put("questionType", definition.getQuestionType().name())
+            .put("questionText", "new question text")
+            .put("questionHelpText", "new help text")
+            .put("options[0]", "chocolate")
+            .put("options[1]", "strawberry")
+            .put("optionIds[0]", "1")
+            .put("optionIds[1]", "2")
+            .put("optionAdminNames[0]", "chocolate_admin")
+            .put("optionAdminNames[1]", "strawberry_admin")
+            .put("optionScores[0]", "9.75")
+            .put("optionScores[1]", "")
+            .put("nextAvailableId", "3")
+            .put("questionExportState", "NON_DEMOGRAPHIC")
+            .put("concurrencyToken", question.getConcurrencyToken().toString())
+            .build();
+    RequestBuilder requestBuilder =
+        fakeRequestBuilder()
+            .addCiviFormSetting("ANSWER_OPTION_SCORING_ENABLED", "true")
+            .bodyForm(formData);
+
+    Result result =
+        controller.update(
+            requestBuilder.build(), question.id, definition.getQuestionType().toString());
+
+    assertThat(result.status()).isEqualTo(SEE_OTHER);
+    MultiOptionQuestionDefinition found =
+        (MultiOptionQuestionDefinition)
+            questionRepo
+                .lookupQuestion(question.id)
+                .toCompletableFuture()
+                .join()
+                .get()
+                .getQuestionDefinition();
+    // Option 1's score is updated; option 2's blank input clears its stored score.
+    assertThat(found.getOptions().stream().map(QuestionOption::score))
+        .containsExactly(Optional.of(9.75), Optional.empty());
+  }
+
+  @Test
+  public void update_flagDisabled_preservesStoredScoresAndIgnoresCraftedScores() {
+    QuestionDefinition definition = createScoredDropdownDefinition();
+    QuestionModel question = testQuestionBank.maybeSave(definition, LifecycleStage.DRAFT);
+
+    ImmutableMap<String, String> formData =
+        ImmutableMap.<String, String>builder()
+            .put("questionName", definition.getName())
+            .put("questionDescription", definition.getDescription())
+            .put("questionType", definition.getQuestionType().name())
+            .put("questionText", "new question text")
+            .put("questionHelpText", "new help text")
+            .put("options[0]", "chocolate")
+            .put("options[1]", "strawberry")
+            .put("optionIds[0]", "1")
+            .put("optionIds[1]", "2")
+            .put("optionAdminNames[0]", "chocolate_admin")
+            .put("optionAdminNames[1]", "strawberry_admin")
+            // Crafted scores; the score inputs are not rendered while the flag is off.
+            .put("optionScores[0]", "1000")
+            .put("optionScores[1]", "1000")
+            .put("nextAvailableId", "3")
+            .put("questionExportState", "NON_DEMOGRAPHIC")
+            .put("concurrencyToken", question.getConcurrencyToken().toString())
+            .build();
+    RequestBuilder requestBuilder = fakeRequestBuilder().bodyForm(formData);
+
+    Result result =
+        controller.update(
+            requestBuilder.build(), question.id, definition.getQuestionType().toString());
+
+    assertThat(result.status()).isEqualTo(SEE_OTHER);
+    MultiOptionQuestionDefinition found =
+        (MultiOptionQuestionDefinition)
+            questionRepo
+                .lookupQuestion(question.id)
+                .toCompletableFuture()
+                .join()
+                .get()
+                .getQuestionDefinition();
+    // The stored scores survive the flag-off edit; the crafted values are discarded.
+    assertThat(found.getOptions().stream().map(QuestionOption::score))
+        .containsExactly(Optional.of(3.5), Optional.empty());
+  }
+
+  @Test
+  public void update_withoutScoreFields_flagEnabled_rendersErrorWithoutWipingScores() {
+    // A crafted post omitting optionScores[] entirely (the rendered form always submits them)
+    // must fail cardinality validation, not silently rebuild every option unscored.
+    QuestionDefinition definition = createScoredDropdownDefinition();
+    QuestionModel question = testQuestionBank.maybeSave(definition, LifecycleStage.DRAFT);
+
+    ImmutableMap<String, String> formData =
+        ImmutableMap.<String, String>builder()
+            .put("questionName", definition.getName())
+            .put("questionDescription", definition.getDescription())
+            .put("questionType", definition.getQuestionType().name())
+            .put("questionText", "new question text")
+            .put("questionHelpText", "new help text")
+            .put("options[0]", "chocolate")
+            .put("options[1]", "strawberry")
+            .put("optionIds[0]", "1")
+            .put("optionIds[1]", "2")
+            .put("optionAdminNames[0]", "chocolate_admin")
+            .put("optionAdminNames[1]", "strawberry_admin")
+            .put("nextAvailableId", "3")
+            .put("questionExportState", "NON_DEMOGRAPHIC")
+            .put("concurrencyToken", question.getConcurrencyToken().toString())
+            .build();
+    Request request =
+        fakeRequestBuilder()
+            .addCSRFToken()
+            .addCiviFormSetting("ANSWER_OPTION_SCORING_ENABLED", "true")
+            .bodyForm(formData)
+            .build();
+
+    Result result =
+        controller.update(request, question.id, definition.getQuestionType().toString());
+
+    assertThat(result.status()).isEqualTo(OK);
+    String unescaped = StringEscapeUtils.unescapeHtml4(contentAsString(result));
+    assertThat(unescaped)
+        .contains("The number of option scores does not match the number of options");
+    MultiOptionQuestionDefinition found =
+        (MultiOptionQuestionDefinition)
+            questionRepo
+                .lookupQuestion(question.id)
+                .toCompletableFuture()
+                .join()
+                .get()
+                .getQuestionDefinition();
+    assertThat(found.getOptions().stream().map(QuestionOption::score))
+        .containsExactly(Optional.of(3.5), Optional.empty());
+  }
+
+  @Test
+  public void update_withInvalidScore_flagEnabled_rendersErrorWithoutSaving() {
+    QuestionDefinition definition = createScoredDropdownDefinition();
+    QuestionModel question = testQuestionBank.maybeSave(definition, LifecycleStage.DRAFT);
+
+    ImmutableMap<String, String> formData =
+        ImmutableMap.<String, String>builder()
+            .put("questionName", definition.getName())
+            .put("questionDescription", definition.getDescription())
+            .put("questionType", definition.getQuestionType().name())
+            .put("questionText", "new question text")
+            .put("questionHelpText", "new help text")
+            .put("options[0]", "chocolate")
+            .put("options[1]", "strawberry")
+            .put("optionIds[0]", "1")
+            .put("optionIds[1]", "2")
+            .put("optionAdminNames[0]", "chocolate_admin")
+            .put("optionAdminNames[1]", "strawberry_admin")
+            .put("optionScores[0]", "NaN")
+            .put("optionScores[1]", "")
+            .put("nextAvailableId", "3")
+            .put("questionExportState", "NON_DEMOGRAPHIC")
+            .put("concurrencyToken", question.getConcurrencyToken().toString())
+            .build();
+    Request request =
+        fakeRequestBuilder()
+            .addCSRFToken()
+            .addCiviFormSetting("ANSWER_OPTION_SCORING_ENABLED", "true")
+            .bodyForm(formData)
+            .build();
+
+    Result result =
+        controller.update(request, question.id, definition.getQuestionType().toString());
+
+    assertThat(result.status()).isEqualTo(OK);
+    String unescaped = StringEscapeUtils.unescapeHtml4(contentAsString(result));
+    assertThat(unescaped).contains("Option score 'NaN' must be a number");
+    MultiOptionQuestionDefinition found =
+        (MultiOptionQuestionDefinition)
+            questionRepo
+                .lookupQuestion(question.id)
+                .toCompletableFuture()
+                .join()
+                .get()
+                .getQuestionDefinition();
+    assertThat(found.getOptions().stream().map(QuestionOption::score))
+        .containsExactly(Optional.of(3.5), Optional.empty());
+  }
+
+  private MultiOptionQuestionDefinition createScoredDropdownDefinition() {
+    QuestionDefinitionConfig config =
+        QuestionDefinitionConfig.builder()
+            .setName("scored ice cream")
+            .setDescription("Select your favorite ice cream flavor")
+            .setQuestionText(LocalizedStrings.of(Locale.US, "Ice cream?"))
+            .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help"))
+            .build();
+    ImmutableList<QuestionOption> questionOptions =
+        ImmutableList.of(
+            QuestionOption.create(
+                /* id= */ 1L,
+                /* displayOrder= */ 0,
+                /* adminName= */ "chocolate_admin",
+                /* optionText= */ LocalizedStrings.of(Locale.US, "chocolate"),
+                /* displayInAnswerOptions= */ Optional.of(true),
+                /* score= */ Optional.of(3.5)),
+            QuestionOption.create(
+                /* id= */ 2L,
+                /* displayOrder= */ 1,
+                /* adminName= */ "strawberry_admin",
+                /* optionText= */ LocalizedStrings.of(Locale.US, "strawberry"),
+                /* displayInAnswerOptions= */ Optional.of(true),
+                /* score= */ Optional.empty()));
+    return new MultiOptionQuestionDefinition(
+        config, questionOptions, MultiOptionQuestionType.DROPDOWN);
+  }
+
+  @Test
   public void update_failsWithErrorMessageAndPopulatedFields() {
     QuestionModel question = testQuestionBank.textApplicantFavoriteColor();
     ImmutableMap.Builder<String, String> formData = ImmutableMap.builder();

--- a/server/test/forms/questions/MultiOptionQuestionFormBindingTest.java
+++ b/server/test/forms/questions/MultiOptionQuestionFormBindingTest.java
@@ -1,0 +1,93 @@
+package forms.questions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static support.FakeRequestBuilder.fakeRequestBuilder;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.Before;
+import org.junit.Test;
+import play.data.FormFactory;
+import play.mvc.Http.Request;
+import repository.ResetPostgres;
+import services.CiviFormError;
+
+/**
+ * Proves Play's binding of the parallel score string lists on a real {@link FormFactory}, in
+ * particular that a blank trailing score row still binds so the lists stay parallel to the option
+ * lists.
+ */
+public class MultiOptionQuestionFormBindingTest extends ResetPostgres {
+
+  private FormFactory formFactory;
+
+  @Before
+  public void setup() {
+    formFactory = instanceOf(FormFactory.class);
+  }
+
+  @Test
+  public void bindFromRequest_bindsParallelScoreLists_includingTrailingBlank() {
+    Request request =
+        fakeRequestBuilder()
+            .bodyForm(
+                ImmutableMap.<String, String>builder()
+                    .put("questionName", "binding test")
+                    .put("questionDescription", "desc")
+                    .put("questionText", "question text")
+                    .put("questionHelpText", "help text")
+                    .put("options[0]", "one")
+                    .put("options[1]", "two")
+                    .put("optionAdminNames[0]", "one_admin")
+                    .put("optionAdminNames[1]", "two_admin")
+                    .put("optionIds[0]", "1")
+                    .put("optionIds[1]", "2")
+                    .put("optionScores[0]", "10.5")
+                    // A trailing blank score row must still bind an entry.
+                    .put("optionScores[1]", "")
+                    .put("newOptions[0]", "three")
+                    .put("newOptionAdminNames[0]", "three_admin")
+                    .put("newOptionScores[0]", "")
+                    .put("nextAvailableId", "3")
+                    .build())
+            .build();
+
+    CheckboxQuestionForm form =
+        formFactory.form(CheckboxQuestionForm.class).bindFromRequest(request).get();
+
+    assertThat(form.getOptions()).containsExactly("one", "two");
+    assertThat(form.getOptionScores()).containsExactly("10.5", "");
+    assertThat(form.getNewOptions()).containsExactly("three");
+    assertThat(form.getNewOptionScores()).containsExactly("");
+    assertThat(form.getOptionScoreErrors()).isEmpty();
+  }
+
+  @Test
+  public void bindFromRequest_missingScoreFields_bindsEmptyLists() {
+    Request request =
+        fakeRequestBuilder()
+            .bodyForm(
+                ImmutableMap.<String, String>builder()
+                    .put("questionName", "binding test")
+                    .put("questionDescription", "desc")
+                    .put("questionText", "question text")
+                    .put("questionHelpText", "help text")
+                    .put("options[0]", "one")
+                    .put("optionAdminNames[0]", "one_admin")
+                    .put("optionIds[0]", "1")
+                    .put("nextAvailableId", "2")
+                    .build())
+            .build();
+
+    CheckboxQuestionForm form =
+        formFactory.form(CheckboxQuestionForm.class).bindFromRequest(request).get();
+
+    assertThat(form.getOptionScores()).isEmpty();
+    assertThat(form.getNewOptionScores()).isEmpty();
+    // Missing score fields bind as empty lists, which fail cardinality validation: the rendered
+    // form always submits a score input per option, so this shape is a crafted post and must not
+    // silently build unscored options.
+    assertThat(form.getOptionScoreErrors())
+        .extracting(CiviFormError::message)
+        .containsExactly("The number of option scores does not match the number of options");
+  }
+}

--- a/server/test/forms/questions/MultiOptionQuestionFormTest.java
+++ b/server/test/forms/questions/MultiOptionQuestionFormTest.java
@@ -4,9 +4,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import java.util.Locale;
+import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.UUID;
 import org.junit.Test;
+import services.CiviFormError;
 import services.LocalizedStrings;
 import services.question.QuestionOption;
 import services.question.types.MultiOptionQuestionDefinition;
@@ -210,5 +212,203 @@ public class MultiOptionQuestionFormTest {
 
     assertThat(questionDefinition.getOptionAdminNames())
         .containsExactly("one admin", "two admin", "three admin", "four admin");
+  }
+
+  private static MultiOptionQuestionDefinition definitionWithScoredOptions() {
+    QuestionDefinitionConfig config =
+        QuestionDefinitionConfig.builder()
+            .setName("name")
+            .setDescription("description")
+            .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
+            .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
+            .setConcurrencyToken(UUID.randomUUID())
+            .build();
+    return new MultiOptionQuestionDefinition(
+        config,
+        ImmutableList.of(
+            QuestionOption.create(
+                /* id= */ 1L,
+                /* displayOrder= */ 0L,
+                /* adminName= */ "one admin",
+                /* optionText= */ LocalizedStrings.of(Locale.US, "option 1"),
+                /* displayInAnswerOptions= */ Optional.of(true),
+                /* score= */ Optional.of(3.5)),
+            QuestionOption.create(
+                /* id= */ 2L,
+                /* displayOrder= */ 1L,
+                /* adminName= */ "two admin",
+                /* optionText= */ LocalizedStrings.of(Locale.US, "option 2"),
+                /* displayInAnswerOptions= */ Optional.of(true),
+                /* score= */ Optional.empty()),
+            QuestionOption.create(
+                /* id= */ 5L,
+                /* displayOrder= */ 2L,
+                /* adminName= */ "five admin",
+                /* optionText= */ LocalizedStrings.of(Locale.US, "option 5"),
+                /* displayInAnswerOptions= */ Optional.of(true),
+                /* score= */ Optional.of(-2.0))),
+        MultiOptionQuestionType.CHECKBOX);
+  }
+
+  @Test
+  public void constructor_withQd_populatesOptionScoresInDisplayOrder() {
+    MultiOptionQuestionForm form = new CheckboxQuestionForm(definitionWithScoredOptions());
+
+    // Blank means unscored; scores are parallel to options.
+    assertThat(form.getOptions()).containsExactly("option 1", "option 2", "option 5");
+    // Whole values populate without a trailing .0 (formatScore).
+    assertThat(form.getOptionScores()).containsExactly("3.5", "", "-2");
+  }
+
+  @Test
+  public void getBuilder_scoringEnabled_appliesScores() throws Exception {
+    MultiOptionQuestionForm form = new CheckboxQuestionForm();
+    form.setQuestionName("name");
+    form.setQuestionDescription("description");
+    form.setQuestionText("What is the question text?");
+    form.setQuestionHelpText("help text");
+    form.setMinChoicesRequired("");
+    form.setMaxChoicesAllowed("");
+    form.setOptions(ImmutableList.of("one", "two", "three"));
+    form.setOptionAdminNames(ImmutableList.of("one admin", "two admin", "three admin"));
+    form.setOptionIds(ImmutableList.of(1L, 2L, 3L));
+    form.setOptionScores(ImmutableList.of("4", "", "0"));
+    form.setNewOptions(ImmutableList.of("four"));
+    form.setNewOptionAdminNames(ImmutableList.of("four admin"));
+    form.setNewOptionScores(ImmutableList.of("-7.25"));
+
+    MultiOptionQuestionDefinition questionDefinition =
+        (MultiOptionQuestionDefinition) form.getBuilder(/* scoringEnabled= */ true).build();
+
+    assertThat(questionDefinition.getOptions().stream().map(QuestionOption::score))
+        .containsExactly(
+            Optional.of(4.0), Optional.empty(), Optional.of(0.0), Optional.of(-7.25));
+  }
+
+  @Test
+  public void getBuilder_scoringDisabled_discardsSubmittedScores() throws Exception {
+    MultiOptionQuestionForm form = new CheckboxQuestionForm();
+    form.setQuestionName("name");
+    form.setQuestionDescription("description");
+    form.setQuestionText("What is the question text?");
+    form.setQuestionHelpText("help text");
+    form.setMinChoicesRequired("");
+    form.setMaxChoicesAllowed("");
+    form.setOptions(ImmutableList.of("one", "two"));
+    form.setOptionAdminNames(ImmutableList.of("one admin", "two admin"));
+    form.setOptionIds(ImmutableList.of(1L, 2L));
+    form.setOptionScores(ImmutableList.of("4", "5"));
+
+    MultiOptionQuestionDefinition viaDefaultOverload =
+        (MultiOptionQuestionDefinition) form.getBuilder().build();
+    MultiOptionQuestionDefinition viaExplicitFalse =
+        (MultiOptionQuestionDefinition) form.getBuilder(/* scoringEnabled= */ false).build();
+
+    assertThat(viaDefaultOverload.getOptions().stream().map(QuestionOption::score))
+        .containsExactly(Optional.empty(), Optional.empty());
+    assertThat(viaExplicitFalse.getOptions().stream().map(QuestionOption::score))
+        .containsExactly(Optional.empty(), Optional.empty());
+  }
+
+  @Test
+  public void getOptionScoreErrors_missingScoreLists_returnsError() {
+    // Score validation only runs when the score inputs were rendered, so a post with options but
+    // no score fields at all is a crafted post; it must error rather than silently build unscored
+    // options, which for an existing question would wipe its stored scores.
+    MultiOptionQuestionForm form = new CheckboxQuestionForm();
+    form.setQuestionName("name");
+    form.setQuestionDescription("description");
+    form.setQuestionText("What is the question text?");
+    form.setQuestionHelpText("help text");
+    form.setMinChoicesRequired("");
+    form.setMaxChoicesAllowed("");
+    form.setOptions(ImmutableList.of("one", "two"));
+    form.setOptionAdminNames(ImmutableList.of("one admin", "two admin"));
+    form.setOptionIds(ImmutableList.of(1L, 2L));
+
+    assertThat(form.getOptionScoreErrors())
+        .extracting(CiviFormError::message)
+        .containsExactly("The number of option scores does not match the number of options");
+  }
+
+  @Test
+  public void getOptionScoreErrors_noOptionsAndNoScores_empty() {
+    // Zero options with zero scores is parallel, not a mismatch.
+    MultiOptionQuestionForm form = new CheckboxQuestionForm();
+    form.setNewOptions(ImmutableList.of("one"));
+    form.setNewOptionAdminNames(ImmutableList.of("one admin"));
+    form.setNewOptionScores(ImmutableList.of("2.5"));
+
+    assertThat(form.getOptionScoreErrors()).isEmpty();
+  }
+
+  @Test
+  public void getBuilder_yesNoForm_neverAppliesScores() throws Exception {
+    MultiOptionQuestionForm form = new YesNoQuestionForm();
+    form.setQuestionName("name");
+    form.setQuestionDescription("description");
+    form.setQuestionText("What is the question text?");
+    form.setQuestionHelpText("help text");
+    form.setOptions(ImmutableList.of("Yes", "No"));
+    form.setOptionAdminNames(ImmutableList.of("yes", "no"));
+    form.setOptionIds(ImmutableList.of(1L, 0L));
+    form.setDisplayedOptionIds(ImmutableList.of(1L, 0L));
+    // Crafted scores on a Yes/No question must be discarded even with the flag on.
+    form.setOptionScores(ImmutableList.of("4", "5"));
+
+    MultiOptionQuestionDefinition questionDefinition =
+        (MultiOptionQuestionDefinition) form.getBuilder(/* scoringEnabled= */ true).build();
+
+    assertThat(questionDefinition.getOptions().stream().map(QuestionOption::score))
+        .containsExactly(Optional.empty(), Optional.empty());
+  }
+
+  @Test
+  public void getOptionScoreErrors_validScores_empty() {
+    MultiOptionQuestionForm form = new CheckboxQuestionForm();
+    form.setOptions(ImmutableList.of("one", "two", "three"));
+    form.setOptionAdminNames(ImmutableList.of("one admin", "two admin", "three admin"));
+    form.setOptionIds(ImmutableList.of(1L, 2L, 3L));
+    // Fractional, exponent-notation, and beyond-32-bit values are all valid decimals; blank
+    // stays "unscored".
+    form.setOptionScores(ImmutableList.of("1.5", "", "2147483648"));
+    form.setNewOptions(ImmutableList.of("four"));
+    form.setNewOptionAdminNames(ImmutableList.of("four admin"));
+    form.setNewOptionScores(ImmutableList.of("-0.125"));
+
+    assertThat(form.getOptionScoreErrors()).isEmpty();
+  }
+
+  @Test
+  public void getOptionScoreErrors_invalidScores_returnsErrorsNotExceptions() {
+    MultiOptionQuestionForm form = new CheckboxQuestionForm();
+    form.setOptions(ImmutableList.of("one", "two", "three", "four"));
+    form.setOptionAdminNames(
+        ImmutableList.of("one admin", "two admin", "three admin", "four admin"));
+    form.setOptionIds(ImmutableList.of(1L, 2L, 3L, 4L));
+    // Junk, NaN, Infinity, and a double-overflowing exponent are all rejected.
+    form.setOptionScores(ImmutableList.of("junk", "NaN", "Infinity", "1e999"));
+
+    assertThat(form.getOptionScoreErrors())
+        .hasSize(4)
+        .allSatisfy(error -> assertThat(error.message()).contains("must be a number"));
+  }
+
+  @Test
+  public void getOptionScoreErrors_cardinalityMismatch_returnsError() {
+    MultiOptionQuestionForm form = new CheckboxQuestionForm();
+    form.setOptions(ImmutableList.of("one", "two"));
+    form.setOptionAdminNames(ImmutableList.of("one admin", "two admin"));
+    form.setOptionIds(ImmutableList.of(1L, 2L));
+    form.setOptionScores(ImmutableList.of("4"));
+    form.setNewOptions(ImmutableList.of("three"));
+    form.setNewOptionAdminNames(ImmutableList.of("three admin"));
+    form.setNewOptionScores(ImmutableList.of("1", "2"));
+
+    assertThat(form.getOptionScoreErrors())
+        .extracting(CiviFormError::message)
+        .containsExactlyInAnyOrder(
+            "The number of option scores does not match the number of options",
+            "The number of new option scores does not match the number of new options");
   }
 }

--- a/server/test/forms/translation/MultiOptionQuestionTranslationFormTest.java
+++ b/server/test/forms/translation/MultiOptionQuestionTranslationFormTest.java
@@ -79,4 +79,36 @@ public class MultiOptionQuestionTranslationFormTest {
                 /* displayInAnswerOptions= */ Optional.empty(),
                 /* locale= */ Locale.FRANCE));
   }
+
+  @Test
+  public void buildsQuestion_preservesOptionScores() throws Exception {
+    QuestionDefinitionConfig config =
+        QuestionDefinitionConfig.builder()
+            .setName("test")
+            .setDescription("desc")
+            .setQuestionText(LocalizedStrings.empty())
+            .setQuestionHelpText(LocalizedStrings.empty())
+            .build();
+    QuestionDefinition question =
+        new MultiOptionQuestionDefinition(
+            config,
+            ImmutableList.of(
+                QuestionOption.create(
+                    /* id= */ 1L,
+                    /* displayOrder= */ 0L,
+                    /* adminName= */ "opt1",
+                    /* optionText= */ LocalizedStrings.withDefaultValue("other"),
+                    /* displayInAnswerOptions= */ Optional.of(true),
+                    /* score= */ Optional.of(7.5))),
+            MultiOptionQuestionType.RADIO_BUTTON);
+
+    MultiOptionQuestionTranslationForm form = new MultiOptionQuestionTranslationForm();
+    form.setOptions(ImmutableList.of("new"));
+    MultiOptionQuestionDefinition updated =
+        (MultiOptionQuestionDefinition) form.builderWithUpdates(question, Locale.CHINA).build();
+
+    // A translation-only edit must not drop stored scores.
+    assertThat(updated.getOptions().stream().map(QuestionOption::score))
+        .containsExactly(Optional.of(7.5));
+  }
 }


### PR DESCRIPTION
MultiOptionQuestionForm gains optionScores/newOptionScores string lists
parallel to the option lists, so blank, 0, and invalid input stay
distinguishable through Play binding. Invalid or mismatched scores
surface as form validation errors (getOptionScoreErrors) instead of
exceptions; AdminQuestionController re-renders the edit view with them.

The flag is resolved once per request in create/update and threaded as
an explicit boolean into getBuilder(scoringEnabled). With the flag off
(or on unsupported types like Yes/No), submitted scores are discarded,
stored scores survive edits via the existing toBuilder() merge, and
create cannot introduce scores. Translation-only edits already preserve
scores; a regression test pins that.

Assisted-by: Claude Code:claude-fable-5

---

Part 3 of 12 in the option-scores stack. Merge in order, top to bottom:

1. https://github.com/civiform/civiform/pull/13796
2. https://github.com/civiform/civiform/pull/13797
3. https://github.com/civiform/civiform/pull/13798
4. https://github.com/civiform/civiform/pull/13799
5. https://github.com/civiform/civiform/pull/13800
6. https://github.com/civiform/civiform/pull/13801
7. https://github.com/civiform/civiform/pull/13802
8. https://github.com/civiform/civiform/pull/13803
9. https://github.com/civiform/civiform/pull/13804
10. https://github.com/civiform/civiform/pull/13805
11. https://github.com/civiform/civiform/pull/13806
12. https://github.com/civiform/civiform/pull/13807
