### PR TITLE
Render answer-option scores on admin application PDFs

### DIFF
--- a/server/app/controllers/admin/AdminApplicationController.java
+++ b/server/app/controllers/admin/AdminApplicationController.java
@@ -296,7 +296,10 @@ public final class AdminApplicationController extends CiviFormController {
     }
     ApplicationModel application = applicationMaybe.get();
     PdfExporter.InMemoryPdf pdf =
-        pdfExporterService.generateApplicationPdf(application, /* isAdmin= */ true);
+        pdfExporterService.generateApplicationPdf(
+            application,
+            /* isAdmin= */ true,
+            /* includeScores= */ settingsManifest.getAnswerOptionScoringEnabled(request));
     return ok(pdf.getByteArray())
         .as("application/pdf")
         .withHeader(

--- a/server/app/controllers/applicant/UpsellController.java
+++ b/server/app/controllers/applicant/UpsellController.java
@@ -241,8 +241,10 @@ public final class UpsellController extends CiviFormController {
                         applicantId, applicationId));
               }
 
+              // Applicants must never see scores, regardless of flag or program settings.
               PdfExporter.InMemoryPdf pdf =
-                  pdfExporterService.generateApplicationPdf(application, /* isAdmin= */ false);
+                  pdfExporterService.generateApplicationPdf(
+                      application, /* isAdmin= */ false, /* includeScores= */ false);
 
               return ok(pdf.getByteArray())
                   .as("application/pdf")

