### PR TITLE
Render option score inputs on the question edit form

### DIFF
--- a/server/app/controllers/admin/AdminQuestionController.java
+++ b/server/app/controllers/admin/AdminQuestionController.java
@@ -207,6 +207,7 @@ public final class AdminQuestionController extends CiviFormController {
                     mapSettings,
                     settingsManifest.getApiBridgeEnabled(request),
                     settingsManifest.getEnumeratorImprovementsEnabled(request),
+                    settingsManifest.getAnswerOptionScoringEnabled(request),
                     roService,
                     Optional.empty());
         return ok(questionFormPageView.render(request, model)).as(Http.MimeTypes.HTML);
@@ -248,16 +249,7 @@ public final class AdminQuestionController extends CiviFormController {
     // silently dropped by the builder below.
     ImmutableSet<CiviFormError> scoreErrors = getOptionScoreErrors(questionForm, scoringEnabled);
     if (!scoreErrors.isEmpty()) {
-      ToastMessage errorMessage = ToastMessage.errorNonLocalized(joinErrors(scoreErrors));
-      ImmutableList<EnumeratorQuestionDefinition> enumeratorQuestionDefinitions =
-          service
-              .getReadOnlyQuestionService()
-              .toCompletableFuture()
-              .join()
-              .getUpToDateEnumeratorQuestions();
-      return ok(
-          editView.renderNewQuestionForm(
-              request, questionForm, enumeratorQuestionDefinitions, errorMessage));
+      return renderNewQuestionFormWithError(request, questionForm, joinErrors(scoreErrors));
     }
 
     QuestionDefinition questionDefinition;
@@ -274,31 +266,7 @@ public final class AdminQuestionController extends CiviFormController {
     ErrorAnd<QuestionDefinition, CiviFormError> result =
         service.create(questionDefinition, enumeratorImprovementsEnabled);
     if (result.isError()) {
-      String errorText = joinErrors(result.getErrors());
-      ReadOnlyQuestionService roService =
-          service.getReadOnlyQuestionService().toCompletableFuture().join();
-      ImmutableList<EnumeratorQuestionDefinition> enumeratorQuestionDefinitions =
-          roService.getUpToDateEnumeratorQuestions();
-
-      if (settingsManifest.getAdminUiMigrationJ2htmlToThymeleafScEnabled(request)) {
-        MapQuestionSettingsPartialViewModel mapSettings = buildMapSettingsViewModel(questionForm);
-        QuestionFormPageViewModel model =
-            new QuestionFormPageMapper()
-                .mapNew(
-                    questionForm,
-                    enumeratorQuestionDefinitions,
-                    mapSettings,
-                    settingsManifest.getApiBridgeEnabled(request),
-                    settingsManifest.getEnumeratorImprovementsEnabled(request),
-                    roService,
-                    Optional.of(errorText));
-        return ok(questionFormPageView.render(request, model)).as(Http.MimeTypes.HTML);
-      }
-
-      ToastMessage errorMessage = ToastMessage.errorNonLocalized(errorText);
-      return ok(
-          editView.renderNewQuestionForm(
-              request, questionForm, enumeratorQuestionDefinitions, errorMessage));
+      return renderNewQuestionFormWithError(request, questionForm, joinErrors(result.getErrors()));
     }
 
     try {
@@ -452,13 +420,13 @@ public final class AdminQuestionController extends CiviFormController {
     // silently dropped by the builder below.
     ImmutableSet<CiviFormError> scoreErrors = getOptionScoreErrors(questionForm, scoringEnabled);
     if (!scoreErrors.isEmpty()) {
-      return ok(
-          editView.renderEditQuestionForm(
-              request,
-              id,
-              questionForm,
-              maybeGetEnumerationQuestion(roService, maybeExisting.get()),
-              ToastMessage.errorNonLocalized(joinErrors(scoreErrors))));
+      return renderEditQuestionFormWithError(
+          request,
+          id,
+          questionForm,
+          maybeGetEnumerationQuestion(roService, maybeExisting.get()),
+          roService,
+          joinErrors(scoreErrors));
     }
 
     QuestionDefinition questionDefinition;
@@ -491,26 +459,13 @@ public final class AdminQuestionController extends CiviFormController {
     }
 
     if (errorAndUpdatedQuestionDefinition.isError()) {
-      String errorText = joinErrors(errorAndUpdatedQuestionDefinition.getErrors());
-      Optional<QuestionDefinition> maybeEnumerationQuestion =
-          maybeGetEnumerationQuestion(roService, questionDefinition);
-
-      if (settingsManifest.getAdminUiMigrationJ2htmlToThymeleafScEnabled(request)) {
-        QuestionFormPageViewModel model =
-            buildEditQuestionPageModel(
-                id,
-                questionForm,
-                maybeEnumerationQuestion,
-                roService,
-                request,
-                Optional.of(errorText));
-        return ok(questionFormPageView.render(request, model)).as(Http.MimeTypes.HTML);
-      }
-
-      ToastMessage errorMessage = ToastMessage.errorNonLocalized(errorText);
-      return ok(
-          editView.renderEditQuestionForm(
-              request, id, questionForm, maybeEnumerationQuestion, errorMessage));
+      return renderEditQuestionFormWithError(
+          request,
+          id,
+          questionForm,
+          maybeGetEnumerationQuestion(roService, questionDefinition),
+          roService,
+          joinErrors(errorAndUpdatedQuestionDefinition.getErrors()));
     }
     try {
       service.setExportState(
@@ -539,6 +494,68 @@ public final class AdminQuestionController extends CiviFormController {
       return multiOptionQuestionForm.getBuilder(scoringEnabled);
     }
     return questionForm.getBuilder();
+  }
+
+  /**
+   * Re-renders the new-question form with a form-level error, honoring the j2html-to-Thymeleaf
+   * migration flag.
+   */
+  private Result renderNewQuestionFormWithError(
+      Request request, QuestionForm questionForm, String errorText) {
+    ReadOnlyQuestionService roService =
+        service.getReadOnlyQuestionService().toCompletableFuture().join();
+    ImmutableList<EnumeratorQuestionDefinition> enumeratorQuestionDefinitions =
+        roService.getUpToDateEnumeratorQuestions();
+
+    if (settingsManifest.getAdminUiMigrationJ2htmlToThymeleafScEnabled(request)) {
+      MapQuestionSettingsPartialViewModel mapSettings = buildMapSettingsViewModel(questionForm);
+      QuestionFormPageViewModel model =
+          new QuestionFormPageMapper()
+              .mapNew(
+                  questionForm,
+                  enumeratorQuestionDefinitions,
+                  mapSettings,
+                  settingsManifest.getApiBridgeEnabled(request),
+                  settingsManifest.getEnumeratorImprovementsEnabled(request),
+                  settingsManifest.getAnswerOptionScoringEnabled(request),
+                  roService,
+                  Optional.of(errorText));
+      return ok(questionFormPageView.render(request, model)).as(Http.MimeTypes.HTML);
+    }
+
+    ToastMessage errorMessage = ToastMessage.errorNonLocalized(errorText);
+    return ok(
+        editView.renderNewQuestionForm(
+            request, questionForm, enumeratorQuestionDefinitions, errorMessage));
+  }
+
+  /**
+   * Re-renders the edit-question form with a form-level error, honoring the j2html-to-Thymeleaf
+   * migration flag.
+   */
+  private Result renderEditQuestionFormWithError(
+      Request request,
+      Long id,
+      QuestionForm questionForm,
+      Optional<QuestionDefinition> maybeEnumerationQuestion,
+      ReadOnlyQuestionService roService,
+      String errorText) {
+    if (settingsManifest.getAdminUiMigrationJ2htmlToThymeleafScEnabled(request)) {
+      QuestionFormPageViewModel model =
+          buildEditQuestionPageModel(
+              id,
+              questionForm,
+              maybeEnumerationQuestion,
+              roService,
+              request,
+              Optional.of(errorText));
+      return ok(questionFormPageView.render(request, model)).as(Http.MimeTypes.HTML);
+    }
+
+    ToastMessage errorMessage = ToastMessage.errorNonLocalized(errorText);
+    return ok(
+        editView.renderEditQuestionForm(
+            request, id, questionForm, maybeEnumerationQuestion, errorMessage));
   }
 
   /**
@@ -810,6 +827,7 @@ public final class AdminQuestionController extends CiviFormController {
             mapSettings,
             settingsManifest.getApiBridgeEnabled(request),
             settingsManifest.getEnumeratorImprovementsEnabled(request),
+            settingsManifest.getAnswerOptionScoringEnabled(request),
             readOnlyQuestionService,
             errorMessage);
   }

--- a/server/app/forms/questions/MultiOptionQuestionForm.java
+++ b/server/app/forms/questions/MultiOptionQuestionForm.java
@@ -278,6 +278,15 @@ public abstract class MultiOptionQuestionForm extends QuestionForm {
   }
 
   /**
+   * Converts a bound score string to its input display value, formatted without trailing zeros.
+   * Blank (unscored) and unparseable values render an empty input; invalid submissions are
+   * re-rendered alongside a form-level error from {@link #getOptionScoreErrors}.
+   */
+  public static Optional<String> formatScoreForDisplay(String scoreAsString) {
+    return parseScore(scoreAsString).map(QuestionOption::formatScore);
+  }
+
+  /**
    * Parses an admin-entered score. Blank means unscored. Parsing goes through {@link BigDecimal}
    * rather than {@link Double#parseDouble} as a server-side backstop against crafted posts: it
    * accepts plain and exponent decimal notation but rejects the NaN/Infinity/hex/suffix forms

--- a/server/app/mapping/admin/questions/QuestionFormPageMapper.java
+++ b/server/app/mapping/admin/questions/QuestionFormPageMapper.java
@@ -28,6 +28,7 @@ public final class QuestionFormPageMapper {
       MapQuestionSettingsPartialViewModel mapSettings,
       boolean apiBridgeEnabled,
       boolean enumeratorImprovementsEnabled,
+      boolean answerOptionScoringEnabled,
       ReadOnlyQuestionService readOnlyQuestionService,
       Optional<String> errorMessage) {
     // Build enumerator options
@@ -51,6 +52,7 @@ public final class QuestionFormPageMapper {
             mapSettings,
             apiBridgeEnabled,
             enumeratorImprovementsEnabled,
+            answerOptionScoringEnabled,
             readOnlyQuestionService,
             errorMessage)
         .editMode(false)
@@ -67,6 +69,7 @@ public final class QuestionFormPageMapper {
       MapQuestionSettingsPartialViewModel mapSettings,
       boolean apiBridgeEnabled,
       boolean enumeratorImprovementsEnabled,
+      boolean answerOptionScoringEnabled,
       ReadOnlyQuestionService readOnlyQuestionService,
       Optional<String> errorMessage) {
     String enumeratorDisplayName =
@@ -77,6 +80,7 @@ public final class QuestionFormPageMapper {
             mapSettings,
             apiBridgeEnabled,
             enumeratorImprovementsEnabled,
+            answerOptionScoringEnabled,
             readOnlyQuestionService,
             errorMessage)
         .editMode(true)
@@ -92,6 +96,7 @@ public final class QuestionFormPageMapper {
       MapQuestionSettingsPartialViewModel mapSettings,
       boolean apiBridgeEnabled,
       boolean enumeratorImprovementsEnabled,
+      boolean answerOptionScoringEnabled,
       ReadOnlyQuestionService readOnlyQuestionService,
       Optional<String> errorMessage) {
     QuestionType questionType = questionForm.getQuestionType();
@@ -150,6 +155,8 @@ public final class QuestionFormPageMapper {
             questionType.equals(QuestionType.YES_NO)
                 ? YesNoConfigMapper.buildYesNoConfig((MultiOptionQuestionForm) questionForm)
                 : null)
+        .showScores(
+            answerOptionScoringEnabled && QuestionType.supportsOptionScores(questionType))
         .errorMessage(errorToastMessage)
         .errorToastId(errorToastMessage.isPresent() ? UUID.randomUUID().toString() : null);
   }

--- a/server/app/views/admin/questions/QuestionConfig.java
+++ b/server/app/views/admin/questions/QuestionConfig.java
@@ -28,6 +28,7 @@ import j2html.tags.specialized.DivTag;
 import j2html.tags.specialized.FieldsetTag;
 import j2html.tags.specialized.InputTag;
 import j2html.tags.specialized.LabelTag;
+import java.util.List;
 import java.util.Optional;
 import java.util.OptionalLong;
 import play.i18n.Messages;
@@ -39,6 +40,7 @@ import services.question.LocalizedQuestionOption;
 import services.question.YesNoQuestionOption;
 import services.question.types.DateQuestionDefinition.DateValidationOption;
 import services.question.types.DateQuestionDefinition.DateValidationOption.DateType;
+import services.question.types.QuestionType;
 import services.settings.SettingsManifest;
 import views.BaseView;
 import views.BaseViewModel;
@@ -70,6 +72,11 @@ public final class QuestionConfig {
       SettingsManifest settingsManifest,
       Request request) {
     QuestionConfig config = new QuestionConfig();
+    // Score inputs render only when the scoring flag is on and the type supports option scores;
+    // Yes/No questions use a separate renderer and never show scores.
+    boolean showScores =
+        settingsManifest.getAnswerOptionScoringEnabled(request)
+            && QuestionType.supportsOptionScores(questionForm.getQuestionType());
     switch (questionForm.getQuestionType()) {
       case ADDRESS:
         return Optional.of(
@@ -78,7 +85,7 @@ public final class QuestionConfig {
         MultiOptionQuestionForm form = (MultiOptionQuestionForm) questionForm;
         return Optional.of(
             config
-                .addMultiOptionQuestionFields(form, messages)
+                .addMultiOptionQuestionFields(form, messages, showScores)
                 .addMultiSelectQuestionValidation(form)
                 .getContainer());
       case ENUMERATOR:
@@ -106,7 +113,8 @@ public final class QuestionConfig {
       case RADIO_BUTTON:
         return Optional.of(
             config
-                .addMultiOptionQuestionFields((MultiOptionQuestionForm) questionForm, messages)
+                .addMultiOptionQuestionFields(
+                    (MultiOptionQuestionForm) questionForm, messages, showScores)
                 .getContainer());
       case FILEUPLOAD:
         return Optional.of(
@@ -312,8 +320,13 @@ public final class QuestionConfig {
    * Creates a template text field where an admin can enter a single multi-option question answer,
    * along with a button to remove the option.
    */
-  public static DivTag multiOptionQuestionFieldTemplate(Messages messages) {
-    return multiOptionQuestionField(Optional.empty(), messages, /* isForNewOption= */ true);
+  public static DivTag multiOptionQuestionFieldTemplate(Messages messages, boolean showScores) {
+    return multiOptionQuestionField(
+        Optional.empty(),
+        messages,
+        /* isForNewOption= */ true,
+        /* scoreValue= */ Optional.empty(),
+        showScores);
   }
 
   /**
@@ -321,7 +334,11 @@ public final class QuestionConfig {
    * answer, along with a button to remove the option.
    */
   private static DivTag multiOptionQuestionField(
-      Optional<LocalizedQuestionOption> existingOption, Messages messages, boolean isForNewOption) {
+      Optional<LocalizedQuestionOption> existingOption,
+      Messages messages,
+      boolean isForNewOption,
+      Optional<String> scoreValue,
+      boolean showScores) {
     DivTag optionAdminName =
         FieldWithLabel.input()
             .setFieldName(isForNewOption ? "newOptionAdminNames[]" : "optionAdminNames[]")
@@ -403,26 +420,57 @@ public final class QuestionConfig {
                 "col-start-8",
                 "row-span-2")
             .attr("aria-label", "delete");
-    return div()
-        .withClasses(
-            ReferenceClasses.MULTI_OPTION_QUESTION_OPTION,
-            ReferenceClasses.MULTI_OPTION_QUESTION_OPTION_EDITABLE,
-            "grid",
-            "grid-cols-8",
-            "grid-rows-4",
-            "items-center",
-            "mb-4")
-        .with(
-            optionIndexInput,
-            optionAdminName,
-            moveUpButton,
-            moveDownButton,
-            optionInput,
-            removeOptionButton);
+    DivTag row =
+        div()
+            .withClasses(
+                ReferenceClasses.MULTI_OPTION_QUESTION_OPTION,
+                ReferenceClasses.MULTI_OPTION_QUESTION_OPTION_EDITABLE,
+                "grid",
+                "grid-cols-8",
+                showScores ? "grid-rows-6" : "grid-rows-4",
+                "items-center",
+                "mb-4")
+            .with(
+                optionIndexInput,
+                optionAdminName,
+                moveUpButton,
+                moveDownButton,
+                optionInput,
+                removeOptionButton);
+    if (showScores) {
+      // FieldWithLabel's numeric value plumbing is long-only, so decimal values are set directly
+      // on the input's value attribute.
+      FieldWithLabel scoreField =
+          FieldWithLabel.number()
+              .setFieldName(isForNewOption ? "newOptionScores[]" : "optionScores[]")
+              .setLabelText("Score")
+              .addReferenceClass(ReferenceClasses.MULTI_OPTION_SCORE_INPUT);
+      scoreValueForDisplay(scoreValue).ifPresent(value -> scoreField.setAttribute("value", value));
+      row.with(
+          scoreField
+              .getNumberTag()
+              .withClasses(
+                  ReferenceClasses.MULTI_OPTION_SCORE_INPUT,
+                  "col-start-1",
+                  "col-span-5",
+                  "mb-2",
+                  "ml-2",
+                  "row-start-5",
+                  "row-span-2"));
+    }
+    return row;
+  }
+
+  private static Optional<String> scoreValueForDisplay(Optional<String> scoreValue) {
+    return scoreValue.flatMap(MultiOptionQuestionForm::formatScoreForDisplay);
+  }
+
+  private static Optional<String> scoreAt(List<String> scores, int index) {
+    return index < scores.size() ? Optional.of(scores.get(index)) : Optional.empty();
   }
 
   private QuestionConfig addMultiOptionQuestionFields(
-      MultiOptionQuestionForm multiOptionQuestionForm, Messages messages) {
+      MultiOptionQuestionForm multiOptionQuestionForm, Messages messages, boolean showScores) {
     Preconditions.checkState(
         multiOptionQuestionForm.getOptionIds().size()
             == multiOptionQuestionForm.getOptions().size(),
@@ -441,7 +489,9 @@ public final class QuestionConfig {
                       /* displayInAnswerOptions= */ Optional.of(true),
                       LocalizedStrings.DEFAULT_LOCALE)),
               messages,
-              /* isForNewOption= */ false));
+              /* isForNewOption= */ false,
+              scoreAt(multiOptionQuestionForm.getOptionScores(), i),
+              showScores));
       optionIndex++;
     }
 
@@ -457,7 +507,9 @@ public final class QuestionConfig {
                       /* displayInAnswerOptions= */ Optional.of(true),
                       LocalizedStrings.DEFAULT_LOCALE)),
               messages,
-              /* isForNewOption= */ true));
+              /* isForNewOption= */ true,
+              scoreAt(multiOptionQuestionForm.getNewOptionScores(), i),
+              showScores));
       optionIndex++;
     }
 

