### PR TITLE
Add explicit type witnesses on score entry maps

### DIFF
--- a/server/app/services/export/JsonExporterService.java
+++ b/server/app/services/export/JsonExporterService.java
@@ -325,7 +325,7 @@ public final class JsonExporterService {
     Path apiPath = contextualizedPath.asNestedEntitiesPath();
     if (applicantQuestion.getType() != QuestionType.CHECKBOX) {
       // Unanswered, unscored option, and scoring-not-applied all read as absent and emit null.
-      return ImmutableMap.of(
+      return ImmutableMap.<Path, Optional<?>>of(
           apiPath.join(SCORE_PROPERTY),
           snapshot.readDouble(ApplicationScoreMetadata.scorePath(contextualizedPath)));
     }
@@ -333,7 +333,7 @@ public final class JsonExporterService {
     Path scoresApiPath = apiPath.join(SCORES_PROPERTY);
     if (totalScore.isEmpty()) {
       // Scoring was not applied to this application: null.
-      return ImmutableMap.of(scoresApiPath, Optional.empty());
+      return ImmutableMap.<Path, Optional<?>>of(scoresApiPath, Optional.empty());
     }
     Optional<ImmutableList<Long>> selections =
         snapshot.readLongList(contextualizedPath.join(Scalar.SELECTIONS));
@@ -343,7 +343,7 @@ public final class JsonExporterService {
         || storedScores.isEmpty()
         || selections.get().size() != storedScores.get().size()) {
       // Scoring applied but unanswered (or corrupt metadata): empty array.
-      return ImmutableMap.of(
+      return ImmutableMap.<Path, Optional<?>>of(
           scoresApiPath, Optional.of(new NullableDoubleArray(ImmutableList.of())));
     }
     // Pair the unchanged stored selection ids with the persisted scores (first occurrence wins),
@@ -362,7 +362,8 @@ public final class JsonExporterService {
             .filter(option -> selectedIds.contains(option.id()))
             .map(QuestionOption::id)
             .forEach(optionId -> emittedScores.add(scoreByOptionId.get(optionId)));
-    return ImmutableMap.of(scoresApiPath, Optional.of(new NullableDoubleArray(emittedScores)));
+    return ImmutableMap.<Path, Optional<?>>of(
+        scoresApiPath, Optional.of(new NullableDoubleArray(emittedScores)));
   }
 
   private CfJsonDocumentContext convertExportDataToJson(

--- a/server/app/services/export/ProgramJsonSampler.java
+++ b/server/app/services/export/ProgramJsonSampler.java
@@ -122,12 +122,12 @@ public final class ProgramJsonSampler {
           sampleScores.add(1.5);
           sampleScores.add(null);
           jsonExportData.addApplicationEntries(
-              ImmutableMap.of(
+              ImmutableMap.<Path, Optional<?>>of(
                   apiPath.join("scores"), Optional.of(new NullableDoubleArray(sampleScores))));
           sampleTotalScore += 1.5;
         } else {
           jsonExportData.addApplicationEntries(
-              ImmutableMap.of(apiPath.join("score"), Optional.of(2.0)));
+              ImmutableMap.<Path, Optional<?>>of(apiPath.join("score"), Optional.of(2.0)));
           sampleTotalScore += 2;
         }
       }


### PR DESCRIPTION
ImmutableMap.of infers Optional<Double>/Optional<NullableDoubleArray>
value types that don't satisfy the Optional<?> map signatures.

Assisted-by: Claude Code:claude-fable-5

---

Part 12 of 12 in the option-scores stack. Merge in order, top to bottom:

1. https://github.com/civiform/civiform/pull/13796
2. https://github.com/civiform/civiform/pull/13797
3. https://github.com/civiform/civiform/pull/13798
4. https://github.com/civiform/civiform/pull/13799
5. https://github.com/civiform/civiform/pull/13800
6. https://github.com/civiform/civiform/pull/13801
7. https://github.com/civiform/civiform/pull/13802
8. https://github.com/civiform/civiform/pull/13803
9. https://github.com/civiform/civiform/pull/13804
10. https://github.com/civiform/civiform/pull/13805
11. https://github.com/civiform/civiform/pull/13806
12. https://github.com/civiform/civiform/pull/13807
