### PR TITLE
Emit scores in JSON export, API, samples, and OpenAPI schemas

### DIFF
--- a/server/app/controllers/admin/AdminApplicationController.java
+++ b/server/app/controllers/admin/AdminApplicationController.java
@@ -177,7 +177,8 @@ public final class AdminApplicationController extends CiviFormController {
         jsonExporterService.export(
             program,
             SubmitTimeSequentialAccessPaginationSpec.APPLICATION_MODEL_MAX_PAGE_SIZE_SPEC,
-            filters);
+            filters,
+            /* includeScores= */ settingsManifest.getAnswerOptionScoringEnabled(request));
     return ok(json)
         .as(Http.MimeTypes.JSON)
         .withHeader("Content-Disposition", String.format("attachment; filename=\"%s\"", filename));

--- a/server/app/controllers/api/ProgramApplicationsApiController.java
+++ b/server/app/controllers/api/ProgramApplicationsApiController.java
@@ -32,6 +32,7 @@ import services.pagination.PaginationResult;
 import services.pagination.RowIdSequentialAccessPaginationSpec;
 import services.program.ProgramNotFoundException;
 import services.program.ProgramService;
+import services.settings.SettingsManifest;
 import services.program.ProgramType;
 
 /** API controller for admin access to a specific program's applications. */
@@ -45,6 +46,7 @@ public final class ProgramApplicationsApiController extends CiviFormApiControlle
   private final ProgramService programService;
   private final ClassLoaderExecutionContext classLoaderExecutionContext;
   private final JsonExporterService jsonExporterService;
+  private final SettingsManifest settingsManifest;
   private final int maxPageSize;
 
   @Inject
@@ -57,12 +59,14 @@ public final class ProgramApplicationsApiController extends CiviFormApiControlle
       ClassLoaderExecutionContext classLoaderExecutionContext,
       ProgramService programService,
       VersionRepository versionRepository,
+      SettingsManifest settingsManifest,
       Config config) {
     super(apiPaginationTokenSerializer, apiPayloadWrapper, profileUtils, versionRepository);
     this.dateConverter = checkNotNull(dateConverter);
     this.classLoaderExecutionContext = checkNotNull(classLoaderExecutionContext);
     this.jsonExporterService = checkNotNull(jsonExporterService);
     this.programService = checkNotNull(programService);
+    this.settingsManifest = checkNotNull(settingsManifest);
     this.maxPageSize = checkNotNull(config).getInt("civiform_api_applications_list_max_page_size");
   }
 
@@ -119,7 +123,10 @@ public final class ProgramApplicationsApiController extends CiviFormApiControlle
                       programDefinition.id(), paginationSpec, filters);
 
               String applicationsJson =