--- a/server/app/views/admin/questions/QuestionEditView.java
+++ b/server/app/views/admin/questions/QuestionEditView.java
@@ -162,7 +162,7 @@ public final class QuestionEditView extends BaseHtmlView {
         String.format("New %s question", questionType.getLabel().toLowerCase(Locale.ROOT));
 
     DivTag formContent =
-        buildQuestionContainer(title)
+        buildQuestionContainer(title, showScores(request, questionType))
             .with(
                 buildNewQuestionForm(questionForm, enumeratorQuestionDefinitions, request)
                     .with(makeCsrfTokenInputTag(request)));
@@ -221,7 +221,7 @@ public final class QuestionEditView extends BaseHtmlView {
         String.format("Edit %s question", questionType.getLabel().toLowerCase(Locale.ROOT));
 
     DivTag formContent =
-        buildQuestionContainer(title)
+        buildQuestionContainer(title, showScores(request, questionType))
             .with(
                 buildEditQuestionForm(
                         id,
@@ -272,7 +272,7 @@ public final class QuestionEditView extends BaseHtmlView {
         questionForm, enumeratorOptions, /* submittable= */ true, forCreate, request);
   }
 
-  private DivTag buildQuestionContainer(String title) {
+  private DivTag buildQuestionContainer(String title, boolean showScores) {
     return div()
         .withId("question-form")
         .attr("hx-ext", "response-targets")
@@ -288,25 +288,34 @@ public final class QuestionEditView extends BaseHtmlView {
             "relative",
             "w-2/5")
         .with(renderHeader(title))
-        .with(multiOptionQuestionField());
+        .with(multiOptionQuestionField(showScores));
   }
 
   // A <template> holding the markup for a new multi-option answer. The id lives
   // on the <template> so the JS can clone its content (see MultiOptionQuestion);
   // the cloned row is shown when appended, so it is not hidden here.
-  private TemplateTag multiOptionQuestionField() {
+  private TemplateTag multiOptionQuestionField(boolean showScores) {
     return template()
         .withId("multi-option-question-answer-template")
         .with(
-            QuestionConfig.multiOptionQuestionFieldTemplate(messages)
+            QuestionConfig.multiOptionQuestionFieldTemplate(messages, showScores)
                 .withClasses(
                     ReferenceClasses.MULTI_OPTION_QUESTION_OPTION,
                     ReferenceClasses.MULTI_OPTION_QUESTION_OPTION_EDITABLE,
                     "grid",
                     "grid-cols-8",
-                    "grid-rows-4",
+                    showScores ? "grid-rows-6" : "grid-rows-4",
                     "items-center",
                     "mb-4"));
+  }
+
+  /**
+   * Whether score inputs should render for this request and question type: the scoring flag is on
+   * and the type supports option scores (which excludes Yes/No).
+   */
+  private boolean showScores(Request request, QuestionType questionType) {
+    return settingsManifest.getAnswerOptionScoringEnabled(request)
+        && QuestionType.supportsOptionScores(questionType);
   }
 
   private FormTag buildNewQuestionForm(

--- a/server/app/views/admin/questions/QuestionFormPage.html
+++ b/server/app/views/admin/questions/QuestionFormPage.html
@@ -13,7 +13,7 @@
     <!--/* Markup cloned by the client when adding a new multi-option answer. */-->
     <template id="multi-option-question-answer-template">
       <div
-        th:replace="~{admin/questions/fragments/MultiOptionRow :: multiOptionRow(true, '', '', '', ${model.randomFieldId()}, ${model.randomFieldId()}, ${model.randomFieldId()})}"
+        th:replace="~{admin/questions/fragments/MultiOptionRow :: multiOptionRow(true, '', '', '', ${model.randomFieldId()}, ${model.randomFieldId()}, ${model.randomFieldId()}, ${model.showScores}, null, ${model.randomFieldId()})}"
       ></div>
     </template>
 

--- a/server/app/views/admin/questions/QuestionFormPageViewModel.java
+++ b/server/app/views/admin/questions/QuestionFormPageViewModel.java
@@ -4,6 +4,7 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 
 import com.google.common.collect.ImmutableList;
 import controllers.admin.routes;
+import forms.questions.MultiOptionQuestionForm;
 import forms.questions.QuestionForm;
 import java.util.List;
 import java.util.Locale;
@@ -94,6 +95,10 @@ public final class QuestionFormPageViewModel implements BaseViewModel {
   // YES_NO: the option rows to render. Null for other question types.
   private final YesNoConfig yesNoConfig;
 
+  // CHECKBOX / DROPDOWN / RADIO_BUTTON: whether the per-option score inputs render (the
+  // answer-option-scoring flag is on and the question type supports scores).
+  private final boolean showScores;
+
   // Error message shown as a toast (already carries the "Error: " prefix)
   private final Optional<String> errorMessage;
   // Random id for the toast container. Null when there is no error message.
@@ -133,6 +138,18 @@ public final class QuestionFormPageViewModel implements BaseViewModel {
    */
   public String randomFieldId() {
     return RandomStringUtils.randomAlphabetic(8);
+  }
+
+  /**
+   * The display value for the score input at {@code index} of a bound score list, formatted
+   * without trailing zeros. Null (attribute omitted) when the entry is missing, blank, or
+   * unparseable; a null-padded or short list from a sparse crafted post is tolerated.
+   */
+  public String scoreDisplayValue(List<String> scores, int index) {
+    if (index >= scores.size()) {
+      return null;
+    }
+    return MultiOptionQuestionForm.formatScoreForDisplay(scores.get(index)).orElse(null);
   }
 
   /** Whether there is a type-specific question config section. */

--- a/server/app/views/admin/questions/fragments/MultiOptionContainerFragment.html
+++ b/server/app/views/admin/questions/fragments/MultiOptionContainerFragment.html
@@ -8,12 +8,12 @@
   <div id="multi-option-container">
     <th:block th:each="optionText, stat : ${questionForm.getOptions()}">
       <div
-        th:replace="~{admin/questions/fragments/MultiOptionRow :: multiOptionRow(false, ${questionForm.getOptionIds().get(stat.index)}, ${questionForm.getOptionAdminNames().get(stat.index)}, ${optionText}, ${model.randomFieldId()}, ${model.randomFieldId()}, ${model.randomFieldId()})}"
+        th:replace="~{admin/questions/fragments/MultiOptionRow :: multiOptionRow(false, ${questionForm.getOptionIds().get(stat.index)}, ${questionForm.getOptionAdminNames().get(stat.index)}, ${optionText}, ${model.randomFieldId()}, ${model.randomFieldId()}, ${model.randomFieldId()}, ${model.showScores}, ${model.scoreDisplayValue(questionForm.getOptionScores(), stat.index)}, ${model.randomFieldId()})}"
       ></div>
     </th:block>
     <th:block th:each="newOptionText, stat : ${questionForm.getNewOptions()}">
       <div
-        th:replace="~{admin/questions/fragments/MultiOptionRow :: multiOptionRow(true, '', ${questionForm.getNewOptionAdminNames().get(stat.index)}, ${newOptionText}, ${model.randomFieldId()}, ${model.randomFieldId()}, ${model.randomFieldId()})}"
+        th:replace="~{admin/questions/fragments/MultiOptionRow :: multiOptionRow(true, '', ${questionForm.getNewOptionAdminNames().get(stat.index)}, ${newOptionText}, ${model.randomFieldId()}, ${model.randomFieldId()}, ${model.randomFieldId()}, ${model.showScores}, ${model.scoreDisplayValue(questionForm.getNewOptionScores(), stat.index)}, ${model.randomFieldId()})}"
       ></div>
     </th:block>
   </div>

--- a/server/app/views/admin/questions/fragments/MultiOptionRow.html
+++ b/server/app/views/admin/questions/fragments/MultiOptionRow.html
@@ -5,11 +5,16 @@
   options are also readonly on the Admin ID.
 
   Callers pass the label/input ids in (optionIdFieldId, adminNameFieldId,
-  optionTextFieldId), generating them with ${model.randomFieldId()} so
-  labels stay associated with inputs. Icons live in LegacySvgFragments.html.
+  optionTextFieldId, scoreFieldId), generating them with
+  ${model.randomFieldId()} so labels stay associated with inputs. When
+  showScores is true (the answer-option-scoring flag is on and the type
+  supports scores) the row grows to six grid rows and renders a score input
+  posting to newOptionScores[] / optionScores[]; scoreValue is the
+  pre-formatted display value or null. Icons live in LegacySvgFragments.html.
 */-->
 <div
-  th:fragment="multiOptionRow(isForNewOption, optionId, adminName, optionText, optionIdFieldId, adminNameFieldId, optionTextFieldId)"
+  th:fragment="multiOptionRow(isForNewOption, optionId, adminName, optionText, optionIdFieldId, adminNameFieldId, optionTextFieldId, showScores, scoreValue, scoreFieldId)"
+  th:class="|cf-multi-option-question-option cf-multi-option-question-option-editable grid grid-cols-8 ${showScores ? 'grid-rows-6' : 'grid-rows-4'} items-center mb-4|"
   class="cf-multi-option-question-option cf-multi-option-question-option-editable grid grid-cols-8 grid-rows-4 items-center mb-4"
 >
   <div th:if="${isForNewOption}"></div>
@@ -123,4 +128,32 @@
       th:replace="~{admin/shared/LegacySvgFragments :: iconDelete('w-6 h-6')}"
     ></svg>
   </button>
+  <div
+    th:if="${showScores}"
+    class="cf-multi-option-score-input col-start-1 col-span-5 mb-2 ml-2 row-start-5 row-span-2"
+  >
+    <label
+      th:for="${scoreFieldId}"
+      class="pointer-events-none text-gray-600 text-base px-1 py-2"
+      >Score<span
+        th:replace="~{admin/shared/LegacyFieldWithLabel/RequiredIndicator :: requiredIndicator(false)}"
+      ></span
+    ></label>
+    <div class="flex flex-col">
+      <input
+        type="number"
+        inputmode="decimal"
+        step="any"
+        th:value="${scoreValue}"
+        maxlength="10000"
+        th:id="${scoreFieldId}"
+        th:name="${isForNewOption} ? 'newOptionScores[]' : 'optionScores[]'"
+        class="px-3 bg-white text-black text-lg py-2 block outline-none box-border m-auto border border-gray-500 rounded-lg w-full focus:border-civiform-blue placeholder-gray-500"
+      />
+      <div
+        th:id="|${scoreFieldId}-errors|"
+        class="text-red-600 text-xs p-1 hidden"
+      ></div>
+    </div>
+  </div>
 </div>

--- a/server/app/views/style/ReferenceClasses.java
+++ b/server/app/views/style/ReferenceClasses.java
@@ -82,6 +82,7 @@ public final class ReferenceClasses {
       "cf-multi-option-question-option-editable";
   public static final String MULTI_OPTION_INPUT = "cf-multi-option-input";
   public static final String MULTI_OPTION_ADMIN_INPUT = "cf-multi-option-admin-input";
+  public static final String MULTI_OPTION_SCORE_INPUT = "cf-multi-option-score-input";
 
   // Keep these values in sync with app/assets/javascript/file_upload.ts.
   public static final String FILEUPLOAD_TOO_LARGE_ERROR_ID = "cf-fileupload-too-large-error";

--- a/server/test/controllers/admin/AdminQuestionControllerTest.java
+++ b/server/test/controllers/admin/AdminQuestionControllerTest.java
@@ -1178,6 +1178,146 @@ public class AdminQuestionControllerTest extends ResetPostgres {
   }
 
   @Test
+  public void create_thymeleafQuestionForm_withOptionScores_savesScores() {
+    ImmutableMap<String, String> formData =
+        ImmutableMap.<String, String>builder()
+            .put("questionName", "thymeleaf scored dropdown")
+            .put("questionDescription", "desc")
+            .put("questionType", "DROPDOWN")
+            .put("questionText", "Pick one")
+            .put("questionHelpText", "help")
+            .put("newOptions[0]", "first")
+            .put("newOptions[1]", "second")
+            .put("newOptionAdminNames[0]", "first_admin")
+            .put("newOptionAdminNames[1]", "second_admin")
+            .put("newOptionScores[0]", "5.5")
+            .put("newOptionScores[1]", "")
+            .build();
+    RequestBuilder requestBuilder =
+        fakeRequestBuilder()
+            .addCiviFormSetting("ANSWER_OPTION_SCORING_ENABLED", "true")
+            .addCiviFormSetting("ADMIN_UI_MIGRATION_J2HTML_TO_THYMELEAF_SC_ENABLED", "true")
+            .bodyForm(formData);
+
+    ImmutableSet<Long> questionIdsBefore = retrieveAllQuestionIds();
+    Result result = controller.create(requestBuilder.build(), "dropdown");
+
+    assertThat(result.status()).isEqualTo(SEE_OTHER);
+    ImmutableSet<Long> questionIdsAfter = retrieveAllQuestionIds();
+    Long newQuestionId = Sets.difference(questionIdsAfter, questionIdsBefore).iterator().next();
+    MultiOptionQuestionDefinition definition =
+        (MultiOptionQuestionDefinition)
+            questionRepo
+                .lookupQuestion(newQuestionId)
+                .toCompletableFuture()
+                .join()
+                .get()
+                .getQuestionDefinition();
+    assertThat(definition.getOptions().stream().map(QuestionOption::score))
+        .containsExactly(Optional.of(5.5), Optional.empty());
+  }
+
+  @Test
+  public void update_thymeleafQuestionForm_withOptionScores_savesScores() {
+    QuestionDefinition definition = createScoredDropdownDefinition();
+    QuestionModel question = testQuestionBank.maybeSave(definition, LifecycleStage.DRAFT);
+
+    ImmutableMap<String, String> formData =
+        ImmutableMap.<String, String>builder()
+            .put("questionName", definition.getName())
+            .put("questionDescription", definition.getDescription())
+            .put("questionType", definition.getQuestionType().name())
+            .put("questionText", "new question text")
+            .put("questionHelpText", "new help text")
+            .put("options[0]", "chocolate")
+            .put("options[1]", "strawberry")
+            .put("optionIds[0]", "1")
+            .put("optionIds[1]", "2")
+            .put("optionAdminNames[0]", "chocolate_admin")
+            .put("optionAdminNames[1]", "strawberry_admin")
+            .put("optionScores[0]", "")
+            .put("optionScores[1]", "-1.25")
+            .put("nextAvailableId", "3")
+            .put("questionExportState", "NON_DEMOGRAPHIC")
+            .put("concurrencyToken", question.getConcurrencyToken().toString())
+            .build();
+    RequestBuilder requestBuilder =
+        fakeRequestBuilder()
+            .addCiviFormSetting("ANSWER_OPTION_SCORING_ENABLED", "true")
+            .addCiviFormSetting("ADMIN_UI_MIGRATION_J2HTML_TO_THYMELEAF_SC_ENABLED", "true")
+            .bodyForm(formData);
+
+    Result result =
+        controller.update(
+            requestBuilder.build(), question.id, definition.getQuestionType().toString());
+
+    assertThat(result.status()).isEqualTo(SEE_OTHER);
+    MultiOptionQuestionDefinition found =
+        (MultiOptionQuestionDefinition)
+            questionRepo
+                .lookupQuestion(question.id)
+                .toCompletableFuture()
+                .join()
+                .get()
+                .getQuestionDefinition();
+    assertThat(found.getOptions().stream().map(QuestionOption::score))
+        .containsExactly(Optional.empty(), Optional.of(-1.25));
+  }
+
+  @Test
+  public void update_thymeleafQuestionForm_invalidScore_rendersScoreInputsWithErrorWithoutSaving() {
+    QuestionDefinition definition = createScoredDropdownDefinition();
+    QuestionModel question = testQuestionBank.maybeSave(definition, LifecycleStage.DRAFT);
+
+    ImmutableMap<String, String> formData =
+        ImmutableMap.<String, String>builder()
+            .put("questionName", definition.getName())
+            .put("questionDescription", definition.getDescription())
+            .put("questionType", definition.getQuestionType().name())
+            .put("questionText", "new question text")
+            .put("questionHelpText", "new help text")
+            .put("options[0]", "chocolate")
+            .put("options[1]", "strawberry")
+            .put("optionIds[0]", "1")
+            .put("optionIds[1]", "2")
+            .put("optionAdminNames[0]", "chocolate_admin")
+            .put("optionAdminNames[1]", "strawberry_admin")
+            .put("optionScores[0]", "junk")
+            .put("optionScores[1]", "")
+            .put("nextAvailableId", "3")
+            .put("questionExportState", "NON_DEMOGRAPHIC")
+            .put("concurrencyToken", question.getConcurrencyToken().toString())
+            .build();
+    Request request =
+        fakeRequestBuilder()
+            .addCSRFToken()
+            .addCiviFormSetting("ANSWER_OPTION_SCORING_ENABLED", "true")
+            .addCiviFormSetting("ADMIN_UI_MIGRATION_J2HTML_TO_THYMELEAF_SC_ENABLED", "true")
+            .bodyForm(formData)
+            .build();
+
+    Result result =
+        controller.update(request, question.id, definition.getQuestionType().toString());
+
+    // The error re-render honors the migration flag: the Thymeleaf page comes back with the
+    // score inputs so the admin can correct and resubmit.
+    assertThat(result.status()).isEqualTo(OK);
+    String unescaped = StringEscapeUtils.unescapeHtml4(contentAsString(result));
+    assertThat(unescaped).contains("Option score 'junk' must be a number");
+    assertThat(unescaped).contains("name=\"optionScores[]\"");
+    MultiOptionQuestionDefinition found =
+        (MultiOptionQuestionDefinition)
+            questionRepo
+                .lookupQuestion(question.id)
+                .toCompletableFuture()
+                .join()
+                .get()
+                .getQuestionDefinition();
+    assertThat(found.getOptions().stream().map(QuestionOption::score))
+        .containsExactly(Optional.of(3.5), Optional.empty());
+  }
+
+  @Test
   public void update_withInvalidScore_flagEnabled_rendersErrorWithoutSaving() {
     QuestionDefinition definition = createScoredDropdownDefinition();
     QuestionModel question = testQuestionBank.maybeSave(definition, LifecycleStage.DRAFT);
@@ -1224,6 +1364,37 @@ public class AdminQuestionControllerTest extends ResetPostgres {
                 .getQuestionDefinition();
     assertThat(found.getOptions().stream().map(QuestionOption::score))
         .containsExactly(Optional.of(3.5), Optional.empty());
+  }
+
+  @Test
+  public void edit_scoredQuestion_flagEnabled_rendersScoreInputsWithValues() {
+    QuestionModel question =
+        testQuestionBank.maybeSave(createScoredDropdownDefinition(), LifecycleStage.DRAFT);
+    Request request =
+        fakeRequestBuilder()
+            .addCSRFToken()
+            .addCiviFormSetting("ANSWER_OPTION_SCORING_ENABLED", "true")
+            .build();
+
+    Result result =
+        controller.edit(request, question.id, /* redirectUrl= */ "").toCompletableFuture().join();
+
+    assertThat(result.status()).isEqualTo(OK);
+    assertThat(contentAsString(result))
+        .containsPattern("name=\"optionScores\\[\\]\"[^>]*value=\"3.5\"");
+  }
+
+  @Test
+  public void edit_scoredQuestion_flagDisabled_rendersNoScoreInputs() {
+    QuestionModel question =
+        testQuestionBank.maybeSave(createScoredDropdownDefinition(), LifecycleStage.DRAFT);
+    Request request = fakeRequestBuilder().addCSRFToken().build();
+
+    Result result =
+        controller.edit(request, question.id, /* redirectUrl= */ "").toCompletableFuture().join();
+
+    assertThat(result.status()).isEqualTo(OK);
+    assertThat(contentAsString(result)).doesNotContain("optionScores[]");
   }
 
   private MultiOptionQuestionDefinition createScoredDropdownDefinition() {

--- a/server/test/mapping/admin/questions/QuestionFormPageMapperTest.java
+++ b/server/test/mapping/admin/questions/QuestionFormPageMapperTest.java
@@ -5,8 +5,11 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
+import forms.questions.DropdownQuestionForm;
 import forms.questions.TextQuestionForm;
 import forms.questions.YesNoQuestionForm;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 import org.junit.Before;
 import org.junit.Test;
@@ -33,6 +36,7 @@ public final class QuestionFormPageMapperTest {
         null,
         /* apiBridgeEnabled= */ false,
         /* enumeratorImprovementsEnabled= */ false,
+        /* answerOptionScoringEnabled= */ false,
         readOnlyQuestionService,
         Optional.empty());
   }
@@ -45,6 +49,7 @@ public final class QuestionFormPageMapperTest {
         null,
         /* apiBridgeEnabled= */ false,
         /* enumeratorImprovementsEnabled= */ false,
+        /* answerOptionScoringEnabled= */ false,
         readOnlyQuestionService,
         Optional.empty());
   }
@@ -174,12 +179,85 @@ public final class QuestionFormPageMapperTest {
             null,
             /* apiBridgeEnabled= */ false,
             /* enumeratorImprovementsEnabled= */ false,
+            /* answerOptionScoringEnabled= */ false,
             readOnlyQuestionService,
             Optional.empty());
 
     assertThat(result.getYesNoConfig()).isNotNull();
     assertThat(result.getYesNoConfig().showLabel()).isTrue();
     assertThat(result.getYesNoConfig().options()).hasSize(4);
+  }
+
+  @Test
+  public void mapNew_scoringEnabledSupportedType_showsScores() {
+    QuestionFormPageViewModel result =
+        mapper.mapNew(
+            new DropdownQuestionForm(),
+            ImmutableList.of(),
+            null,
+            /* apiBridgeEnabled= */ false,
+            /* enumeratorImprovementsEnabled= */ false,
+            /* answerOptionScoringEnabled= */ true,
+            readOnlyQuestionService,
+            Optional.empty());
+
+    assertThat(result.isShowScores()).isTrue();
+  }
+
+  @Test
+  public void mapNew_scoringDisabled_hidesScores() {
+    QuestionFormPageViewModel result =
+        mapper.mapNew(
+            new DropdownQuestionForm(),
+            ImmutableList.of(),
+            null,
+            /* apiBridgeEnabled= */ false,
+            /* enumeratorImprovementsEnabled= */ false,
+            /* answerOptionScoringEnabled= */ false,
+            readOnlyQuestionService,
+            Optional.empty());
+
+    assertThat(result.isShowScores()).isFalse();
+  }
+
+  @Test
+  public void mapNew_scoringEnabledUnsupportedTypes_hidesScores() {
+    QuestionFormPageViewModel yesNoResult =
+        mapper.mapNew(
+            new YesNoQuestionForm(),
+            ImmutableList.of(),
+            null,
+            /* apiBridgeEnabled= */ false,
+            /* enumeratorImprovementsEnabled= */ false,
+            /* answerOptionScoringEnabled= */ true,
+            readOnlyQuestionService,
+            Optional.empty());
+    QuestionFormPageViewModel textResult =
+        mapper.mapNew(
+            new TextQuestionForm(),
+            ImmutableList.of(),
+            null,
+            /* apiBridgeEnabled= */ false,
+            /* enumeratorImprovementsEnabled= */ false,
+            /* answerOptionScoringEnabled= */ true,
+            readOnlyQuestionService,
+            Optional.empty());
+
+    assertThat(yesNoResult.isShowScores()).isFalse();
+    assertThat(textResult.isShowScores()).isFalse();
+  }
+
+  @Test
+  public void scoreDisplayValue_formatsAndToleratesBlankInvalidAndSparseEntries() {
+    QuestionFormPageViewModel model = mapNewTextForm(new TextQuestionForm());
+
+    assertThat(model.scoreDisplayValue(List.of("2.0"), 0)).isEqualTo("2");
+    assertThat(model.scoreDisplayValue(List.of("1.50"), 0)).isEqualTo("1.5");
+    assertThat(model.scoreDisplayValue(List.of("-0.50"), 0)).isEqualTo("-0.5");
+    assertThat(model.scoreDisplayValue(List.of(""), 0)).isNull();
+    assertThat(model.scoreDisplayValue(List.of("junk"), 0)).isNull();
+    assertThat(model.scoreDisplayValue(List.of(), 0)).isNull();
+    assertThat(model.scoreDisplayValue(Arrays.asList((String) null), 0)).isNull();
   }
 
   @Test
@@ -193,6 +271,7 @@ public final class QuestionFormPageMapperTest {
             null,
             /* apiBridgeEnabled= */ false,
             /* enumeratorImprovementsEnabled= */ false,
+            /* answerOptionScoringEnabled= */ false,
             readOnlyQuestionService,
             Optional.of("Something went wrong"));
 
@@ -230,6 +309,7 @@ public final class QuestionFormPageMapperTest {
             null,
             /* apiBridgeEnabled= */ true,
             /* enumeratorImprovementsEnabled= */ false,
+            /* answerOptionScoringEnabled= */ false,
             readOnlyQuestionService,
             Optional.empty());
 
@@ -275,6 +355,7 @@ public final class QuestionFormPageMapperTest {
             null,
             /* apiBridgeEnabled= */ false,
             /* enumeratorImprovementsEnabled= */ false,
+            /* answerOptionScoringEnabled= */ false,
             readOnlyQuestionService,
             Optional.empty());
 
@@ -313,6 +394,7 @@ public final class QuestionFormPageMapperTest {
             null,
             /* apiBridgeEnabled= */ false,
             /* enumeratorImprovementsEnabled= */ false,
+            /* answerOptionScoringEnabled= */ false,
             readOnlyQuestionService,
             Optional.empty());
 
@@ -331,6 +413,7 @@ public final class QuestionFormPageMapperTest {
             null,
             /* apiBridgeEnabled= */ false,
             /* enumeratorImprovementsEnabled= */ false,
+            /* answerOptionScoringEnabled= */ false,
             readOnlyQuestionService,
             Optional.of("Error occurred"));
 

--- a/server/test/resources/thymeleaf/admin/questions/legacyQuestionFragments/multiOptionRowExisting.thtest
+++ b/server/test/resources/thymeleaf/admin/questions/legacyQuestionFragments/multiOptionRowExisting.thtest
@@ -6,7 +6,7 @@ adminValidation.multiOptionAdminError=Admin names can only contain lowercase let
 adminValidation.multiOptionEmpty=Multi option questions cannot have blank options.
 # ----------------------------------------------------------------------
 %INPUT
-<div th:replace="~{admin/questions/fragments/MultiOptionRow :: multiOptionRow(false, '42', 'option_one', 'Option one', 'field-1', 'field-2', 'field-3')}"></div>
+<div th:replace="~{admin/questions/fragments/MultiOptionRow :: multiOptionRow(false, '42', 'option_one', 'Option one', 'field-1', 'field-2', 'field-3', false, null, 'field-4')}"></div>
 # ----------------------------------------------------------------------
 %OUTPUT
 <div

--- a/server/test/resources/thymeleaf/admin/questions/legacyQuestionFragments/multiOptionRowScored.thtest
+++ b/server/test/resources/thymeleaf/admin/questions/legacyQuestionFragments/multiOptionRowScored.thtest
@@ -1,4 +1,4 @@
-%NAME multiOptionRow - new option posts to the newOptions fields and has no optionIds field
+%NAME multiOptionRow - showScores grows the grid and renders an editable score input
 %TEMPLATE_MODE HTML
 %MESSAGES
 toast.errorMessageOutline=Error: {0}
@@ -6,13 +6,28 @@ adminValidation.multiOptionAdminError=Admin names can only contain lowercase let
 adminValidation.multiOptionEmpty=Multi option questions cannot have blank options.
 # ----------------------------------------------------------------------
 %INPUT
-<div th:replace="~{admin/questions/fragments/MultiOptionRow :: multiOptionRow(true, null, '', '', 'field-1', 'field-2', 'field-3', false, null, 'field-4')}"></div>
+<div th:replace="~{admin/questions/fragments/MultiOptionRow :: multiOptionRow(false, '42', 'option_one', 'Option one', 'field-1', 'field-2', 'field-3', true, '2.5', 'field-4')}"></div>
 # ----------------------------------------------------------------------
 %OUTPUT
 <div
-  class="cf-multi-option-question-option cf-multi-option-question-option-editable grid grid-cols-8 grid-rows-4 items-center mb-4"
+  class="cf-multi-option-question-option cf-multi-option-question-option-editable grid grid-cols-8 grid-rows-6 items-center mb-4"
 >
-  <div></div>
+  <div class="hidden">
+    <label for="field-1" class="sr-only"
+      >option ids<span class="usa-hint--required hidden" aria-hidden="true">&nbsp;*</span></label
+    >
+    <div class="flex flex-col">
+      <input
+        type="text"
+        value="42"
+        maxlength="10000"
+        id="field-1"
+        name="optionIds[]"
+        class="px-3 bg-white text-black text-lg py-2 block outline-none box-border m-auto border border-gray-500 rounded-lg w-full focus:border-civiform-blue placeholder-gray-500"
+      />
+      <div id="field-1-errors" class="text-red-600 text-xs p-1 hidden"></div>
+    </div>
+  </div>
   <div
     class="cf-multi-option-admin-input col-start-1 col-span-5 mb-2 ml-2 row-start-1 row-span-2"
   >
@@ -24,12 +39,13 @@ adminValidation.multiOptionEmpty=Multi option questions cannot have blank option
     <div class="flex flex-col">
       <input
         type="text"
-        value=""
+        value="option_one"
         maxlength="10000"
         aria-required="true"
         id="field-2"
-        name="newOptionAdminNames[]"
-        class="px-3 bg-white text-black text-lg py-2 block outline-none box-border m-auto border border-gray-500 rounded-lg w-full focus:border-civiform-blue placeholder-gray-500"
+        name="optionAdminNames[]"
+        readonly="readonly"
+        class="px-3 bg-white text-black text-lg py-2 block outline-none box-border m-auto border border-gray-500 rounded-lg w-full focus:border-civiform-blue placeholder-gray-500 read-only:text-gray-500 read-only:bg-gray-100"
       />
       <div
         id="field-2-errors"
@@ -82,11 +98,11 @@ adminValidation.multiOptionEmpty=Multi option questions cannot have blank option
     <div class="flex flex-col">
       <input
         type="text"
-        value=""
+        value="Option one"
         maxlength="10000"
         aria-required="true"
         id="field-3"
-        name="newOptions[]"
+        name="options[]"
         class="px-3 bg-white text-black text-lg py-2 block outline-none box-border m-auto border border-gray-500 rounded-lg w-full focus:border-civiform-blue placeholder-gray-500"
       />
       <div
@@ -139,4 +155,26 @@ adminValidation.multiOptionEmpty=Multi option questions cannot have blank option
       ></path>
     </svg>
   </button>
+  <div
+    class="cf-multi-option-score-input col-start-1 col-span-5 mb-2 ml-2 row-start-5 row-span-2"
+  >
+    <label
+      for="field-4"
+      class="pointer-events-none text-gray-600 text-base px-1 py-2"
+      >Score<span class="usa-hint--required hidden" aria-hidden="true">&nbsp;*</span></label
+    >
+    <div class="flex flex-col">
+      <input
+        type="number"
+        inputmode="decimal"
+        step="any"
+        value="2.5"
+        maxlength="10000"
+        id="field-4"
+        name="optionScores[]"
+        class="px-3 bg-white text-black text-lg py-2 block outline-none box-border m-auto border border-gray-500 rounded-lg w-full focus:border-civiform-blue placeholder-gray-500"
+      />
+      <div id="field-4-errors" class="text-red-600 text-xs p-1 hidden"></div>
+    </div>
+  </div>
 </div>

--- a/server/test/views/admin/question/QuestionConfigTest.java
+++ b/server/test/views/admin/question/QuestionConfigTest.java
@@ -3,6 +3,7 @@ package views.admin.question;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static play.test.Helpers.stubMessagesApi;
 
 import com.google.common.collect.ImmutableList;
@@ -166,6 +167,67 @@ public class QuestionConfigTest extends ResetPostgres {
     assertThat(result).contains("existing-option-admin-b");
     assertThat(result).contains("new-option-admin-c");
     assertThat(result).contains("new-option-admin-d");
+  }
+
+  @Test
+  public void checkboxForm_scoringFlagEnabled_rendersScoreInputsWithValues() {
+    when(settingsManifest.getAnswerOptionScoringEnabled(request)).thenReturn(true);
+    CheckboxQuestionForm form = new CheckboxQuestionForm();
+    form.setOptions(ImmutableList.of("option-a", "option-b"));
+    form.setOptionAdminNames(ImmutableList.of("option-admin-a", "option-admin-b"));
+    form.setOptionIds(ImmutableList.of(1L, 2L));
+    form.setOptionScores(ImmutableList.of("4.25", ""));
+    form.setNewOptions(ImmutableList.of("option-c"));
+    form.setNewOptionAdminNames(ImmutableList.of("option-admin-c"));
+    // Trailing zeros are stripped for display: -2.50 renders as -2.5.
+    form.setNewOptionScores(ImmutableList.of("-2.50"));
+
+    Optional<DivTag> maybeConfig =
+        QuestionConfig.buildQuestionConfig(form, messages, settingsManifest, request);
+    assertThat(maybeConfig).isPresent();
+    String result = maybeConfig.get().renderFormatted();
+
+    assertThat(result).contains("Score");
+    assertThat(result).contains("cf-multi-option-score-input");
+    assertThat(result).contains("grid-rows-6");
+    assertThat(result)
+        .containsPattern("name=\"optionScores\\[\\]\"[^>]*value=\"4.25\"");
+    assertThat(result)
+        .containsPattern("name=\"newOptionScores\\[\\]\"[^>]*value=\"-2.5\"");
+    // The unscored option renders an empty score input, keeping the lists parallel.
+    Matcher scoreInputs = Pattern.compile("name=\"optionScores\\[\\]\"").matcher(result);
+    assertThat(scoreInputs.results().count()).isEqualTo(2);
+  }
+
+  @Test
+  public void checkboxForm_scoringFlagDisabled_rendersNoScoreInputs() {
+    CheckboxQuestionForm form = new CheckboxQuestionForm();
+    form.setOptions(ImmutableList.of("option-a"));
+    form.setOptionAdminNames(ImmutableList.of("option-admin-a"));
+    form.setOptionIds(ImmutableList.of(1L));
+
+    Optional<DivTag> maybeConfig =
+        QuestionConfig.buildQuestionConfig(form, messages, settingsManifest, request);
+    assertThat(maybeConfig).isPresent();
+    String result = maybeConfig.get().renderFormatted();
+
+    assertThat(result).doesNotContain("optionScores[]");
+    assertThat(result).doesNotContain("cf-multi-option-score-input");
+    assertThat(result).contains("grid-rows-4");
+  }
+
+  @Test
+  public void yesNoForm_scoringFlagEnabled_rendersNoScoreInputs() {
+    when(settingsManifest.getAnswerOptionScoringEnabled(request)).thenReturn(true);
+    YesNoQuestionForm form = new YesNoQuestionForm();
+
+    Optional<DivTag> maybeConfig =
+        QuestionConfig.buildQuestionConfig(form, messages, settingsManifest, request);
+    assertThat(maybeConfig).isPresent();
+    String result = maybeConfig.get().renderFormatted();
+
+    assertThat(result).doesNotContain("optionScores[]");
+    assertThat(result).doesNotContain("cf-multi-option-score-input");
   }
 
   @Test

--- a/server/test/views/admin/questions/LegacyQuestionFragmentsTest.java
+++ b/server/test/views/admin/questions/LegacyQuestionFragmentsTest.java
@@ -95,4 +95,14 @@ public class LegacyQuestionFragmentsTest {
   public void multiOptionRow_existingOption() {
     ThymeleafFragmentTester.run(DIR + "multiOptionRowExisting.thtest");
   }
+
+  /**
+   * With showScores on (the answer-option-scoring flag and a supported question type), the row
+   * grows to six grid rows and renders a never-readonly score input posting to optionScores[],
+   * with the pre-formatted display value.
+   */
+  @Test
+  public void multiOptionRow_scoredOption() {
+    ThymeleafFragmentTester.run(DIR + "multiOptionRowScored.thtest");
+  }
 }


### PR DESCRIPTION
Behind the scoring flag, each option row on checkbox, dropdown, and
radio question forms gets a Score number input (optionScores[] /
newOptionScores[], reference class cf-multi-option-score-input) under
the option text, extending the row grid from grid-rows-4 to grid-rows-6.
The <template> for new rows always includes the input when scoring UI is
shown, so cloned rows keep the score lists parallel; no TypeScript
changes are needed since multi_option_question.ts clones the whole row.
The Yes/No renderer is a separate code path and stays untouched.

Assisted-by: Claude Code:claude-fable-5

---

Part 4 of 12 in the option-scores stack. Merge in order, top to bottom:

1. https://github.com/civiform/civiform/pull/13796
2. https://github.com/civiform/civiform/pull/13797
3. https://github.com/civiform/civiform/pull/13798
4. https://github.com/civiform/civiform/pull/13799
5. https://github.com/civiform/civiform/pull/13800
6. https://github.com/civiform/civiform/pull/13801
7. https://github.com/civiform/civiform/pull/13802
8. https://github.com/civiform/civiform/pull/13803
9. https://github.com/civiform/civiform/pull/13804
10. https://github.com/civiform/civiform/pull/13805
11. https://github.com/civiform/civiform/pull/13806
12. https://github.com/civiform/civiform/pull/13807
