### PR TITLE
Update ActiveAndDraftQuestions.referencingDraftProgramsByName naming

### DIFF
--- a/server/app/services/question/ActiveAndDraftQuestions.java
+++ b/server/app/services/question/ActiveAndDraftQuestions.java
@@ -28,8 +28,13 @@ public final class ActiveAndDraftQuestions {
           String, Pair<Optional<QuestionDefinition>, Optional<QuestionDefinition>>>
       versionedByName;
   private final ImmutableMap<String, DeletionStatus> deletionStatusByName;
+  // TODO(#13814): This variable name and utility smells and needs to be cleaned up. In particular,
+  // the data here overlaps with
+  // referencingActiveProgramsByName and that is possibly not desired in how
+  // it is consumed. It's also odd that we rely on a view of publishing the
+  // draft, and not just the draft itself.
   private final ImmutableMap<String, ImmutableSet<PublishProgramPreview>>
-      referencingDraftProgramsByName;
+      publishPreviewProgramsByName;
   private final ImmutableMap<String, ImmutableSet<ProgramDefinition>>
       referencingActiveProgramsByName;
   private final boolean draftVersionHasAnyEdits;
@@ -46,7 +51,7 @@ public final class ActiveAndDraftQuestions {
     VersionModel active = repository.getActiveVersion();
     VersionModel draft = repository.getDraftVersionOrCreate();
     this.referencingActiveProgramsByName = repository.buildReferencingProgramsMap(active);
-    this.referencingDraftProgramsByName = repository.previewPublishNewVersion();
+    this.publishPreviewProgramsByName = repository.previewPublishNewVersion();
 
     ImmutableMap<String, QuestionDefinition> activeNameToQuestion =
         repository.getQuestionDefinitionsForVersion(active).stream()
@@ -84,7 +89,7 @@ public final class ActiveAndDraftQuestions {
                     questionName -> {
                       ImmutableSet<?> referencesToExamine =
                           draftVersionHasAnyEdits
-                              ? referencingDraftProgramsByName.getOrDefault(
+                              ? publishPreviewProgramsByName.getOrDefault(
                                   questionName, ImmutableSet.of())
                               : referencingActiveProgramsByName.getOrDefault(
                                   questionName, ImmutableSet.of());
@@ -126,7 +131,7 @@ public final class ActiveAndDraftQuestions {
   public ReferencingPrograms getReferencingPrograms(String name) {
     return ReferencingPrograms.builder()
         .setActiveReferences(referencingActiveProgramsByName.getOrDefault(name, ImmutableSet.of()))
-        .setDraftReferences(referencingDraftProgramsByName.getOrDefault(name, ImmutableSet.of()))
+        .setDraftReferences(publishPreviewProgramsByName.getOrDefault(name, ImmutableSet.of()))
         .build();
   }
 


### PR DESCRIPTION
### Description

Change the name from `referencingDraftProgramsByName` to `publishPreviewProgramsByName` to be "less" confusing and add a todo to properly clean this up.


### Checklist

Remove any sections below that do not apply to your PR. For sections that do apply, complete all of the appropriate checklist items and check them off. If a checklist item doesn't apply to your PR, leave it unchecked but do not delete it.

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [ ] Added an additional reviewer as required if changes potentially affect the security of the application.
- [ ] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

Informs: #13814