-                  jsonExporterService.exportPage(programDefinition, paginationResult);
+                  jsonExporterService.exportPage(
+                      programDefinition,
+                      paginationResult,
+                      /* includeScores= */ settingsManifest.getAnswerOptionScoringEnabled(request));
 
               String responseJson =
                   apiPayloadWrapper.wrapPayload(

--- a/server/app/controllers/docs/ApiDocsController.java
+++ b/server/app/controllers/docs/ApiDocsController.java
@@ -74,7 +74,11 @@ public final class ApiDocsController {
         apiDocsService.getProgramDefinition(selectedProgramSlug, lifecycleStage);
 
     if (settingsManifest.getAdminUiMigrationUxRedesignScEnabled(request)) {
-      String jsonPreview = programDefinition.map(apiDocsService::getSampleJsonPreview).orElse("");
+      boolean includeScores = settingsManifest.getAnswerOptionScoringEnabled(request);
+      String jsonPreview =
+          programDefinition
+              .map(pd -> apiDocsService.getSampleJsonPreview(pd, includeScores))
+              .orElse("");
       ImmutableMap<String, ImmutableList<String>> historicOptionsByQuestionNameKey =
           programDefinition
               .map(apiDocsService::getHistoricOptionsByQuestionNameKey)

--- a/server/app/controllers/docs/OpenApiSchemaController.java
+++ b/server/app/controllers/docs/OpenApiSchemaController.java
@@ -82,7 +82,8 @@ public final class OpenApiSchemaController {
           new OpenApiSchemaSettings(
               settingsManifest.getBaseUrl().orElse(""),
               getEmailAddress(request),
-              deploymentType.isDev());
+              deploymentType.isDev(),
+              settingsManifest.getAnswerOptionScoringEnabled(request));
 
       OpenApiSchemaGenerator openApiSchemaGenerator =
           OpenApiSchemaGeneratorFactory.createGenerator(openApiVersionType, openApiSchemaSettings);

--- a/server/app/services/docs/ApiDocsService.java
+++ b/server/app/services/docs/ApiDocsService.java
@@ -66,9 +66,18 @@ public final class ApiDocsService {
     }
   }
 
-  /** Returns a pretty-printed JSON sample of the program's API response. */
+  /** Returns a pretty-printed JSON sample of the program's API response, without scores. */
   public String getSampleJsonPreview(ProgramDefinition programDefinition) {
-    return asPrettyJsonString(programJsonSampler.getSampleJson(programDefinition));
+    return getSampleJsonPreview(programDefinition, /* includeScores= */ false);
+  }
+
+  /**
+   * Returns a pretty-printed JSON sample of the program's API response.
+   *
+   * @param includeScores whether the answer-option-scoring feature flag is on for this request
+   */
+  public String getSampleJsonPreview(ProgramDefinition programDefinition, boolean includeScores) {
+    return asPrettyJsonString(programJsonSampler.getSampleJson(programDefinition, includeScores));
   }
 
   /**

--- a/server/app/services/export/JsonExporterService.java
+++ b/server/app/services/export/JsonExporterService.java
@@ -5,11 +5,16 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.jayway.jsonpath.DocumentContext;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
 import models.ApplicationModel;
@@ -22,14 +27,18 @@ import services.DateConverter;
 import services.Path;
 import services.applicant.ApplicantData;
 import services.applicant.ApplicantService;
+import services.applicant.ApplicationScoreMetadata;
 import services.applicant.JsonPathProvider;
 import services.applicant.question.ApplicantQuestion;
+import services.applicant.question.Scalar;
 import services.export.enums.RevisionState;
 import services.export.enums.SubmitterType;
 import services.pagination.PaginationResult;
 import services.pagination.SubmitTimeSequentialAccessPaginationSpec;
 import services.program.ProgramDefinition;
 import services.program.ProgramService;
+import services.question.QuestionOption;
+import services.question.types.MultiOptionQuestionDefinition;
 import services.question.types.QuestionType;
 
 /** Exports all applications for a given program as JSON. */
@@ -40,6 +49,12 @@ public final class JsonExporterService {
   private final DateConverter dateConverter;
   private final QuestionJsonPresenter.Factory presenterFactory;
   private static final String EMPTY_VALUE = "";
+  // API property names for answer-option scores. These match the storage keys in
+  // ApplicationScoreMetadata but are kept separate: those name persisted snapshot keys, these
+  // name the exported shape.
+  private static final String SCORE_PROPERTY = "score";
+  private static final String SCORES_PROPERTY = "scores";
+  private static final String TOTAL_SCORE_PROPERTY = "total_score";
 
   @Inject
   JsonExporterService(
@@ -66,11 +81,38 @@ public final class JsonExporterService {
       ProgramDefinition programDefinition,
       SubmitTimeSequentialAccessPaginationSpec paginationSpec,
       SubmittedApplicationFilter filters) {
+    return export(programDefinition, paginationSpec, filters, /* includeScores= */ false);
+  }
+
+  /**
+   * Returns a JSON list of applications to the given program, using the pagination behavior and
+   * filters supplied.
+   *
+   * @param includeScores whether the answer-option-scoring feature flag is on for this request,
+   *     resolved at the controller boundary. When true, supported questions gain {@code
+   *     score}/{@code scores} properties and applications gain a top-level {@code total_score};
+   *     when false the properties are absent entirely.
+   */
+  public String export(
+      ProgramDefinition programDefinition,
+      SubmitTimeSequentialAccessPaginationSpec paginationSpec,
+      SubmittedApplicationFilter filters,
+      boolean includeScores) {
     PaginationResult<ApplicationModel> paginationResult =
         programService.getSubmittedProgramApplicationsAllVersions(
             programDefinition.id(), paginationSpec, filters);
 
-    return exportPage(programDefinition, paginationResult);
+    return exportPage(programDefinition, paginationResult, includeScores);
+  }
+
+  /**
+   * Returns a JSON list of applications to the given program, using the page of applications
+   * supplied, without answer-option scores. See {@link #exportPage(ProgramDefinition,
+   * PaginationResult, boolean)}.
+   */
+  public String exportPage(
+      ProgramDefinition programDefinition, PaginationResult<ApplicationModel> paginationResult) {
+    return exportPage(programDefinition, paginationResult, /* includeScores= */ false);
   }
 
   /**
@@ -79,10 +121,13 @@ public final class JsonExporterService {
    *
    * @param programDefinition the program definition of the exported applications
    * @param paginationResult the page of applications to export
+   * @param includeScores whether the answer-option-scoring feature flag is on for this request
    * @return a JSON string representing a list of applications
    */
   public String exportPage(
-      ProgramDefinition programDefinition, PaginationResult<ApplicationModel> paginationResult) {
+      ProgramDefinition programDefinition,
+      PaginationResult<ApplicationModel> paginationResult,
+      boolean includeScores) {
     ImmutableList<ApplicationModel> applications = paginationResult.getPageContents();
 
     ImmutableMap<Long, ProgramDefinition> programDefinitionsForAllVersions =
@@ -104,6 +149,13 @@ public final class JsonExporterService {
           .forEach(aq -> answersToExport.putIfAbsent(aq.getContextualizedPath(), aq));
     }
     ImmutableMap.Builder<Path, Optional<?>> entriesBuilder = ImmutableMap.builder();
+    // The template contains questions from all represented versions. Checkbox score paths cannot
+    // take a single static template value (per application they are null when scoring was not
+    // applied and [] when it was but the question is unanswered), so they are collected here and
+    // initialized per application before persisted values are overlaid. They are stored
+    // application-rooted because they are written directly into each application's output
+    // document, not through the entry dispatch that rewrites the root.
+    Set<Path> templateCheckboxScoreApiPaths = new HashSet<>();
     for (ApplicantQuestion applicantQuestion : answersToExport.values()) {
       // We suppress the unchecked warning because create() returns a genericized
       // QuestionJsonPresenter, but we ignore the generic's type so that we can get
@@ -114,13 +166,25 @@ public final class JsonExporterService {
               .create(applicantQuestion.getType())
               .getAllJsonEntries(applicantQuestion.getQuestion());
       entriesBuilder.putAll(questionEntries);
+      if (includeScores
+          && QuestionType.supportsOptionScores(applicantQuestion.getType())) {
+        Path apiPath = applicantQuestion.getContextualizedPath().asNestedEntitiesPath();
+        if (applicantQuestion.getType() == QuestionType.CHECKBOX) {
+          Path scoresApiPath = apiPath.join(SCORES_PROPERTY);
+          entriesBuilder.put(scoresApiPath, Optional.empty());
+          templateCheckboxScoreApiPaths.add(scoresApiPath.asApplicationPath());
+        } else {
+          entriesBuilder.put(apiPath.join(SCORE_PROPERTY), Optional.empty());
+        }
+      }
     }
     CfJsonDocumentContext template = new CfJsonDocumentContext();
-    exportApplicationEntriesToJsonApplication(template, entriesBuilder.build());
+    exportApplicationEntriesToJsonApplication(template, entriesBuilder.buildKeepingLast());
     // TODO(#8147): I'm not sure if reading the template out into a string, just to re-parse it into
     // a JsonData for each application, is more or less efficient than trying to clone a JsonData
     // object.
     String jsonStringTemplate = template.asJsonString();
+    ImmutableSet<Path> checkboxScoreApiPaths = ImmutableSet.copyOf(templateCheckboxScoreApiPaths);
 
     // Then use the template when exporting each application.
     DocumentContext jsonData =
@@ -128,31 +192,53 @@ public final class JsonExporterService {
             .map(
                 app ->
                     buildApplicationExportData(
-                        app, programDefinitionsForAllVersions.get(app.getProgram().id)))
+                        app,
+                        programDefinitionsForAllVersions.get(app.getProgram().id),
+                        includeScores))
             .collect(
                 Collectors.collectingAndThen(
                     ImmutableList.toImmutableList(),
                     appDataList ->
                         convertApplicationExportDataListToJsonArray(
-                            appDataList, jsonStringTemplate)));
+                            appDataList, jsonStringTemplate, includeScores, checkboxScoreApiPaths)));
 
     return jsonData.jsonString();
+  }
+
+  /**
+   * Converts a list of {@link ApplicationExportData} to a JSON array, without answer-option
+   * scores.
+   */
+  public DocumentContext convertApplicationExportDataListToJsonArray(
+      ImmutableList<ApplicationExportData> applicationExportDataList, String jsonTemplate) {
+    return convertApplicationExportDataListToJsonArray(
+        applicationExportDataList,
+        jsonTemplate,
+        /* includeScores= */ false,
+        /* checkboxScoreApiPaths= */ ImmutableSet.of());
   }
 
   /**
    * Converts a list of {@link ApplicationExportData} to a JSON array.
    *
    * @param applicationExportDataList the list of applications to export as JSON
+   * @param checkboxScoreApiPaths the application-rooted paths of all checkbox {@code scores}
+   *     properties in the template, initialized per application before persisted values are
+   *     overlaid
    * @return the exported applications, as a JSON array
    */
   public DocumentContext convertApplicationExportDataListToJsonArray(
-      ImmutableList<ApplicationExportData> applicationExportDataList, String jsonTemplate) {
+      ImmutableList<ApplicationExportData> applicationExportDataList,
+      String jsonTemplate,
+      boolean includeScores,
+      ImmutableSet<Path> checkboxScoreApiPaths) {
     DocumentContext applications = makeEmptyJsonArray();
     applicationExportDataList.forEach(
         applicationExportData -> {
           applications.add(
               "$",
-              convertExportDataToJson(applicationExportData, jsonTemplate)
+              convertExportDataToJson(
+                      applicationExportData, jsonTemplate, includeScores, checkboxScoreApiPaths)
                   .getDocumentContext()
                   .json());
         });
@@ -160,7 +246,16 @@ public final class JsonExporterService {
   }
 
   private ApplicationExportData buildApplicationExportData(
-      ApplicationModel application, ProgramDefinition programDefinition) {
+      ApplicationModel application, ProgramDefinition programDefinition, boolean includeScores) {
+    // A fresh private copy of the application's stored snapshot; score values come from its
+    // persisted metadata only, never re-resolved from current question versions, so exports are
+    // stable across later score edits.
+    ApplicantData snapshot = application.getApplicantData();
+    Optional<Double> totalScore =
+        includeScores
+            ? snapshot.readDouble(ApplicationScoreMetadata.totalScorePath())
+            : Optional.empty();
+
     ImmutableMap.Builder<Path, Optional<?>> entriesBuilder = ImmutableMap.builder();
     applicantService
         .getReadOnlyApplicantProgramService(application, programDefinition)
@@ -175,9 +270,13 @@ public final class JsonExporterService {
               ImmutableMap<Path, Optional<?>> questionEntries =
                   presenterFactory.create(aq.getType()).getAllJsonEntries(aq.getQuestion());
               entriesBuilder.putAll(questionEntries);
+              if (includeScores) {
+                entriesBuilder.putAll(buildScoreEntries(aq, snapshot, totalScore));
+              }
             });
 
     return ApplicationExportData.builder()
+        .setTotalScore(totalScore)
         .setAdminName(programDefinition.adminName())
         .setApplicantId(application.getOriginalApplicantId().orElse(application.getApplicant().id))
         .setApplicationId(application.id)
@@ -212,9 +311,84 @@ public final class JsonExporterService {
         .build();
   }
 
+  /**
+   * Builds the additive {@code score}/{@code scores} entries for a supported-type question,
+   * reading persisted score metadata from the application snapshot. This runs centrally rather
+   * than in each {@link QuestionJsonPresenter}.
+   */
+  private static ImmutableMap<Path, Optional<?>> buildScoreEntries(
+      ApplicantQuestion applicantQuestion, ApplicantData snapshot, Optional<Double> totalScore) {
+    if (!QuestionType.supportsOptionScores(applicantQuestion.getType())) {
+      return ImmutableMap.of();
+    }
+    Path contextualizedPath = applicantQuestion.getContextualizedPath();
+    Path apiPath = contextualizedPath.asNestedEntitiesPath();
+    if (applicantQuestion.getType() != QuestionType.CHECKBOX) {
+      // Unanswered, unscored option, and scoring-not-applied all read as absent and emit null.
+      return ImmutableMap.of(
+          apiPath.join(SCORE_PROPERTY),
+          snapshot.readDouble(ApplicationScoreMetadata.scorePath(contextualizedPath)));
+    }
+
+    Path scoresApiPath = apiPath.join(SCORES_PROPERTY);
+    if (totalScore.isEmpty()) {
+      // Scoring was not applied to this application: null.
+      return ImmutableMap.of(scoresApiPath, Optional.empty());
+    }
+    Optional<ImmutableList<Long>> selections =
+        snapshot.readLongList(contextualizedPath.join(Scalar.SELECTIONS));
+    Optional<List<Double>> storedScores =
+        snapshot.readNullableDoubleList(ApplicationScoreMetadata.scoresPath(contextualizedPath));
+    if (selections.isEmpty()
+        || storedScores.isEmpty()
+        || selections.get().size() != storedScores.get().size()) {
+      // Scoring applied but unanswered (or corrupt metadata): empty array.
+      return ImmutableMap.of(
+          scoresApiPath, Optional.of(new NullableDoubleArray(ImmutableList.of())));
+    }
+    // Pair the unchanged stored selection ids with the persisted scores (first occurrence wins),
+    // then emit in the same definition order and duplicate-filtering as the selections presenter.
+    Map<Long, Double> scoreByOptionId = new HashMap<>();
+    for (int i = 0; i < selections.get().size(); i++) {
+      Double score = storedScores.get().get(i);
+      if (score != null) {
+        scoreByOptionId.putIfAbsent(selections.get().get(i), score);
+      }
+    }
+    ImmutableList<Long> selectedIds = selections.get();
+    List<Double> emittedScores = new ArrayList<>();
+    ((MultiOptionQuestionDefinition) applicantQuestion.getQuestionDefinition())
+        .getOptions().stream()
+            .filter(option -> selectedIds.contains(option.id()))
+            .map(QuestionOption::id)
+            .forEach(optionId -> emittedScores.add(scoreByOptionId.get(optionId)));
+    return ImmutableMap.of(scoresApiPath, Optional.of(new NullableDoubleArray(emittedScores)));
+  }
+
   private CfJsonDocumentContext convertExportDataToJson(
-      ApplicationExportData applicationExportData, String jsonTemplate) {
+      ApplicationExportData applicationExportData,
+      String jsonTemplate,
+      boolean includeScores,
+      ImmutableSet<Path> checkboxScoreApiPaths) {
     CfJsonDocumentContext jsonApplication = new CfJsonDocumentContext(jsonTemplate);
+
+    if (includeScores) {
+      // Initialize every checkbox scores property for this application: null when scoring was not
+      // applied, [] when it was; persisted values overlay below.
+      for (Path scoresApiPath : checkboxScoreApiPaths) {
+        if (applicationExportData.totalScore().isPresent()) {
+          jsonApplication.putArray(scoresApiPath, ImmutableList.of());
+        } else {
+          jsonApplication.putNull(scoresApiPath);
+        }
+      }
+      Path totalScorePath = Path.create(TOTAL_SCORE_PROPERTY);
+      applicationExportData
+          .totalScore()
+          .ifPresentOrElse(
+              total -> jsonApplication.putDouble(totalScorePath, total),
+              () -> jsonApplication.putNull(totalScorePath));
+    }
 
     jsonApplication.putString(Path.create("program_name"), applicationExportData.adminName());
     jsonApplication.putLong(Path.create("program_version_id"), applicationExportData.programId());
@@ -282,6 +456,10 @@ public final class JsonExporterService {
         jsonApplication.putLong(path, l);
       } else if (maybeJsonValue.get() instanceof Double d) {
         jsonApplication.putDouble(path, d);
+      } else if (maybeJsonValue.get() instanceof NullableDoubleArray nullableDoubleArray) {
+        // Null-holed numeric score arrays cross the dispatch in an explicit wrapper; without it
+        // they would be silently dropped here.
+        jsonApplication.putArray(path, nullableDoubleArray.values());
       } else if (instanceOfNonEmptyImmutableListOfString(maybeJsonValue.get())) {
         @SuppressWarnings("unchecked")
         ImmutableList<String> list = (ImmutableList<String>) maybeJsonValue.get();
@@ -356,6 +534,13 @@ public final class JsonExporterService {
 
     public abstract RevisionState revisionState();
 
+    /**
+     * The application's total answer-option score; empty when scoring was not applied (or scores
+     * were not requested). Emitted as a nullable 64-bit {@code total_score} when scores are
+     * included.
+     */
+    public abstract Optional<Double> totalScore();
+
     public abstract ImmutableMap<Path, Optional<?>> applicationEntries();
 
     static Builder builder() {
@@ -392,6 +577,8 @@ public final class JsonExporterService {
       public abstract Builder setApplicationNote(Optional<String> applicationNote);
 
       public abstract Builder setRevisionState(RevisionState revisionState);
+
+      public abstract Builder setTotalScore(Optional<Double> totalScore);
 
       abstract ImmutableMap.Builder<Path, Optional<?>> applicationEntriesBuilder();
 

--- a/server/app/services/export/NullableDoubleArray.java
+++ b/server/app/services/export/NullableDoubleArray.java
@@ -1,0 +1,15 @@
+package services.export;
+
+import java.util.List;
+
+/**
+ * Wrapper for a numeric JSON array that may contain null entries, used for answer-option score
+ * arrays.
+ *
+ * <p>The JSON export dispatch ({@code
+ * JsonExporterService#exportApplicationEntriesToJsonApplication}) silently drops values that
+ * aren't one of its known types, and Guava's {@link com.google.common.collect.ImmutableList}
+ * rejects nulls outright, so null-holed score arrays cross the dispatch inside this explicit
+ * wrapper and are written with null positions preserved.
+ */
+public record NullableDoubleArray(List<Double> values) {}

--- a/server/app/services/export/ProgramJsonSampler.java
+++ b/server/app/services/export/ProgramJsonSampler.java
@@ -4,20 +4,25 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import controllers.api.ApiPayloadWrapper;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 import javax.inject.Inject;
 import repository.ApplicationStatusesRepository;
 import services.DeploymentType;
 import services.Path;
+import services.applicant.ApplicantData;
 import services.export.JsonExporterService.ApplicationExportData;
 import services.export.QuestionJsonSampler.SampleDataContext;
 import services.export.enums.RevisionState;
 import services.export.enums.SubmitterType;
 import services.program.ProgramDefinition;
 import services.question.types.QuestionDefinition;
+import services.question.types.QuestionType;
 import services.statuses.StatusDefinitions.Status;
 
 /** Contains methods related to sampling JSON data for programs. */
@@ -46,9 +51,21 @@ public final class ProgramJsonSampler {
 
   /**
    * Samples JSON for a {@link ProgramDefinition} with fake data, appropriate for previews of what
-   * the API response looks like.
+   * the API response looks like, without answer-option scores.
    */
   public String getSampleJson(ProgramDefinition programDefinition) {
+    return getSampleJson(programDefinition, /* includeScores= */ false);
+  }
+
+  /**
+   * Samples JSON for a {@link ProgramDefinition} with fake data, appropriate for previews of what
+   * the API response looks like.
+   *
+   * @param includeScores whether the answer-option-scoring feature flag is on for this request;
+   *     when true, supported questions gain sample {@code score}/{@code scores} values and the
+   *     response gains a {@code total_score}
+   */
+  public String getSampleJson(ProgramDefinition programDefinition, boolean includeScores) {
     ApplicationExportData.Builder jsonExportData =
         ApplicationExportData.builder()
             // Customizable program-specific API fields
@@ -81,6 +98,7 @@ public final class ProgramJsonSampler {
 
     SampleDataContext sampleDataContext = new SampleDataContext();
 
+    double sampleTotalScore = 0;
     for (QuestionDefinition questionDefinition : questionDefinitions) {
       @SuppressWarnings("unchecked")
       ImmutableMap<Path, Optional<?>> questionEntries =
@@ -89,12 +107,42 @@ public final class ProgramJsonSampler {
               .getSampleJsonEntries(questionDefinition, sampleDataContext);
 
       jsonExportData.addApplicationEntries(questionEntries);
+
+      // Sample score values for supported non-repeated question types; repeated sample questions
+      // are left unscored.
+      if (includeScores
+          && QuestionType.supportsOptionScores(questionDefinition.getQuestionType())
+          && questionDefinition.getEnumeratorId().isEmpty()) {
+        Path apiPath =
+            ApplicantData.APPLICANT_PATH.join(questionDefinition.getQuestionPathSegment());
+        if (questionDefinition.getQuestionType() == QuestionType.CHECKBOX) {
+          // One scored (fractional, demonstrating decimals) and one unscored (null) sample
+          // selection.
+          List<Double> sampleScores = new ArrayList<>();
+          sampleScores.add(1.5);
+          sampleScores.add(null);
+          jsonExportData.addApplicationEntries(
+              ImmutableMap.of(
+                  apiPath.join("scores"), Optional.of(new NullableDoubleArray(sampleScores))));
+          sampleTotalScore += 1.5;
+        } else {
+          jsonExportData.addApplicationEntries(
+              ImmutableMap.of(apiPath.join("score"), Optional.of(2.0)));
+          sampleTotalScore += 2;
+        }
+      }
+    }
+    if (includeScores) {
+      jsonExportData.setTotalScore(Optional.of(sampleTotalScore));
     }
 
     return apiPayloadWrapper.wrapPayload(
         jsonExporterService
             .convertApplicationExportDataListToJsonArray(
-                ImmutableList.of(jsonExportData.build()), "{}")
+                ImmutableList.of(jsonExportData.build()),
+                "{}",
+                includeScores,
+                /* checkboxScoreApiPaths= */ ImmutableSet.of())
             .jsonString(),
         /* paginationTokenPayload= */ Optional.empty());
   }

--- a/server/app/services/openapi/OpenApiSchemaSettings.java
+++ b/server/app/services/openapi/OpenApiSchemaSettings.java
@@ -2,4 +2,10 @@ package services.openapi;
 
 /** Common settings used when building an OpenApi schema */
 public record OpenApiSchemaSettings(
-    String baseUrl, String itEmailAddress, Boolean allowHttpScheme) {}
+    String baseUrl, String itEmailAddress, Boolean allowHttpScheme, Boolean includeScores) {
+
+  /** Builds settings without answer-option score properties. */
+  public OpenApiSchemaSettings(String baseUrl, String itEmailAddress, Boolean allowHttpScheme) {
+    this(baseUrl, itEmailAddress, allowHttpScheme, /* includeScores= */ false);
+  }
+}

--- a/server/app/services/openapi/v2/Swagger2SchemaGenerator.java
+++ b/server/app/services/openapi/v2/Swagger2SchemaGenerator.java
@@ -16,6 +16,7 @@ import io.swagger.models.auth.BasicAuthDefinition;
 import io.swagger.models.parameters.QueryParameter;
 import io.swagger.models.properties.ArrayProperty;
 import io.swagger.models.properties.DateTimeProperty;
+import io.swagger.models.properties.DoubleProperty;
 import io.swagger.models.properties.IntegerProperty;
 import io.swagger.models.properties.ObjectProperty;
 import io.swagger.models.properties.Property;
@@ -155,33 +156,7 @@ public class Swagger2SchemaGenerator extends AbstractOpenApiSchemaGenerator
           "result",
           new ModelImpl()
               .type("object")
-              .property(
-                  "payload",
-                  new ArrayProperty(
-                      new ObjectProperty()
-                          .property("applicant_id", new IntegerProperty())
-                          .property("application", buildApplicationDefinitions(programDefinition))
-                          .property("application_id", new IntegerProperty())
-                          .property(
-                              "application_note",
-                              new StringProperty().vendorExtension("x-nullable", true))
-                          .property("create_time", new DateTimeProperty())
-                          .property("language", new StringProperty())
-                          .property("program_name", new StringProperty())
-                          .property("program_version_id", new IntegerProperty())
-                          .property("revision_state", new StringProperty())
-                          .property(
-                              "status", new StringProperty().vendorExtension("x-nullable", true))
-                          .property(
-                              "status_last_modified_time",
-                              new DateTimeProperty().vendorExtension("x-nullable", true))
-                          .property("submit_time", new DateTimeProperty())
-                          .property("submitter_type", new StringProperty())
-                          .property(
-                              "ti_email", new StringProperty().vendorExtension("x-nullable", true))
-                          .property(
-                              "ti_organization",
-                              new StringProperty().vendorExtension("x-nullable", true))))
+              .property("payload", new ArrayProperty(buildResultItemProperty(programDefinition)))
               .property("nextPageToken", new StringProperty()));
 
       return Yaml.pretty().writeValueAsString(swaggerRoot);
@@ -191,6 +166,35 @@ public class Swagger2SchemaGenerator extends AbstractOpenApiSchemaGenerator
         | JsonProcessingException ex) {
       throw new RuntimeException("Unable to generate OpenAPI schema for Swagger 2.", ex);
     }
+  }
+
+  /** Builds the schema of one payload item. */
+  private ObjectProperty buildResultItemProperty(ProgramDefinition programDefinition)
+      throws InvalidQuestionTypeException, UnsupportedQuestionTypeException {
+    ObjectProperty resultItem =
+        new ObjectProperty()
+            .property("applicant_id", new IntegerProperty())
+            .property("application", buildApplicationDefinitions(programDefinition))
+            .property("application_id", new IntegerProperty())
+            .property("application_note", new StringProperty().vendorExtension("x-nullable", true))
+            .property("create_time", new DateTimeProperty())
+            .property("language", new StringProperty())
+            .property("program_name", new StringProperty())
+            .property("program_version_id", new IntegerProperty())
+            .property("revision_state", new StringProperty())
+            .property("status", new StringProperty().vendorExtension("x-nullable", true))
+            .property(
+                "status_last_modified_time",
+                new DateTimeProperty().vendorExtension("x-nullable", true))
+            .property("submit_time", new DateTimeProperty())
+            .property("submitter_type", new StringProperty())
+            .property("ti_email", new StringProperty().vendorExtension("x-nullable", true))
+            .property("ti_organization", new StringProperty().vendorExtension("x-nullable", true));
+    if (openApiSchemaSettings.includeScores()) {
+      // Null when the application predates scoring or scoring wasn't applied; double precision.
+      resultItem.property("total_score", new DoubleProperty().vendorExtension("x-nullable", true));
+    }
+    return resultItem;
   }
 
   /***
@@ -239,6 +243,20 @@ public class Swagger2SchemaGenerator extends AbstractOpenApiSchemaGenerator
               fieldName,
               getPropertyFromType(
                   definitionType, getSwaggerFormat(scalar), arrayItemDefinitionType));
+        }
+        // Score properties are deliberately not question scalars, so they are added here rather
+        // than picked up by the scalar loop.
+        if (openApiSchemaSettings.includeScores()
+            && QuestionType.supportsOptionScores(questionDefinition.getQuestionType())) {
+          if (questionDefinition.getQuestionType() == QuestionType.CHECKBOX) {
+            containerDefinition.property(
+                "scores",
+                new ArrayProperty(new DoubleProperty().vendorExtension("x-nullable", true))
+                    .vendorExtension("x-nullable", true));
+          } else {
+            containerDefinition.property(
+                "score", new DoubleProperty().vendorExtension("x-nullable", true));
+          }
         }
       } else {
         var enumeratorProperties =

--- a/server/app/services/openapi/v3/OpenApi3SchemaGenerator.java
+++ b/server/app/services/openapi/v3/OpenApi3SchemaGenerator.java
@@ -15,6 +15,7 @@ import io.swagger.v3.oas.models.media.ArraySchema;
 import io.swagger.v3.oas.models.media.Content;
 import io.swagger.v3.oas.models.media.IntegerSchema;
 import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.media.NumberSchema;
 import io.swagger.v3.oas.models.media.ObjectSchema;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.media.StringSchema;
@@ -73,45 +74,7 @@ public class OpenApi3SchemaGenerator extends AbstractOpenApiSchemaGenerator
                               .addProperty(
                                   "payload",
                                   new ArraySchema()
-                                      .items(
-                                          new ObjectSchema()
-                                              .addProperty("applicant_id", new IntegerSchema())
-                                              .addProperty(
-                                                  "application",
-                                                  buildApplicationDefinitions(programDefinition))
-                                              .addProperty("application_id", new IntegerSchema())
-                                              .addProperty(
-                                                  "application_note",
-                                                  new StringSchema().nullable(true))
-                                              .addProperty(
-                                                  "create_time",
-                                                  new StringSchema().format("date-time"))
-                                              .addProperty(
-                                                  "language", new StringSchema().example("en-US"))
-                                              .addProperty(
-                                                  "program_name",
-                                                  new StringSchema().example("program-name-123"))
-                                              .addProperty(
-                                                  "program_version_id", new IntegerSchema())
-                                              .addProperty(
-                                                  "revision_state",
-                                                  new StringSchema().example("CURRENT"))
-                                              .addProperty(
-                                                  "status", new StringSchema().nullable(true))
-                                              .addProperty(
-                                                  "status_last_modified_time",
-                                                  new StringSchema()
-                                                      .format("date-time")
-                                                      .nullable(true))
-                                              .addProperty(
-                                                  "submit_time",
-                                                  new StringSchema().format("date-time"))
-                                              .addProperty("submitter_type", new StringSchema())
-                                              .addProperty(
-                                                  "ti_email", new StringSchema().nullable(true))
-                                              .addProperty(
-                                                  "ti_organization",
-                                                  new StringSchema().nullable(true))))
+                                      .items(buildResultItemSchema(programDefinition)))
                               .addProperty("nextPageToken", new StringSchema()))
                       .addSecuritySchemes(
                           "basicAuth",
@@ -241,6 +204,33 @@ public class OpenApi3SchemaGenerator extends AbstractOpenApiSchemaGenerator
     return result.build();
   }
 
+  /** Builds the schema of one payload item. */
+  private ObjectSchema buildResultItemSchema(ProgramDefinition programDefinition)
+      throws InvalidQuestionTypeException, UnsupportedQuestionTypeException {
+    ObjectSchema resultItem = new ObjectSchema();
+    resultItem.addProperty("applicant_id", new IntegerSchema());
+    resultItem.addProperty("application", buildApplicationDefinitions(programDefinition));
+    resultItem.addProperty("application_id", new IntegerSchema());
+    resultItem.addProperty("application_note", new StringSchema().nullable(true));
+    resultItem.addProperty("create_time", new StringSchema().format("date-time"));
+    resultItem.addProperty("language", new StringSchema().example("en-US"));
+    resultItem.addProperty("program_name", new StringSchema().example("program-name-123"));
+    resultItem.addProperty("program_version_id", new IntegerSchema());
+    resultItem.addProperty("revision_state", new StringSchema().example("CURRENT"));
+    resultItem.addProperty("status", new StringSchema().nullable(true));
+    resultItem.addProperty(
+        "status_last_modified_time", new StringSchema().format("date-time").nullable(true));
+    resultItem.addProperty("submit_time", new StringSchema().format("date-time"));
+    resultItem.addProperty("submitter_type", new StringSchema());
+    resultItem.addProperty("ti_email", new StringSchema().nullable(true));
+    resultItem.addProperty("ti_organization", new StringSchema().nullable(true));
+    if (openApiSchemaSettings.includeScores()) {
+      // Null when the application predates scoring or scoring wasn't applied; double precision.
+      resultItem.addProperty("total_score", new NumberSchema().format("double").nullable(true));
+    }
+    return resultItem;
+  }
+
   /***
    * Entry point to start building the program specific definitions for questions
    */
@@ -290,6 +280,21 @@ public class OpenApi3SchemaGenerator extends AbstractOpenApiSchemaGenerator
               fieldName,
               getPropertyFromType(
                   definitionType, getSwaggerFormat(scalar), arrayItemDefinitionType));
+        }
+        // Score properties are deliberately not question scalars, so they are added here rather
+        // than picked up by the scalar loop.
+        if (openApiSchemaSettings.includeScores()
+            && QuestionType.supportsOptionScores(questionDefinition.getQuestionType())) {
+          if (questionDefinition.getQuestionType() == QuestionType.CHECKBOX) {
+            containerDefinition.addProperty(
+                "scores",
+                new ArraySchema()
+                    .items(new NumberSchema().format("double").nullable(true))
+                    .nullable(true));
+          } else {
+            containerDefinition.addProperty(
+                "score", new NumberSchema().format("double").nullable(true));
+          }
         }
       } else {
         var enumeratorProperties =

--- a/server/app/views/docs/ApiDocsView.java
+++ b/server/app/views/docs/ApiDocsView.java
@@ -47,6 +47,7 @@ import services.export.ProgramJsonSampler;
 import services.program.ProgramDefinition;
 import services.question.types.MultiOptionQuestionDefinition;
 import services.question.types.QuestionDefinition;
+import services.settings.SettingsManifest;
 import views.BaseHtmlLayout;
 import views.BaseHtmlView;
 import views.HtmlBundle;
@@ -73,6 +74,7 @@ public class ApiDocsView extends BaseHtmlView {
   private final AdminLayout authenticatedlayout;
   private final ProgramJsonSampler programJsonSampler;
   private final ExportServiceRepository exportServiceRepository;
+  private final SettingsManifest settingsManifest;
 
   @Inject
   public ApiDocsView(
@@ -80,11 +82,13 @@ public class ApiDocsView extends BaseHtmlView {
       BaseHtmlLayout unauthenticatedlayout,
       AdminLayoutFactory layoutFactory,
       ProgramJsonSampler programJsonSampler,
-      ExportServiceRepository exportServiceRepository) {
+      ExportServiceRepository exportServiceRepository,
+      SettingsManifest settingsManifest) {
     this.profileUtils = profileUtils;
     this.unauthenticatedlayout = unauthenticatedlayout;
     this.authenticatedlayout = layoutFactory.getLayout(NavPage.API_DOCS);
     this.programJsonSampler = programJsonSampler;
+    this.settingsManifest = settingsManifest;
     this.exportServiceRepository = exportServiceRepository;
   }
 
@@ -190,7 +194,7 @@ public class ApiDocsView extends BaseHtmlView {
 
       AsideTag rightSide = aside().withClasses("w-full flex-grow");
       rightSide.with(h2("API response preview").withClasses("pl-4"));
-      rightSide.with(apiResponseSampleDiv(programDefinition.get()));
+      rightSide.with(apiResponseSampleDiv(programDefinition.get(), request));
 
       fullProgramDiv.with(leftSide);
       fullProgramDiv.with(rightSide);
@@ -217,9 +221,11 @@ public class ApiDocsView extends BaseHtmlView {
         .withClasses("my-4", BaseStyles.LINK_TEXT, BaseStyles.LINK_HOVER_TEXT);
   }
 
-  private DivTag apiResponseSampleDiv(ProgramDefinition programDefinition) {
+  private DivTag apiResponseSampleDiv(ProgramDefinition programDefinition, Http.Request request) {
     DivTag apiResponseSampleDiv = div();
-    String fullJsonResponsePreview = programJsonSampler.getSampleJson(programDefinition);
+    String fullJsonResponsePreview =
+        programJsonSampler.getSampleJson(
+            programDefinition, settingsManifest.getAnswerOptionScoringEnabled(request));
     String fullJsonResponsePreviewPretty = asPrettyJsonString(fullJsonResponsePreview);
 
     apiResponseSampleDiv.with(

--- a/server/test/services/export/JsonExporterServiceTest.java
+++ b/server/test/services/export/JsonExporterServiceTest.java
@@ -5,11 +5,15 @@ import static play.api.test.Helpers.testServerPort;
 
 import com.google.common.collect.ImmutableList;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 import models.ApplicantModel;
+import models.ApplicationModel;
 import models.LifecycleStage;
 import models.ProgramModel;
+import models.QuestionModel;
 import org.junit.Test;
 import repository.ProgramRepository;
 import repository.SubmittedApplicationFilter;
@@ -17,6 +21,8 @@ import repository.VersionRepository;
 import services.CfJsonDocumentContext;
 import services.LocalizedStrings;
 import services.Path;
+import services.applicant.ApplicantData;
+import services.applicant.ApplicationScoreMetadata;
 import services.application.ApplicationEventDetails;
 import services.application.ApplicationEventDetails.StatusEvent;
 import services.geo.CorrectedAddressState;
@@ -2650,6 +2656,256 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
         """);
   }
 
+  private QuestionModel createScoredQuestion(
+      String name, MultiOptionQuestionDefinition.MultiOptionQuestionType type) {
+    QuestionDefinitionConfig config =
+        QuestionDefinitionConfig.builder()
+            .setName(name)
+            .setDescription(name)
+            .setQuestionText(LocalizedStrings.of(Locale.US, name + "?"))
+            .setQuestionHelpText(LocalizedStrings.empty())
+            .build();
+    ImmutableList<QuestionOption> options =
+        ImmutableList.of(
+            QuestionOption.create(
+                /* id= */ 1L,
+                /* displayOrder= */ 0L,
+                /* adminName= */ "scored_option",
+                /* optionText= */ LocalizedStrings.of(Locale.US, "scored option"),
+                /* displayInAnswerOptions= */ Optional.of(true),
+                /* score= */ Optional.of(10.5)),
+            QuestionOption.create(
+                /* id= */ 2L,
+                /* displayOrder= */ 1L,
+                /* adminName= */ "unscored_option",
+                /* optionText= */ LocalizedStrings.of(Locale.US, "unscored option"),
+                /* displayInAnswerOptions= */ Optional.of(true),
+                /* score= */ Optional.empty()));
+    return testQuestionBank.maybeSave(
+        new MultiOptionQuestionDefinition(config, options, type), LifecycleStage.ACTIVE);
+  }
+
+  private Path questionContextualizedPath(QuestionModel question) {
+    return question
+        .getQuestionDefinition()
+        .getContextualizedPath(
+            /* repeatedEntity= */ Optional.empty(), ApplicantData.APPLICANT_PATH);
+  }
+
+  @Test
+  public void export_includeScores_scoredApplication_emitsScoresAndTotal() {
+    QuestionModel dropdown =
+        createScoredQuestion(
+            "json scored dropdown",
+            MultiOptionQuestionDefinition.MultiOptionQuestionType.DROPDOWN);
+    QuestionModel checkbox =
+        createScoredQuestion(
+            "json scored checkbox",
+            MultiOptionQuestionDefinition.MultiOptionQuestionType.CHECKBOX);
+    var fakeProgram =
+        FakeProgramBuilder.newActiveProgram("json-scored-program")
+            .withUsesScoring()
+            .withQuestion(dropdown)
+            .withQuestion(checkbox)
+            .build();
+    ApplicationModel application =
+        FakeApplicationFiller.newFillerFor(fakeProgram)
+            .answerDropdownQuestion(dropdown, 1L)
+            .answerCheckboxQuestion(checkbox, ImmutableList.of(1L, 2L))
+            .submit()
+            .getApplication();
+    ApplicantData data = application.getApplicantData();
+    data.putDouble(
+        ApplicationScoreMetadata.scorePath(questionContextualizedPath(dropdown)), 10.5);
+    List<Double> checkboxScores = new ArrayList<>();
+    checkboxScores.add(10.5);
+    checkboxScores.add(null);
+    data.putArray(
+        ApplicationScoreMetadata.scoresPath(questionContextualizedPath(checkbox)), checkboxScores);
+    data.putDouble(ApplicationScoreMetadata.totalScorePath(), 21.0);
+    application.setApplicantData(data);
+    application.save();
+
+    JsonExporterService exporter = instanceOf(JsonExporterService.class);
+    String resultJsonString =
+        exporter.export(
+            fakeProgram.getProgramDefinition(),
+            SubmitTimeSequentialAccessPaginationSpec.APPLICATION_MODEL_MAX_PAGE_SIZE_SPEC,
+            SubmittedApplicationFilter.EMPTY,
+            /* includeScores= */ true);
+    ResultAsserter resultAsserter = new ResultAsserter(resultJsonString);
+
+    resultAsserter.assertValueAtPath("application.json_scored_dropdown.score", 10.5);
+    // Scores align with the emitted selections order; the unscored selection is null.
+    resultAsserter.assertJsonAtApplicationPath(".json_scored_checkbox.scores", "[ 10.5, null ]");
+    resultAsserter.assertValueAtPath("total_score", 21.0);
+  }
+
+  @Test
+  public void export_includeScores_scoringNotApplied_emitsNulls() {
+    QuestionModel dropdown =
+        createScoredQuestion(
+            "json scored dropdown",
+            MultiOptionQuestionDefinition.MultiOptionQuestionType.DROPDOWN);
+    QuestionModel checkbox =
+        createScoredQuestion(
+            "json scored checkbox",
+            MultiOptionQuestionDefinition.MultiOptionQuestionType.CHECKBOX);
+    var fakeProgram =
+        FakeProgramBuilder.newActiveProgram("json-unscored-program")
+            .withQuestion(dropdown)
+            .withQuestion(checkbox)
+            .build();
+    // Submitted without score metadata: e.g. pre-feature or a non-scoring program.
+    FakeApplicationFiller.newFillerFor(fakeProgram)
+        .answerDropdownQuestion(dropdown, 1L)
+        .answerCheckboxQuestion(checkbox, ImmutableList.of(1L))
+        .submit();
+
+    JsonExporterService exporter = instanceOf(JsonExporterService.class);
+    String resultJsonString =
+        exporter.export(
+            fakeProgram.getProgramDefinition(),
+            SubmitTimeSequentialAccessPaginationSpec.APPLICATION_MODEL_MAX_PAGE_SIZE_SPEC,
+            SubmittedApplicationFilter.EMPTY,
+            /* includeScores= */ true);
+    ResultAsserter resultAsserter = new ResultAsserter(resultJsonString);
+
+    resultAsserter.assertNullValueAtPath("application.json_scored_dropdown.score");
+    resultAsserter.assertNullValueAtPath("application.json_scored_checkbox.scores");
+    resultAsserter.assertNullValueAtPath("total_score");
+  }
+
+  @Test
+  public void export_includeScores_scoringAppliedButUnanswered_checkboxEmitsEmptyArray() {
+    QuestionModel dropdown =
+        createScoredQuestion(
+            "json scored dropdown",
+            MultiOptionQuestionDefinition.MultiOptionQuestionType.DROPDOWN);
+    QuestionModel checkbox =
+        createScoredQuestion(
+            "json scored checkbox",
+            MultiOptionQuestionDefinition.MultiOptionQuestionType.CHECKBOX);
+    var fakeProgram =
+        FakeProgramBuilder.newActiveProgram("json-scored-program")
+            .withUsesScoring()
+            .withQuestion(dropdown)
+            .withQuestion(checkbox)
+            .build();
+    ApplicationModel application =
+        FakeApplicationFiller.newFillerFor(fakeProgram)
+            .answerDropdownQuestion(dropdown, 2L)
+            .submit()
+            .getApplication();
+    // Scoring was applied (total present, zero) but the checkbox is unanswered and the selected
+    // dropdown option is unscored.
+    ApplicantData data = application.getApplicantData();
+    data.putDouble(ApplicationScoreMetadata.totalScorePath(), 0.0);
+    application.setApplicantData(data);
+    application.save();
+
+    JsonExporterService exporter = instanceOf(JsonExporterService.class);
+    String resultJsonString =
+        exporter.export(
+            fakeProgram.getProgramDefinition(),
+            SubmitTimeSequentialAccessPaginationSpec.APPLICATION_MODEL_MAX_PAGE_SIZE_SPEC,
+            SubmittedApplicationFilter.EMPTY,
+            /* includeScores= */ true);
+    ResultAsserter resultAsserter = new ResultAsserter(resultJsonString);
+
+    resultAsserter.assertNullValueAtPath("application.json_scored_dropdown.score");
+    resultAsserter.assertJsonAtApplicationPath(".json_scored_checkbox.scores", "[ ]");
+    // An explicit zero total passes through.
+    resultAsserter.assertValueAtPath("total_score", 0.0);
+  }
+
+  @Test
+  public void export_includeScores_checkboxOnlyInAnotherVersion_initializesScoresPerApplication()
+      throws ProgramNotFoundException {
+    QuestionModel dropdown =
+        createScoredQuestion(
+            "json scored dropdown",
+            MultiOptionQuestionDefinition.MultiOptionQuestionType.DROPDOWN);
+    var fakeProgram =
+        FakeProgramBuilder.newActiveProgram("json-scored-program")
+            .withUsesScoring()
+            .withQuestion(dropdown)
+            .build();
+    ApplicationModel application =
+        FakeApplicationFiller.newFillerFor(fakeProgram)
+            .answerDropdownQuestion(dropdown, 1L)
+            .submit()
+            .getApplication();
+    ApplicantData data = application.getApplicantData();
+    data.putDouble(
+        ApplicationScoreMetadata.scorePath(questionContextualizedPath(dropdown)), 10.5);
+    data.putDouble(ApplicationScoreMetadata.totalScorePath(), 10.5);
+    application.setApplicantData(data);
+    application.save();
+
+    // A later program version adds a scored checkbox the application's version never had.
+    QuestionModel checkbox =
+        createScoredQuestion(
+            "json scored checkbox",
+            MultiOptionQuestionDefinition.MultiOptionQuestionType.CHECKBOX);
+    ProgramModel updatedFakeProgram =
+        FakeProgramBuilder.newDraftOf(fakeProgram).withQuestion(checkbox).build();
+
+    JsonExporterService exporter = instanceOf(JsonExporterService.class);
+    String resultJsonString =
+        exporter.export(
+            updatedFakeProgram.getProgramDefinition(),
+            SubmitTimeSequentialAccessPaginationSpec.APPLICATION_MODEL_MAX_PAGE_SIZE_SPEC,
+            SubmittedApplicationFilter.EMPTY,
+            /* includeScores= */ true);
+    ResultAsserter resultAsserter = new ResultAsserter(resultJsonString);
+
+    resultAsserter.assertValueAtPath("application.json_scored_dropdown.score", 10.5);
+    // Scoring was applied to this application, so the other version's checkbox emits [] rather
+    // than keeping the template's null.
+    resultAsserter.assertJsonAtApplicationPath(".json_scored_checkbox.scores", "[ ]");
+    resultAsserter.assertValueAtPath("total_score", 10.5);
+    // The per-application initializer writes into the application object only; it must not leak
+    // an applicant-rooted copy of the score paths into the export.
+    resultAsserter.assertTopLevelPathAbsent("applicant");
+  }
+
+  @Test
+  public void export_includeScoresFalse_scorePropertiesAreAbsent() {
+    QuestionModel dropdown =
+        createScoredQuestion(
+            "json scored dropdown",
+            MultiOptionQuestionDefinition.MultiOptionQuestionType.DROPDOWN);
+    var fakeProgram =
+        FakeProgramBuilder.newActiveProgram("json-scored-program")
+            .withUsesScoring()
+            .withQuestion(dropdown)
+            .build();
+    ApplicationModel application =
+        FakeApplicationFiller.newFillerFor(fakeProgram)
+            .answerDropdownQuestion(dropdown, 1L)
+            .submit()
+            .getApplication();
+    ApplicantData data = application.getApplicantData();
+    data.putDouble(
+        ApplicationScoreMetadata.scorePath(questionContextualizedPath(dropdown)), 10.5);
+    data.putDouble(ApplicationScoreMetadata.totalScorePath(), 10.5);
+    application.setApplicantData(data);
+    application.save();
+
+    JsonExporterService exporter = instanceOf(JsonExporterService.class);
+    String resultJsonString =
+        exporter.export(
+            fakeProgram.getProgramDefinition(),
+            SubmitTimeSequentialAccessPaginationSpec.APPLICATION_MODEL_MAX_PAGE_SIZE_SPEC,
+            SubmittedApplicationFilter.EMPTY);
+    ResultAsserter resultAsserter = new ResultAsserter(resultJsonString);
+
+    // With the flag off, the properties are absent, not null.
+    resultAsserter.assertJsonDoesNotContainApplicationPath(".json_scored_dropdown.score");
+    resultAsserter.assertTopLevelPathAbsent("total_score");
+  }
+
   private static class ResultAsserter {
     final CfJsonDocumentContext resultJson;
 
@@ -2675,6 +2931,15 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
       assertThat(resultJson.readLong(jsonPath).get()).isEqualTo(value);
     }
 
+    private void assertValueAtPath(String path, Double value) {
+      assertValueAtPath(0, path, value);
+    }
+
+    private void assertValueAtPath(int resultNumber, String path, Double value) {
+      Path jsonPath = Path.create("$[" + resultNumber + "]." + path);
+      assertThat(resultJson.readDouble(jsonPath).get()).isEqualTo(value);
+    }
+
     private void assertNullValueAtPath(String path) {
       assertNullValueAtPath(0, path);
     }
@@ -2686,6 +2951,11 @@ public class JsonExporterServiceTest extends AbstractExporterTest {
 
     private void assertJsonDoesNotContainApplicationPath(String innerPath) {
       Path path = Path.create("$[0].application" + innerPath);
+      assertThat(resultJson.hasPath(path)).isFalse();
+    }
+
+    private void assertTopLevelPathAbsent(String topLevelPath) {
+      Path path = Path.create("$[0]." + topLevelPath);
       assertThat(resultJson.hasPath(path)).isFalse();
     }
 

--- a/server/test/services/export/ProgramJsonSamplerTest.java
+++ b/server/test/services/export/ProgramJsonSamplerTest.java
@@ -87,6 +87,26 @@ public class ProgramJsonSamplerTest extends ResetPostgres {
   }
 
   @Test
+  public void getSampleJson_withScores_includesSampleScoreValues() {
+    String json = programJsonSampler.getSampleJson(programDefinition, /* includeScores= */ true);
+
+    // Single-select sample questions (dropdown, radio) get a sample score.
+    assertThat(json).contains("\"score\" : 2.0");
+    // Checkbox sample questions show the nullable-array semantics.
+    assertThat(json).contains("\"scores\" : [ 1.5, null ]");
+    assertThat(json).contains("\"total_score\" : ");
+  }
+
+  @Test
+  public void getSampleJson_withoutScores_omitsScoreProperties() {
+    String json = programJsonSampler.getSampleJson(programDefinition);
+
+    assertThat(json).doesNotContain("\"score\"");
+    assertThat(json).doesNotContain("\"scores\"");
+    assertThat(json).doesNotContain("\"total_score\"");
+  }
+
+  @Test
   public void samplesFullProgram() {
     String json = programJsonSampler.getSampleJson(programDefinition);
 

--- a/server/test/services/openapi/v2/Swagger2SchemaGeneratorTest.java
+++ b/server/test/services/openapi/v2/Swagger2SchemaGeneratorTest.java
@@ -33,6 +33,76 @@ public class Swagger2SchemaGeneratorTest {
       SampleQuestionDefinitions.ALL_SAMPLE_QUESTION_DEFINITIONS.stream()
           .map(QuestionDefinition::withPopulatedTestId);
 
+  private static ProgramDefinition programWithAllSampleQuestions() {
+    ImmutableList<BlockDefinition> blockDefinitions =
+        ImmutableList.of(
+            BlockDefinition.builder()
+                .setId(135L)
+                .setName("Test Block Definition")
+                .setDescription("Test Block Description")
+                .setProgramQuestionDefinitions(
+                    SampleQuestionDefinitions.ALL_SAMPLE_QUESTION_DEFINITIONS.stream()
+                        .map(QuestionDefinition::withPopulatedTestId)
+                        .map(
+                            questionDefinition ->
+                                ProgramQuestionDefinition.create(
+                                    questionDefinition, Optional.empty()))
+                        .collect(toImmutableList()))
+                .setLocalizedName(LocalizedStrings.builder().build())
+                .setLocalizedDescription(LocalizedStrings.builder().build())
+                .build());
+
+    return ProgramDefinition.builder()
+        .setId(789L)
+        .setAdminName("test-program-admin-name")
+        .setAdminDescription("Test Admin Description")
+        .setExternalLink("https://mytestlink.gov")
+        .setDisplayMode(DisplayMode.PUBLIC)
+        .setProgramType(ProgramType.DEFAULT)
+        .setEligibilityIsGating(false)
+        .setLoginOnly(false)
+        .setAcls(new ProgramAcls())
+        .setBlockDefinitions(blockDefinitions)
+        .setApplicationSteps(
+            ImmutableList.of(new ApplicationStep("step-1-title", "step-1-description")))
+        .setCategories(ImmutableList.of())
+        .setBridgeDefinitions(ImmutableMap.of())
+        .build();
+  }
+
+  @Test
+  public void createSchema_includeScores_addsScoreProperties() {
+    OpenApiSchemaSettings settings =
+        new OpenApiSchemaSettings(
+            "baseUrl",
+            "email123@example.com",
+            /* allowHttpScheme= */ true,
+            /* includeScores= */ true);
+
+    String actual =
+        new Swagger2SchemaGenerator(settings).createSchema(programWithAllSampleQuestions());
+
+    assertThat(actual).contains("total_score:");
+    assertThat(actual).contains("score:");
+    assertThat(actual).contains("scores:");
+    // Scores are decimal: double-precision numbers, not integers.
+    assertThat(actual).contains("format: double");
+    assertThat(actual).contains("x-nullable: true");
+  }
+
+  @Test
+  public void createSchema_withoutIncludeScores_omitsScoreProperties() {
+    OpenApiSchemaSettings settings =
+        new OpenApiSchemaSettings("baseUrl", "email123@example.com", /* allowHttpScheme= */ true);
+
+    String actual =
+        new Swagger2SchemaGenerator(settings).createSchema(programWithAllSampleQuestions());
+
+    assertThat(actual).doesNotContain("total_score");
+    assertThat(actual).doesNotContain("score:");
+    assertThat(actual).doesNotContain("scores:");
+  }
+
   @Test
   public void createSchema_withNoPrograms() {
     ImmutableList<BlockDefinition> blockDefinitions =

--- a/server/test/services/openapi/v3/OpenApi3SchemaGeneratorTest.java
+++ b/server/test/services/openapi/v3/OpenApi3SchemaGeneratorTest.java
@@ -33,6 +33,75 @@ public class OpenApi3SchemaGeneratorTest {
       SampleQuestionDefinitions.ALL_SAMPLE_QUESTION_DEFINITIONS.stream()
           .map(QuestionDefinition::withPopulatedTestId);
 
+  private static ProgramDefinition programWithAllSampleQuestions() {
+    ImmutableList<BlockDefinition> blockDefinitions =
+        ImmutableList.of(
+            BlockDefinition.builder()
+                .setId(135L)
+                .setName("Test Block Definition")
+                .setDescription("Test Block Description")
+                .setProgramQuestionDefinitions(
+                    SampleQuestionDefinitions.ALL_SAMPLE_QUESTION_DEFINITIONS.stream()
+                        .map(QuestionDefinition::withPopulatedTestId)
+                        .map(
+                            questionDefinition ->
+                                ProgramQuestionDefinition.create(
+                                    questionDefinition, Optional.empty()))
+                        .collect(toImmutableList()))
+                .setLocalizedName(LocalizedStrings.builder().build())
+                .setLocalizedDescription(LocalizedStrings.builder().build())
+                .build());
+
+    return ProgramDefinition.builder()
+        .setId(789L)
+        .setAdminName("test-program-admin-name")
+        .setAdminDescription("Test Admin Description")
+        .setExternalLink("https://mytestlink.gov")
+        .setDisplayMode(DisplayMode.PUBLIC)
+        .setProgramType(ProgramType.DEFAULT)
+        .setEligibilityIsGating(false)
+        .setLoginOnly(false)
+        .setAcls(new ProgramAcls())
+        .setBlockDefinitions(blockDefinitions)
+        .setApplicationSteps(
+            ImmutableList.of(new ApplicationStep("step-1-title", "step-1-description")))
+        .setCategories(ImmutableList.of())
+        .setBridgeDefinitions(ImmutableMap.of())
+        .build();
+  }
+
+  @Test
+  public void createSchema_includeScores_addsScoreProperties() {
+    OpenApiSchemaSettings settings =
+        new OpenApiSchemaSettings(
+            "baseUrl",
+            "email123@example.com",
+            /* allowHttpScheme= */ true,
+            /* includeScores= */ true);
+
+    String actual =
+        new OpenApi3SchemaGenerator(settings).createSchema(programWithAllSampleQuestions());
+
+    assertThat(actual).contains("total_score:");
+    assertThat(actual).contains("score:");
+    assertThat(actual).contains("scores:");
+    // Scores are decimal: double-precision numbers, not integers.
+    assertThat(actual).contains("format: double");
+  }
+
+  @Test
+  public void createSchema_withoutIncludeScores_omitsScoreProperties() {
+    OpenApiSchemaSettings settings =
+        new OpenApiSchemaSettings("baseUrl", "email123@example.com", /* allowHttpScheme= */ true);
+
+    String actual =
+        new OpenApi3SchemaGenerator(settings).createSchema(programWithAllSampleQuestions());
+
+    assertThat(actual).doesNotContain("total_score");
+    assertThat(actual).doesNotContain("score:");
+    assertThat(actual).doesNotContain("scores:");
+  }
+
   @Test
   public void createSchema_withNoPrograms() {
     ImmutableList<BlockDefinition> blockDefinitions =


### PR DESCRIPTION
JsonExporterService gains an includeScores boolean threaded from the
scoring flag by ProgramApplicationsApiController and
AdminApplicationController. A central helper (not the 15 per-question
presenters) adds application.<q>.score for single-selects and
application.<q>.scores for checkboxes, plus a top-level nullable 64-bit
total_score. Semantics: score is null when unanswered/unscored/scoring
not applied; scores is null when scoring wasn't applied, [] when
applied but unanswered, and otherwise pairs the persisted metadata with
the stored selections, emitted in the same definition order and
duplicate-filtering as the selections presenter. Null-holed arrays
cross the export dispatch in an explicit NullableDoubleArray wrapper -
without it the dispatch would silently drop them. Checkbox scores
template values are initialized per application since a static template
cannot represent both the null and [] states. With the flag off, the
properties are absent and responses are unchanged.

ProgramJsonSampler adds sample score values (non-repeated supported
questions) and a sample total_score; both OpenAPI generators add
score (nullable int32), scores (nullable array of nullable int32, via
x-nullable in v2), and total_score (nullable int64), gated by a new
includeScores component on OpenApiSchemaSettings.

Assisted-by: Claude Code:claude-fable-5

---

Part 10 of 12 in the option-scores stack. Merge in order, top to bottom:

1. https://github.com/civiform/civiform/pull/13796
2. https://github.com/civiform/civiform/pull/13797
3. https://github.com/civiform/civiform/pull/13798
4. https://github.com/civiform/civiform/pull/13799
5. https://github.com/civiform/civiform/pull/13800
6. https://github.com/civiform/civiform/pull/13801
7. https://github.com/civiform/civiform/pull/13802
8. https://github.com/civiform/civiform/pull/13803
9. https://github.com/civiform/civiform/pull/13804
10. https://github.com/civiform/civiform/pull/13805
11. https://github.com/civiform/civiform/pull/13806
12. https://github.com/civiform/civiform/pull/13807
