### PR TITLE
[Enumerators] Removing unused translation messages and the upstream Messages params

### DIFF
--- a/server/app/controllers/admin/AdminProgramBlocksController.java
+++ b/server/app/controllers/admin/AdminProgramBlocksController.java
@@ -170,14 +170,12 @@ public final class AdminProgramBlocksController extends CiviFormController {
             programService.addNestedRepeatedSetToProgram(
                 programId,
                 enumeratorId.get(),
-                messagesApi.preferred(request),
                 settingsManifest.getEnumeratorImprovementsEnabled(request));
       } else if (enumeratorId.isPresent()) {
         result =
             programService.addRepeatedBlockToProgram(
                 programId,
                 enumeratorId.get(),
-                messagesApi.preferred(request),
                 settingsManifest.getEnumeratorImprovementsEnabled(request));
       } else {
         result =
@@ -186,7 +184,6 @@ public final class AdminProgramBlocksController extends CiviFormController {
                 BlockType.ENUMERATOR.equals(blockType.orElse(null))
                     ? Optional.of(true)
                     : Optional.empty(),
-                messagesApi.preferred(request),
                 settingsManifest.getEnumeratorImprovementsEnabled(request));
       }
       ProgramDefinition program = result.getResult().program();
@@ -208,7 +205,6 @@ public final class AdminProgramBlocksController extends CiviFormController {
             programService.addRepeatedBlockToProgram(
                 programId,
                 addedBlockId,
-                messagesApi.preferred(request),
                 settingsManifest.getEnumeratorImprovementsEnabled(request));
         if (result.isError()) {
           ToastMessage message = ToastMessage.errorNonLocalized(joinErrors(result.getErrors()));

--- a/server/app/controllers/admin/AdminProgramController.java
+++ b/server/app/controllers/admin/AdminProgramController.java
@@ -21,7 +21,6 @@ import models.ProgramTab;
 import org.pac4j.play.java.Secure;
 import play.data.Form;
 import play.data.FormFactory;
-import play.i18n.MessagesApi;
 import play.mvc.Http.Request;
 import play.mvc.Result;
 import repository.VersionRepository;
@@ -51,7 +50,6 @@ public final class AdminProgramController extends CiviFormController {
   private final ProgramMetaDataEditView editView;
   private final FormFactory formFactory;
   private final RequestChecker requestChecker;
-  private final MessagesApi messagesApi;
   private final SettingsManifest settingsManifest;
 
   @Inject
@@ -65,7 +63,6 @@ public final class AdminProgramController extends CiviFormController {
       ProfileUtils profileUtils,
       FormFactory formFactory,
       RequestChecker requestChecker,
-      MessagesApi messagesApi,
       SettingsManifest settingsManifest) {
     super(profileUtils, versionRepository);
     this.programService = checkNotNull(programService);
@@ -75,7 +72,6 @@ public final class AdminProgramController extends CiviFormController {
     this.editView = checkNotNull(editView);
     this.formFactory = checkNotNull(formFactory);
     this.requestChecker = checkNotNull(requestChecker);
-    this.messagesApi = checkNotNull(messagesApi);
     this.settingsManifest = checkNotNull(settingsManifest);
   }
 
@@ -178,7 +174,6 @@ public final class AdminProgramController extends CiviFormController {
             ImmutableList.copyOf(programData.getTiGroups()),
             ImmutableList.copyOf(programData.getCategories()),
             applicationSteps,
-            messagesApi.preferred(request),
             settingsManifest.getEnumeratorImprovementsEnabled(request));
     // There shouldn't be any errors since we already validated the program, but check for errors
     // again just in case.

--- a/server/app/controllers/dev/DevToolsController.java
+++ b/server/app/controllers/dev/DevToolsController.java
@@ -28,7 +28,6 @@ import play.cache.AsyncCacheApi;
 import play.cache.NamedCache;
 import play.data.DynamicForm;
 import play.data.FormFactory;
-import play.i18n.MessagesApi;
 import play.mvc.Controller;
 import play.mvc.Http;
 import play.mvc.Http.Request;
@@ -66,7 +65,6 @@ public class DevToolsController extends Controller {
   private final TransactionManager transactionManager = new TransactionManager();
   private final FormFactory formFactory;
   private final DevToolsPageView devToolsPageView;
-  private final MessagesApi messagesApi;
 
   @Inject
   public DevToolsController(
@@ -78,7 +76,6 @@ public class DevToolsController extends Controller {
       Clock clock,
       DeploymentType deploymentType,
       FormFactory formFactory,
-      MessagesApi messagesApi,
       @NamedCache("version-questions") AsyncCacheApi questionsByVersionCache,
       @NamedCache("version-programs") AsyncCacheApi programsByVersionCache,
       @NamedCache("program") AsyncCacheApi programCache,
@@ -104,7 +101,6 @@ public class DevToolsController extends Controller {
     this.deploymentType = checkNotNull(deploymentType);
     this.formFactory = checkNotNull(formFactory);
     this.devToolsPageView = checkNotNull(devToolsPageView);
-    this.messagesApi = checkNotNull(messagesApi);
   }
 
   /**
@@ -185,13 +181,9 @@ public class DevToolsController extends Controller {
           devDatabaseSeedTask.seedQuestions();
       devDatabaseSeedTask.seedProgramCategories();
       devDatabaseSeedTask.insertMinimalSampleProgram(
-          createdSampleQuestions,
-          messagesApi.preferred(request),
-          settingsManifest.getEnumeratorImprovementsEnabled(request));
+          createdSampleQuestions, settingsManifest.getEnumeratorImprovementsEnabled(request));
       devDatabaseSeedTask.insertComprehensiveSampleProgram(
-          createdSampleQuestions,
-          messagesApi.preferred(request),
-          settingsManifest.getEnumeratorImprovementsEnabled(request));
+          createdSampleQuestions, settingsManifest.getEnumeratorImprovementsEnabled(request));
 
       return true;
     } catch (RuntimeException ex) {

--- a/server/app/controllers/dev/seeding/DevDatabaseSeedTask.java
+++ b/server/app/controllers/dev/seeding/DevDatabaseSeedTask.java
@@ -47,7 +47,6 @@ import models.LifecycleStage;
 import models.ProgramNotificationPreference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import play.i18n.Messages;
 import repository.CategoryRepository;
 import repository.VersionRepository;
 import services.CiviFormError;
@@ -171,7 +170,6 @@ public final class DevDatabaseSeedTask {
 
   public void insertMinimalSampleProgram(
       ImmutableList<QuestionDefinition> createdSampleQuestions,
-      Messages messages,
       boolean enumeratorImprovementsEnabled) {
     try {
       ErrorAnd<ProgramDefinition, CiviFormError> programDefinitionResult =
@@ -193,7 +191,6 @@ public final class DevDatabaseSeedTask {
               /* categoryIds= */ ImmutableList.of(),
               /* applicationSteps= */ ImmutableList.of(
                   new ApplicationStep("step 1 title", "step 1 description")),
-              messages,
               enumeratorImprovementsEnabled);
       if (programDefinitionResult.isError()) {
         throw new RuntimeException(programDefinitionResult.getErrors().toString());
@@ -227,7 +224,6 @@ public final class DevDatabaseSeedTask {
 
   public void insertComprehensiveSampleProgram(
       ImmutableList<QuestionDefinition> createdSampleQuestions,
-      Messages messages,
       boolean enumeratorImprovementsEnabled) {
     try {
       ErrorAnd<ProgramDefinition, CiviFormError> programDefinitionResult =
@@ -249,7 +245,6 @@ public final class DevDatabaseSeedTask {
               /* categoryIds= */ ImmutableList.of(),
               /* applicationSteps= */ ImmutableList.of(
                   new ApplicationStep("step 1 title", "step 1 description")),
-              messages,
               enumeratorImprovementsEnabled);
       if (programDefinitionResult.isError()) {
         throw new RuntimeException(programDefinitionResult.getErrors().toString());
@@ -291,8 +286,7 @@ public final class DevDatabaseSeedTask {
 
       blockId =
           programService
-              .addBlockToProgram(
-                  programId, Optional.empty(), messages, enumeratorImprovementsEnabled)
+              .addBlockToProgram(programId, Optional.empty(), enumeratorImprovementsEnabled)
               .getResult()
               .maybeAddedBlock()
               .get()
@@ -314,8 +308,7 @@ public final class DevDatabaseSeedTask {
 
       blockId =
           programService
-              .addBlockToProgram(
-                  programId, Optional.of(true), messages, enumeratorImprovementsEnabled)
+              .addBlockToProgram(programId, Optional.of(true), enumeratorImprovementsEnabled)
               .getResult()
               .maybeAddedBlock()
               .get()
@@ -335,7 +328,7 @@ public final class DevDatabaseSeedTask {
       blockId =
           programService
               .addRepeatedBlockToProgram(
-                  programId, enumeratorBlockId, messages, enumeratorImprovementsEnabled)
+                  programId, enumeratorBlockId, enumeratorImprovementsEnabled)
               .getResult()
               .maybeAddedBlock()
               .get()
@@ -359,8 +352,7 @@ public final class DevDatabaseSeedTask {
 
       blockId =
           programService
-              .addBlockToProgram(
-                  programId, Optional.empty(), messages, enumeratorImprovementsEnabled)
+              .addBlockToProgram(programId, Optional.empty(), enumeratorImprovementsEnabled)
               .getResult()
               .maybeAddedBlock()
               .get()
@@ -379,8 +371,7 @@ public final class DevDatabaseSeedTask {
 
       blockId =
           programService
-              .addBlockToProgram(
-                  programId, Optional.empty(), messages, enumeratorImprovementsEnabled)
+              .addBlockToProgram(programId, Optional.empty(), enumeratorImprovementsEnabled)
               .getResult()
               .maybeAddedBlock()
               .get()
@@ -411,8 +402,7 @@ public final class DevDatabaseSeedTask {
       // Add file upload as optional to make local testing easier.
       blockId =
           programService
-              .addBlockToProgram(
-                  programId, Optional.empty(), messages, enumeratorImprovementsEnabled)
+              .addBlockToProgram(programId, Optional.empty(), enumeratorImprovementsEnabled)
               .getResult()
               .maybeAddedBlock()
               .get()

--- a/server/app/services/MessageKey.java
+++ b/server/app/services/MessageKey.java
@@ -249,8 +249,6 @@ public enum MessageKey {
   TEXT_REPEATED_QUESTIONS_DESCRIPTION("text.repeatedQuestions.description"),
   TEXT_REPEATED_SET("text.repeatedSet"),
   TEXT_REPEATED_SET_ADD_QUESTION_DESCRIPTION("text.repeatedSet.addQuestionDescription"),
-  TEXT_REPEATED_SET_PREFIX("text.repeatedSet.prefix"),
-  TEXT_REPEATED_SET_NESTED_PREFIX("text.repeatedSet.nestedPrefix"),
   TEXT_REPEATED_SET_SCREEN_NAME_DESCRIPTION("text.repeatedSet.screenNameDescription"),
   TEXT_VALIDATION_TOO_LONG("validation.textTooLong"),
   TEXT_VALIDATION_TOO_SHORT("validation.textTooShort"),

--- a/server/app/services/program/ProgramService.java
+++ b/server/app/services/program/ProgramService.java
@@ -39,7 +39,6 @@ import models.ProgramNotificationPreference;
 import models.VersionModel;
 import modules.MainModule;
 import org.apache.commons.lang3.StringUtils;
-import play.i18n.Messages;
 import play.libs.concurrent.ClassLoaderExecutionContext;
 import play.mvc.Http.Request;
 import repository.AccountRepository;
@@ -51,7 +50,6 @@ import repository.VersionRepository;
 import services.CiviFormError;
 import services.ErrorAnd;
 import services.LocalizedStrings;
-import services.MessageKey;
 import services.ProgramBlockValidation.AddQuestionResult;
 import services.ProgramBlockValidationFactory;
 import services.TranslationLocales;
@@ -407,7 +405,6 @@ public final class ProgramService {
       ImmutableList<Long> tiGroups,
       ImmutableList<Long> categoryIds,
       ImmutableList<ApplicationStep> applicationSteps,
-      Messages messages,
       boolean enumeratorImprovementsEnabled) {
     ImmutableSet<CiviFormError> errors =
         validateProgramDataForCreate(
@@ -432,7 +429,6 @@ public final class ProgramService {
             /* maybeEnumeratorBlockId= */ Optional.empty(),
             /* isEnumerator= */ Optional.empty(),
             /* isNested= */ false,
-            messages,
             enumeratorImprovementsEnabled);
     if (maybeEmptyBlock.isError()) {
       return ErrorAnd.error(maybeEmptyBlock.getErrors());
@@ -1369,14 +1365,11 @@ public final class ProgramService {
    * @throws ProgramNotFoundException when programId does not correspond to a real Program.
    */
   public ErrorAnd<ProgramBlockAdditionResult, CiviFormError> addBlockToProgram(
-      long programId,
-      Optional<Boolean> isEnumerator,
-      Messages messages,
-      boolean enumeratorImprovementsEnabled)
+      long programId, Optional<Boolean> isEnumerator, boolean enumeratorImprovementsEnabled)
       throws ProgramNotFoundException {
     try {
       return addBlockToProgram(
-          programId, Optional.empty(), isEnumerator, messages, enumeratorImprovementsEnabled);
+          programId, Optional.empty(), isEnumerator, enumeratorImprovementsEnabled);
     } catch (ProgramBlockDefinitionNotFoundException e) {
       throw new RuntimeException(
           "The ProgramBlockDefinitionNotFoundException should never be thrown when the enumerator"
@@ -1399,16 +1392,12 @@ public final class ProgramService {
    *     an enumerator block in the Program.
    */
   public ErrorAnd<ProgramBlockAdditionResult, CiviFormError> addRepeatedBlockToProgram(
-      long programId,
-      long enumeratorBlockId,
-      Messages messages,
-      boolean enumeratorImprovementsEnabled)
+      long programId, long enumeratorBlockId, boolean enumeratorImprovementsEnabled)
       throws ProgramNotFoundException, ProgramBlockDefinitionNotFoundException {
     return addBlockToProgram(
         programId,
         Optional.of(enumeratorBlockId),
         /* isEnumerator= */ Optional.empty(),
-        messages,
         enumeratorImprovementsEnabled);
   }
 
@@ -1428,16 +1417,12 @@ public final class ProgramService {
    *     correspond to an enumerator block in the Program.
    */
   public ErrorAnd<ProgramBlockAdditionResult, CiviFormError> addNestedRepeatedSetToProgram(
-      long programId,
-      long parentEnumeratorBlockId,
-      Messages messages,
-      boolean enumeratorImprovementsEnabled)
+      long programId, long parentEnumeratorBlockId, boolean enumeratorImprovementsEnabled)
       throws ProgramNotFoundException, ProgramBlockDefinitionNotFoundException {
     return addBlockToProgram(
         programId,
         Optional.of(parentEnumeratorBlockId),
         /* isEnumerator= */ Optional.of(true),
-        messages,
         enumeratorImprovementsEnabled);
   }
 
@@ -1445,7 +1430,6 @@ public final class ProgramService {
       long programId,
       Optional<Long> enumeratorBlockId,
       Optional<Boolean> isEnumerator,
-      Messages messages,
       boolean enumeratorImprovementsEnabled)
       throws ProgramNotFoundException, ProgramBlockDefinitionNotFoundException {
     ProgramDefinition programDefinition = getFullProgramDefinition(programId);
@@ -1465,7 +1449,6 @@ public final class ProgramService {
                     .enumeratorId()
                     .isPresent()
                 : false,
-            messages,
             enumeratorImprovementsEnabled);
     if (maybeBlockDefinition.isError()) {
       return ErrorAnd.errorAnd(
@@ -2230,7 +2213,6 @@ public final class ProgramService {
       Optional<Long> maybeEnumeratorBlockId,
       Optional<Boolean> isEnumerator,
       boolean isNested,
-      Messages messages,
       boolean enumeratorImprovementsEnabled) {
     String blockName =
         maybeEnumeratorBlockId.isPresent()
@@ -2239,15 +2221,11 @@ public final class ProgramService {
     String blockDescription = String.format("Screen %d description", blockId);
     Optional<String> namePrefix = Optional.empty();
     if (maybeEnumeratorBlockId.isPresent() && enumeratorImprovementsEnabled) {
+      // Placeholder tokens for a repeated block's name prefix. These are never displayed: admins
+      // see the bare block name, and Block.getLocalizedName() replaces each token with the
+      // applicant's listed entity name.
       namePrefix =
-          Optional.of(
-              isNested
-                  ? String.format(
-                      "[%s] - [%s] - ",
-                      messages.at(MessageKey.TEXT_REPEATED_SET_PREFIX.getKeyName()),
-                      messages.at(MessageKey.TEXT_REPEATED_SET_NESTED_PREFIX.getKeyName()))
-                  : String.format(
-                      "[%s] - ", messages.at(MessageKey.TEXT_REPEATED_SET_PREFIX.getKeyName())));
+          Optional.of(isNested ? "[parent entity] - [child entity] - " : "[parent entity] - ");
     }
     BlockDefinition blockDefinition =
         BlockDefinition.builder()

--- a/server/conf/i18n/messages
+++ b/server/conf/i18n/messages
@@ -1242,10 +1242,6 @@ button.repeatedSet.initialQuestion.removeAriaLabel=Remove the {0} initial questi
 text.repeatedSet=List set
 # Text letting admins know which block represents the group of screens for nested repeating questions
 text.nestedRepeatedSet=Nested list set
-# An uneditable prefix for the enumerator screen name representing the repeated object that will be enumerated
-text.repeatedSet.prefix=parent label
-# An uneditable prefix for the enumerator screen name representing the nested repeated object that will be enumerated
-text.repeatedSet.nestedPrefix=child label
 # Description shown beneath the screen name field in the screen editing modal, explaining that the applicant's listed entity appears in the screen name
 text.repeatedSet.screenNameDescription=Applicants will see the listed entity they answered from the initial question as part of the screen name. You can add more text in the first box below to provide further context. For example, if the initial question asks for household members and the applicant listed "Jennifer," the screen name could be: "Jennifer - Background Information".
 #An additional description explaining what the add question button does

--- a/server/conf/i18n/messages.am
+++ b/server/conf/i18n/messages.am
@@ -1240,10 +1240,6 @@ button.repeatedSet.initialQuestion.removeAriaLabel=
 text.repeatedSet=
 # Text letting admins know which block represents the group of screens for nested repeating questions
 text.nestedRepeatedSet=
-# An uneditable prefix for the enumerator screen name representing the repeated object that will be enumerated
-text.repeatedSet.prefix=የወላጅ መሰየሚያ
-# An uneditable prefix for the enumerator screen name representing the nested repeated object that will be enumerated
-text.repeatedSet.nestedPrefix=የልጅ መሰየሚያ
 #An additional description explaining the uneditable prefix within the screen editing modal
 text.repeatedSet.screenNameDescription=
 #An additional description explaining what the add question button does

--- a/server/conf/i18n/messages.ar
+++ b/server/conf/i18n/messages.ar
@@ -1240,10 +1240,6 @@ button.repeatedSet.initialQuestion.removeAriaLabel=
 text.repeatedSet=
 # Text letting admins know which block represents the group of screens for nested repeating questions
 text.nestedRepeatedSet=
-# An uneditable prefix for the enumerator screen name representing the repeated object that will be enumerated
-text.repeatedSet.prefix=التصنيف الرئيسي
-# An uneditable prefix for the enumerator screen name representing the nested repeated object that will be enumerated
-text.repeatedSet.nestedPrefix=التصنيف الفرعي
 #An additional description explaining the uneditable prefix within the screen editing modal
 text.repeatedSet.screenNameDescription=
 #An additional description explaining what the add question button does

--- a/server/conf/i18n/messages.de
+++ b/server/conf/i18n/messages.de
@@ -1240,10 +1240,6 @@ button.repeatedSet.initialQuestion.removeAriaLabel=
 text.repeatedSet=
 # Text letting admins know which block represents the group of screens for nested repeating questions
 text.nestedRepeatedSet=
-# An uneditable prefix for the enumerator screen name representing the repeated object that will be enumerated
-text.repeatedSet.prefix=
-# An uneditable prefix for the enumerator screen name representing the nested repeated object that will be enumerated
-text.repeatedSet.nestedPrefix=
 #An additional description explaining the uneditable prefix within the screen editing modal
 text.repeatedSet.screenNameDescription=
 #An additional description explaining what the add question button does

--- a/server/conf/i18n/messages.es-US
+++ b/server/conf/i18n/messages.es-US
@@ -1240,10 +1240,6 @@ button.repeatedSet.initialQuestion.removeAriaLabel=
 text.repeatedSet=
 # Text letting admins know which block represents the group of screens for nested repeating questions
 text.nestedRepeatedSet=
-# An uneditable prefix for the enumerator screen name representing the repeated object that will be enumerated
-text.repeatedSet.prefix=etiqueta principal
-# An uneditable prefix for the enumerator screen name representing the nested repeated object that will be enumerated
-text.repeatedSet.nestedPrefix=etiqueta secundaria
 #An additional description explaining the uneditable prefix within the screen editing modal
 text.repeatedSet.screenNameDescription=
 #An additional description explaining what the add question button does

--- a/server/conf/i18n/messages.fr
+++ b/server/conf/i18n/messages.fr
@@ -1240,10 +1240,6 @@ button.repeatedSet.initialQuestion.removeAriaLabel=
 text.repeatedSet=
 # Text letting admins know which block represents the group of screens for nested repeating questions
 text.nestedRepeatedSet=
-# An uneditable prefix for the enumerator screen name representing the repeated object that will be enumerated
-text.repeatedSet.prefix=étiquette parent
-# An uneditable prefix for the enumerator screen name representing the nested repeated object that will be enumerated
-text.repeatedSet.nestedPrefix=étiquette enfant
 #An additional description explaining the uneditable prefix within the screen editing modal
 text.repeatedSet.screenNameDescription=
 #An additional description explaining what the add question button does

--- a/server/conf/i18n/messages.ja
+++ b/server/conf/i18n/messages.ja
@@ -1240,10 +1240,6 @@ button.repeatedSet.initialQuestion.removeAriaLabel=
 text.repeatedSet=
 # Text letting admins know which block represents the group of screens for nested repeating questions
 text.nestedRepeatedSet=
-# An uneditable prefix for the enumerator screen name representing the repeated object that will be enumerated
-text.repeatedSet.prefix=親ラベル
-# An uneditable prefix for the enumerator screen name representing the nested repeated object that will be enumerated
-text.repeatedSet.nestedPrefix=子ラベル
 #An additional description explaining the uneditable prefix within the screen editing modal
 text.repeatedSet.screenNameDescription=
 #An additional description explaining what the add question button does

--- a/server/conf/i18n/messages.ko
+++ b/server/conf/i18n/messages.ko
@@ -1240,10 +1240,6 @@ button.repeatedSet.initialQuestion.removeAriaLabel=
 text.repeatedSet=
 # Text letting admins know which block represents the group of screens for nested repeating questions
 text.nestedRepeatedSet=
-# An uneditable prefix for the enumerator screen name representing the repeated object that will be enumerated
-text.repeatedSet.prefix=상위 라벨
-# An uneditable prefix for the enumerator screen name representing the nested repeated object that will be enumerated
-text.repeatedSet.nestedPrefix=하위 라벨
 #An additional description explaining the uneditable prefix within the screen editing modal
 text.repeatedSet.screenNameDescription=
 #An additional description explaining what the add question button does

--- a/server/conf/i18n/messages.lo
+++ b/server/conf/i18n/messages.lo
@@ -1240,10 +1240,6 @@ button.repeatedSet.initialQuestion.removeAriaLabel=
 text.repeatedSet=
 # Text letting admins know which block represents the group of screens for nested repeating questions
 text.nestedRepeatedSet=
-# An uneditable prefix for the enumerator screen name representing the repeated object that will be enumerated
-text.repeatedSet.prefix=
-# An uneditable prefix for the enumerator screen name representing the nested repeated object that will be enumerated
-text.repeatedSet.nestedPrefix=
 #An additional description explaining the uneditable prefix within the screen editing modal
 text.repeatedSet.screenNameDescription=
 #An additional description explaining what the add question button does

--- a/server/conf/i18n/messages.mh
+++ b/server/conf/i18n/messages.mh
@@ -1240,10 +1240,6 @@ button.repeatedSet.initialQuestion.removeAriaLabel=
 text.repeatedSet=
 # Text letting admins know which block represents the group of screens for nested repeating questions
 text.nestedRepeatedSet=
-# An uneditable prefix for the enumerator screen name representing the repeated object that will be enumerated
-text.repeatedSet.prefix=
-# An uneditable prefix for the enumerator screen name representing the nested repeated object that will be enumerated
-text.repeatedSet.nestedPrefix=
 #An additional description explaining the uneditable prefix within the screen editing modal
 text.repeatedSet.screenNameDescription=
 #An additional description explaining what the add question button does

--- a/server/conf/i18n/messages.om
+++ b/server/conf/i18n/messages.om
@@ -1240,10 +1240,6 @@ button.repeatedSet.initialQuestion.removeAriaLabel=
 text.repeatedSet=
 # Text letting admins know which block represents the group of screens for nested repeating questions
 text.nestedRepeatedSet=
-# An uneditable prefix for the enumerator screen name representing the repeated object that will be enumerated
-text.repeatedSet.prefix=
-# An uneditable prefix for the enumerator screen name representing the nested repeated object that will be enumerated
-text.repeatedSet.nestedPrefix=
 #An additional description explaining the uneditable prefix within the screen editing modal
 text.repeatedSet.screenNameDescription=
 #An additional description explaining what the add question button does

--- a/server/conf/i18n/messages.ru
+++ b/server/conf/i18n/messages.ru
@@ -1240,10 +1240,6 @@ button.repeatedSet.initialQuestion.removeAriaLabel=
 text.repeatedSet=
 # Text letting admins know which block represents the group of screens for nested repeating questions
 text.nestedRepeatedSet=
-# An uneditable prefix for the enumerator screen name representing the repeated object that will be enumerated
-text.repeatedSet.prefix=заголовок родительского элемента
-# An uneditable prefix for the enumerator screen name representing the nested repeated object that will be enumerated
-text.repeatedSet.nestedPrefix=заголовок дочернего элемента
 #An additional description explaining the uneditable prefix within the screen editing modal
 text.repeatedSet.screenNameDescription=
 #An additional description explaining what the add question button does

--- a/server/conf/i18n/messages.so
+++ b/server/conf/i18n/messages.so
@@ -1240,10 +1240,6 @@ button.repeatedSet.initialQuestion.removeAriaLabel=
 text.repeatedSet=
 # Text letting admins know which block represents the group of screens for nested repeating questions
 text.nestedRepeatedSet=
-# An uneditable prefix for the enumerator screen name representing the repeated object that will be enumerated
-text.repeatedSet.prefix=calaamada waalidka
-# An uneditable prefix for the enumerator screen name representing the nested repeated object that will be enumerated
-text.repeatedSet.nestedPrefix=calaamada ilmaha
 #An additional description explaining the uneditable prefix within the screen editing modal
 text.repeatedSet.screenNameDescription=
 #An additional description explaining what the add question button does

--- a/server/conf/i18n/messages.ti
+++ b/server/conf/i18n/messages.ti
@@ -1240,10 +1240,6 @@ button.repeatedSet.initialQuestion.removeAriaLabel=
 text.repeatedSet=
 # Text letting admins know which block represents the group of screens for nested repeating questions
 text.nestedRepeatedSet=
-# An uneditable prefix for the enumerator screen name representing the repeated object that will be enumerated
-text.repeatedSet.prefix=
-# An uneditable prefix for the enumerator screen name representing the nested repeated object that will be enumerated
-text.repeatedSet.nestedPrefix=
 #An additional description explaining the uneditable prefix within the screen editing modal
 text.repeatedSet.screenNameDescription=
 #An additional description explaining what the add question button does

--- a/server/conf/i18n/messages.tl
+++ b/server/conf/i18n/messages.tl
@@ -1240,10 +1240,6 @@ button.repeatedSet.initialQuestion.removeAriaLabel=
 text.repeatedSet=
 # Text letting admins know which block represents the group of screens for nested repeating questions
 text.nestedRepeatedSet=
-# An uneditable prefix for the enumerator screen name representing the repeated object that will be enumerated
-text.repeatedSet.prefix=magulang na label
-# An uneditable prefix for the enumerator screen name representing the nested repeated object that will be enumerated
-text.repeatedSet.nestedPrefix=anak na label
 #An additional description explaining the uneditable prefix within the screen editing modal
 text.repeatedSet.screenNameDescription=
 #An additional description explaining what the add question button does

--- a/server/conf/i18n/messages.vi
+++ b/server/conf/i18n/messages.vi
@@ -1240,10 +1240,6 @@ button.repeatedSet.initialQuestion.removeAriaLabel=
 text.repeatedSet=
 # Text letting admins know which block represents the group of screens for nested repeating questions
 text.nestedRepeatedSet=
-# An uneditable prefix for the enumerator screen name representing the repeated object that will be enumerated
-text.repeatedSet.prefix=nhãn chính
-# An uneditable prefix for the enumerator screen name representing the nested repeated object that will be enumerated
-text.repeatedSet.nestedPrefix=nhãn phụ
 #An additional description explaining the uneditable prefix within the screen editing modal
 text.repeatedSet.screenNameDescription=
 #An additional description explaining what the add question button does

--- a/server/conf/i18n/messages.zh-TW
+++ b/server/conf/i18n/messages.zh-TW
@@ -1240,10 +1240,6 @@ button.repeatedSet.initialQuestion.removeAriaLabel=
 text.repeatedSet=
 # Text letting admins know which block represents the group of screens for nested repeating questions
 text.nestedRepeatedSet=
-# An uneditable prefix for the enumerator screen name representing the repeated object that will be enumerated
-text.repeatedSet.prefix=父標籤
-# An uneditable prefix for the enumerator screen name representing the nested repeated object that will be enumerated
-text.repeatedSet.nestedPrefix=子標籤
 #An additional description explaining the uneditable prefix within the screen editing modal
 text.repeatedSet.screenNameDescription=
 #An additional description explaining what the add question button does

--- a/server/test/controllers/admin/AdminProgramControllerTest.java
+++ b/server/test/controllers/admin/AdminProgramControllerTest.java
@@ -21,7 +21,6 @@ import models.ProgramModel;
 import org.junit.Before;
 import org.junit.Test;
 import play.data.FormFactory;
-import play.i18n.MessagesApi;
 import play.mvc.Http.Request;
 import play.mvc.Result;
 import repository.ProgramRepository;
@@ -88,7 +87,6 @@ public class AdminProgramControllerTest extends ResetPostgres {
             instanceOf(ProfileUtils.class),
             instanceOf(FormFactory.class),
             instanceOf(RequestChecker.class),
-            instanceOf(MessagesApi.class),
             instanceOf(SettingsManifest.class));
   }
 

--- a/server/test/controllers/dev/seeding/DevDatabaseSeedTaskTest.java
+++ b/server/test/controllers/dev/seeding/DevDatabaseSeedTaskTest.java
@@ -4,7 +4,6 @@ import static controllers.dev.seeding.SampleQuestionDefinitions.ADDRESS_QUESTION
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import java.util.Set;
 import models.CategoryModel;
 import models.LifecycleStage;
@@ -12,8 +11,6 @@ import models.QuestionModel;
 import org.junit.Before;
 import org.junit.Test;
 import play.i18n.Lang;
-import play.i18n.Messages;
-import play.i18n.MessagesApi;
 import repository.CategoryRepository;
 import repository.ProgramRepository;
 import repository.QuestionRepository;
@@ -27,7 +24,6 @@ public class DevDatabaseSeedTaskTest extends ResetPostgres {
   private ProgramRepository programRepository;
   private CategoryRepository categoryRepository;
   private DevDatabaseSeedTask devDatabaseSeedTask;
-  private Messages messages;
 
   @Before
   public void setUp() {
@@ -35,7 +31,6 @@ public class DevDatabaseSeedTaskTest extends ResetPostgres {
     programRepository = instanceOf(ProgramRepository.class);
     categoryRepository = instanceOf(CategoryRepository.class);
     devDatabaseSeedTask = instanceOf(DevDatabaseSeedTask.class);
-    messages = instanceOf(MessagesApi.class).preferred(ImmutableSet.of(Lang.defaultLang()));
   }
 
   @Test
@@ -66,9 +61,9 @@ public class DevDatabaseSeedTaskTest extends ResetPostgres {
     ImmutableList<QuestionDefinition> seededQuestions = devDatabaseSeedTask.seedQuestions();
 
     devDatabaseSeedTask.insertMinimalSampleProgram(
-        seededQuestions, messages, /* enumeratorImprovementsEnabled= */ false);
+        seededQuestions, /* enumeratorImprovementsEnabled= */ false);
     devDatabaseSeedTask.insertComprehensiveSampleProgram(
-        seededQuestions, messages, /* enumeratorImprovementsEnabled= */ false);
+        seededQuestions, /* enumeratorImprovementsEnabled= */ false);
 
     assertThat(programRepository.getAllProgramNames())
         .containsExactlyInAnyOrder("comprehensive-sample-program", "minimal-sample-program");

--- a/server/test/services/program/ProgramServiceTest.java
+++ b/server/test/services/program/ProgramServiceTest.java
@@ -4190,7 +4190,7 @@ public class ProgramServiceTest extends ResetPostgres {
             /* isNested= */ false,
             /* enumeratorImprovementsEnabled= */ true);
 
-    assertThat(result.getResult().namePrefix().get()).isEqualTo("[parent label] - ");
+    assertThat(result.getResult().namePrefix().get()).isEqualTo("[parent entity] - ");
 
     ErrorAnd<BlockDefinition, CiviFormError> nestedBlock =
         ps.createEmptyBlockDefinition(
@@ -4201,6 +4201,6 @@ public class ProgramServiceTest extends ResetPostgres {
             /* enumeratorImprovementsEnabled= */ true);
 
     assertThat(nestedBlock.getResult().namePrefix().get())
-        .isEqualTo("[parent label] - [child label] - ");
+        .isEqualTo("[parent entity] - [child entity] - ");
   }
 }

--- a/server/test/services/program/ProgramServiceTest.java
+++ b/server/test/services/program/ProgramServiceTest.java
@@ -43,8 +43,6 @@ import org.mockito.Mockito;
 import play.cache.NamedCacheImpl;
 import play.cache.SyncCacheApi;
 import play.i18n.Lang;
-import play.i18n.Messages;
-import play.i18n.MessagesApi;
 import play.inject.BindingKey;
 import play.libs.concurrent.ClassLoaderExecutionContext;
 import play.mvc.Http.Request;
@@ -88,7 +86,6 @@ public class ProgramServiceTest extends ResetPostgres {
   private TranslationLocales translationLocales;
   private SettingsManifest mockSettingsManifest;
   private final Request fakeRequest = fakeRequestBuilder().build();
-  private Messages messages;
 
   @Before
   public void setProgramServiceImpl() {
@@ -121,7 +118,6 @@ public class ProgramServiceTest extends ResetPostgres {
         testQuestionBank.enumeratorApplicantHouseholdMembers().getQuestionDefinition();
     categoryRepository = instanceOf(CategoryRepository.class);
     mockSettingsManifest = Mockito.mock(SettingsManifest.class);
-    messages = instanceOf(MessagesApi.class).preferred(ImmutableSet.of(Lang.defaultLang()));
   }
 
   @Test
@@ -537,7 +533,6 @@ public class ProgramServiceTest extends ResetPostgres {
             ImmutableList.of(),
             /* categoryIds= */ ImmutableList.of(),
             ImmutableList.of(new ApplicationStep("title", "description")),
-            messages,
             /* enumeratorImprovementsEnabled= */ false);
 
     assertThat(result.hasResult()).isTrue();
@@ -565,7 +560,6 @@ public class ProgramServiceTest extends ResetPostgres {
             ImmutableList.of(),
             /* categoryIds= */ ImmutableList.of(),
             ImmutableList.of(new ApplicationStep("title", "description")),
-            messages,
             /* enumeratorImprovementsEnabled= */ false);
 
     assertThat(result.hasResult()).isTrue();
@@ -593,7 +587,6 @@ public class ProgramServiceTest extends ResetPostgres {
             ImmutableList.of(),
             /* categoryIds= */ ImmutableList.of(),
             ImmutableList.of(new ApplicationStep("title", "description")),
-            messages,
             /* enumeratorImprovementsEnabled= */ false);
 
     assertThat(result.hasResult()).isTrue();
@@ -623,7 +616,6 @@ public class ProgramServiceTest extends ResetPostgres {
             ImmutableList.of(),
             /* categoryIds= */ ImmutableList.of(),
             ImmutableList.of(new ApplicationStep("title", "description")),
-            messages,
             /* enumeratorImprovementsEnabled= */ false);
 
     assertThat(result.hasResult()).isFalse();
@@ -655,7 +647,6 @@ public class ProgramServiceTest extends ResetPostgres {
             /* tiGroup */ ImmutableList.of(),
             /* categoryIds= */ ImmutableList.of(),
             ImmutableList.of(new ApplicationStep("title", "description")),
-            messages,
             /* enumeratorImprovementsEnabled= */ false);
 
     assertThat(result.hasResult()).isFalse();
@@ -685,7 +676,6 @@ public class ProgramServiceTest extends ResetPostgres {
             /* tiGroup */ ImmutableList.of(),
             /* categoryIds= */ ImmutableList.of(),
             ImmutableList.of(new ApplicationStep("title", "description")),
-            messages,
             /* enumeratorImprovementsEnabled= */ false);
 
     assertThat(result.hasResult()).isFalse();
@@ -712,7 +702,6 @@ public class ProgramServiceTest extends ResetPostgres {
         ImmutableList.of(),
         /* categoryIds= */ ImmutableList.of(),
         ImmutableList.of(new ApplicationStep("title", "description")),
-        messages,
         /* enumeratorImprovementsEnabled= */ false);
 
     ErrorAnd<ProgramDefinition, CiviFormError> result =
@@ -732,7 +721,6 @@ public class ProgramServiceTest extends ResetPostgres {
             ImmutableList.of(),
             /* categoryIds= */ ImmutableList.of(),
             ImmutableList.of(new ApplicationStep("title", "description")),
-            messages,
             /* enumeratorImprovementsEnabled= */ false);
 
     assertThat(result.hasResult()).isFalse();
@@ -761,7 +749,6 @@ public class ProgramServiceTest extends ResetPostgres {
             ImmutableList.of(),
             /* categoryIds= */ ImmutableList.of(),
             ImmutableList.of(new ApplicationStep("title", "description")),
-            messages,
             /* enumeratorImprovementsEnabled= */ false);
 
     assertThat(result.hasResult()).isFalse();
@@ -794,7 +781,6 @@ public class ProgramServiceTest extends ResetPostgres {
                 ImmutableList.of(),
                 /* categoryIds= */ ImmutableList.of(),
                 ImmutableList.of(new ApplicationStep("title", "description")),
-                messages,
                 /* enumeratorImprovementsEnabled= */ false)
             .getResult();
     // Program name here is missing the extra space
@@ -822,7 +808,6 @@ public class ProgramServiceTest extends ResetPostgres {
             ImmutableList.of(),
             /* categoryIds= */ ImmutableList.of(),
             ImmutableList.of(new ApplicationStep("title", "description")),
-            messages,
             /* enumeratorImprovementsEnabled= */ false);
     assertThat(result.hasResult()).isFalse();
     assertThat(result.isError()).isTrue();
@@ -849,7 +834,6 @@ public class ProgramServiceTest extends ResetPostgres {
             ImmutableList.of(),
             /* categoryIds= */ ImmutableList.of(),
             ImmutableList.of(new ApplicationStep("title", "description")),
-            messages,
             /* enumeratorImprovementsEnabled= */ false);
 
     assertThat(result.hasResult()).isTrue();
@@ -876,7 +860,6 @@ public class ProgramServiceTest extends ResetPostgres {
             ImmutableList.of(),
             /* categoryIds= */ ImmutableList.of(),
             ImmutableList.of(new ApplicationStep("title", "description")),
-            messages,
             /* enumeratorImprovementsEnabled= */ false);
 
     assertThat(result.hasResult()).isTrue();
@@ -902,7 +885,6 @@ public class ProgramServiceTest extends ResetPostgres {
         ImmutableList.of(),
         /* categoryIds= */ ImmutableList.of(),
         ImmutableList.of(new ApplicationStep("title", "description")),
-        messages,
         /* enumeratorImprovementsEnabled= */ false);
     ErrorAnd<ProgramDefinition, CiviFormError> result =
         ps.createProgramDefinition(
@@ -921,7 +903,6 @@ public class ProgramServiceTest extends ResetPostgres {
             ImmutableList.of(),
             /* categoryIds= */ ImmutableList.of(),
             ImmutableList.of(new ApplicationStep("title", "description")),
-            messages,
             /* enumeratorImprovementsEnabled= */ false);
 
     assertThat(result.hasResult()).isTrue();
@@ -947,7 +928,6 @@ public class ProgramServiceTest extends ResetPostgres {
         ImmutableList.of(),
         /* categoryIds= */ ImmutableList.of(),
         ImmutableList.of(new ApplicationStep("title", "description")),
-        messages,
         /* enumeratorImprovementsEnabled= */ false);
 
     Optional<ProgramDefinition> preScreenerForm = ps.getPreScreenerForm();
@@ -971,7 +951,6 @@ public class ProgramServiceTest extends ResetPostgres {
             ImmutableList.of(),
             /* categoryIds= */ ImmutableList.of(),
             ImmutableList.of(new ApplicationStep("title", "description")),
-            messages,
             /* enumeratorImprovementsEnabled= */ false);
     assertThat(result.hasResult()).isTrue();
     assertThat(result.isError()).isFalse();
@@ -1187,7 +1166,6 @@ public class ProgramServiceTest extends ResetPostgres {
                 ImmutableList.of(),
                 /* categoryIds= */ ImmutableList.of(),
                 ImmutableList.of(new ApplicationStep("title", "description")),
-                messages,
                 /* enumeratorImprovementsEnabled= */ false)
             .getResult();
     // Program name here is missing the extra space
@@ -1655,7 +1633,6 @@ public class ProgramServiceTest extends ResetPostgres {
         ImmutableList.of(),
         /* categoryIds= */ ImmutableList.of(),
         ImmutableList.of(new ApplicationStep("title", "description")),
-        messages,
         /* enumeratorImprovementsEnabled= */ false);
 
     Optional<ProgramDefinition> preScreenerForm = ps.getPreScreenerForm();
@@ -1713,7 +1690,6 @@ public class ProgramServiceTest extends ResetPostgres {
             ImmutableList.of(),
             /* categoryIds= */ ImmutableList.of(),
             ImmutableList.of(new ApplicationStep("title", "description")),
-            messages,
             /* enumeratorImprovementsEnabled= */ false);
 
     ErrorAnd<ProgramDefinition, CiviFormError> result =
@@ -1758,7 +1734,6 @@ public class ProgramServiceTest extends ResetPostgres {
             ImmutableList.of(),
             /* categoryIds= */ ImmutableList.of(),
             ImmutableList.of(new ApplicationStep("title", "description")),
-            messages,
             /* enumeratorImprovementsEnabled= */ false);
 
     ErrorAnd<ProgramDefinition, CiviFormError> result =
@@ -2214,7 +2189,6 @@ public class ProgramServiceTest extends ResetPostgres {
                 ps.addBlockToProgram(
                     /* programId= */ 1L,
                     /* isEnumerator= */ Optional.empty(),
-                    messages,
                     /* enumeratorImprovementsEnabled= */ false))
         .isInstanceOf(ProgramNotFoundException.class)
         .hasMessage("Program not found for ID: 1");
@@ -2228,7 +2202,6 @@ public class ProgramServiceTest extends ResetPostgres {
         ps.addBlockToProgram(
             /* programId= */ programDefinition.id(),
             /* isEnumerator= */ Optional.empty(),
-            messages,
             /* enumeratorImprovementsEnabled= */ false);
 
     assertThat(result.isError()).isFalse();
@@ -2264,7 +2237,6 @@ public class ProgramServiceTest extends ResetPostgres {
         ps.addBlockToProgram(
             /* programId= */ programDefinition.id(),
             /* isEnumerator= */ Optional.empty(),
-            messages,
             /* enumeratorImprovementsEnabled= */ false);
 
     assertThat(result.isError()).isFalse();
@@ -2291,7 +2263,6 @@ public class ProgramServiceTest extends ResetPostgres {
         ps.addBlockToProgram(
             /* programId= */ programDefinition.id(),
             /* isEnumerator= */ Optional.of(true),
-            messages,
             /* enumeratorImprovementsEnabled= */ false);
 
     assertThat(result.isError()).isFalse();
@@ -2320,8 +2291,7 @@ public class ProgramServiceTest extends ResetPostgres {
             .build();
 
     ErrorAnd<ProgramBlockAdditionResult, CiviFormError> result =
-        ps.addRepeatedBlockToProgram(
-            program.id, 1L, messages, /* enumeratorImprovementsEnabled= */ false);
+        ps.addRepeatedBlockToProgram(program.id, 1L, /* enumeratorImprovementsEnabled= */ false);
 
     assertThat(result.isError()).isFalse();
     assertThat(result.hasResult()).isTrue();
@@ -2373,8 +2343,7 @@ public class ProgramServiceTest extends ResetPostgres {
             .build();
 
     ErrorAnd<ProgramBlockAdditionResult, CiviFormError> result =
-        ps.addRepeatedBlockToProgram(
-            program.id, 2L, messages, /* enumeratorImprovementsEnabled= */ false);
+        ps.addRepeatedBlockToProgram(program.id, 2L, /* enumeratorImprovementsEnabled= */ false);
 
     assertThat(result.isError()).isFalse();
     assertThat(result.hasResult()).isTrue();
@@ -2416,9 +2385,7 @@ public class ProgramServiceTest extends ResetPostgres {
   @Test
   public void addRepeatedBlockToProgram_invalidProgramId_throwsProgramNotFoundException() {
     assertThatThrownBy(
-            () ->
-                ps.addRepeatedBlockToProgram(
-                    1L, 1L, messages, /* enumeratorImprovementsEnabled= */ false))
+            () -> ps.addRepeatedBlockToProgram(1L, 1L, /* enumeratorImprovementsEnabled= */ false))
         .isInstanceOf(ProgramNotFoundException.class);
   }
 
@@ -2430,7 +2397,7 @@ public class ProgramServiceTest extends ResetPostgres {
     assertThatThrownBy(
             () ->
                 ps.addRepeatedBlockToProgram(
-                    program.id, 5L, messages, /* enumeratorImprovementsEnabled= */ false))
+                    program.id, 5L, /* enumeratorImprovementsEnabled= */ false))
         .isInstanceOf(ProgramBlockDefinitionNotFoundException.class);
   }
 
@@ -2518,7 +2485,6 @@ public class ProgramServiceTest extends ResetPostgres {
                 ImmutableList.of(),
                 /* categoryIds= */ ImmutableList.of(),
                 ImmutableList.of(new ApplicationStep("title", "description")),
-                messages,
                 /* enumeratorImprovementsEnabled= */ false)
             .getResult();
     assertThatThrownBy(() -> ps.setBlockQuestions(p.id(), 100L, ImmutableList.of()))
@@ -3248,7 +3214,6 @@ public class ProgramServiceTest extends ResetPostgres {
         ps.addBlockToProgram(
             /* programId= */ programDefinition.id(),
             /* isEnumerator= */ Optional.empty(),
-            messages,
             /* enumeratorImprovementsEnabled= */ false);
     Optional<LocalizedStrings> eligibilityMsg =
         Optional.of(LocalizedStrings.of(Locale.US, "custom eligibility message"));
@@ -3274,7 +3239,6 @@ public class ProgramServiceTest extends ResetPostgres {
         ps.addBlockToProgram(
             /* programId= */ programDefinition.id(),
             /* isEnumerator= */ Optional.empty(),
-            messages,
             /* enumeratorImprovementsEnabled= */ false);
     Optional<LocalizedStrings> firstEligibilityMsg =
         Optional.of(LocalizedStrings.of(Locale.US, "first custom eligibility message"));
@@ -4224,7 +4188,6 @@ public class ProgramServiceTest extends ResetPostgres {
             Optional.of(2L),
             Optional.of(true),
             /* isNested= */ false,
-            messages,
             /* enumeratorImprovementsEnabled= */ true);
 
     assertThat(result.getResult().namePrefix().get()).isEqualTo("[parent label] - ");
@@ -4235,7 +4198,6 @@ public class ProgramServiceTest extends ResetPostgres {
             Optional.of(2L),
             Optional.of(true),
             /* isNested= */ true,
-            messages,
             /* enumeratorImprovementsEnabled= */ true);
 
     assertThat(nestedBlock.getResult().namePrefix().get())


### PR DESCRIPTION
### Description

Removing two translation messages which are no longer needed as a result of PR #13817 in which we removed the screen name prefix placeholders from view.  The actual placeholder text is no longer important.  Only the number of  dash-delimited parts (1 = single level, 2 = nested) is load-bearing, so this text does not need to be localized.

Removed all the now-unused piping of the Messages object.

### Checklist

#### General

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [ ] Added an additional reviewer as required if changes potentially affect the security of the application.
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

