### PR TITLE
Write score metadata to the application snapshot at submit

### DIFF
--- a/server/app/controllers/applicant/ApplicantProgramReviewController.java
+++ b/server/app/controllers/applicant/ApplicantProgramReviewController.java
@@ -298,7 +298,12 @@ public class ApplicantProgramReviewController extends CiviFormController {
     CiviFormProfile submittingProfile = profileUtils.currentUserProfile(request);
 
     return applicantService
-        .submitApplication(applicantId, programId, submittingProfile, request)
+        .submitApplication(
+            applicantId,
+            programId,
+            submittingProfile,
+            request,
+            settingsManifest.getAnswerOptionScoringEnabled(request))
         .thenApplyAsync(
             (application) -> {
               Long applicationId = application.id;

--- a/server/app/repository/ApplicationRepository.java
+++ b/server/app/repository/ApplicationRepository.java
@@ -21,8 +21,11 @@ import models.LifecycleStage;
 import models.ProgramModel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import services.applicant.ApplicantData;
+import services.applicant.ApplicationScoreCalculator;
 import services.applicant.exception.ApplicantNotFoundException;
 import services.applicant.exception.DuplicateApplicationException;
+import services.program.ProgramDefinition;
 import services.program.ProgramNotFoundException;
 
 /**
@@ -38,18 +41,21 @@ public final class ApplicationRepository {
   private final ProgramRepository programRepository;
   private final AccountRepository accountRepository;
   private final DatabaseExecutionContext dbExecutionContext;
+  private final ApplicationScoreCalculator applicationScoreCalculator;
   private static final Logger logger = LoggerFactory.getLogger(ApplicationRepository.class);
 
   @Inject
   public ApplicationRepository(
       ProgramRepository programRepository,
       AccountRepository accountRepository,
-      DatabaseExecutionContext dbExecutionContext) {
+      DatabaseExecutionContext dbExecutionContext,
+      ApplicationScoreCalculator applicationScoreCalculator) {
     this.database = DB.getDefault();
     this.transactionManager = new TransactionManager();
     this.programRepository = checkNotNull(programRepository);
     this.accountRepository = checkNotNull(accountRepository);
     this.dbExecutionContext = checkNotNull(dbExecutionContext);
+    this.applicationScoreCalculator = checkNotNull(applicationScoreCalculator);
   }
 
   @VisibleForTesting
@@ -61,33 +67,71 @@ public final class ApplicationRepository {
     return supplyAsync(
         () ->
             submitApplicationInternal(
-                applicant, program, tiSubmitterEmail, eligibilityDetermination),
+                applicant,
+                program,
+                tiSubmitterEmail,
+                eligibilityDetermination,
+                /* fullProgramDefinition= */ Optional.empty(),
+                /* scoringEnabled= */ false),
         dbExecutionContext.current());
   }
 
   /**
-   * Submit an application, which will delete any in-progress drafts, obsolete any submitted
-   * applications to a program with the same name (to include past versions of the same program),
-   * and create a new application in the active state.
+   * Submit an application without applying answer-option scoring. See {@link
+   * #submitApplication(long, long, Optional, EligibilityDetermination, Optional, boolean)}.
    */
   public CompletionStage<Optional<ApplicationModel>> submitApplication(
       long applicantId,
       long programId,
       Optional<String> tiSubmitterEmail,
       EligibilityDetermination eligibilityDetermination) {
+    return submitApplication(
+        applicantId,
+        programId,
+        tiSubmitterEmail,
+        eligibilityDetermination,
+        /* fullProgramDefinition= */ Optional.empty(),
+        /* scoringEnabled= */ false);
+  }
+
+  /**
+   * Submit an application, which will delete any in-progress drafts, obsolete any submitted
+   * applications to a program with the same name (to include past versions of the same program),
+   * and create a new application in the active state.
+   *
+   * @param fullProgramDefinition the full definition of the submitted program version, used to
+   *     resolve answer-option scores
+   * @param scoringEnabled whether the answer-option-scoring feature flag is on for this request;
+   *     score metadata is written only when this is true and the program version has {@code
+   *     usesScoring}
+   */
+  public CompletionStage<Optional<ApplicationModel>> submitApplication(
+      long applicantId,
+      long programId,
+      Optional<String> tiSubmitterEmail,
+      EligibilityDetermination eligibilityDetermination,
+      Optional<ProgramDefinition> fullProgramDefinition,
+      boolean scoringEnabled) {
     return this.perform(
         applicantId,
         programId,
         (ApplicationArguments appArgs) ->
             submitApplicationInternal(
-                appArgs.applicant, appArgs.program, tiSubmitterEmail, eligibilityDetermination));
+                appArgs.applicant,
+                appArgs.program,
+                tiSubmitterEmail,
+                eligibilityDetermination,
+                fullProgramDefinition,
+                scoringEnabled));
   }
 
   private ApplicationModel submitApplicationInternal(
       ApplicantModel applicant,
       ProgramModel program,
       Optional<String> tiSubmitterEmail,
-      EligibilityDetermination eligibilityDetermination) {
+      EligibilityDetermination eligibilityDetermination,
+      Optional<ProgramDefinition> fullProgramDefinition,
+      boolean scoringEnabled) {
     return transactionManager.execute(
         () -> {
           List<ApplicationModel> oldApplications =
@@ -163,9 +207,37 @@ public final class ApplicationRepository {
             appModel.setLifecycleStage(LifecycleStage.OBSOLETE);
             appModel.save();
           }
+          boolean applyScoring =
+              scoringEnabled
+                  && fullProgramDefinition.isPresent()
+                  && fullProgramDefinition.get().usesScoring();
+          final ApplicantData snapshot;
+          if (applyScoring) {
+            ProgramDefinition submittedVersion = fullProgramDefinition.get();
+            // The controller's fast-forward normally guarantees the draft points at the version
+            // being submitted, but do not depend on it: repoint stale drafts so scores resolve
+            // from the exact version the application is associated with.
+            if (application.getProgram().id != submittedVersion.id()) {
+              application.setProgram(program);
+            }
+            // Enrich a private copy, preserving the source's preferred locale. Never mutate
+            // applicant.getApplicantData(): ApplicantModel memoizes it, so enriching it in place
+            // would leak score metadata into the applicant's shared row on a later save.
+            snapshot =
+                new ApplicantData(
+                    applicant.getApplicantData().hasPreferredLocale()
+                        ? Optional.of(applicant.getApplicantData().preferredLocale())
+                        : Optional.empty(),
+                    applicant.getApplicantData().asJsonString());
+            applicationScoreCalculator.enrich(applicant, snapshot, submittedVersion);
+          } else {
+            snapshot = applicant.getApplicantData();
+          }
+          // Enrichment, activation, and save share this transaction, so the application cannot go
+          // active without its complete score snapshot.
           application
               .setEligibilityDetermination(eligibilityDetermination)
-              .setApplicantData(applicant.getApplicantData())
+              .setApplicantData(snapshot)
               .setLifecycleStage(LifecycleStage.ACTIVE)
               .setSubmitTimeToNow();
           tiSubmitterEmail.ifPresent(application::setSubmitterEmail);

--- a/server/app/services/CfJsonDocumentContext.java
+++ b/server/app/services/CfJsonDocumentContext.java
@@ -258,6 +258,10 @@ public class CfJsonDocumentContext {
   /**
    * Puts an array at a given path, building parent objects as needed.
    *
+   * <p>This is the supported way to persist numeric arrays with null holes: pass a plain {@link
+   * java.util.ArrayList} (Guava's immutable collections reject nulls) and read the values back
+   * with {@link #readNullableDoubleList}.
+   *
    * @param path the {@link Path} where the array should be added.
    * @param list a {@link List} containing scalar values such as strings or longs.
    */
@@ -437,6 +441,27 @@ public class CfJsonDocumentContext {
    */
   public Optional<ImmutableList<String>> readStringList(Path path) {
     return this.readList(path, new TypeRef<ImmutableList<String>>() {});
+  }
+
+  /**
+   * Attempt to read a list of doubles that may contain null entries at the given {@link Path}.
+   * Returns {@code Optional#empty} if the path does not exist or holds a value of another type.
+   *
+   * <p>Unlike the immutable-list reads, this tolerates null holes: Guava's {@link ImmutableList}
+   * rejects nulls, so a null-holed array read through an immutable list would surface as {@code
+   * Optional#empty} and silently vanish. Write such arrays with {@link #putArray(Path, List)}
+   * using a plain {@link ArrayList}.
+   *
+   * @param path the {@link Path} to the list
+   * @return an Optional containing a List<Double> that may contain nulls
+   */
+  public Optional<List<Double>> readNullableDoubleList(Path path) {
+    try {
+      Optional<ArrayList<Double>> result = this.read(path, new TypeRef<ArrayList<Double>>() {});
+      return result.map(list -> (List<Double>) list);
+    } catch (JsonPathTypeMismatchException e) {
+      return Optional.empty();
+    }
   }
 
   /**

--- a/server/app/services/applicant/ApplicantData.java
+++ b/server/app/services/applicant/ApplicantData.java
@@ -120,6 +120,23 @@ public class ApplicantData extends CfJsonDocumentContext {
     } catch (PathNotFoundException _) {
       // Metadata may be missing in unit tests. No harm, no foul.
     }
+    // Score keys are derived from answers at submit time and live only on submitted snapshots,
+    // as siblings of the answer they score, so they should not affect duplicate detection. Delete
+    // them only from objects that hold both the answer scalar and the score key — i.e.
+    // single/multi-select question objects, where a score key can only be ours. A bare recursive
+    // $..score delete would also remove a question subtree admin-named "score" from both sides
+    // and blind the comparison to real changes in that question.
+    for (String scoreJsonPath :
+        ImmutableList.of(
+            "$..[?(@.selection && @.score)].score",
+            "$..[?(@.selections && @.scores)].scores",
+            "$." + ApplicationScoreMetadata.TOTAL_SCORE_KEY)) {
+      try {
+        applicantData.getDocumentContext().delete(scoreJsonPath);
+      } catch (PathNotFoundException _) {
+        // Documents with no scored answers have nothing to scrub.
+      }
+    }
   }
 
   /**

--- a/server/app/services/applicant/ApplicantService.java
+++ b/server/app/services/applicant/ApplicantService.java
@@ -297,6 +297,19 @@ public final class ApplicantService {
           new IllegalArgumentException("Path contained reserved scalar key"));
     }
 
+    // Reject crafted updates targeting a reserved score key as defense in depth; score keys are
+    // written only at submit time, as siblings of the answer scalars, and are never applicant
+    // updatable. "keyName[]" collides with "keyName".
+    boolean updatePathsContainScoreKeys =
+        updates.stream()
+            .map(Update::path)
+            .map(path -> path.isArrayElement() ? path.withoutArrayReference() : path)
+            .anyMatch(path -> ApplicationScoreMetadata.isReservedScoreKey(path.keyName()));
+    if (updatePathsContainScoreKeys) {
+      return CompletableFuture.failedFuture(
+          new IllegalArgumentException("Path contained reserved score key"));
+    }
+
     return stageAndUpdateIfValid(
         applicantId,
         programId,
@@ -477,6 +490,23 @@ public final class ApplicantService {
    */
   public CompletionStage<ApplicationModel> submitApplication(
       long applicantId, long programId, CiviFormProfile submitterProfile, Request request) {
+    return submitApplication(
+        applicantId, programId, submitterProfile, request, /* scoringEnabled= */ false);
+  }
+
+  /**
+   * See {@link #submitApplication(long, long, CiviFormProfile, Request)}.
+   *
+   * @param scoringEnabled whether the answer-option-scoring feature flag is on for this request,
+   *     resolved at the controller boundary. When true and the submitted program version has
+   *     {@code usesScoring}, score metadata is written to the application's private snapshot.
+   */
+  public CompletionStage<ApplicationModel> submitApplication(
+      long applicantId,
+      long programId,
+      CiviFormProfile submitterProfile,
+      Request request,
+      boolean scoringEnabled) {
     try {
       ProgramDefinition pd = programService.getFullProgramDefinition(programId);
       if (submitterProfile.isTrustedIntermediary()) {
@@ -501,7 +531,8 @@ public final class ApplicantService {
                                       ? Optional.empty()
                                       : Optional.of(tiAccount.getEmailAddress()),
                                   eligibilityDetermination,
-                                  request);
+                                  pd,
+                                  scoringEnabled);
                             },
                             classLoaderExecutionContext.current()));
       }
@@ -519,7 +550,8 @@ public final class ApplicantService {
                                 programId,
                                 /* tiSubmitterEmail= */ Optional.empty(),
                                 eligibilityDetermination,
-                                request);
+                                pd,
+                                scoringEnabled);
                           }));
     } catch (ProgramNotFoundException e) {
       throw new RuntimeException("Could not find program.", e);
@@ -647,9 +679,31 @@ public final class ApplicantService {
       Optional<String> tiSubmitterEmail,
       EligibilityDetermination eligibilityDetermination,
       Request request) {
+    return submitApplication(
+        applicantId,
+        programId,
+        tiSubmitterEmail,
+        eligibilityDetermination,
+        /* fullProgramDefinition= */ null,
+        /* scoringEnabled= */ false);
+  }
+
+  private CompletionStage<ApplicationModel> submitApplication(
+      long applicantId,
+      long programId,
+      Optional<String> tiSubmitterEmail,
+      EligibilityDetermination eligibilityDetermination,
+      ProgramDefinition fullProgramDefinition,
+      boolean scoringEnabled) {
     CompletableFuture<Optional<ApplicationModel>> applicationFuture =
         applicationRepository
-            .submitApplication(applicantId, programId, tiSubmitterEmail, eligibilityDetermination)
+            .submitApplication(
+                applicantId,
+                programId,
+                tiSubmitterEmail,
+                eligibilityDetermination,
+                Optional.ofNullable(fullProgramDefinition),
+                scoringEnabled)
             .thenComposeAsync(
                 application -> savePrimaryApplicantInfoAnswers(application),
                 classLoaderExecutionContext.current())

--- a/server/app/services/applicant/ApplicationScoreCalculator.java
+++ b/server/app/services/applicant/ApplicationScoreCalculator.java
@@ -1,0 +1,150 @@
+package services.applicant;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import javax.inject.Inject;
+import models.ApplicantModel;
+import services.Path;
+import services.applicant.predicate.JsonPathPredicateGeneratorFactory;
+import services.applicant.question.ApplicantQuestion;
+import services.applicant.question.Scalar;
+import services.program.ProgramDefinition;
+import services.question.QuestionOption;
+import services.question.types.MultiOptionQuestionDefinition;
+import services.question.types.QuestionType;
+
+/**
+ * Computes answer-option scores for a submitted application and writes them, along with the total
+ * score, to the application's private snapshot at the {@link ApplicationScoreMetadata} paths:
+ * per-question scores as siblings of the {@code selection}/{@code selections} answer, the total at
+ * the document root.
+ *
+ * <p>The calculator only adds {@code score}/{@code scores} keys to question objects that already
+ * exist and the one root {@code total_score} key; it never creates question objects and never
+ * modifies any existing answer value, including checkbox {@code selections} values and ordering.
+ */
+public final class ApplicationScoreCalculator {
+
+  private final JsonPathPredicateGeneratorFactory jsonPathPredicateGeneratorFactory;
+
+  @Inject
+  public ApplicationScoreCalculator(
+      JsonPathPredicateGeneratorFactory jsonPathPredicateGeneratorFactory) {
+    this.jsonPathPredicateGeneratorFactory = checkNotNull(jsonPathPredicateGeneratorFactory);
+  }
+
+  /**
+   * Enriches the given snapshot with per-question score metadata and the application total score.
+   *
+   * <p>Always writes {@code total_score} (an enriched application with no scored answers persists
+   * {@code 0}); its presence is the authoritative "scoring was applied" marker. Repeated and
+   * nested-repeated questions expand to concrete instances via a snapshot-backed {@link
+   * ReadOnlyApplicantProgramService}.
+   *
+   * @param applicant the applicant model, used only to construct the read-only service
+   * @param snapshot the application's private {@link ApplicantData} copy; never the applicant's
+   *     own shared instance
+   * @param submittedVersion the program version the application is associated with; scores resolve
+   *     from this version's question definitions
+   */
+  public void enrich(
+      ApplicantModel applicant, ApplicantData snapshot, ProgramDefinition submittedVersion) {
+    ReadOnlyApplicantProgramService roService =
+        new ReadOnlyApplicantProgramService(
+            jsonPathPredicateGeneratorFactory, applicant, snapshot, submittedVersion);
+
+    // Totals accumulate in BigDecimal over each score's shortest decimal representation, so sums
+    // of admin-entered decimals carry no binary floating-point artifacts (0.1 + 0.2 persists 0.3).
+    BigDecimal total = BigDecimal.ZERO;
+    // Deduplicate by contextualized path so a malformed program containing the same question more
+    // than once cannot double-count a score; mirrors the exporters' buildKeepingLast behavior for
+    // known issue #9212.
+    Set<Path> seenPaths = new HashSet<>();
+    ImmutableList<ApplicantQuestion> questions =
+        roService.getAllQuestionsIncludingHidden().collect(ImmutableList.toImmutableList());
+    for (ApplicantQuestion question : questions) {
+      if (!QuestionType.supportsOptionScores(question.getType())) {
+        continue;
+      }
+      Path contextualizedPath = question.getContextualizedPath();
+      if (!seenPaths.add(contextualizedPath)) {
+        continue;
+      }
+      ImmutableMap<Long, Double> scoresByOptionId =
+          optionScoresById((MultiOptionQuestionDefinition) question.getQuestionDefinition());
+      if (question.getType() == QuestionType.CHECKBOX) {
+        total = total.add(enrichCheckboxQuestion(snapshot, contextualizedPath, scoresByOptionId));
+      } else {
+        total =
+            total.add(enrichSingleSelectQuestion(snapshot, contextualizedPath, scoresByOptionId));
+      }
+    }
+
+    snapshot.putDouble(ApplicationScoreMetadata.totalScorePath(), total.doubleValue());
+  }
+
+  private static ImmutableMap<Long, Double> optionScoresById(
+      MultiOptionQuestionDefinition definition) {
+    return definition.getOptions().stream()
+        .filter(option -> option.score().isPresent())
+        .collect(
+            ImmutableMap.toImmutableMap(
+                QuestionOption::id, option -> option.score().get(), (first, second) -> first));
+  }
+
+  /**
+   * Scores a radio/dropdown answer. The stored {@code selection} value is the selected option id.
+   * No key is written for unanswered questions or unscored options; export layers emit null from
+   * absence.
+   */
+  private static BigDecimal enrichSingleSelectQuestion(
+      ApplicantData snapshot, Path contextualizedPath, ImmutableMap<Long, Double> scoresById) {
+    Optional<Long> selectedOptionId =
+        snapshot.readLong(contextualizedPath.join(Scalar.SELECTION));
+    if (selectedOptionId.isEmpty() || !scoresById.containsKey(selectedOptionId.get())) {
+      return BigDecimal.ZERO;
+    }
+    double score = scoresById.get(selectedOptionId.get());
+    snapshot.putDouble(ApplicationScoreMetadata.scorePath(contextualizedPath), score);
+    return BigDecimal.valueOf(score);
+  }
+
+  /**
+   * Scores a checkbox answer without modifying the stored {@code selections}. Writes a same-length
+   * nullable score array preserving the stored selection order. Unknown ids, unscored options, and
+   * occurrences after the first duplicate id get null; only the first scored occurrence of an id
+   * contributes to the total, so an option contributes at most once.
+   */
+  private static BigDecimal enrichCheckboxQuestion(
+      ApplicantData snapshot, Path contextualizedPath, ImmutableMap<Long, Double> scoresById) {
+    Optional<ImmutableList<Long>> maybeSelections =
+        snapshot.readLongList(contextualizedPath.join(Scalar.SELECTIONS));
+    if (maybeSelections.isEmpty()) {
+      // Unanswered: no per-question metadata at all.
+      return BigDecimal.ZERO;
+    }
+    BigDecimal subtotal = BigDecimal.ZERO;
+    // ArrayList because the array may contain null holes; see CfJsonDocumentContext#putArray.
+    List<Double> scores = new ArrayList<>();
+    Set<Long> countedOptionIds = new HashSet<>();
+    for (Long selectedOptionId : maybeSelections.get()) {
+      Double score = scoresById.get(selectedOptionId);
+      if (score != null && countedOptionIds.add(selectedOptionId)) {
+        scores.add(score);
+        subtotal = subtotal.add(BigDecimal.valueOf(score));
+      } else {
+        scores.add(null);
+      }
+    }
+    snapshot.putArray(ApplicationScoreMetadata.scoresPath(contextualizedPath), scores);
+    return subtotal;
+  }
+}

--- a/server/app/services/applicant/ApplicationScoreMetadata.java
+++ b/server/app/services/applicant/ApplicationScoreMetadata.java
@@ -1,0 +1,103 @@
+package services.applicant;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import services.Path;
+
+/**
+ * Owns the JSON keys and paths of the answer-option score data written to a submitted
+ * application's private snapshot.
+ *
+ * <p>Per-question scores live inside the scored question's own JSON object, as siblings of the
+ * {@code selection}/{@code selections} answer scalar — the same additive-sibling shape the {@code
+ * updated_at}/{@code program_updated_in} metadata scalars already use. The application total lives
+ * at the document root, as a sibling of the {@code applicant} object. These keys are deliberately
+ * not {@link services.applicant.question.Scalar}s, which keeps them out of question scalar sets,
+ * predicates, API bridges, and scalar-driven schema generation by construction.
+ *
+ * <p>The sibling keys cannot collide with any question admin name: a question's JSON object
+ * contains only scalar keys, and no question type has a scalar named {@code score} or {@code
+ * scores}. A question admin-named {@code score} produces a question <em>object</em> one level
+ * higher, never a key inside another question's object, and {@code total_score} sits outside the
+ * {@code applicant} tree entirely. Applicant update endpoints reject the three key names in
+ * scalar position as reserved (see {@link #isReservedScoreKey}).
+ */
+public final class ApplicationScoreMetadata {
+
+  /** Key of a single-select question's score, a sibling of its {@code selection} scalar. */
+  public static final String SCORE_KEY = "score";
+
+  /** Key of a checkbox question's score array, a sibling of its {@code selections} scalar. */
+  public static final String SCORES_KEY = "scores";
+
+  /** Root-level key of the application's total score, a sibling of {@code applicant}. */
+  public static final String TOTAL_SCORE_KEY = "total_score";
+
+  private static final ImmutableSet<String> RESERVED_SCORE_KEYS =
+      ImmutableSet.of(SCORE_KEY, SCORES_KEY, TOTAL_SCORE_KEY);
+
+  private static final Path TOTAL_SCORE = Path.create(TOTAL_SCORE_KEY);
+
+  private ApplicationScoreMetadata() {}
+
+  /**
+   * Path of the application's total score. Presence of a value at this path is the authoritative
+   * marker that scoring was applied to the application at submission time.
+   */
+  public static Path totalScorePath() {
+    return TOTAL_SCORE;
+  }
+
+  /**
+   * Path of a single-select question's score: a {@code score} key inside the question's object,
+   * next to its {@code selection} scalar.
+   */
+  public static Path scorePath(Path contextualizedQuestionPath) {
+    return checkApplicantRooted(contextualizedQuestionPath).join(SCORE_KEY);
+  }
+
+  /**
+   * Path of a checkbox question's score array (parallel to its stored {@code selections} array): a
+   * {@code scores} key inside the question's object, next to its {@code selections} scalar.
+   */
+  public static Path scoresPath(Path contextualizedQuestionPath) {
+    return checkApplicantRooted(contextualizedQuestionPath).join(SCORES_KEY);
+  }
+
+  /**
+   * Returns true if the key name is reserved for score storage. Applicant update endpoints reject
+   * updates whose path ends in a reserved key as defense in depth: score keys occupy scalar
+   * position, so reserving them as scalar key names is sufficient, and question admin names are
+   * unaffected because they occupy a different path depth.
+   */
+  public static boolean isReservedScoreKey(String keyName) {
+    return RESERVED_SCORE_KEYS.contains(keyName);
+  }
+
+  /**
+   * Returns true if the path is rooted at the application-private metadata namespace. Applicant
+   * update endpoints reject such paths as defense in depth.
+   */
+  public static boolean isMetadataPath(Path path) {
+    if (path.isEmpty()) {
+      return false;
+    }
+    String root = path.segments().get(0);
+    int arrayStart = root.indexOf('[');
+    if (arrayStart >= 0) {
+      root = root.substring(0, arrayStart);
+    }
+    return root.equals("application_metadata");
+  }
+
+  private static Path checkApplicantRooted(Path contextualizedQuestionPath) {
+    ImmutableList<String> segments = contextualizedQuestionPath.segments();
+    checkArgument(
+        !segments.isEmpty() && segments.get(0).equals(ApplicantData.APPLICANT_PATH.toString()),
+        "Contextualized question path must be rooted at 'applicant', got: %s",
+        contextualizedQuestionPath);
+    return contextualizedQuestionPath;
+  }
+}

--- a/server/test/repository/ApplicationRepositoryTest.java
+++ b/server/test/repository/ApplicationRepositoryTest.java
@@ -22,10 +22,20 @@ import models.VersionModel;
 import org.junit.Before;
 import org.junit.Test;
 import services.DateConverter;
+import services.LocalizedStrings;
 import services.Path;
+import services.applicant.ApplicationScoreMetadata;
 import services.applicant.exception.DuplicateApplicationException;
+import services.program.ProgramDefinition;
 import services.program.ProgramType;
+import services.question.QuestionAnswerer;
+import services.question.QuestionOption;
+import services.question.types.MultiOptionQuestionDefinition;
+import services.question.types.MultiOptionQuestionDefinition.MultiOptionQuestionType;
+import services.question.types.QuestionDefinition;
+import services.question.types.QuestionDefinitionConfig;
 import support.CfTestHelpers;
+import support.ProgramBuilder;
 
 public class ApplicationRepositoryTest extends ResetPostgres {
   private ApplicationRepository repo;
@@ -595,6 +605,222 @@ public class ApplicationRepositoryTest extends ResetPostgres {
     assertThatThrownBy(() -> repo.updateDraftApplicationProgram(applicant.id, fakeProgramV2Id))
         .isInstanceOf(RuntimeException.class)
         .hasMessageContaining("Program not found");
+  }
+
+  private QuestionDefinition saveScoredDropdown(String name, double score) {
+    return testQuestionBank
+        .maybeSave(
+            new MultiOptionQuestionDefinition(
+                QuestionDefinitionConfig.builder()
+                    .setName(name)
+                    .setDescription(name)
+                    .setQuestionText(LocalizedStrings.of(Locale.US, name + "?"))
+                    .setQuestionHelpText(LocalizedStrings.empty())
+                    .build(),
+                ImmutableList.of(
+                    QuestionOption.create(
+                        /* id= */ 1L,
+                        /* displayOrder= */ 0L,
+                        /* adminName= */ "scored_option",
+                        /* optionText= */ LocalizedStrings.of(Locale.US, "scored option"),
+                        /* displayInAnswerOptions= */ Optional.of(true),
+                        /* score= */ Optional.of(score))),
+                MultiOptionQuestionType.DROPDOWN),
+            LifecycleStage.ACTIVE)
+        .getQuestionDefinition();
+  }
+
+  private Path answerScoredDropdown(ApplicantModel applicant, QuestionDefinition dropdown) {
+    Path path = Path.create("applicant").join(dropdown.getQuestionPathSegment());
+    QuestionAnswerer.answerSingleSelectQuestion(applicant.getApplicantData(), path, 1L);
+    applicant.save();
+    return path;
+  }
+
+  @Test
+  public void submitApplication_scoringNotRequested_writesNoScoreMetadata() {
+    ApplicantModel applicant = saveApplicant("Alice");
+    QuestionDefinition dropdown = saveScoredDropdown("no scoring dropdown", 10);
+    ProgramModel program =
+        ProgramBuilder.newActiveProgram("no-scoring-requested")
+            .withUsesScoring(true)
+            .withBlock()
+            .withRequiredQuestionDefinition(dropdown)
+            .build();
+    answerScoredDropdown(applicant, dropdown);
+
+    // The legacy overload never applies scoring, matching the flag-off behavior.
+    ApplicationModel application =
+        repo.submitApplication(
+                applicant, program, Optional.empty(), EligibilityDetermination.NOT_COMPUTED)
+            .toCompletableFuture()
+            .join();
+
+    assertThat(
+            application
+                .getApplicantData()
+                .hasPath(ApplicationScoreMetadata.totalScorePath()))
+        .isFalse();
+    assertThat(application.getApplicantData().asJsonString())
+        .doesNotContain("\"score\":")
+        .doesNotContain("\"total_score\":");
+  }
+
+  @Test
+  public void submitApplication_flagOnButProgramNotScoring_writesNoScoreMetadata() {
+    ApplicantModel applicant = saveApplicant("Alice");
+    QuestionDefinition dropdown = saveScoredDropdown("program off dropdown", 10);
+    ProgramModel program =
+        ProgramBuilder.newActiveProgram("program-not-scoring")
+            .withBlock()
+            .withRequiredQuestionDefinition(dropdown)
+            .build();
+    answerScoredDropdown(applicant, dropdown);
+
+    ApplicationModel application =
+        repo.submitApplication(
+                applicant.id,
+                program.id,
+                Optional.empty(),
+                EligibilityDetermination.NOT_COMPUTED,
+                Optional.of(program.getProgramDefinition()),
+                /* scoringEnabled= */ true)
+            .toCompletableFuture()
+            .join()
+            .get();
+
+    assertThat(
+            application
+                .getApplicantData()
+                .hasPath(ApplicationScoreMetadata.totalScorePath()))
+        .isFalse();
+  }
+
+  @Test
+  public void submitApplication_scoringApplied_writesMetadataToSnapshotOnly() {
+    ApplicantModel applicant = saveApplicant("Alice");
+    QuestionDefinition dropdown = saveScoredDropdown("applied dropdown", 10.5);
+    ProgramModel program =
+        ProgramBuilder.newActiveProgram("scoring-applied")
+            .withUsesScoring(true)
+            .withBlock()
+            .withRequiredQuestionDefinition(dropdown)
+            .build();
+    Path questionPath = answerScoredDropdown(applicant, dropdown);
+    applicant.getApplicantData().setPreferredLocale(Locale.FRENCH);
+    applicant.save();
+    String applicantJsonBefore = applicant.getApplicantData().asJsonString();
+
+    ApplicationModel application =
+        repo.submitApplication(
+                applicant.id,
+                program.id,
+                Optional.empty(),
+                EligibilityDetermination.NOT_COMPUTED,
+                Optional.of(program.getProgramDefinition()),
+                /* scoringEnabled= */ true)
+            .toCompletableFuture()
+            .join()
+            .get();
+
+    // The snapshot carries the score metadata and keeps the source's preferred locale.
+    assertThat(
+            application.getApplicantData().readDouble(ApplicationScoreMetadata.totalScorePath()))
+        .hasValue(10.5);
+    assertThat(
+            application
+                .getApplicantData()
+                .readDouble(ApplicationScoreMetadata.scorePath(questionPath)))
+        .hasValue(10.5);
+    assertThat(application.getApplicantData().preferredLocale()).isEqualTo(Locale.FRENCH);
+
+    // The applicant's own shared row never carries score metadata.
+    ApplicantModel refreshedApplicant =
+        instanceOf(AccountRepository.class)
+            .lookupApplicant(applicant.id)
+            .toCompletableFuture()
+            .join()
+            .get();
+    assertThat(refreshedApplicant.getApplicantData().asJsonString())
+        .doesNotContain("\"score\":")
+        .doesNotContain("\"total_score\":");
+    assertThat(refreshedApplicant.getApplicantData().asJsonString())
+        .isEqualTo(applicantJsonBefore);
+  }
+
+  @Test
+  public void submitApplication_duplicateOfScoredSnapshot_stillDetected() {
+    ApplicantModel applicant = saveApplicant("Alice");
+    QuestionDefinition dropdown = saveScoredDropdown("duplicate dropdown", 10);
+    ProgramModel program =
+        ProgramBuilder.newActiveProgram("scored-duplicate")
+            .withUsesScoring(true)
+            .withBlock()
+            .withRequiredQuestionDefinition(dropdown)
+            .build();
+    answerScoredDropdown(applicant, dropdown);
+
+    repo.submitApplication(
+            applicant.id,
+            program.id,
+            Optional.empty(),
+            EligibilityDetermination.NOT_COMPUTED,
+            Optional.of(program.getProgramDefinition()),
+            /* scoringEnabled= */ true)
+        .toCompletableFuture()
+        .join();
+
+    // The previous snapshot carries score metadata and the live applicant does not; identical
+    // answers must still be detected as a duplicate.
+    assertThatThrownBy(
+            () ->
+                repo.submitApplication(
+                        applicant,
+                        program,
+                        Optional.empty(),
+                        EligibilityDetermination.NOT_COMPUTED)
+                    .toCompletableFuture()
+                    .join())
+        .hasCauseInstanceOf(DuplicateApplicationException.class);
+  }
+
+  @Test
+  public void submitApplication_staleDraft_repointsAndScoresFromSubmittedVersion() {
+    ApplicantModel applicant = saveApplicant("Alice");
+    QuestionDefinition oldDropdown = saveScoredDropdown("stale dropdown old", 10);
+    QuestionDefinition newDropdown = saveScoredDropdown("stale dropdown new", 99.25);
+    ProgramModel oldVersion =
+        ProgramBuilder.newObsoleteProgram("stale-program")
+            .withUsesScoring(true)
+            .withBlock()
+            .withRequiredQuestionDefinition(oldDropdown)
+            .build();
+    ProgramModel newVersion =
+        ProgramBuilder.newActiveProgram("stale-program")
+            .withUsesScoring(true)
+            .withBlock()
+            .withRequiredQuestionDefinition(newDropdown)
+            .build();
+    // The draft still points at the old program version.
+    repo.createOrUpdateDraft(applicant, oldVersion).toCompletableFuture().join();
+    answerScoredDropdown(applicant, newDropdown);
+
+    ApplicationModel application =
+        repo.submitApplication(
+                applicant.id,
+                newVersion.id,
+                Optional.empty(),
+                EligibilityDetermination.NOT_COMPUTED,
+                Optional.of(newVersion.getProgramDefinition()),
+                /* scoringEnabled= */ true)
+            .toCompletableFuture()
+            .join()
+            .get();
+
+    assertThat(application.getProgram().id).isEqualTo(newVersion.id);
+    assertThat(
+            application.getApplicantData().readDouble(ApplicationScoreMetadata.totalScorePath()))
+        .hasValue(99.25);
   }
 
   private ApplicantModel saveApplicant(String name) {

--- a/server/test/repository/CiviFormAccountMergerTest.java
+++ b/server/test/repository/CiviFormAccountMergerTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import services.Path;
 import services.applicant.ApplicantData;
+import services.applicant.ApplicationScoreCalculator;
 import services.cloud.ApplicantFileNameFormatter;
 import services.settings.SettingsManifest;
 
@@ -49,7 +50,8 @@ public class CiviFormAccountMergerTest extends ResetPostgres {
         new ApplicationRepository(
             instanceOf(ProgramRepository.class),
             acctRepo,
-            instanceOf(DatabaseExecutionContext.class));
+            instanceOf(DatabaseExecutionContext.class),
+            instanceOf(ApplicationScoreCalculator.class));
   }
 
   public enum Newer {

--- a/server/test/services/CfJsonDocumentContextTest.java
+++ b/server/test/services/CfJsonDocumentContextTest.java
@@ -542,6 +542,43 @@ public class CfJsonDocumentContextTest {
   }
 
   @Test
+  public void readNullableDoubleList_roundTripsNullHoles() {
+    CfJsonDocumentContext data = new CfJsonDocumentContext();
+    Path path = Path.create("applicant.toppings.scores");
+    java.util.List<Double> scores = new java.util.ArrayList<>();
+    scores.add(3.5);
+    scores.add(null);
+    scores.add(-7.25);
+
+    data.putArray(path, scores);
+
+    assertThat(data.readNullableDoubleList(path)).hasValue(scores);
+  }
+
+  @Test
+  public void readNullableDoubleList_allNullAndEmptyLists_roundTrip() {
+    CfJsonDocumentContext data = new CfJsonDocumentContext();
+    Path allNullPath = Path.create("applicant.all_null.scores");
+    java.util.List<Double> allNull = new java.util.ArrayList<>();
+    allNull.add(null);
+    allNull.add(null);
+    data.putArray(allNullPath, allNull);
+
+    Path emptyPath = Path.create("applicant.empty.scores");
+    data.putArray(emptyPath, new java.util.ArrayList<Double>());
+
+    assertThat(data.readNullableDoubleList(allNullPath)).hasValue(allNull);
+    assertThat(data.readNullableDoubleList(emptyPath)).hasValue(java.util.List.of());
+  }
+
+  @Test
+  public void readNullableDoubleList_pathNotPresent_returnsEmptyOptional() {
+    CfJsonDocumentContext data = new CfJsonDocumentContext();
+
+    assertThat(data.readNullableDoubleList(Path.create("not.here"))).isEmpty();
+  }
+
+  @Test
   public void readLongList_withTypeMismatch_returnsEmptyOptional() {
     String testData =
         """

--- a/server/test/services/applicant/ApplicantDataTest.java
+++ b/server/test/services/applicant/ApplicantDataTest.java
@@ -99,6 +99,46 @@ public class ApplicantDataTest extends ResetPostgres {
   }
 
   @Test
+  public void isDuplicate_ignoresSiblingScoreKeys() {
+    // A previously submitted snapshot of a scoring program carries score keys as siblings of the
+    // answers plus the root total_score; a live applicant answering identically does not. The
+    // comparison must be score-blind. The unscored radio (selection without score) exercises the
+    // filtered delete against partial matches.
+    ApplicantData submittedSnapshot =
+        new ApplicantData(
+            "{\"applicant\":{\"color\":{\"selection\":3,\"score\":7},"
+                + "\"toppings\":{\"selections\":[1,9,2],\"scores\":[5,null,2]},"
+                + "\"unscored_radio\":{\"selection\":8}},"
+                + "\"total_score\":14}");
+    ApplicantData liveApplicant =
+        new ApplicantData(
+            "{\"applicant\":{\"color\":{\"selection\":3},"
+                + "\"toppings\":{\"selections\":[1,9,2]},"
+                + "\"unscored_radio\":{\"selection\":8}}}");
+
+    assertThat(liveApplicant.isDuplicateOf(submittedSnapshot)).isTrue();
+    assertThat(submittedSnapshot.isDuplicateOf(liveApplicant)).isTrue();
+  }
+
+  @Test
+  public void isDuplicate_keepsQuestionKeysNamedLikeScoreKeys() {
+    // Question admin names may legitimately produce keys called score/scores/total_score below
+    // `applicant`. The scrub only removes score keys that sit next to a selection/selections
+    // scalar, and only the root-level total_score, so these question subtrees stay compared.
+    ApplicantData data1 =
+        new ApplicantData(
+            "{\"applicant\":{\"score\":{\"text\":\"a\"},\"scores\":{\"text\":\"b\"},"
+                + "\"total_score\":{\"text\":\"c\"}}}");
+    ApplicantData data2 =
+        new ApplicantData(
+            "{\"applicant\":{\"score\":{\"text\":\"a\"},\"scores\":{\"text\":\"b\"},"
+                + "\"total_score\":{\"text\":\"DIFFERENT\"}}}");
+
+    assertThat(data1.isDuplicateOf(data2)).isFalse();
+    assertThat(data1.isDuplicateOf(new ApplicantData(data1.asJsonString()))).isTrue();
+  }
+
+  @Test
   public void putServiceAreaInclusionEntities_setsCorrectValues() {
     Path path = Path.create("applicant.address").join(Scalar.SERVICE_AREAS.name()).asArrayElement();
     ImmutableList<ServiceAreaInclusion> entityNames =

--- a/server/test/services/applicant/ApplicantServiceTest.java
+++ b/server/test/services/applicant/ApplicantServiceTest.java
@@ -1085,6 +1085,33 @@ public class ApplicantServiceTest extends ResetPostgres {
   }
 
   @Test
+  public void stageAndUpdateIfValid_pathEndingInReservedScoreKey_isRejected() {
+    ApplicantModel applicant = subject.createApplicant().toCompletableFuture().join();
+    ImmutableMap<String, String> updates =
+        ImmutableMap.of(
+            "applicant.color.score", "9999",
+            "applicant.toppings.scores[0]", "9999",
+            "total_score", "9999");
+
+    assertThatExceptionOfType(CompletionException.class)
+        .isThrownBy(
+            () ->
+                subject
+                    .stageAndUpdateIfValid(
+                        applicant.id,
+                        programDefinition.id(),
+                        "1",
+                        updates,
+                        false,
+                        false,
+                        /* apiBridgeEnabled= */ false)
+                    .toCompletableFuture()
+                    .join())
+        .withCauseInstanceOf(IllegalArgumentException.class)
+        .withMessageContaining("Path contained reserved score key");
+  }
+
+  @Test
   public void createApplicant_createsANewApplicant() {
     ApplicantModel applicant = subject.createApplicant().toCompletableFuture().join();
 

--- a/server/test/services/applicant/ApplicationScoreCalculatorTest.java
+++ b/server/test/services/applicant/ApplicationScoreCalculatorTest.java
@@ -1,0 +1,330 @@
+package services.applicant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.collect.ImmutableList;
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.Optional;
+import models.ApplicantModel;
+import models.LifecycleStage;
+import org.junit.Before;
+import org.junit.Test;
+import repository.ResetPostgres;
+import services.LocalizedStrings;
+import services.ObjectMapperSingleton;
+import services.Path;
+import services.applicant.predicate.JsonPathPredicateGeneratorFactory;
+import services.program.ProgramDefinition;
+import services.question.QuestionAnswerer;
+import services.question.QuestionOption;
+import services.question.types.MultiOptionQuestionDefinition;
+import services.question.types.MultiOptionQuestionDefinition.MultiOptionQuestionType;
+import services.question.types.QuestionDefinition;
+import services.question.types.QuestionDefinitionConfig;
+import support.ProgramBuilder;
+
+public class ApplicationScoreCalculatorTest extends ResetPostgres {
+
+  private static final ObjectMapper mapper = ObjectMapperSingleton.instance();
+
+  private ApplicationScoreCalculator calculator;
+  private ApplicantModel applicant;
+  private ApplicantData snapshot;
+
+  @Before
+  public void setUp() {
+    calculator = new ApplicationScoreCalculator(instanceOf(JsonPathPredicateGeneratorFactory.class));
+    applicant = new ApplicantModel();
+    snapshot = new ApplicantData();
+  }
+
+  private static ImmutableList<QuestionOption> scoredOptions() {
+    return ImmutableList.of(
+        option(1L, 0L, "ten_and_a_half", Optional.of(10.5)),
+        option(2L, 1L, "unscored", Optional.empty()),
+        option(3L, 2L, "minus_four_and_a_quarter", Optional.of(-4.25)),
+        option(4L, 3L, "zero", Optional.of(0.0)));
+  }
+
+  private static QuestionOption option(
+      long id, long displayOrder, String adminName, Optional<Double> score) {
+    return QuestionOption.create(
+        id,
+        displayOrder,
+        adminName,
+        LocalizedStrings.of(Locale.US, adminName),
+        /* displayInAnswerOptions= */ Optional.of(true),
+        score);
+  }
+
+  private QuestionDefinition saveMultiOptionQuestion(
+      String name, MultiOptionQuestionType type, ImmutableList<QuestionOption> options) {
+    return saveMultiOptionQuestion(name, type, options, Optional.empty());
+  }
+
+  private QuestionDefinition saveMultiOptionQuestion(
+      String name,
+      MultiOptionQuestionType type,
+      ImmutableList<QuestionOption> options,
+      Optional<Long> enumeratorId) {
+    QuestionDefinitionConfig.Builder config =
+        QuestionDefinitionConfig.builder()
+            .setName(name)
+            .setDescription(name)
+            .setQuestionText(LocalizedStrings.of(Locale.US, name + "?"))
+            .setQuestionHelpText(LocalizedStrings.empty());
+    enumeratorId.ifPresent(config::setEnumeratorId);
+    return testQuestionBank
+        .maybeSave(
+            new MultiOptionQuestionDefinition(config.build(), options, type),
+            LifecycleStage.ACTIVE)
+        .getQuestionDefinition();
+  }
+
+  private static Path questionPath(QuestionDefinition question) {
+    return ApplicantData.APPLICANT_PATH.join(question.getQuestionPathSegment());
+  }
+
+  private ProgramDefinition programWith(QuestionDefinition... questions) {
+    ProgramBuilder builder = ProgramBuilder.newActiveProgram("score calc program");
+    ProgramBuilder.BlockBuilder block = builder.withBlock();
+    for (QuestionDefinition question : questions) {
+      block = block.withRequiredQuestionDefinition(question);
+    }
+    return block.buildDefinition();
+  }
+
+  @Test
+  public void enrich_singleSelect_scoredOption_writesScoreAndTotal() {
+    QuestionDefinition dropdown =
+        saveMultiOptionQuestion("scored dropdown", MultiOptionQuestionType.DROPDOWN, scoredOptions());
+    ProgramDefinition program = programWith(dropdown);
+    Path path = questionPath(dropdown);
+    QuestionAnswerer.answerSingleSelectQuestion(snapshot, path, 1L);
+
+    calculator.enrich(applicant, snapshot, program);
+
+    assertThat(snapshot.readDouble(ApplicationScoreMetadata.scorePath(path))).hasValue(10.5);
+    assertThat(snapshot.readDouble(ApplicationScoreMetadata.totalScorePath())).hasValue(10.5);
+  }
+
+  @Test
+  public void enrich_singleSelect_negativeScore_contributesNegative() {
+    QuestionDefinition dropdown =
+        saveMultiOptionQuestion("negative dropdown", MultiOptionQuestionType.DROPDOWN, scoredOptions());
+    ProgramDefinition program = programWith(dropdown);
+    Path path = questionPath(dropdown);
+    QuestionAnswerer.answerSingleSelectQuestion(snapshot, path, 3L);
+
+    calculator.enrich(applicant, snapshot, program);
+
+    assertThat(snapshot.readDouble(ApplicationScoreMetadata.scorePath(path))).hasValue(-4.25);
+    assertThat(snapshot.readDouble(ApplicationScoreMetadata.totalScorePath())).hasValue(-4.25);
+  }
+
+  @Test
+  public void enrich_singleSelect_unscoredOption_writesNoKeyButZeroTotal() {
+    QuestionDefinition dropdown =
+        saveMultiOptionQuestion("unscored dropdown", MultiOptionQuestionType.DROPDOWN, scoredOptions());
+    ProgramDefinition program = programWith(dropdown);
+    Path path = questionPath(dropdown);
+    QuestionAnswerer.answerSingleSelectQuestion(snapshot, path, 2L);
+
+    calculator.enrich(applicant, snapshot, program);
+
+    assertThat(snapshot.hasPath(ApplicationScoreMetadata.scorePath(path))).isFalse();
+    // A zero-sum enrichment still persists 0: presence marks that scoring was applied.
+    assertThat(snapshot.readDouble(ApplicationScoreMetadata.totalScorePath())).hasValue(0.0);
+  }
+
+  @Test
+  public void enrich_unansweredQuestions_writeNoPerQuestionKeys() {
+    QuestionDefinition dropdown =
+        saveMultiOptionQuestion("blank dropdown", MultiOptionQuestionType.DROPDOWN, scoredOptions());
+    QuestionDefinition checkbox =
+        saveMultiOptionQuestion("blank checkbox", MultiOptionQuestionType.CHECKBOX, scoredOptions());
+    ProgramDefinition program = programWith(dropdown, checkbox);
+
+    calculator.enrich(applicant, snapshot, program);
+
+    assertThat(snapshot.hasPath(ApplicationScoreMetadata.scorePath(questionPath(dropdown))))
+        .isFalse();
+    assertThat(snapshot.hasPath(ApplicationScoreMetadata.scoresPath(questionPath(checkbox))))
+        .isFalse();
+    assertThat(snapshot.readDouble(ApplicationScoreMetadata.totalScorePath())).hasValue(0.0);
+  }
+
+  @Test
+  public void enrich_checkbox_mixedSelections_writesAlignedNullableArray() {
+    QuestionDefinition checkbox =
+        saveMultiOptionQuestion("mixed checkbox", MultiOptionQuestionType.CHECKBOX, scoredOptions());
+    ProgramDefinition program = programWith(checkbox);
+    Path path = questionPath(checkbox);
+    // Stored order: scored, unscored, unknown id, duplicate of first, scored-negative.
+    long[] selections = {3L, 2L, 999L, 3L, 1L};
+    for (int i = 0; i < selections.length; i++) {
+      QuestionAnswerer.answerMultiSelectQuestion(snapshot, path, i, selections[i]);
+    }
+    String selectionsBefore =
+        snapshot.readLongList(path.join("selections")).orElseThrow().toString();
+
+    calculator.enrich(applicant, snapshot, program);
+
+    // Same length, stored order preserved; unscored/unknown/duplicate occurrences are null.
+    assertThat(snapshot.readNullableDoubleList(ApplicationScoreMetadata.scoresPath(path)))
+        .hasValue(Arrays.asList(-4.25, null, null, null, 10.5));
+    // Only the first occurrence of the duplicated id contributes.
+    assertThat(snapshot.readDouble(ApplicationScoreMetadata.totalScorePath())).hasValue(6.25);
+    // The stored selections answer is byte-identical.
+    assertThat(snapshot.readLongList(path.join("selections")).orElseThrow().toString())
+        .isEqualTo(selectionsBefore);
+  }
+
+  @Test
+  public void enrich_checkbox_zeroScoredOption_contributesExplicitZero() {
+    QuestionDefinition checkbox =
+        saveMultiOptionQuestion("zero checkbox", MultiOptionQuestionType.CHECKBOX, scoredOptions());
+    ProgramDefinition program = programWith(checkbox);
+    Path path = questionPath(checkbox);
+    QuestionAnswerer.answerMultiSelectQuestion(snapshot, path, 0, 4L);
+
+    calculator.enrich(applicant, snapshot, program);
+
+    assertThat(snapshot.readNullableDoubleList(ApplicationScoreMetadata.scoresPath(path)))
+        .hasValue(Arrays.asList(0.0));
+    assertThat(snapshot.readDouble(ApplicationScoreMetadata.totalScorePath())).hasValue(0.0);
+  }
+
+  @Test
+  public void enrich_decimalScores_totalUsesExactDecimalArithmetic() {
+    QuestionDefinition checkbox =
+        saveMultiOptionQuestion(
+            "decimal checkbox",
+            MultiOptionQuestionType.CHECKBOX,
+            ImmutableList.of(
+                option(1L, 0L, "tenth", Optional.of(0.1)),
+                option(2L, 1L, "fifth", Optional.of(0.2))));
+    ProgramDefinition program = programWith(checkbox);
+    Path path = questionPath(checkbox);
+    QuestionAnswerer.answerMultiSelectQuestion(snapshot, path, 0, 1L);
+    QuestionAnswerer.answerMultiSelectQuestion(snapshot, path, 1, 2L);
+
+    calculator.enrich(applicant, snapshot, program);
+
+    // Naive double addition would persist 0.30000000000000004; BigDecimal accumulation over the
+    // entered values persists the exact decimal sum.
+    assertThat(snapshot.readDouble(ApplicationScoreMetadata.totalScorePath())).hasValue(0.3);
+  }
+
+  @Test
+  public void enrich_yesNoQuestion_neverScores() {
+    // A Yes/No question whose stored options somehow carry scores must still not score.
+    QuestionDefinition yesNo =
+        saveMultiOptionQuestion(
+            "scored yes no",
+            MultiOptionQuestionType.YES_NO,
+            ImmutableList.of(
+                option(1L, 0L, "yes", Optional.of(100.0)),
+                option(0L, 1L, "no", Optional.of(50.0))));
+    ProgramDefinition program = programWith(yesNo);
+    Path path = questionPath(yesNo);
+    QuestionAnswerer.answerSingleSelectQuestion(snapshot, path, 1L);
+
+    calculator.enrich(applicant, snapshot, program);
+
+    assertThat(snapshot.hasPath(ApplicationScoreMetadata.scorePath(path))).isFalse();
+    assertThat(snapshot.readDouble(ApplicationScoreMetadata.totalScorePath())).hasValue(0.0);
+  }
+
+  @Test
+  public void enrich_duplicateContextualizedPaths_countedOnce() {
+    QuestionDefinition dropdown =
+        saveMultiOptionQuestion("dup dropdown", MultiOptionQuestionType.DROPDOWN, scoredOptions());
+    // A malformed program containing the same question in two blocks.
+    ProgramDefinition program =
+        ProgramBuilder.newActiveProgram("duplicate question program")
+            .withBlock()
+            .withRequiredQuestionDefinition(dropdown)
+            .withBlock()
+            .withRequiredQuestionDefinition(dropdown)
+            .buildDefinition();
+    Path path = questionPath(dropdown);
+    QuestionAnswerer.answerSingleSelectQuestion(snapshot, path, 1L);
+
+    calculator.enrich(applicant, snapshot, program);
+
+    assertThat(snapshot.readDouble(ApplicationScoreMetadata.totalScorePath())).hasValue(10.5);
+  }
+
+  @Test
+  public void enrich_repeatedQuestion_scoresEachInstance() {
+    QuestionDefinition enumerator =
+        testQuestionBank.enumeratorApplicantHouseholdMembers().getQuestionDefinition();
+    QuestionDefinition repeatedDropdown =
+        saveMultiOptionQuestion(
+            "repeated scored dropdown",
+            MultiOptionQuestionType.DROPDOWN,
+            scoredOptions(),
+            Optional.of(enumerator.getId()));
+    ProgramDefinition program =
+        ProgramBuilder.newActiveProgram("repeated scoring program")
+            .withBlock()
+            .withRequiredQuestionDefinition(enumerator)
+            .withRepeatedBlock()
+            .withRequiredQuestionDefinition(repeatedDropdown)
+            .buildDefinition();
+
+    Path enumeratorPath =
+        ApplicantData.APPLICANT_PATH.join(enumerator.getQuestionPathSegment());
+    QuestionAnswerer.answerEnumeratorQuestion(
+        snapshot, enumeratorPath, ImmutableList.of("first", "second"));
+    Path firstInstance =
+        enumeratorPath.atIndex(0).join(repeatedDropdown.getQuestionPathSegment());
+    Path secondInstance =
+        enumeratorPath.atIndex(1).join(repeatedDropdown.getQuestionPathSegment());
+    QuestionAnswerer.answerSingleSelectQuestion(snapshot, firstInstance, 1L);
+    QuestionAnswerer.answerSingleSelectQuestion(snapshot, secondInstance, 3L);
+
+    calculator.enrich(applicant, snapshot, program);
+
+    assertThat(snapshot.readDouble(ApplicationScoreMetadata.scorePath(firstInstance)))
+        .hasValue(10.5);
+    assertThat(snapshot.readDouble(ApplicationScoreMetadata.scorePath(secondInstance)))
+        .hasValue(-4.25);
+    assertThat(snapshot.readDouble(ApplicationScoreMetadata.totalScorePath())).hasValue(6.25);
+  }
+
+  @Test
+  public void enrich_onlyAddsSiblingScoreKeys_preservesExistingAnswers() throws Exception {
+    QuestionDefinition dropdown =
+        saveMultiOptionQuestion("subtree dropdown", MultiOptionQuestionType.DROPDOWN, scoredOptions());
+    QuestionDefinition checkbox =
+        saveMultiOptionQuestion("subtree checkbox", MultiOptionQuestionType.CHECKBOX, scoredOptions());
+    ProgramDefinition program = programWith(dropdown, checkbox);
+    QuestionAnswerer.answerSingleSelectQuestion(snapshot, questionPath(dropdown), 1L);
+    QuestionAnswerer.answerMultiSelectQuestion(snapshot, questionPath(checkbox), 0, 999L);
+    QuestionAnswerer.answerMultiSelectQuestion(snapshot, questionPath(checkbox), 1, 3L);
+    QuestionAnswerer.answerMultiSelectQuestion(snapshot, questionPath(checkbox), 2, 3L);
+    JsonNode applicantSubtreeBefore = mapper.readTree(snapshot.asJsonString()).get("applicant");
+
+    calculator.enrich(applicant, snapshot, program);
+
+    JsonNode after = mapper.readTree(snapshot.asJsonString());
+    // Enrichment adds exactly a score key inside each scored question object and the root
+    // total_score. Removing those additions must restore the applicant subtree byte for byte,
+    // proving nothing else changed — including checkbox order, unknown ids, and duplicate ids.
+    ObjectNode applicantAfter = ((ObjectNode) after.get("applicant")).deepCopy();
+    JsonNode removedScore =
+        ((ObjectNode) applicantAfter.get(questionPath(dropdown).keyName())).remove("score");
+    JsonNode removedScores =
+        ((ObjectNode) applicantAfter.get(questionPath(checkbox).keyName())).remove("scores");
+    assertThat(removedScore).isNotNull();
+    assertThat(removedScores).isNotNull();
+    assertThat(applicantAfter).isEqualTo(applicantSubtreeBefore);
+    assertThat(after.has("total_score")).isTrue();
+  }
+}

--- a/server/test/services/applicant/ApplicationScoreMetadataTest.java
+++ b/server/test/services/applicant/ApplicationScoreMetadataTest.java
@@ -1,0 +1,78 @@
+package services.applicant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.Test;
+import services.Path;
+
+public class ApplicationScoreMetadataTest {
+
+  @Test
+  public void isReservedScoreKey_matchesOnlyScoreKeyNames() {
+    assertThat(ApplicationScoreMetadata.isReservedScoreKey("score")).isTrue();
+    assertThat(ApplicationScoreMetadata.isReservedScoreKey("scores")).isTrue();
+    assertThat(ApplicationScoreMetadata.isReservedScoreKey("total_score")).isTrue();
+    assertThat(ApplicationScoreMetadata.isReservedScoreKey("selection")).isFalse();
+    assertThat(ApplicationScoreMetadata.isReservedScoreKey("selections")).isFalse();
+    assertThat(ApplicationScoreMetadata.isReservedScoreKey("text")).isFalse();
+  }
+
+  @Test
+  public void totalScorePath_isTheRootLevelSiblingOfApplicant() {
+    // Outside the applicant tree entirely, so it cannot collide with a question admin-named
+    // "total_score" (which lives at applicant.total_score).
+    assertThat(ApplicationScoreMetadata.totalScorePath().toString()).isEqualTo("total_score");
+  }
+
+  @Test
+  public void scorePaths_areSiblingsOfTheAnswerScalar() {
+    Path questionPath = Path.create("applicant.favorite_color");
+
+    assertThat(ApplicationScoreMetadata.scorePath(questionPath).toString())
+        .isEqualTo("applicant.favorite_color.score");
+    assertThat(ApplicationScoreMetadata.scoresPath(questionPath).toString())
+        .isEqualTo("applicant.favorite_color.scores");
+  }
+
+  @Test
+  public void scorePaths_repeatedContextualizedPath() {
+    Path questionPath = Path.create("applicant.household_members[2].favorite_color");
+
+    assertThat(ApplicationScoreMetadata.scorePath(questionPath).toString())
+        .isEqualTo("applicant.household_members[2].favorite_color.score");
+  }
+
+  @Test
+  public void scorePaths_nestedRepeatedContextualizedPath() {
+    Path questionPath =
+        Path.create("applicant.household_members[1].household_members_jobs[0].days_worked");
+
+    assertThat(ApplicationScoreMetadata.scoresPath(questionPath).toString())
+        .isEqualTo("applicant.household_members[1].household_members_jobs[0].days_worked.scores");
+  }
+
+  @Test
+  public void scorePaths_rejectPathsNotRootedAtApplicant() {
+    assertThatThrownBy(
+            () -> ApplicationScoreMetadata.scorePath(Path.create("other.favorite_color")))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> ApplicationScoreMetadata.scoresPath(Path.empty()))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void isMetadataPath_matchesOnlyTheMetadataRoot() {
+    assertThat(ApplicationScoreMetadata.isMetadataPath(Path.create("application_metadata")))
+        .isTrue();
+    assertThat(
+            ApplicationScoreMetadata.isMetadataPath(
+                Path.create("application_metadata.option_scoring.total_score")))
+        .isTrue();
+    assertThat(ApplicationScoreMetadata.isMetadataPath(Path.create("application_metadata[0].x")))
+        .isTrue();
+    assertThat(ApplicationScoreMetadata.isMetadataPath(Path.create("applicant.total_score")))
+        .isFalse();
+    assertThat(ApplicationScoreMetadata.isMetadataPath(Path.empty())).isFalse();
+  }
+}


### PR DESCRIPTION
When the scoring flag is on and the submitted program version has
usesScoring, ApplicationRepository enriches a private copy of the
applicant data inside the existing submit transaction: per-question
score keys and a total_score land under a new application_metadata
root, outside the applicant answer tree, whose paths are owned by
ApplicationScoreMetadata (deliberately not Scalars). total_score
presence is the authoritative "scoring was applied" marker; a zero sum
persists 0.

ApplicationScoreCalculator expands repeated instances via a
snapshot-backed ReadOnlyApplicantProgramService, dedupes by
contextualized path, scores single-selects by stored option id, and
writes checkbox scores as a nullable array aligned to the unchanged
stored selections order (unknown/duplicate/unscored ids are null; an
option contributes at most once). Null-holed arrays get a dedicated
CfJsonDocumentContext.readNullableLongList since Guava lists reject
nulls.

Stale drafts are repointed to the submitted version before scoring; the
applicant's shared row is never mutated. Duplicate detection scrubs
exactly the application_metadata root, and applicant block updates
rooted there are rejected as defense in depth. The flag-off path is
byte-identical to before.

Assisted-by: Claude Code:claude-fable-5

---

Part 7 of 12 in the option-scores stack. Merge in order, top to bottom:

1. https://github.com/civiform/civiform/pull/13796
2. https://github.com/civiform/civiform/pull/13797
3. https://github.com/civiform/civiform/pull/13798
4. https://github.com/civiform/civiform/pull/13799
5. https://github.com/civiform/civiform/pull/13800
6. https://github.com/civiform/civiform/pull/13801
7. https://github.com/civiform/civiform/pull/13802
8. https://github.com/civiform/civiform/pull/13803
9. https://github.com/civiform/civiform/pull/13804
10. https://github.com/civiform/civiform/pull/13805
11. https://github.com/civiform/civiform/pull/13806
12. https://github.com/civiform/civiform/pull/13807
