### PR TITLE
Codify applicant-invisibility invariants for option scores

### DIFF
--- a/server/app/services/applicant/ApplicationScoreMetadata.java
+++ b/server/app/services/applicant/ApplicationScoreMetadata.java
@@ -76,22 +76,6 @@ public final class ApplicationScoreMetadata {
     return RESERVED_SCORE_KEYS.contains(keyName);
   }
 
-  /**
-   * Returns true if the path is rooted at the application-private metadata namespace. Applicant
-   * update endpoints reject such paths as defense in depth.
-   */
-  public static boolean isMetadataPath(Path path) {
-    if (path.isEmpty()) {
-      return false;
-    }
-    String root = path.segments().get(0);
-    int arrayStart = root.indexOf('[');
-    if (arrayStart >= 0) {
-      root = root.substring(0, arrayStart);
-    }
-    return root.equals("application_metadata");
-  }
-
   private static Path checkApplicantRooted(Path contextualizedQuestionPath) {
     ImmutableList<String> segments = contextualizedQuestionPath.segments();
     checkArgument(

--- a/server/test/services/applicant/ApplicationScoreMetadataTest.java
+++ b/server/test/services/applicant/ApplicationScoreMetadataTest.java
@@ -62,17 +62,13 @@ public class ApplicationScoreMetadataTest {
   }
 
   @Test
-  public void isMetadataPath_matchesOnlyTheMetadataRoot() {
-    assertThat(ApplicationScoreMetadata.isMetadataPath(Path.create("application_metadata")))
-        .isTrue();
+  public void scoreKeysAreDeliberatelyNotScalars() {
+    // Score storage must stay out of question scalar sets, predicates, API bridges, and
+    // scalar-driven schema generation by construction (D4). Adding these as Scalars would leak
+    // them into all of those surfaces.
     assertThat(
-            ApplicationScoreMetadata.isMetadataPath(
-                Path.create("application_metadata.option_scoring.total_score")))
-        .isTrue();
-    assertThat(ApplicationScoreMetadata.isMetadataPath(Path.create("application_metadata[0].x")))
-        .isTrue();
-    assertThat(ApplicationScoreMetadata.isMetadataPath(Path.create("applicant.total_score")))
-        .isFalse();
-    assertThat(ApplicationScoreMetadata.isMetadataPath(Path.empty())).isFalse();
+            java.util.Arrays.stream(services.applicant.question.Scalar.values())
+                .map(Enum::name))
+        .doesNotContain("SCORE", "SCORES", "TOTAL_SCORE");
   }
 }

--- a/server/test/services/question/types/QuestionOptionTest.java
+++ b/server/test/services/question/types/QuestionOptionTest.java
@@ -251,6 +251,28 @@ public class QuestionOptionTest {
   }
 
   @Test
+  public void localize_neverExposesScore() {
+    // D6: the applicant-facing LocalizedQuestionOption must never carry the score. This guards
+    // against a future accessor being added and picked up by applicant rendering.
+    QuestionOption scored =
+        QuestionOption.create(
+            /* id= */ 1L,
+            /* displayOrder= */ 0L,
+            /* adminName= */ "invisible",
+            /* optionText= */ LocalizedStrings.of(Locale.US, "option"),
+            /* displayInAnswerOptions= */ Optional.of(true),
+            /* score= */ Optional.of(987654.5));
+
+    LocalizedQuestionOption localized = scored.localizeOrDefault(Locale.US);
+
+    assertThat(
+            java.util.Arrays.stream(LocalizedQuestionOption.class.getMethods())
+                .map(java.lang.reflect.Method::getName))
+        .noneMatch(name -> name.toLowerCase(Locale.ROOT).contains("score"));
+    assertThat(localized.toString()).doesNotContain("987654");
+  }
+
+  @Test
   public void jsonCreator_legacyBranch_preservesScore() {
     QuestionOption option =
         QuestionOption.jsonCreator(


### PR DESCRIPTION
Two structural guard tests: LocalizedQuestionOption (the only option
object applicant rendering sees) exposes no score accessor and its
string form never carries a score value; and SCORE/SCORES/TOTAL_SCORE
are never Scalars, keeping score storage out of predicates, API
bridges, applicant paths, and scalar-driven schema generation by
construction.

Grep audit of applicant-facing surfaces found no score references:
nothing under views/questiontypes or views/applicant mentions scores;
the only applicant controller touching scoring is UpsellController's
hard-coded includeScores=false; preview.ts reads only [name="options[]"]
so admin score inputs are invisible to it; and nothing under
services/applicant/predicate or services/apibridge references the
application_metadata namespace.

Assisted-by: Claude Code:claude-fable-5

---

Part 11 of 12 in the option-scores stack. Merge in order, top to bottom:

1. https://github.com/civiform/civiform/pull/13796
2. https://github.com/civiform/civiform/pull/13797
3. https://github.com/civiform/civiform/pull/13798
4. https://github.com/civiform/civiform/pull/13799
5. https://github.com/civiform/civiform/pull/13800
6. https://github.com/civiform/civiform/pull/13801
7. https://github.com/civiform/civiform/pull/13802
8. https://github.com/civiform/civiform/pull/13803
9. https://github.com/civiform/civiform/pull/13804
10. https://github.com/civiform/civiform/pull/13805
11. https://github.com/civiform/civiform/pull/13806
12. https://github.com/civiform/civiform/pull/13807