--- a/server/app/services/applications/PdfExporterService.java
+++ b/server/app/services/applications/PdfExporterService.java
@@ -26,12 +26,16 @@ public final class PdfExporterService {
    *
    * <p>Used for applicants to download a copy of their submitted application and for program admins
    * to review applications.
+   *
+   * @param includeScores whether the answer-option-scoring feature flag is on for this request;
+   *     score text renders only for admins when the application snapshot carries score metadata.
+   *     Applicant downloads always pass false.
    */
   public PdfExporter.InMemoryPdf generateApplicationPdf(
-      ApplicationModel application, boolean isAdmin) {
+      ApplicationModel application, boolean isAdmin, boolean includeScores) {
     PdfExporter.InMemoryPdf pdf;
     try {
-      pdf = pdfExporter.exportApplication(application, isAdmin);
+      pdf = pdfExporter.exportApplication(application, isAdmin, includeScores);
     } catch (DocumentException | IOException e) {
       throw new RuntimeException(e);
     }

--- a/server/app/services/export/PdfExporter.java
+++ b/server/app/services/export/PdfExporter.java
@@ -28,14 +28,23 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import javax.inject.Inject;
 import models.ApplicationModel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import services.DateConverter;
+import services.Path;
 import services.TranslationNotFoundException;
 import services.applicant.AnswerData;
+import services.applicant.ApplicantData;
 import services.applicant.ApplicantService;
+import services.applicant.ApplicationScoreMetadata;
 import services.applicant.ReadOnlyApplicantProgramService;
+import services.applicant.question.Scalar;
 import services.program.BlockDefinition;
 import services.program.EligibilityDefinition;
 import services.program.ProgramBlockDefinitionNotFoundException;
@@ -51,6 +60,8 @@ import services.statuses.StatusService;
 
 /** PdfExporter is meant to generate PDF files. */
 public final class PdfExporter {
+  private static final Logger logger = LoggerFactory.getLogger(PdfExporter.class);
+
   private final ApplicantService applicantService;
   private final Provider<LocalDateTime> nowProvider;
   private final String baseUrl;
@@ -97,13 +108,25 @@ public final class PdfExporter {
    * inMemoryPDF object. The InMemoryPdf object is passed back to the AdminController Class to
    * generate the required PDF.
    */
-  public InMemoryPdf exportApplication(ApplicationModel application, boolean isAdmin)
+  public InMemoryPdf exportApplication(
+      ApplicationModel application, boolean isAdmin, boolean includeScores)
       throws DocumentException, IOException {
     ReadOnlyApplicantProgramService roApplicantService =
         applicantService
             .getReadOnlyApplicantProgramService(application)
             .toCompletableFuture()
             .join();
+
+    // Score text renders only for admins with the scoring flag on, and only when the snapshot
+    // actually carries score metadata (a pre-feature or unscored application has none). The
+    // snapshot is a fresh private copy of the application's stored data.
+    ApplicantData snapshot = application.getApplicantData();
+    Optional<Double> totalScore =
+        snapshot.readDouble(ApplicationScoreMetadata.totalScorePath());
+    Optional<ApplicantData> scoreData =
+        isAdmin && includeScores && totalScore.isPresent()
+            ? Optional.of(snapshot)
+            : Optional.empty();
 
     ImmutableList<AnswerData> answersOnlyActive =
         isAdmin
@@ -130,7 +153,8 @@ public final class PdfExporter {
             application.getProgram().getProgramDefinition(),
             application.getLatestStatus(),
             getSubmitTime(application.getSubmitTime()),
-            isAdmin);
+            isAdmin,
+            scoreData);
     return new InMemoryPdf(bytes, filename);
   }
 
@@ -138,6 +162,73 @@ public final class PdfExporter {
     return submitTime == null
         ? "Application submitted without submission time marked."
         : dateConverter.renderDateTimeHumanReadable(submitTime);
+  }
+
+  /**
+   * Returns the answer text with persisted score annotations rendered inline with the option text
+   * they belong to: {@code optionText (Score: N)}, per selected option line for checkbox. Scores
+   * are read from the application snapshot by contextualized path; answers of unsupported types or
+   * with no persisted score keys render exactly as before.
+   */
+  private static String scoreAnnotatedAnswerText(AnswerData answerData, ApplicantData scoreData) {
+    String answerText = answerData.answerText();
+    QuestionType questionType = answerData.questionDefinition().getQuestionType();
+    if (!QuestionType.supportsOptionScores(questionType)) {
+      return answerText;
+    }
+    Path contextualizedPath = answerData.contextualizedPath();
+    if (questionType != QuestionType.CHECKBOX) {
+      return scoreData
+          .readDouble(ApplicationScoreMetadata.scorePath(contextualizedPath))
+          .map(
+              score ->
+                  String.format("%s (Score: %s)", answerText, QuestionOption.formatScore(score)))
+          .orElse(answerText);
+    }
+
+    Optional<ImmutableList<Long>> selections =
+        scoreData.readLongList(contextualizedPath.join(Scalar.SELECTIONS));
+    Optional<java.util.List<Double>> scores =
+        scoreData.readNullableDoubleList(ApplicationScoreMetadata.scoresPath(contextualizedPath));
+    if (selections.isEmpty() || scores.isEmpty()) {
+      return answerText;
+    }
+    if (selections.get().size() != scores.get().size()) {
+      // Corrupt metadata: render the answer without scores rather than mispairing values.
+      logger.warn(
+          "Score metadata length mismatch at {}: {} selections vs {} scores",
+          contextualizedPath,
+          selections.get().size(),
+          scores.get().size());
+      return answerText;
+    }
+    Map<Long, Double> scoreByOptionId = new HashMap<>();
+    for (int i = 0; i < selections.get().size(); i++) {
+      Double score = scores.get().get(i);
+      if (score != null) {
+        scoreByOptionId.putIfAbsent(selections.get().get(i), score);
+      }
+    }
+    // Rebuild the same option lines MultiSelectQuestion#getAnswerString joins (same source list,
+    // same localized text, same order), appending each scored option's suffix to its own line.
+    return answerData
+        .applicantQuestion()
+        .createMultiSelectQuestion()
+        .getSelectedOptionValues()
+        .map(
+            options ->
+                options.stream()
+                    .map(
+                        option -> {
+                          Double score = scoreByOptionId.get(option.id());
+                          return score == null
+                              ? option.optionText()
+                              : String.format(
+                                  "%s (Score: %s)",
+                                  option.optionText(), QuestionOption.formatScore(score));
+                        })
+                    .collect(Collectors.joining("\n")))
+        .orElse(answerText);
   }
 
   private byte[] buildApplicationPdf(
@@ -148,7 +239,8 @@ public final class PdfExporter {
       ProgramDefinition programDefinition,
       Optional<String> statusValue,
       String submitTime,
-      boolean isAdmin)
+      boolean isAdmin,
+      Optional<ApplicantData> scoreData)
       throws DocumentException, IOException {
     ByteArrayOutputStream byteArrayOutputStream = null;
     PdfWriter writer = null;
@@ -178,6 +270,15 @@ public final class PdfExporter {
           new Paragraph(
               "Submit Time: " + submitTime, FontFactory.getFont(FontFactory.HELVETICA_BOLD, 12));
       document.add(submitTimeInformation);
+      if (scoreData.isPresent()) {
+        double totalScore =
+            scoreData.get().readDouble(ApplicationScoreMetadata.totalScorePath()).orElse(0.0);
+        Paragraph totalScoreParagraph =
+            new Paragraph(
+                "Total score: " + QuestionOption.formatScore(totalScore),
+                FontFactory.getFont(FontFactory.HELVETICA_BOLD, 12));
+        document.add(totalScoreParagraph);
+      }
       document.add(Chunk.NEWLINE);
       boolean isEligibilityEnabledInProgram = programDefinition.hasEligibilityEnabled();
       for (AnswerData answerData : answersOnlyActive) {
@@ -215,9 +316,11 @@ public final class PdfExporter {
           answer = new Paragraph();
           answer.add(anchor);
         } else {
-          answer =
-              new Paragraph(
-                  answerData.answerText(), FontFactory.getFont(FontFactory.HELVETICA, 11));
+          String answerText =
+              scoreData.isPresent()
+                  ? scoreAnnotatedAnswerText(answerData, scoreData.get())
+                  : answerData.answerText();
+          answer = new Paragraph(answerText, FontFactory.getFont(FontFactory.HELVETICA, 11));
         }
         LocalDate date =
             Instant.ofEpochMilli(answerData.timestamp())

--- a/server/test/services/applications/PdfExporterServiceTest.java
+++ b/server/test/services/applications/PdfExporterServiceTest.java
@@ -36,7 +36,8 @@ public class PdfExporterServiceTest extends AbstractExporterTest {
     String applicantNameWithApplicationId =
         String.format("%s (%d)", applicantName, applicationOne.id);
     PdfExporter.InMemoryPdf result =
-        service.generateApplicationPdf(applicationOne, /* isAdmin= */ true);
+        service.generateApplicationPdf(
+            applicationOne, /* isAdmin= */ true, /* includeScores= */ false);
     PdfReader pdfReader = new PdfReader(result.getByteArray());
     StringBuilder textFromPDF = new StringBuilder();
 

--- a/server/test/services/export/PdfExporterTest.java
+++ b/server/test/services/export/PdfExporterTest.java
@@ -13,6 +13,7 @@ import com.itextpdf.text.pdf.PdfReader;
 import com.itextpdf.text.pdf.PdfString;
 import com.itextpdf.text.pdf.parser.PdfTextExtractor;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import junitparams.JUnitParamsRunner;
@@ -23,11 +24,13 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import services.Path;
 import services.applicant.ApplicantData;
+import services.applicant.ApplicationScoreMetadata;
 import services.applications.PdfExporterService;
 import services.program.BlockDefinition;
 import services.program.ProgramDefinition;
 import services.question.QuestionAnswerer;
 import services.question.types.QuestionDefinition;
+import services.question.types.QuestionType;
 
 @RunWith(JUnitParamsRunner.class)
 public class PdfExporterTest extends AbstractExporterTest {
@@ -47,7 +50,8 @@ public class PdfExporterTest extends AbstractExporterTest {
     String applicantNameWithApplicationId =
         String.format("%s (%d)", applicantName, applicationOne.id);
     PdfExporter.InMemoryPdf result =
-        exporter.exportApplication(applicationOne, /* isAdmin= */ false);
+        exporter.exportApplication(
+            applicationOne, /* isAdmin= */ false, /* includeScores= */ false);
     PdfReader pdfReader = new PdfReader(result.getByteArray());
     StringBuilder textFromPDF = new StringBuilder();
 
@@ -106,7 +110,8 @@ public class PdfExporterTest extends AbstractExporterTest {
     String applicantNameWithApplicationId =
         String.format("%s (%d)", applicantName, applicationFive.id);
     PdfExporter.InMemoryPdf result =
-        exporter.exportApplication(applicationFive, /* isAdmin= */ true);
+        exporter.exportApplication(
+            applicationFive, /* isAdmin= */ true, /* includeScores= */ false);
     PdfReader pdfReader = new PdfReader(result.getByteArray());
     StringBuilder textFromPDF = new StringBuilder();
 
@@ -161,7 +166,8 @@ public class PdfExporterTest extends AbstractExporterTest {
     String applicantNameWithApplicationId =
         String.format("%s (%d)", applicantName, applicationFive.id);
     PdfExporter.InMemoryPdf result =
-        exporter.exportApplication(applicationFive, /* isAdmin= */ true);
+        exporter.exportApplication(
+            applicationFive, /* isAdmin= */ true, /* includeScores= */ false);
     PdfReader pdfReader = new PdfReader(result.getByteArray());
     StringBuilder textFromPDF = new StringBuilder();
 
@@ -211,7 +217,8 @@ public class PdfExporterTest extends AbstractExporterTest {
     PdfExporter exporter = instanceOf(PdfExporter.class);
 
     PdfExporter.InMemoryPdf result =
-        exporter.exportApplication(applicationFive, /* isAdmin= */ false);
+        exporter.exportApplication(
+            applicationFive, /* isAdmin= */ false, /* includeScores= */ false);
     PdfReader pdfReader = new PdfReader(result.getByteArray());
     StringBuilder textFromPDF = new StringBuilder();
 
@@ -262,7 +269,8 @@ public class PdfExporterTest extends AbstractExporterTest {
     PdfExporter exporter = instanceOf(PdfExporter.class);
 
     PdfExporter.InMemoryPdf result =
-        exporter.exportApplication(applicationFive, /* isAdmin= */ false);
+        exporter.exportApplication(
+            applicationFive, /* isAdmin= */ false, /* includeScores= */ false);
     PdfReader pdfReader = new PdfReader(result.getByteArray());
 
     assertFileUploadLink(
@@ -302,7 +310,8 @@ public class PdfExporterTest extends AbstractExporterTest {
     PdfExporter exporter = instanceOf(PdfExporter.class);
 
     PdfExporter.InMemoryPdf result =
-        exporter.exportApplication(applicationFive, /* isAdmin= */ false);
+        exporter.exportApplication(
+            applicationFive, /* isAdmin= */ false, /* includeScores= */ false);
     PdfReader pdfReader = new PdfReader(result.getByteArray());
 
     assertFileUploadLink(
@@ -344,7 +353,8 @@ public class PdfExporterTest extends AbstractExporterTest {
     PdfExporter exporter = instanceOf(PdfExporter.class);
 
     PdfExporter.InMemoryPdf result =
-        exporter.exportApplication(applicationFive, /* isAdmin= */ false);
+        exporter.exportApplication(
+            applicationFive, /* isAdmin= */ false, /* includeScores= */ false);
     PdfReader pdfReader = new PdfReader(result.getByteArray());
     StringBuilder textFromPDF = new StringBuilder();
     textFromPDF.append(PdfTextExtractor.getTextFromPage(pdfReader, 1));
@@ -387,7 +397,8 @@ public class PdfExporterTest extends AbstractExporterTest {
     String applicantNameWithApplicationId =
         String.format("%s (%d)", applicantName, applicationFive.id);
     PdfExporter.InMemoryPdf result =
-        exporter.exportApplication(applicationFive, /* isAdmin= */ true);
+        exporter.exportApplication(
+            applicationFive, /* isAdmin= */ true, /* includeScores= */ false);
     PdfReader pdfReader = new PdfReader(result.getByteArray());
     StringBuilder textFromPDF = new StringBuilder();
 
@@ -424,7 +435,8 @@ public class PdfExporterTest extends AbstractExporterTest {
     String applicantNameWithApplicationId =
         String.format("%s (%d)", applicantName, applicationSeven.id);
     PdfExporter.InMemoryPdf result =
-        exporter.exportApplication(applicationSeven, /* isAdmin= */ true);
+        exporter.exportApplication(
+            applicationSeven, /* isAdmin= */ true, /* includeScores= */ false);
     PdfReader pdfReader = new PdfReader(result.getByteArray());
     StringBuilder textFromPDF = new StringBuilder();
     String programName = applicationSeven.getProgram().getProgramDefinition().adminName();
@@ -448,7 +460,8 @@ public class PdfExporterTest extends AbstractExporterTest {
     String applicantNameWithApplicationId =
         String.format("%s (%d)", applicantName, applicationTwo.id);
     PdfExporter.InMemoryPdf result =
-        exporter.exportApplication(applicationTwo, /* isAdmin= */ false);
+        exporter.exportApplication(
+            applicationTwo, /* isAdmin= */ false, /* includeScores= */ false);
     PdfReader pdfReader = new PdfReader(result.getByteArray());
     StringBuilder textFromPDF = new StringBuilder();
     textFromPDF.append(PdfTextExtractor.getTextFromPage(pdfReader, 1));
@@ -460,7 +473,8 @@ public class PdfExporterTest extends AbstractExporterTest {
     assertThat(linesFromPDF.get(1)).isEqualTo("Program Name : " + programName);
     assertThat(textFromPDF).doesNotContain("Meets eligibility");
     PdfExporter.InMemoryPdf resultWithEligibility =
-        exporter.exportApplication(applicationTwo, /* isAdmin= */ true);
+        exporter.exportApplication(
+            applicationTwo, /* isAdmin= */ true, /* includeScores= */ false);
     PdfReader pdfReaderTwo = new PdfReader(resultWithEligibility.getByteArray());
     StringBuilder textFromPDFTwo = new StringBuilder();
     textFromPDFTwo.append(PdfTextExtractor.getTextFromPage(pdfReaderTwo, 1));
@@ -469,6 +483,155 @@ public class PdfExporterTest extends AbstractExporterTest {
     List<String> linesFromPDFTwo = Splitter.on('\n').splitToList(textFromPDFTwo.toString());
     assertThat(linesFromPDFTwo.get(1)).isEqualTo("Program Name : " + programName);
     assertThat(textFromPDFTwo).contains("Meets eligibility");
+  }
+
+  private void addScoreMetadataToApplicationOne(
+      double total, double dropdownScore, List<Double> checkboxScores) {
+    ApplicantData data = applicationOne.getApplicantData();
+    data.putDouble(
+        ApplicationScoreMetadata.scorePath(sampleQuestionPath(
+            QuestionType.DROPDOWN)),
+        dropdownScore);
+    data.putArray(
+        ApplicationScoreMetadata.scoresPath(sampleQuestionPath(
+            QuestionType.CHECKBOX)),
+        checkboxScores);
+    data.putDouble(ApplicationScoreMetadata.totalScorePath(), total);
+    applicationOne.setApplicantData(data);
+    applicationOne.save();
+  }
+
+  private Path sampleQuestionPath(QuestionType questionType) {
+    return testQuestionBank
+        .getSampleQuestionsForAllTypes()
+        .get(questionType)
+        .getQuestionDefinition()
+        .getContextualizedPath(/* repeatedEntity= */ Optional.empty(), ApplicantData.APPLICANT_PATH);
+  }
+
+  private String extractAllPdfText(PdfExporter.InMemoryPdf pdf) throws IOException {
+    PdfReader pdfReader = new PdfReader(pdf.getByteArray());
+    StringBuilder textFromPDF = new StringBuilder();
+    for (int pageNum = 1; pageNum <= pdfReader.getNumberOfPages(); pageNum++) {
+      textFromPDF.append(PdfTextExtractor.getTextFromPage(pdfReader, pageNum));
+    }
+    pdfReader.close();
+    return textFromPDF.toString();
+  }
+
+  @Test
+  public void exportApplication_withScores_asAdmin_rendersTotalAndPerAnswerScores()
+      throws IOException, DocumentException {
+    // applicationOne answered the sample dropdown (option 2) and checkbox (options 1 and 2).
+    // Whole and fractional values both render without trailing zeros.
+    List<Double> checkboxScores = new ArrayList<>();
+    checkboxScores.add(2.25);
+    checkboxScores.add(null);
+    addScoreMetadataToApplicationOne(/* total= */ 7.25, /* dropdownScore= */ 5.0, checkboxScores);
+    PdfExporter exporter = instanceOf(PdfExporter.class);
+
+    String text =
+        extractAllPdfText(
+            exporter.exportApplication(
+                applicationOne, /* isAdmin= */ true, /* includeScores= */ true));
+
+    assertThat(text).contains("Total score: 7.25");
+    // Scores render inline with the option text they belong to.
+    assertThat(text).contains("Strawberry (Score: 5)");
+    assertThat(text).doesNotContain("Score: 5.0");
+    assertThat(text).contains("Toaster (Score: 2.25)");
+    // The unscored checkbox selection renders its line without a score suffix.
+    assertThat(text).contains("Pepper Grinder");
+    assertThat(text).doesNotContain("Pepper Grinder (Score");
+  }
+
+  @Test
+  public void exportApplication_withScores_zeroTotal_rendersZero()
+      throws IOException, DocumentException {
+    ApplicantData data = applicationOne.getApplicantData();
+    data.putDouble(ApplicationScoreMetadata.totalScorePath(), 0.0);
+    applicationOne.setApplicantData(data);
+    applicationOne.save();
+    PdfExporter exporter = instanceOf(PdfExporter.class);
+
+    String text =
+        extractAllPdfText(
+            exporter.exportApplication(
+                applicationOne, /* isAdmin= */ true, /* includeScores= */ true));
+
+    assertThat(text).contains("Total score: 0");
+  }
+
+  @Test
+  public void exportApplication_withScores_flagOff_noScoreText()
+      throws IOException, DocumentException {
+    List<Double> checkboxScores = new ArrayList<>();
+    checkboxScores.add(2.25);
+    checkboxScores.add(null);
+    addScoreMetadataToApplicationOne(/* total= */ 7.25, /* dropdownScore= */ 5.0, checkboxScores);
+    PdfExporter exporter = instanceOf(PdfExporter.class);
+
+    String text =
+        extractAllPdfText(
+            exporter.exportApplication(
+                applicationOne, /* isAdmin= */ true, /* includeScores= */ false));
+
+    assertThat(text).doesNotContain("Total score");
+    assertThat(text).doesNotContain("Score:");
+  }
+
+  @Test
+  public void exportApplication_withScores_asApplicant_noScoreText()
+      throws IOException, DocumentException {
+    List<Double> checkboxScores = new ArrayList<>();
+    checkboxScores.add(2.25);
+    checkboxScores.add(null);
+    addScoreMetadataToApplicationOne(/* total= */ 7.25, /* dropdownScore= */ 5.0, checkboxScores);
+    PdfExporter exporter = instanceOf(PdfExporter.class);
+
+    // All other conditions are true, but the applicant download path never shows scores.
+    String text =
+        extractAllPdfText(
+            exporter.exportApplication(
+                applicationOne, /* isAdmin= */ false, /* includeScores= */ true));
+
+    assertThat(text).doesNotContain("Total score");
+    assertThat(text).doesNotContain("Score:");
+  }
+
+  @Test
+  public void exportApplication_applicationWithoutScoreMetadata_noScoreText()
+      throws IOException, DocumentException {
+    // An application predating scoring (or from a non-scoring program) has no total_score.
+    PdfExporter exporter = instanceOf(PdfExporter.class);
+
+    String text =
+        extractAllPdfText(
+            exporter.exportApplication(
+                applicationOne, /* isAdmin= */ true, /* includeScores= */ true));
+
+    assertThat(text).doesNotContain("Total score");
+    assertThat(text).doesNotContain("Score:");
+  }
+
+  @Test
+  public void exportApplication_checkboxScoreLengthMismatch_rendersAnswerWithoutScores()
+      throws IOException, DocumentException {
+    // Two selections but only one score entry: corrupt metadata renders without checkbox scores.
+    List<Double> mismatchedScores = new ArrayList<>();
+    mismatchedScores.add(2.25);
+    addScoreMetadataToApplicationOne(/* total= */ 7.25, /* dropdownScore= */ 5.0, mismatchedScores);
+    PdfExporter exporter = instanceOf(PdfExporter.class);
+
+    String text =
+        extractAllPdfText(
+            exporter.exportApplication(
+                applicationOne, /* isAdmin= */ true, /* includeScores= */ true));
+
+    assertThat(text).contains("Total score: 7.25");
+    // The intact single-select score still renders; the corrupt checkbox metadata does not.
+    assertThat(text).contains("Strawberry (Score: 5)");
+    assertThat(text).doesNotContain("(Score: 2.25)");
   }
 
   @Test


### PR DESCRIPTION
PdfExporterService/PdfExporter gain an explicit includeScores boolean:
AdminApplicationController.download passes the scoring flag, the
applicant download path (UpsellController) hard-codes false. Score text
renders only when isAdmin && includeScores && the snapshot carries
total_score, so pre-feature and non-scoring applications are unchanged
and a persisted 0 renders "Total score: 0".

Per-answer scores come from the snapshot metadata by contextualized
path (never from AnswerData): single-selects get a small "Score: N"
line, checkboxes pair the unchanged stored selection ids with the
persisted nullable scores array and render selected options in
definition display order, falling back to no score text (with a log)
on a length mismatch instead of mispairing.

Assisted-by: Claude Code:claude-fable-5

---

Part 8 of 12 in the option-scores stack. Merge in order, top to bottom:

1. https://github.com/civiform/civiform/pull/13796
2. https://github.com/civiform/civiform/pull/13797
3. https://github.com/civiform/civiform/pull/13798
4. https://github.com/civiform/civiform/pull/13799
5. https://github.com/civiform/civiform/pull/13800
6. https://github.com/civiform/civiform/pull/13801
7. https://github.com/civiform/civiform/pull/13802
8. https://github.com/civiform/civiform/pull/13803
9. https://github.com/civiform/civiform/pull/13804
10. https://github.com/civiform/civiform/pull/13805
11. https://github.com/civiform/civiform/pull/13806
12. https://github.com/civiform/civiform/pull/13807
