### PR TITLE
Add program-level usesScoring setting

### DIFF
--- a/server/app/controllers/admin/AdminProgramController.java
+++ b/server/app/controllers/admin/AdminProgramController.java
@@ -161,6 +161,12 @@ public final class AdminProgramController extends CiviFormController {
       }
     }
 
+    // While the scoring flag is off the setting is not rendered, and a new program cannot acquire
+    // it through a crafted post.
+    boolean usesScoring =
+        settingsManifest.getAnswerOptionScoringEnabled(request)
+            && Boolean.TRUE.equals(programData.getUsesScoring());
+
     ErrorAnd<ProgramDefinition, CiviFormError> result =
         programService.createProgramDefinition(
             programData.getAdminName(),
@@ -174,6 +180,7 @@ public final class AdminProgramController extends CiviFormController {
             ImmutableList.copyOf(programData.getNotificationPreferences()),
             programData.getEligibilityIsGating(),
             programData.getLoginOnly(),
+            usesScoring,
             programData.getProgramType(),
             ImmutableList.copyOf(programData.getTiGroups()),
             ImmutableList.copyOf(programData.getCategories()),
@@ -310,6 +317,13 @@ public final class AdminProgramController extends CiviFormController {
       }
     }
 
+    // While the scoring flag is off the setting is not rendered, so preserve the stored value and
+    // discard any crafted post value.
+    boolean usesScoring =
+        settingsManifest.getAnswerOptionScoringEnabled(request)
+            ? Boolean.TRUE.equals(programData.getUsesScoring())
+            : programDefinition.usesScoring();
+
     programService.updateProgramDefinition(
         programDefinition.id(),
         LocalizedStrings.DEFAULT_LOCALE,
@@ -323,6 +337,7 @@ public final class AdminProgramController extends CiviFormController {
         programData.getNotificationPreferences(),
         programData.getEligibilityIsGating(),
         programData.getLoginOnly(),
+        usesScoring,
         programData.getProgramType(),
         ImmutableList.copyOf(programData.getTiGroups()),
         ImmutableList.copyOf(programData.getCategories()),

--- a/server/app/forms/ProgramForm.java
+++ b/server/app/forms/ProgramForm.java
@@ -27,6 +27,7 @@ public final class ProgramForm {
   private Boolean confirmedChangePreScreenerForm = false;
   private Boolean eligibilityIsGating = true;
   private Boolean loginOnly = false;
+  private Boolean usesScoring = false;
   private List<Long> tiGroups = new ArrayList<>();
   private List<Long> categories = new ArrayList<>();
   private List<Map<String, String>> applicationSteps = new ArrayList<>();

--- a/server/app/models/ProgramModel.java
+++ b/server/app/models/ProgramModel.java
@@ -70,6 +70,9 @@ public class ProgramModel extends BaseModel {
   /** If the program is for logged in applicants only. */
   @Constraints.Required private Boolean loginOnly;
 
+  /** If true, the program applies answer-option scores to submitted applications. */
+  @Constraints.Required private Boolean usesScoring;
+
   /** The notification preferences for this program */
   @Constraints.Required
   private @DbArray List<ProgramNotificationPreference> notificationPreferences;
@@ -195,6 +198,7 @@ public class ProgramModel extends BaseModel {
     this.notificationPreferences = new ArrayList<>(definition.notificationPreferences());
     this.programType = definition.programType();
     this.eligibilityIsGating = definition.eligibilityIsGating();
+    this.usesScoring = definition.usesScoring();
     this.acls = definition.acls();
 
     // Ebeans needs to manage the collection so add categories instead of
@@ -216,6 +220,49 @@ public class ProgramModel extends BaseModel {
 
   /**
    * Construct a new Program object with the given program name, description, and block definitions.
+   * Includes program categories. The program does not use answer-option scoring.
+   */
+  public ProgramModel(
+      String adminName,
+      String adminDescription,
+      String defaultDisplayName,
+      String defaultDisplayDescription,
+      String defaultShortDescription,
+      String defaultConfirmationMessage,
+      String externalLink,
+      String displayMode,
+      ImmutableList<ProgramNotificationPreference> notificationPreferences,
+      ImmutableList<BlockDefinition> blockDefinitions,
+      VersionModel associatedVersion,
+      ProgramType programType,
+      boolean eligibilityIsGating,
+      boolean loginOnly,
+      ProgramAcls programAcls,
+      ImmutableList<CategoryModel> categories,
+      ImmutableList<ApplicationStep> applicationSteps) {
+    this(
+        adminName,
+        adminDescription,
+        defaultDisplayName,
+        defaultDisplayDescription,
+        defaultShortDescription,
+        defaultConfirmationMessage,
+        externalLink,
+        displayMode,
+        notificationPreferences,
+        blockDefinitions,
+        associatedVersion,
+        programType,
+        eligibilityIsGating,
+        loginOnly,
+        /* usesScoring= */ false,
+        programAcls,
+        categories,
+        applicationSteps);
+  }
+
+  /**
+   * Construct a new Program object with the given program name, description, and block definitions.
    * Includes program categories.
    */
   public ProgramModel(
@@ -233,6 +280,7 @@ public class ProgramModel extends BaseModel {
       ProgramType programType,
       boolean eligibilityIsGating,
       boolean loginOnly,
+      boolean usesScoring,
       ProgramAcls programAcls,
       ImmutableList<CategoryModel> categories,
       ImmutableList<ApplicationStep> applicationSteps) {
@@ -253,6 +301,7 @@ public class ProgramModel extends BaseModel {
     this.programType = programType;
     this.eligibilityIsGating = eligibilityIsGating;
     this.loginOnly = loginOnly;
+    this.usesScoring = usesScoring;
     this.acls = programAcls;
 
     // Ebeans needs to manage the collection so add categories instead of
@@ -280,6 +329,7 @@ public class ProgramModel extends BaseModel {
     programType = programDefinition.programType();
     eligibilityIsGating = programDefinition.eligibilityIsGating();
     loginOnly = programDefinition.loginOnly();
+    usesScoring = programDefinition.usesScoring();
     acls = programDefinition.acls();
     localizedSummaryImageDescription =
         programDefinition.localizedSummaryImageDescription().orElse(null);
@@ -318,6 +368,8 @@ public class ProgramModel extends BaseModel {
             .setProgramType(programType)
             .setEligibilityIsGating(eligibilityIsGating)
             .setLoginOnly(loginOnly)
+            // Rows created before the uses_scoring evolution may load a null column value.
+            .setUsesScoring(usesScoring != null && usesScoring)
             .setAcls(acls)
             .setCategories(ImmutableList.copyOf(categories))
             .setApplicationSteps(ImmutableList.copyOf(applicationSteps))

--- a/server/app/services/program/ProgramDefinition.java
+++ b/server/app/services/program/ProgramDefinition.java
@@ -141,6 +141,20 @@ public abstract class ProgramDefinition {
   @JsonProperty("eligibilityIsGating")
   public abstract boolean eligibilityIsGating();
 
+  /**
+   * Internal storage for {@link #usesScoring()}. Optional so that program exports created before
+   * the property existed still deserialize; a missing property reads as false. Use {@link
+   * #usesScoring()} instead.
+   */
+  @JsonProperty("usesScoring")
+  abstract Optional<Boolean> usesScoringInternal();
+
+  /** Whether the program applies answer-option scores to submitted applications. */
+  @JsonIgnore
+  public final boolean usesScoring() {
+    return usesScoringInternal().orElse(false);
+  }
+
   @JsonProperty("acls")
   public abstract ProgramAcls acls();
 
@@ -910,6 +924,13 @@ public abstract class ProgramDefinition {
 
     @JsonProperty("eligibilityIsGating")
     public abstract Builder setEligibilityIsGating(boolean eligibilityIsGating);
+
+    @JsonProperty("usesScoring")
+    abstract Builder setUsesScoringInternal(Optional<Boolean> usesScoring);
+
+    public final Builder setUsesScoring(boolean usesScoring) {
+      return setUsesScoringInternal(Optional.of(usesScoring));
+    }
 
     @JsonProperty("loginOnly")
     public abstract Builder setLoginOnly(boolean loginOnly);

--- a/server/app/services/program/ProgramService.java
+++ b/server/app/services/program/ProgramService.java
@@ -409,6 +409,53 @@ public final class ProgramService {
       ImmutableList<ApplicationStep> applicationSteps,
       Messages messages,
       boolean enumeratorImprovementsEnabled) {
+    return createProgramDefinition(
+        adminName,
+        adminDescription,
+        defaultDisplayName,
+        defaultDisplayDescription,
+        defaultShortDescription,
+        defaultConfirmationMessage,
+        externalLink,
+        displayMode,
+        notificationPreferences,
+        eligibilityIsGating,
+        loginOnly,
+        /* usesScoring= */ false,
+        programType,
+        tiGroups,
+        categoryIds,
+        applicationSteps,
+        messages,
+        enumeratorImprovementsEnabled);
+  }
+
+  /**
+   * Creates a new program with an empty block, specifying whether the program applies
+   * answer-option scores to submitted applications. See {@link #createProgramDefinition(String,
+   * String, String, String, String, String, String, String, ImmutableList, boolean, boolean,
+   * ProgramType, ImmutableList, ImmutableList, ImmutableList, Messages, boolean)} for the other
+   * parameters.
+   */
+  public ErrorAnd<ProgramDefinition, CiviFormError> createProgramDefinition(
+      String adminName,
+      String adminDescription,
+      String defaultDisplayName,
+      String defaultDisplayDescription,
+      String defaultShortDescription,
+      String defaultConfirmationMessage,
+      String externalLink,
+      String displayMode,
+      ImmutableList<String> notificationPreferences,
+      boolean eligibilityIsGating,
+      boolean loginOnly,
+      boolean usesScoring,
+      ProgramType programType,
+      ImmutableList<Long> tiGroups,
+      ImmutableList<Long> categoryIds,
+      ImmutableList<ApplicationStep> applicationSteps,
+      Messages messages,
+      boolean enumeratorImprovementsEnabled) {
     ImmutableSet<CiviFormError> errors =
         validateProgramDataForCreate(
             adminName,
@@ -463,6 +510,7 @@ public final class ProgramService {
             programType,
             eligibilityIsGating,
             loginOnly,
+            usesScoring,
             programAcls,
             categoryRepository.findCategoriesByIds(categoryIds),
             applicationSteps);
@@ -592,6 +640,88 @@ public final class ProgramService {
       ImmutableList<Long> categoryIds,
       ImmutableList<ApplicationStep> applicationSteps)
       throws ProgramNotFoundException {
+    return updateProgramDefinitionInternal(
+        programId,
+        locale,
+        adminDescription,
+        displayName,
+        displayDescription,
+        shortDescription,
+        confirmationMessage,
+        externalLink,
+        displayMode,
+        notificationPreferences,
+        eligibilityIsGating,
+        loginOnly,
+        /* usesScoring= */ Optional.empty(),
+        programType,
+        tiGroups,
+        categoryIds,
+        applicationSteps);
+  }
+
+  /**
+   * Updates a program, including whether it applies answer-option scores to submitted
+   * applications. The overload without {@code usesScoring} leaves the stored value unchanged.
+   */
+  public ErrorAnd<ProgramDefinition, CiviFormError> updateProgramDefinition(
+      long programId,
+      Locale locale,
+      String adminDescription,
+      String displayName,
+      String displayDescription,
+      String shortDescription,
+      String confirmationMessage,
+      String externalLink,
+      String displayMode,
+      List<String> notificationPreferences,
+      boolean eligibilityIsGating,
+      boolean loginOnly,
+      boolean usesScoring,
+      ProgramType programType,
+      ImmutableList<Long> tiGroups,
+      ImmutableList<Long> categoryIds,
+      ImmutableList<ApplicationStep> applicationSteps)
+      throws ProgramNotFoundException {
+    return updateProgramDefinitionInternal(
+        programId,
+        locale,
+        adminDescription,
+        displayName,
+        displayDescription,
+        shortDescription,
+        confirmationMessage,
+        externalLink,
+        displayMode,
+        notificationPreferences,
+        eligibilityIsGating,
+        loginOnly,
+        Optional.of(usesScoring),
+        programType,
+        tiGroups,
+        categoryIds,
+        applicationSteps);
+  }
+
+  private ErrorAnd<ProgramDefinition, CiviFormError> updateProgramDefinitionInternal(
+      long programId,
+      Locale locale,
+      String adminDescription,
+      String displayName,
+      String displayDescription,
+      String shortDescription,
+      String confirmationMessage,
+      String externalLink,
+      String displayMode,
+      List<String> notificationPreferences,
+      boolean eligibilityIsGating,
+      boolean loginOnly,
+      Optional<Boolean> usesScoring,
+      ProgramType programType,
+      ImmutableList<Long> tiGroups,
+      ImmutableList<Long> categoryIds,
+      ImmutableList<ApplicationStep> applicationSteps)
+      throws ProgramNotFoundException {
     ProgramDefinition programDefinition = getFullProgramDefinition(programId);
     ImmutableSet<CiviFormError> errors =
         validateProgramDataForUpdate(
@@ -630,7 +760,7 @@ public final class ProgramService {
         notificationPreferences.stream()
             .map(ProgramNotificationPreference::valueOf)
             .collect(ImmutableList.toImmutableList());
-    ProgramModel program =
+    ProgramDefinition.Builder programBuilder =
         programDefinition.toBuilder()
             .setAdminDescription(adminDescription)
             .setLocalizedName(
@@ -655,9 +785,10 @@ public final class ProgramService {
             .setAcls(new ProgramAcls(new HashSet<>(tiGroups)))
             .setCategories(categoryRepository.findCategoriesByIds(categoryIds))
             .setApplicationSteps(applicationSteps)
-            .setBridgeDefinitions(programDefinition.bridgeDefinitions())
-            .build()
-            .toProgram();
+            .setBridgeDefinitions(programDefinition.bridgeDefinitions());
+    // When absent, toBuilder() has already carried over the stored value.
+    usesScoring.ifPresent(programBuilder::setUsesScoring);
+    ProgramModel program = programBuilder.build().toProgram();
 
     return ErrorAnd.of(
         syncProgramDefinitionQuestions(

--- a/server/app/views/admin/programs/ProgramFormBuilder.java
+++ b/server/app/views/admin/programs/ProgramFormBuilder.java
@@ -37,6 +37,7 @@ import modules.MainModule;
 import play.i18n.Lang;
 import play.i18n.Messages;
 import play.i18n.MessagesApi;
+import play.mvc.Http.Request;
 import repository.AccountRepository;
 import repository.CategoryRepository;
 import services.AlertType;
@@ -44,6 +45,7 @@ import services.MessageKey;
 import services.Path;
 import services.program.ProgramDefinition;
 import services.program.ProgramType;
+import services.settings.SettingsManifest;
 import views.AlertComponent;
 import views.AlertComponent.HeadingLevel;
 import views.BaseHtmlView;
@@ -66,29 +68,34 @@ public class ProgramFormBuilder extends BaseHtmlView {
   private static final String ELIGIBILITY_FIELD_NAME = "eligibilityIsGating";
   private static final String NOTIFICATIONS_PREFERENCES_FIELD_NAME = "notificationPreferences";
   private static final String PROGRAM_TYPE_FIELD_NAME = "programTypeValue";
+  private static final String SCORING_FIELD_NAME = "usesScoring";
   private static final String TI_GROUPS_FIELD_NAME = "tiGroups[]";
 
   private final String baseUrl;
   private final AccountRepository accountRepository;
   private final CategoryRepository categoryRepository;
   private final Messages messages;
+  private final SettingsManifest settingsManifest;
 
   @Inject
   ProgramFormBuilder(
       Config configuration,
       AccountRepository accountRepository,
       CategoryRepository categoryRepository,
-      MessagesApi messagesApi) {
+      MessagesApi messagesApi,
+      SettingsManifest settingsManifest) {
     this.baseUrl = checkNotNull(configuration).getString("base_url");
     this.accountRepository = checkNotNull(accountRepository);
     this.categoryRepository = checkNotNull(categoryRepository);
     this.messages = messagesApi.preferred(ImmutableList.of(Lang.defaultLang()));
+    this.settingsManifest = checkNotNull(settingsManifest);
   }
 
   /** Builds the form using program form data. */
   protected final FormTag buildProgramForm(
-      ProgramForm program, ProgramEditStatus programEditStatus) {
+      Request request, ProgramForm program, ProgramEditStatus programEditStatus) {
     return buildProgramForm(
+        request,
         program.getAdminName(),
         program.getAdminDescription(),
         program.getLocalizedDisplayName(),
@@ -100,6 +107,7 @@ public class ProgramFormBuilder extends BaseHtmlView {
         ImmutableList.copyOf(program.getNotificationPreferences()),
         program.getEligibilityIsGating(),
         program.getLoginOnly(),
+        program.getUsesScoring(),
         program.getProgramType(),
         programEditStatus,
         ImmutableSet.copyOf(program.getTiGroups()),
@@ -109,8 +117,9 @@ public class ProgramFormBuilder extends BaseHtmlView {
 
   /* Builds the form using program definition data. */
   protected final FormTag buildProgramForm(
-      ProgramDefinition program, ProgramEditStatus programEditStatus) {
+      Request request, ProgramDefinition program, ProgramEditStatus programEditStatus) {
     return buildProgramForm(
+        request,
         program.adminName(),
         program.adminDescription(),
         program.localizedName().getDefault(),
@@ -124,6 +133,7 @@ public class ProgramFormBuilder extends BaseHtmlView {
             .collect(ImmutableList.toImmutableList()),
         program.eligibilityIsGating(),
         program.loginOnly(),
+        program.usesScoring(),
         program.programType(),
         programEditStatus,
         program.acls().getTiProgramViewAcls(),
@@ -142,6 +152,7 @@ public class ProgramFormBuilder extends BaseHtmlView {
   }
 
   private FormTag buildProgramForm(
+      Request request,
       String adminName,
       String adminDescription,
       String displayName,
@@ -153,6 +164,7 @@ public class ProgramFormBuilder extends BaseHtmlView {
       ImmutableList<String> notificationPreferences,
       boolean eligibilityIsGating,
       boolean loginOnly,
+      boolean usesScoring,
       ProgramType programType,
       ProgramEditStatus programEditStatus,
       ImmutableSet<Long> selectedTi,
@@ -234,6 +246,33 @@ public class ProgramFormBuilder extends BaseHtmlView {
                         /* description= */ Optional.empty()))
                 .withId("program-eligibility")
                 .withClasses("usa-fieldset", SPACE_BETWEEN_FORM_ELEMENTS),
+            // Application scoring; rendered only while the answer-option-scoring flag is on.
+            // Preservation of the stored value while the flag is off is handled controller-side.
+            iff(
+                settingsManifest.getAnswerOptionScoringEnabled(request),
+                fieldset(
+                        legend("Application scoring")
+                            .withClass("text-gray-600")
+                            .with(ViewUtils.requiredQuestionIndicator()),
+                        buildUSWDSRadioOption(
+                            /* id= */ "program-uses-scoring",
+                            /* name= */ SCORING_FIELD_NAME,
+                            /* value= */ String.valueOf(true),
+                            /* isChecked= */ usesScoring,
+                            /* isDisabled= */ false,
+                            /* label= */ "Yes — apply answer option scores to submitted"
+                                + " applications",
+                            /* description= */ Optional.empty()),
+                        buildUSWDSRadioOption(
+                            /* id= */ "program-no-scoring",
+                            /* name= */ SCORING_FIELD_NAME,
+                            /* value= */ String.valueOf(false),
+                            /* isChecked= */ !usesScoring,
+                            /* isDisabled= */ false,
+                            /* label= */ "No",
+                            /* description= */ Optional.empty()))
+                    .withId("program-scoring")
+                    .withClasses("usa-fieldset", SPACE_BETWEEN_FORM_ELEMENTS)),
             // Program categories
             iff(
                 !categoryOptions.isEmpty(),

--- a/server/app/views/admin/programs/ProgramMetaDataEditView.java
+++ b/server/app/views/admin/programs/ProgramMetaDataEditView.java
@@ -16,6 +16,7 @@ import repository.AccountRepository;
 import repository.CategoryRepository;
 import services.program.ProgramDefinition;
 import services.program.ProgramType;
+import services.settings.SettingsManifest;
 import views.HtmlBundle;
 import views.admin.AdminLayout;
 import views.admin.AdminLayout.NavPage;
@@ -34,8 +35,9 @@ public final class ProgramMetaDataEditView extends ProgramFormBuilder {
       Config configuration,
       AccountRepository accountRepository,
       CategoryRepository categoryRepository,
-      MessagesApi messagesApi) {
-    super(configuration, accountRepository, categoryRepository, messagesApi);
+      MessagesApi messagesApi,
+      SettingsManifest settingsManifest) {
+    super(configuration, accountRepository, categoryRepository, messagesApi, settingsManifest);
     this.layout = checkNotNull(layoutFactory).getLayout(NavPage.PROGRAMS);
   }
 
@@ -102,8 +104,8 @@ public final class ProgramMetaDataEditView extends ProgramFormBuilder {
 
     FormTag formTag =
         programForm.isPresent()
-            ? buildProgramForm(programForm.get(), programEditStatus)
-            : buildProgramForm(existingProgram, programEditStatus);
+            ? buildProgramForm(request, programForm.get(), programEditStatus)
+            : buildProgramForm(request, existingProgram, programEditStatus);
 
     HtmlBundle htmlBundle =
         layout

--- a/server/app/views/admin/programs/ProgramNewOneView.java
+++ b/server/app/views/admin/programs/ProgramNewOneView.java
@@ -14,6 +14,7 @@ import play.mvc.Http.Request;
 import play.twirl.api.Content;
 import repository.AccountRepository;
 import repository.CategoryRepository;
+import services.settings.SettingsManifest;
 import views.HtmlBundle;
 import views.admin.AdminLayout;
 import views.admin.AdminLayout.NavPage;
@@ -31,8 +32,9 @@ public final class ProgramNewOneView extends ProgramFormBuilder {
       Config configuration,
       AccountRepository accountRepository,
       CategoryRepository categoryRepository,
-      MessagesApi messagesApi) {
-    super(configuration, accountRepository, categoryRepository, messagesApi);
+      MessagesApi messagesApi,
+      SettingsManifest settingsManifest) {
+    super(configuration, accountRepository, categoryRepository, messagesApi, settingsManifest);
     this.layout = checkNotNull(layoutFactory).getLayout(NavPage.PROGRAMS);
   }
 
@@ -80,7 +82,7 @@ public final class ProgramNewOneView extends ProgramFormBuilder {
     DivTag contentDiv =
         div(
                 renderHeader(title),
-                buildProgramForm(programForm, ProgramEditStatus.CREATION)
+                buildProgramForm(request, programForm, ProgramEditStatus.CREATION)
                     .with(makeCsrfTokenInputTag(request))
                     .withAction(controllers.admin.routes.AdminProgramController.create().url()))
             .withClasses("mx-4", "my-12", "flex", "flex-col");

--- a/server/conf/evolutions/default/97.sql
+++ b/server/conf/evolutions/default/97.sql
@@ -1,0 +1,8 @@
+# --- Whether the program applies answer-option scores to submitted applications
+# --- !Ups
+ALTER TABLE IF EXISTS programs
+ADD COLUMN IF NOT EXISTS uses_scoring boolean DEFAULT FALSE NOT NULL;
+
+# --- !Downs
+ALTER TABLE IF EXISTS programs
+DROP COLUMN IF EXISTS uses_scoring;

--- a/server/test/controllers/admin/AdminProgramControllerTest.java
+++ b/server/test/controllers/admin/AdminProgramControllerTest.java
@@ -201,6 +201,64 @@ public class AdminProgramControllerTest extends ResetPostgres {
   }
 
   @Test
+  public void create_usesScoring_flagEnabled_savesSetting() {
+    Map<String, String> formData = new HashMap<>(DEFAULT_FORM_FIELDS);
+    formData.put("usesScoring", "true");
+
+    controller.create(
+        fakeRequestBuilder()
+            .addCiviFormSetting("ANSWER_OPTION_SCORING_ENABLED", "true")
+            .bodyForm(formData)
+            .build());
+
+    assertThat(getDraftProgram().getProgramDefinition().usesScoring()).isTrue();
+  }
+
+  @Test
+  public void create_usesScoring_flagDisabled_craftedPostCannotEnable() {
+    Map<String, String> formData = new HashMap<>(DEFAULT_FORM_FIELDS);
+    formData.put("usesScoring", "true");
+
+    controller.create(fakeRequestBuilder().bodyForm(formData).build());
+
+    assertThat(getDraftProgram().getProgramDefinition().usesScoring()).isFalse();
+  }
+
+  @Test
+  public void update_usesScoring_flagEnabled_roundTrips() throws Exception {
+    ProgramModel program = ProgramBuilder.newDraftProgram("Scoring program").build();
+    Map<String, String> formData = new HashMap<>(DEFAULT_FORM_FIELDS);
+    formData.put("usesScoring", "true");
+
+    controller.update(
+        fakeRequestBuilder()
+            .addCiviFormSetting("ANSWER_OPTION_SCORING_ENABLED", "true")
+            .bodyForm(formData)
+            .build(),
+        program.id,
+        ProgramEditStatus.EDIT.name());
+
+    ProgramModel found = programRepository.lookupProgram(program.id).toCompletableFuture().join().get();
+    assertThat(found.getProgramDefinition().usesScoring()).isTrue();
+  }
+
+  @Test
+  public void update_usesScoring_flagDisabled_preservesStoredSetting() throws Exception {
+    ProgramModel program =
+        ProgramBuilder.newDraftProgram("Scoring program").withUsesScoring(true).build();
+    Map<String, String> formData = new HashMap<>(DEFAULT_FORM_FIELDS);
+    // Crafted post attempts to disable scoring while the flag is off; the input is not rendered,
+    // so the stored value must survive.
+    formData.put("usesScoring", "false");
+
+    controller.update(
+        fakeRequestBuilder().bodyForm(formData).build(), program.id, ProgramEditStatus.EDIT.name());
+
+    ProgramModel found = programRepository.lookupProgram(program.id).toCompletableFuture().join().get();
+    assertThat(found.getProgramDefinition().usesScoring()).isTrue();
+  }
+
+  @Test
   public void create_includesNewAndExistingProgramsInList() {
     ProgramBuilder.newActiveProgram("Existing One").build();
 

--- a/server/test/models/ProgramModelTest.java
+++ b/server/test/models/ProgramModelTest.java
@@ -47,6 +47,20 @@ public class ProgramModelTest extends ResetPostgres {
   }
 
   @Test
+  public void usesScoring_roundTripsThroughDatabase() {
+    ProgramModel scoringProgram =
+        support.ProgramBuilder.newDraftProgram("scoring program").withUsesScoring(true).build();
+    ProgramModel plainProgram = support.ProgramBuilder.newDraftProgram("plain program").build();
+
+    ProgramModel foundScoring =
+        repo.lookupProgram(scoringProgram.id).toCompletableFuture().join().get();
+    ProgramModel foundPlain = repo.lookupProgram(plainProgram.id).toCompletableFuture().join().get();
+
+    assertThat(foundScoring.getProgramDefinition().usesScoring()).isTrue();
+    assertThat(foundPlain.getProgramDefinition().usesScoring()).isFalse();
+  }
+
+  @Test
   public void canSaveProgram() throws UnsupportedQuestionTypeException {
     QuestionDefinition questionDefinition =
         new QuestionDefinitionBuilder()

--- a/server/test/services/program/ProgramDefinitionTest.java
+++ b/server/test/services/program/ProgramDefinitionTest.java
@@ -7,6 +7,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import auth.ProgramAcls;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.google.common.collect.ImmutableList;
@@ -1906,5 +1907,81 @@ public class ProgramDefinitionTest extends ResetPostgres {
             .build();
     assertThat(result.blockDefinitions())
         .containsExactly(expectedBlockA, expectedBlockB, expectedBlockC, expectedBlockD);
+  }
+
+  private ProgramDefinition minimalProgramDefinition(boolean usesScoring) {
+    ProgramDefinition.Builder builder =
+        ProgramDefinition.builder()
+            .setId(123L)
+            .setAdminName("uses-scoring-test")
+            .setAdminDescription("Admin description")
+            .setLocalizedName(LocalizedStrings.of(Locale.US, "The Program"))
+            .setLocalizedDescription(LocalizedStrings.of(Locale.US, "This program is for testing."))
+            .setLocalizedShortDescription(
+                LocalizedStrings.of(Locale.US, "This program is for testing."))
+            .setLocalizedConfirmationMessage(LocalizedStrings.withEmptyDefault())
+            .setExternalLink("")
+            .setDisplayMode(DisplayMode.PUBLIC)
+            .setBlockDefinitions(ImmutableList.of())
+            .setProgramType(ProgramType.DEFAULT)
+            .setEligibilityIsGating(true)
+            .setLoginOnly(false)
+            .setAcls(new ProgramAcls())
+            .setCategories(ImmutableList.of())
+            .setApplicationSteps(ImmutableList.of(new ApplicationStep("title", "description")))
+            .setBridgeDefinitions(ImmutableMap.of());
+    if (usesScoring) {
+      builder.setUsesScoring(true);
+    }
+    return builder.build();
+  }
+
+  private static ObjectMapper migrationStyleObjectMapper() {
+    return new ObjectMapper().registerModule(new GuavaModule()).registerModule(new Jdk8Module());
+  }
+
+  @Test
+  public void usesScoring_unset_buildsAndReadsFalse() {
+    // Builders that never call setUsesScoring must still build (deserialization-safe default).
+    assertThat(minimalProgramDefinition(/* usesScoring= */ false).usesScoring()).isFalse();
+  }
+
+  @Test
+  public void serde_usesScoringTrue_roundTrips() throws JsonProcessingException {
+    ObjectMapper objectMapper = migrationStyleObjectMapper();
+
+    String json = objectMapper.writeValueAsString(minimalProgramDefinition(true));
+    ProgramDefinition result = objectMapper.readValue(json, ProgramDefinition.class);
+
+    assertThat(json).contains("\"usesScoring\"");
+    assertThat(result.usesScoring()).isTrue();
+  }
+
+  @Test
+  public void deserialize_preFeatureExportWithoutUsesScoring_readsFalse()
+      throws JsonProcessingException {
+    ObjectMapper objectMapper = migrationStyleObjectMapper();
+    // Simulate a program export created before the property existed.
+    ObjectNode node =
+        (ObjectNode)
+            objectMapper.readTree(objectMapper.writeValueAsString(minimalProgramDefinition(true)));
+    node.remove("usesScoring");
+
+    ProgramDefinition result = objectMapper.readValue(node.toString(), ProgramDefinition.class);
+
+    assertThat(result.usesScoring()).isFalse();
+  }
+
+  @Test
+  public void deserialize_explicitNullUsesScoring_readsFalse() throws JsonProcessingException {
+    ObjectMapper objectMapper = migrationStyleObjectMapper();
+    ObjectNode node =
+        (ObjectNode)
+            objectMapper.readTree(objectMapper.writeValueAsString(minimalProgramDefinition(true)));
+    node.putNull("usesScoring");
+
+    ProgramDefinition result = objectMapper.readValue(node.toString(), ProgramDefinition.class);
+
+    assertThat(result.usesScoring()).isFalse();
   }
 }

--- a/server/test/services/program/ProgramServiceTest.java
+++ b/server/test/services/program/ProgramServiceTest.java
@@ -546,6 +546,139 @@ public class ProgramServiceTest extends ResetPostgres {
   }
 
   @Test
+  public void createProgram_withUsesScoring_persistsSetting() throws Exception {
+    ErrorAnd<ProgramDefinition, CiviFormError> result =
+        ps.createProgramDefinition(
+            "scoring-program",
+            "description",
+            "name",
+            "description",
+            "short display description",
+            "",
+            "https://usa.gov",
+            DisplayMode.PUBLIC.getValue(),
+            ImmutableList.of(),
+            /* eligibilityIsGating= */ true,
+            /* loginOnly= */ false,
+            /* usesScoring= */ true,
+            ProgramType.DEFAULT,
+            ImmutableList.of(),
+            /* categoryIds= */ ImmutableList.of(),
+            ImmutableList.of(new ApplicationStep("title", "description")),
+            messages,
+            /* enumeratorImprovementsEnabled= */ false);
+
+    assertThat(result.hasResult()).isTrue();
+    assertThat(result.getResult().usesScoring()).isTrue();
+    assertThat(ps.getFullProgramDefinition(result.getResult().id()).usesScoring()).isTrue();
+  }
+
+  @Test
+  public void createProgram_legacyOverloadWithoutUsesScoring_defaultsToFalse() {
+    ErrorAnd<ProgramDefinition, CiviFormError> result =
+        ps.createProgramDefinition(
+            "no-scoring-program",
+            "description",
+            "name",
+            "description",
+            "short display description",
+            "",
+            "https://usa.gov",
+            DisplayMode.PUBLIC.getValue(),
+            ImmutableList.of(),
+            /* eligibilityIsGating= */ true,
+            /* loginOnly= */ false,
+            ProgramType.DEFAULT,
+            ImmutableList.of(),
+            /* categoryIds= */ ImmutableList.of(),
+            ImmutableList.of(new ApplicationStep("title", "description")),
+            messages,
+            /* enumeratorImprovementsEnabled= */ false);
+
+    assertThat(result.hasResult()).isTrue();
+    assertThat(result.getResult().usesScoring()).isFalse();
+  }
+
+  @Test
+  public void updateProgram_withUsesScoring_updatesSetting() throws Exception {
+    ProgramDefinition originalProgram =
+        ProgramBuilder.newDraftProgram("scoring update program").buildDefinition();
+    assertThat(originalProgram.usesScoring()).isFalse();
+
+    ErrorAnd<ProgramDefinition, CiviFormError> result =
+        ps.updateProgramDefinition(
+            originalProgram.id(),
+            Locale.US,
+            "new description",
+            "name",
+            "description",
+            "short description",
+            "",
+            "https://usa.gov",
+            DisplayMode.PUBLIC.getValue(),
+            ImmutableList.of(),
+            /* eligibilityIsGating= */ true,
+            /* loginOnly= */ false,
+            /* usesScoring= */ true,
+            ProgramType.DEFAULT,
+            ImmutableList.of(),
+            /* categoryIds= */ ImmutableList.of(),
+            ImmutableList.of(new ApplicationStep("title", "description")));
+
+    assertThat(result.hasResult()).isTrue();
+    assertThat(result.getResult().usesScoring()).isTrue();
+  }
+
+  @Test
+  public void updateProgram_legacyOverloadWithoutUsesScoring_preservesStoredSetting()
+      throws Exception {
+    ProgramDefinition originalProgram =
+        ProgramBuilder.newDraftProgram("scoring preserve program").buildDefinition();
+    // Turn scoring on through the scoring-aware overload first.
+    ps.updateProgramDefinition(
+        originalProgram.id(),
+        Locale.US,
+        "new description",
+        "name",
+        "description",
+        "short description",
+        "",
+        "https://usa.gov",
+        DisplayMode.PUBLIC.getValue(),
+        ImmutableList.of(),
+        /* eligibilityIsGating= */ true,
+        /* loginOnly= */ false,
+        /* usesScoring= */ true,
+        ProgramType.DEFAULT,
+        ImmutableList.of(),
+        /* categoryIds= */ ImmutableList.of(),
+        ImmutableList.of(new ApplicationStep("title", "description")));
+
+    // An update through the legacy overload must not clobber the stored value.
+    ErrorAnd<ProgramDefinition, CiviFormError> result =
+        ps.updateProgramDefinition(
+            originalProgram.id(),
+            Locale.US,
+            "another description",
+            "name",
+            "description",
+            "short description",
+            "",
+            "https://usa.gov",
+            DisplayMode.PUBLIC.getValue(),
+            ImmutableList.of(),
+            /* eligibilityIsGating= */ true,
+            /* loginOnly= */ false,
+            ProgramType.DEFAULT,
+            ImmutableList.of(),
+            /* categoryIds= */ ImmutableList.of(),
+            ImmutableList.of(new ApplicationStep("title", "description")));
+
+    assertThat(result.hasResult()).isTrue();
+    assertThat(result.getResult().usesScoring()).isTrue();
+  }
+
+  @Test
   public void createProgram_setsNotificationPreferences() {
     ErrorAnd<ProgramDefinition, CiviFormError> result =
         ps.createProgramDefinition(

--- a/server/test/support/ProgramBuilder.java
+++ b/server/test/support/ProgramBuilder.java
@@ -386,6 +386,11 @@ public class ProgramBuilder {
     return this;
   }
 
+  public ProgramBuilder withUsesScoring(boolean usesScoring) {
+    builder.setUsesScoring(usesScoring);
+    return this;
+  }
+
   /**
    * Creates a {@link BlockBuilder} with this {@link ProgramBuilder} with empty name and
    * description.

--- a/server/test/views/admin/programs/ProgramFormBuilderTest.java
+++ b/server/test/views/admin/programs/ProgramFormBuilderTest.java
@@ -18,6 +18,7 @@ import repository.AccountRepository;
 import repository.CategoryRepository;
 import repository.ResetPostgres;
 import services.program.ProgramType;
+import services.settings.SettingsManifest;
 
 public class ProgramFormBuilderTest extends ResetPostgres {
   private ProgramFormBuilder formBuilder;
@@ -45,7 +46,11 @@ public class ProgramFormBuilderTest extends ResetPostgres {
     CategoryRepository mockCategoryRepo = mock(CategoryRepository.class);
     formBuilder =
         new ProgramFormBuilder(
-            config, mockAccountRepo, mockCategoryRepo, instanceOf(MessagesApi.class)) {};
+            config,
+            mockAccountRepo,
+            mockCategoryRepo,
+            instanceOf(MessagesApi.class),
+            instanceOf(SettingsManifest.class)) {};
   }
 
   @Test


### PR DESCRIPTION
New programs.uses_scoring column (DEFAULT FALSE NOT NULL) mirrored
through ProgramModel and ProgramDefinition. The definition stores the
value as an internal Optional<Boolean> so pre-feature program exports
without the property still deserialize and read as false; explicit JSON
null is tolerated for the same reason.

The setting renders as a yes/no radio pair on the program form only
while the scoring flag is on. Preservation is controller-side: create
forces false with the flag off, update keeps the stored value and
discards crafted posts. ProgramService gains scoring-aware overloads;
the legacy update overload leaves the stored value untouched via
toBuilder(), so existing callers cannot clobber it. The existing
positional ProgramModel constructor delegates with usesScoring=false to
avoid breaking existing construction sites.

Assisted-by: Claude Code:claude-fable-5

---

Part 5 of 12 in the option-scores stack. Merge in order, top to bottom:

1. https://github.com/civiform/civiform/pull/13796
2. https://github.com/civiform/civiform/pull/13797
3. https://github.com/civiform/civiform/pull/13798
4. https://github.com/civiform/civiform/pull/13799
5. https://github.com/civiform/civiform/pull/13800
6. https://github.com/civiform/civiform/pull/13801
7. https://github.com/civiform/civiform/pull/13802
8. https://github.com/civiform/civiform/pull/13803
9. https://github.com/civiform/civiform/pull/13804
10. https://github.com/civiform/civiform/pull/13805
11. https://github.com/civiform/civiform/pull/13806
12. https://github.com/civiform/civiform/pull/13807
