### PR TITLE
[Scored Questions] Frontend work for new score option

### DIFF
--- a/browser-test/src/admin/admin_dropdown_create_and_edit.test.ts
+++ b/browser-test/src/admin/admin_dropdown_create_and_edit.test.ts
@@ -1,5 +1,10 @@
 import {test, expect} from '../support/civiform_fixtures'
-import {enableFeatureFlag, loginAsAdmin, waitForPageJsLoad} from '../support'
+import {
+  disableFeatureFlag,
+  enableFeatureFlag,
+  loginAsAdmin,
+  waitForPageJsLoad,
+} from '../support'
 
 test.describe('create dropdown question with options', () => {
   test.beforeEach(async ({page}) => {
@@ -123,6 +128,132 @@ test.describe('create dropdown question with options', () => {
     await adminQuestions.expectExistingMultiOptionAnswer(1, {
       adminName: 'mango_admin',
       text: 'mango',
+    })
+  })
+
+  test('options scoring works correctly', async ({page, adminQuestions}) => {
+    const questionName = 'favorite ice cream'
+
+    await test.step(`setup`, async () => {
+      await enableFeatureFlag(page, 'ANSWER_OPTION_SCORING_ENABLED')
+
+      await loginAsAdmin(page)
+
+      await page.click('text=Questions')
+      await waitForPageJsLoad(page)
+
+      await page.click('#create-question-button')
+      await page.click('#create-dropdown-question')
+      await waitForPageJsLoad(page)
+
+      // Fill in basic info
+      await page.fill('text=Question Text', 'questionText')
+      await page.fill('text=Question help text', 'helpText')
+      await page.fill('text=Administrative identifier', questionName)
+      await page.fill(
+        'text=Question note for administrative use only',
+        'description',
+      )
+    })
+
+    await test.step(`add options with scores`, async () => {
+      // Add three options
+      await page.click('#add-new-option')
+      await adminQuestions.fillMultiOptionAnswer(0, {
+        adminName: 'chocolate_admin',
+        text: 'chocolate',
+        score: '1',
+      })
+      await page.click('#add-new-option')
+      await adminQuestions.fillMultiOptionAnswer(1, {
+        adminName: 'vanilla_admin',
+        text: 'vanilla',
+        score: '2',
+      })
+      await page.click('#add-new-option')
+      await adminQuestions.fillMultiOptionAnswer(2, {
+        adminName: 'strawberry_admin',
+        text: 'strawberry',
+        score: '3',
+      })
+      await adminQuestions.clickSubmitButtonAndNavigate('Create')
+      await adminQuestions.expectDraftQuestionExist(questionName)
+    })
+
+    await test.step(`edit the question and check scores were preserved`, async () => {
+      await adminQuestions.gotoQuestionEditPage(questionName)
+      await adminQuestions.expectExistingMultiOptionAnswer(0, {
+        adminName: 'chocolate_admin',
+        text: 'chocolate',
+        score: '1',
+      })
+      await adminQuestions.expectExistingMultiOptionAnswer(1, {
+        adminName: 'vanilla_admin',
+        text: 'vanilla',
+        score: '2',
+      })
+      await adminQuestions.expectExistingMultiOptionAnswer(2, {
+        adminName: 'strawberry_admin',
+        text: 'strawberry',
+        score: '3',
+      })
+    })
+
+    await test.step(`trigger missing score error`, async () => {
+      await adminQuestions.changeMultiOptionScore(1, '')
+      await adminQuestions.clickSubmitButtonAndNavigate('Update')
+      await expect(
+        page.getByRole('alert').filter({
+          hasText:
+            'Error: When creating a scored question, all options must include scores.',
+        }),
+      ).toBeVisible()
+    })
+
+    await test.step(`remove all scores and submit successfully`, async () => {
+      await adminQuestions.changeMultiOptionScore(0, '')
+      await adminQuestions.changeMultiOptionScore(1, '')
+      await adminQuestions.changeMultiOptionScore(2, '')
+      await adminQuestions.clickSubmitButtonAndNavigate('Update')
+      await adminQuestions.expectDraftQuestionExist(questionName)
+    })
+
+    await test.step(`confirm scores are preserved even when flag is turned off`, async () => {
+      // add scores back in
+      await adminQuestions.gotoQuestionEditPage(questionName)
+      await adminQuestions.changeMultiOptionScore(0, '4')
+      await adminQuestions.changeMultiOptionScore(1, '5')
+      await adminQuestions.changeMultiOptionScore(2, '6')
+      await adminQuestions.clickSubmitButtonAndNavigate('Update')
+      await adminQuestions.expectDraftQuestionExist(questionName)
+
+      // disable flag and edit question
+      await disableFeatureFlag(page, 'ANSWER_OPTION_SCORING_ENABLED')
+      await adminQuestions.gotoQuestionEditPage(questionName)
+      await adminQuestions.expectMultiOptionScoreInputHidden(1)
+      await adminQuestions.expectMultiOptionScoreInputHidden(2)
+      await adminQuestions.expectMultiOptionScoreInputHidden(3)
+      await adminQuestions.changeMultiOptionAnswer(0, 'pistachio')
+      await adminQuestions.clickSubmitButtonAndNavigate('Update')
+
+      // toggle flag on, edit question, see old scores preserved
+      await enableFeatureFlag(page, 'ANSWER_OPTION_SCORING_ENABLED')
+      await adminQuestions.gotoQuestionEditPage(questionName)
+      await adminQuestions.expectExistingMultiOptionAnswer(0, {
+        adminName: 'chocolate_admin',
+        text: 'pistachio',
+        score: '4',
+      })
+      await adminQuestions.expectExistingMultiOptionAnswer(1, {
+        adminName: 'vanilla_admin',
+        text: 'vanilla',
+        score: '5',
+      })
+      await adminQuestions.expectExistingMultiOptionAnswer(2, {
+        adminName: 'strawberry_admin',
+        text: 'strawberry',
+        score: '6',
+      })
     })
   })
 })

--- a/browser-test/src/admin/admin_dropdown_create_and_edit_legacy.test.ts
+++ b/browser-test/src/admin/admin_dropdown_create_and_edit_legacy.test.ts
@@ -1,5 +1,10 @@
 import {test, expect} from '../support/civiform_fixtures'
-import {disableFeatureFlag, loginAsAdmin, waitForPageJsLoad} from '../support'
+import {
+  enableFeatureFlag,
+  disableFeatureFlag,
+  loginAsAdmin,
+  waitForPageJsLoad,
+} from '../support'
 
 test.describe('create dropdown question with options', () => {
   test.beforeEach(async ({page}) => {
@@ -123,6 +128,132 @@ test.describe('create dropdown question with options', () => {
     await adminQuestions.expectExistingMultiOptionAnswer(1, {
       adminName: 'mango_admin',
       text: 'mango',
+    })
+  })
+
+  test('options scoring works correctly', async ({page, adminQuestions}) => {
+    const questionName = 'favorite ice cream'
+
+    await test.step(`setup`, async () => {
+      await enableFeatureFlag(page, 'ANSWER_OPTION_SCORING_ENABLED')
+
+      await loginAsAdmin(page)
+
+      await page.click('text=Questions')
+      await waitForPageJsLoad(page)
+
+      await page.click('#create-question-button')
+      await page.click('#create-dropdown-question')
+      await waitForPageJsLoad(page)
+
+      // Fill in basic info
+      await page.fill('text=Question Text', 'questionText')
+      await page.fill('text=Question help text', 'helpText')
+      await page.fill('text=Administrative identifier', questionName)
+      await page.fill(
+        'text=Question note for administrative use only',
+        'description',
+      )
+    })
+
+    await test.step(`add options with scores`, async () => {
+      // Add three options
+      await page.click('#add-new-option')
+      await adminQuestions.fillMultiOptionAnswer(0, {
+        adminName: 'chocolate_admin',
+        text: 'chocolate',
+        score: '1',
+      })
+      await page.click('#add-new-option')
+      await adminQuestions.fillMultiOptionAnswer(1, {
+        adminName: 'vanilla_admin',
+        text: 'vanilla',
+        score: '2',
+      })
+      await page.click('#add-new-option')
+      await adminQuestions.fillMultiOptionAnswer(2, {
+        adminName: 'strawberry_admin',
+        text: 'strawberry',
+        score: '3',
+      })
+      await adminQuestions.clickSubmitButtonAndNavigate('Create')
+      await adminQuestions.expectDraftQuestionExist(questionName)
+    })
+
+    await test.step(`edit the question and check scores were preserved`, async () => {
+      await adminQuestions.gotoQuestionEditPage(questionName)
+      await adminQuestions.expectExistingMultiOptionAnswer(0, {
+        adminName: 'chocolate_admin',
+        text: 'chocolate',
+        score: '1',
+      })
+      await adminQuestions.expectExistingMultiOptionAnswer(1, {
+        adminName: 'vanilla_admin',
+        text: 'vanilla',
+        score: '2',
+      })
+      await adminQuestions.expectExistingMultiOptionAnswer(2, {
+        adminName: 'strawberry_admin',
+        text: 'strawberry',
+        score: '3',
+      })
+    })
+
+    await test.step(`trigger missing score error`, async () => {
+      await adminQuestions.changeMultiOptionScore(1, '')
+      await adminQuestions.clickSubmitButtonAndNavigate('Update')
+      await expect(
+        page.getByRole('alert').filter({
+          hasText:
+            'Error: When creating a scored question, all options must include scores.',
+        }),
+      ).toBeVisible()
+    })
+
+    await test.step(`remove all scores and submit successfully`, async () => {
+      await adminQuestions.changeMultiOptionScore(0, '')
+      await adminQuestions.changeMultiOptionScore(1, '')
+      await adminQuestions.changeMultiOptionScore(2, '')
+      await adminQuestions.clickSubmitButtonAndNavigate('Update')
+      await adminQuestions.expectDraftQuestionExist(questionName)
+    })
+
+    await test.step(`confirm scores are preserved even when flag is turned off`, async () => {
+      // add scores back in
+      await adminQuestions.gotoQuestionEditPage(questionName)
+      await adminQuestions.changeMultiOptionScore(0, '4')
+      await adminQuestions.changeMultiOptionScore(1, '5')
+      await adminQuestions.changeMultiOptionScore(2, '6')
+      await adminQuestions.clickSubmitButtonAndNavigate('Update')
+      await adminQuestions.expectDraftQuestionExist(questionName)
+
+      // disable flag and edit question
+      await disableFeatureFlag(page, 'ANSWER_OPTION_SCORING_ENABLED')
+      await adminQuestions.gotoQuestionEditPage(questionName)
+      await adminQuestions.expectMultiOptionScoreInputHidden(1)
+      await adminQuestions.expectMultiOptionScoreInputHidden(2)
+      await adminQuestions.expectMultiOptionScoreInputHidden(3)
+      await adminQuestions.changeMultiOptionAnswer(0, 'pistachio')
+      await adminQuestions.clickSubmitButtonAndNavigate('Update')
+
+      // toggle flag on, edit question, see old scores preserved
+      await enableFeatureFlag(page, 'ANSWER_OPTION_SCORING_ENABLED')
+      await adminQuestions.gotoQuestionEditPage(questionName)
+      await adminQuestions.expectExistingMultiOptionAnswer(0, {
+        adminName: 'chocolate_admin',
+        text: 'pistachio',
+        score: '4',
+      })
+      await adminQuestions.expectExistingMultiOptionAnswer(1, {
+        adminName: 'vanilla_admin',
+        text: 'vanilla',
+        score: '5',
+      })
+      await adminQuestions.expectExistingMultiOptionAnswer(2, {
+        adminName: 'strawberry_admin',
+        text: 'strawberry',
+        score: '6',
+      })
     })
   })
 })

--- a/browser-test/src/admin/admin_yes_no_question.test.ts
+++ b/browser-test/src/admin/admin_yes_no_question.test.ts
@@ -70,4 +70,19 @@ test.describe('Yes/no translations', () => {
       await expect(page.getByText('Answer options')).toHaveCount(0)
     })
   })
+
+  test('optional question scores do not show up for yes/no questions', async ({
+    page,
+    adminQuestions,
+  }) => {
+    await test.step('setup', async () => {
+      await enableFeatureFlag(page, 'ANSWER_OPTION_SCORING_ENABLED')
+      await loginAsAdmin(page)
+    })
+
+    await test.step('scores are hidden', async () => {
+      await adminQuestions.startCreatingQuestion('#create-yes_no-question')
+      await adminQuestions.expectMultiOptionScoreInputHidden(0)
+    })
+  })
 })

--- a/browser-test/src/admin/admin_yes_no_question_legacy.test.ts
+++ b/browser-test/src/admin/admin_yes_no_question_legacy.test.ts
@@ -1,5 +1,6 @@
 import {expect, test} from '../support/civiform_fixtures'
 import {
+  enableFeatureFlag,
   disableFeatureFlag,
   loginAsAdmin,
   validateScreenshot,
@@ -68,6 +69,21 @@ test.describe('Yes/no translations', () => {
         page.getByText('Yes/No question options are pre-translated.'),
       ).toBeVisible()
       await expect(page.getByText('Answer options')).toHaveCount(0)
+    })
+  })
+
+  test('optional question scores do not show up for yes/no questions', async ({
+    page,
+    adminQuestions,
+  }) => {
+    await test.step('setup', async () => {
+      await enableFeatureFlag(page, 'ANSWER_OPTION_SCORING_ENABLED')
+      await loginAsAdmin(page)
+    })
+
+    await test.step('scores are hidden', async () => {
+      await adminQuestions.startCreatingQuestion('#create-yes_no-question')
+      await adminQuestions.expectMultiOptionScoreInputHidden(0)
     })
   })
 })

--- a/browser-test/src/question_lifecycle.test.ts
+++ b/browser-test/src/question_lifecycle.test.ts
@@ -1,6 +1,7 @@
 import {test, expect} from './support/civiform_fixtures'
 import {
   AdminQuestions,
+  disableFeatureFlag,
   enableFeatureFlag,
   isLocalDevEnvironment,
   loginAsAdmin,
@@ -604,6 +605,54 @@ test.describe('normal question lifecycle', () => {
       await expect(page.getByLabel('Question enumerator')).toHaveAttribute(
         'readonly',
       )
+    })
+  })
+
+  test('radio and checkbox questions show optional score fields when flag enabled', async ({
+    page,
+    adminQuestions,
+  }) => {
+    await test.step('setup', async () => {
+      await enableFeatureFlag(page, 'ANSWER_OPTION_SCORING_ENABLED')
+      await loginAsAdmin(page)
+    })
+
+    await test.step('radio button question', async () => {
+      await adminQuestions.startCreatingQuestion(
+        '#create-radio_button-question',
+      )
+      await page.click('#add-new-option')
+      await adminQuestions.expectMultiOptionScoreInputShown(0)
+    })
+
+    await test.step('checkbox question', async () => {
+      await adminQuestions.startCreatingQuestion('#create-checkbox-question')
+      await page.click('#add-new-option')
+      await adminQuestions.expectMultiOptionScoreInputShown(0)
+    })
+  })
+
+  test('radio and dropdown questions hide optional score fields when flag disabled', async ({
+    page,
+    adminQuestions,
+  }) => {
+    await test.step('setup', async () => {
+      await disableFeatureFlag(page, 'ANSWER_OPTION_SCORING_ENABLED')
+      await loginAsAdmin(page)
+    })
+
+    await test.step('radio button question', async () => {
+      await adminQuestions.startCreatingQuestion(
+        '#create-radio_button-question',
+      )
+      await page.click('#add-new-option')
+      await adminQuestions.expectMultiOptionScoreInputHidden(0)
+    })
+
+    await test.step('checkbox question', async () => {
+      await adminQuestions.startCreatingQuestion('#create-checkbox-question')
+      await page.click('#add-new-option')
+      await adminQuestions.expectMultiOptionScoreInputHidden(0)
     })
   })
 })

--- a/browser-test/src/question_lifecycle_legacy.test.ts
+++ b/browser-test/src/question_lifecycle_legacy.test.ts
@@ -1,6 +1,7 @@
 import {test, expect} from './support/civiform_fixtures'
 import {
   AdminQuestions,
+  enableFeatureFlag,
   disableFeatureFlag,
   isLocalDevEnvironment,
   loginAsAdmin,
@@ -604,6 +605,54 @@ test.describe('normal question lifecycle', () => {
       await expect(page.getByLabel('Question enumerator')).toHaveAttribute(
         'readonly',
       )
+    })
+  })
+
+  test('radio and checkbox questions show optional score fields when flag enabled', async ({
+    page,
+    adminQuestions,
+  }) => {
+    await test.step('setup', async () => {
+      await enableFeatureFlag(page, 'ANSWER_OPTION_SCORING_ENABLED')
+      await loginAsAdmin(page)
+    })
+
+    await test.step('radio button question', async () => {
+      await adminQuestions.startCreatingQuestion(
+        '#create-radio_button-question',
+      )
+      await page.click('#add-new-option')
+      await adminQuestions.expectMultiOptionScoreInputShown(0)
+    })
+
+    await test.step('checkbox question', async () => {
+      await adminQuestions.startCreatingQuestion('#create-checkbox-question')
+      await page.click('#add-new-option')
+      await adminQuestions.expectMultiOptionScoreInputShown(0)
+    })
+  })
+
+  test('radio and dropdown questions hide optional score fields when flag disabled', async ({
+    page,
+    adminQuestions,
+  }) => {
+    await test.step('setup', async () => {
+      await disableFeatureFlag(page, 'ANSWER_OPTION_SCORING_ENABLED')
+      await loginAsAdmin(page)
+    })
+
+    await test.step('radio button question', async () => {
+      await adminQuestions.startCreatingQuestion(
+        '#create-radio_button-question',
+      )
+      await page.click('#add-new-option')
+      await adminQuestions.expectMultiOptionScoreInputHidden(0)
+    })
+
+    await test.step('checkbox question', async () => {
+      await adminQuestions.startCreatingQuestion('#create-checkbox-question')
+      await page.click('#add-new-option')
+      await adminQuestions.expectMultiOptionScoreInputHidden(0)
     })
   })
 })

--- a/browser-test/src/support/admin_questions.ts
+++ b/browser-test/src/support/admin_questions.ts
@@ -10,6 +10,7 @@ import {
 type QuestionOption = {
   adminName: string
   text: string
+  score?: string
 }
 
 type QuestionParams = {
@@ -113,6 +114,10 @@ export class AdminQuestions {
     `:nth-match(#question-settings div.cf-multi-option-question-option, ${
       index + 1
     }) .multi-option-question-field-remove-button`
+  public static readonly multiOptionScoreInputSelector = (index: number) =>
+    `:nth-match(#question-settings div.cf-multi-option-question-option, ${
+      index + 1
+    }) .cf-multi-option-score-input input`
 
   constructor(page: Page) {
     this.page = page
@@ -1080,6 +1085,13 @@ export class AdminQuestions {
     )
   }
 
+  async changeMultiOptionScore(index: number, score: string) {
+    await this.page.fill(
+      AdminQuestions.multiOptionScoreInputSelector(index),
+      score,
+    )
+  }
+
   async addMultiOptionAnswer(option: QuestionOption) {
     await this.page.click('#add-new-option')
     const lastDiv = this.page
@@ -1101,6 +1113,13 @@ export class AdminQuestions {
       AdminQuestions.multiOptionAdminInputSelector(index),
       option.adminName,
     )
+
+    if (option.score) {
+      await this.page.fill(
+        AdminQuestions.multiOptionScoreInputSelector(index),
+        option.score,
+      )
+    }
   }
 
   async expectNewMultiOptionAnswer(index: number, option: QuestionOption) {
@@ -1125,6 +1144,27 @@ export class AdminQuestions {
     await expect(
       this.page.locator(AdminQuestions.multiOptionAdminInputSelector(index)),
     ).toBeEditable({editable: adminNameIsEditable})
+  }
+
+  async expectMultiOptionScoreInputHidden(index: number) {
+    await expect(
+      this.page.locator(AdminQuestions.multiOptionScoreInputSelector(index)),
+    ).toBeHidden()
+  }
+
+  async expectMultiOptionScoreInputShown(index: number) {
+    await expect(
+      this.page.locator(AdminQuestions.multiOptionScoreInputSelector(index)),
+    ).toBeVisible()
+  }
+
+  async startCreatingQuestion(questionSelector: string) {
+    await this.page.click('text=Questions')
+    await waitForPageJsLoad(this.page)
+
+    await this.page.click('#create-question-button')
+    await this.page.click(questionSelector)
+    await waitForPageJsLoad(this.page)
   }
 
   async addCurrencyQuestion({

--- a/server/app/controllers/admin/AdminQuestionController.java
+++ b/server/app/controllers/admin/AdminQuestionController.java
@@ -238,6 +238,7 @@ public final class AdminQuestionController extends CiviFormController {
                     mapSettings,
                     settingsManifest.getApiBridgeEnabled(request),
                     settingsManifest.getEnumeratorImprovementsEnabled(request),
+                    settingsManifest.getAnswerOptionScoringEnabled(request),
                     roService,
                     Optional.empty());
         return ok(questionFormPageView.render(request, model)).as(Http.MimeTypes.HTML);
@@ -279,16 +280,7 @@ public final class AdminQuestionController extends CiviFormController {
     // silently dropped by the builder below.
     ImmutableSet<CiviFormError> scoreErrors = getOptionScoreErrors(questionForm, scoringEnabled);
     if (!scoreErrors.isEmpty()) {
-      ToastMessage errorMessage = ToastMessage.errorNonLocalized(joinErrors(scoreErrors));
-      ImmutableList<EnumeratorQuestionDefinition> enumeratorQuestionDefinitions =
-          service
-              .getReadOnlyQuestionService()
-              .toCompletableFuture()
-              .join()
-              .getUpToDateEnumeratorQuestions();
-      return ok(
-          editView.renderNewQuestionForm(
-              request, questionForm, enumeratorQuestionDefinitions, errorMessage));
+      return renderNewQuestionFormWithError(request, questionForm, joinErrors(scoreErrors));
     }
 
     QuestionDefinition questionDefinition;
@@ -305,31 +297,7 @@ public final class AdminQuestionController extends CiviFormController {
     ErrorAnd<QuestionDefinition, CiviFormError> result =
         service.create(questionDefinition, enumeratorImprovementsEnabled);
     if (result.isError()) {
-      String errorText = joinErrors(result.getErrors());
-      ReadOnlyQuestionService roService =
-          service.getReadOnlyQuestionService().toCompletableFuture().join();
-      ImmutableList<EnumeratorQuestionDefinition> enumeratorQuestionDefinitions =
-          roService.getUpToDateEnumeratorQuestions();
-
-      if (settingsManifest.getAdminUiMigrationJ2htmlToThymeleafScEnabled(request)) {
-        MapQuestionSettingsPartialViewModel mapSettings = buildMapSettingsViewModel(questionForm);
-        QuestionFormPageViewModel model =
-            new QuestionFormPageMapper()
-                .mapNew(
-                    questionForm,
-                    enumeratorQuestionDefinitions,
-                    mapSettings,
-                    settingsManifest.getApiBridgeEnabled(request),
-                    settingsManifest.getEnumeratorImprovementsEnabled(request),
-                    roService,
-                    Optional.of(errorText));
-        return ok(questionFormPageView.render(request, model)).as(Http.MimeTypes.HTML);
-      }
-
-      ToastMessage errorMessage = ToastMessage.errorNonLocalized(errorText);
-      return ok(
-          editView.renderNewQuestionForm(
-              request, questionForm, enumeratorQuestionDefinitions, errorMessage));
+      return renderNewQuestionFormWithError(request, questionForm, joinErrors(result.getErrors()));
     }
 
     try {
@@ -483,13 +451,13 @@ public final class AdminQuestionController extends CiviFormController {
     // silently dropped by the builder below.
     ImmutableSet<CiviFormError> scoreErrors = getOptionScoreErrors(questionForm, scoringEnabled);
     if (!scoreErrors.isEmpty()) {
-      return ok(
-          editView.renderEditQuestionForm(
-              request,
-              id,
-              questionForm,
-              maybeGetEnumerationQuestion(roService, maybeExisting.get()),
-              ToastMessage.errorNonLocalized(joinErrors(scoreErrors))));
+      return renderEditQuestionFormWithError(
+          request,
+          id,
+          questionForm,
+          maybeGetEnumerationQuestion(roService, maybeExisting.get()),
+          roService,
+          joinErrors(scoreErrors));
     }
 
     QuestionDefinition questionDefinition;
@@ -522,26 +490,13 @@ public final class AdminQuestionController extends CiviFormController {
     }
 
     if (errorAndUpdatedQuestionDefinition.isError()) {
-      String errorText = joinErrors(errorAndUpdatedQuestionDefinition.getErrors());
-      Optional<QuestionDefinition> maybeEnumerationQuestion =
-          maybeGetEnumerationQuestion(roService, questionDefinition);
-
-      if (settingsManifest.getAdminUiMigrationJ2htmlToThymeleafScEnabled(request)) {
-        QuestionFormPageViewModel model =
-            buildEditQuestionPageModel(
-                id,
-                questionForm,
-                maybeEnumerationQuestion,
-                roService,
-                request,
-                Optional.of(errorText));
-        return ok(questionFormPageView.render(request, model)).as(Http.MimeTypes.HTML);
-      }
-
-      ToastMessage errorMessage = ToastMessage.errorNonLocalized(errorText);
-      return ok(
-          editView.renderEditQuestionForm(
-              request, id, questionForm, maybeEnumerationQuestion, errorMessage));
+      return renderEditQuestionFormWithError(
+          request,
+          id,
+          questionForm,
+          maybeGetEnumerationQuestion(roService, questionDefinition),
+          roService,
+          joinErrors(errorAndUpdatedQuestionDefinition.getErrors()));
     }
     try {
       service.setExportState(
@@ -570,6 +525,68 @@ public final class AdminQuestionController extends CiviFormController {
       return multiOptionQuestionForm.getBuilder(scoringEnabled);
     }
     return questionForm.getBuilder();
+  }
+
+  /**
+   * Re-renders the new-question form with a form-level error, honoring the j2html-to-Thymeleaf
+   * migration flag.
+   */
+  private Result renderNewQuestionFormWithError(
+      Request request, QuestionForm questionForm, String errorText) {
+    ReadOnlyQuestionService roService =
+        service.getReadOnlyQuestionService().toCompletableFuture().join();
+    ImmutableList<EnumeratorQuestionDefinition> enumeratorQuestionDefinitions =
+        roService.getUpToDateEnumeratorQuestions();
+
+    if (settingsManifest.getAdminUiMigrationJ2htmlToThymeleafScEnabled(request)) {
+      MapQuestionSettingsPartialViewModel mapSettings = buildMapSettingsViewModel(questionForm);
+      QuestionFormPageViewModel model =
+          new QuestionFormPageMapper()
+              .mapNew(
+                  questionForm,
+                  enumeratorQuestionDefinitions,
+                  mapSettings,
+                  settingsManifest.getApiBridgeEnabled(request),
+                  settingsManifest.getEnumeratorImprovementsEnabled(request),
+                  settingsManifest.getAnswerOptionScoringEnabled(request),
+                  roService,
+                  Optional.of(errorText));
+      return ok(questionFormPageView.render(request, model)).as(Http.MimeTypes.HTML);
+    }
+
+    ToastMessage errorMessage = ToastMessage.errorNonLocalized(errorText);
+    return ok(
+        editView.renderNewQuestionForm(
+            request, questionForm, enumeratorQuestionDefinitions, errorMessage));
+  }
+
+  /**
+   * Re-renders the edit-question form with a form-level error, honoring the j2html-to-Thymeleaf
+   * migration flag.
+   */
+  private Result renderEditQuestionFormWithError(
+      Request request,
+      Long id,
+      QuestionForm questionForm,
+      Optional<QuestionDefinition> maybeEnumerationQuestion,
+      ReadOnlyQuestionService roService,
+      String errorText) {
+    if (settingsManifest.getAdminUiMigrationJ2htmlToThymeleafScEnabled(request)) {
+      QuestionFormPageViewModel model =
+          buildEditQuestionPageModel(
+              id,
+              questionForm,
+              maybeEnumerationQuestion,
+              roService,
+              request,
+              Optional.of(errorText));
+      return ok(questionFormPageView.render(request, model)).as(Http.MimeTypes.HTML);
+    }
+
+    ToastMessage errorMessage = ToastMessage.errorNonLocalized(errorText);
+    return ok(
+        editView.renderEditQuestionForm(
+            request, id, questionForm, maybeEnumerationQuestion, errorMessage));
   }
 
   /**
@@ -842,6 +859,7 @@ public final class AdminQuestionController extends CiviFormController {
             mapSettings,
             settingsManifest.getApiBridgeEnabled(request),
             settingsManifest.getEnumeratorImprovementsEnabled(request),
+            settingsManifest.getAnswerOptionScoringEnabled(request),
             readOnlyQuestionService,
             errorMessage);
   }

--- a/server/app/forms/questions/MultiOptionQuestionForm.java
+++ b/server/app/forms/questions/MultiOptionQuestionForm.java
@@ -292,9 +292,20 @@ public abstract class MultiOptionQuestionForm extends QuestionForm {
   }
 
   /**
-   * Parses an admin-entered score, returning empty if blank or invalid. Uses {@link BigDecimal}
-   * instead of {@link Double#parseDouble} so malicious input like "NaN", "Infinity", or hex/suffix
-   * forms can't sneak through; the finite check also catches values that overflow to infinity.
+   * Converts a bound score string to its input display value, formatted without trailing zeros.
+   * Blank (unscored) and unparseable values render an empty input; invalid submissions are
+   * re-rendered alongside a form-level error from {@link #getOptionScoreErrors}.
+   */
+  public static Optional<String> formatScoreForDisplay(String scoreAsString) {
+    return parseScore(scoreAsString).map(QuestionOption::formatScore);
+  }
+
+  /**
+   * Parses an admin-entered score. Blank means unscored. Parsing goes through {@link BigDecimal}
+   * rather than {@link Double#parseDouble} as a server-side backstop against crafted posts: it
+   * accepts plain and exponent decimal notation but rejects the NaN/Infinity/hex/suffix forms
+   * Double.parseDouble tolerates, and the finite check rejects double-overflowing exponents.
+   * Invalid input surfaces as empty here and as errors in {@link #getOptionScoreErrors}.
    */
   private static Optional<Double> parseScore(String scoreAsString) {
     if (isBlank(scoreAsString)) {

--- a/server/app/forms/questions/MultiOptionQuestionForm.java
+++ b/server/app/forms/questions/MultiOptionQuestionForm.java
@@ -256,7 +256,7 @@ public abstract class MultiOptionQuestionForm extends QuestionForm {
             .anyMatch(MultiOptionQuestionForm::isBlank);
     if (anyScored && anyBlank) {
       errors.add(
-          CiviFormError.of("When creating a scored question, all options must include scores."));
+          CiviFormError.of("When creating a scored question, all options must include scores"));
     }
 
     // Checks for missing indexed fields

--- a/server/app/forms/questions/MultiOptionQuestionForm.java
+++ b/server/app/forms/questions/MultiOptionQuestionForm.java
@@ -301,11 +301,9 @@ public abstract class MultiOptionQuestionForm extends QuestionForm {
   }
 
   /**
-   * Parses an admin-entered score. Blank means unscored. Parsing goes through {@link BigDecimal}
-   * rather than {@link Double#parseDouble} as a server-side backstop against crafted posts: it
-   * accepts plain and exponent decimal notation but rejects the NaN/Infinity/hex/suffix forms
-   * Double.parseDouble tolerates, and the finite check rejects double-overflowing exponents.
-   * Invalid input surfaces as empty here and as errors in {@link #getOptionScoreErrors}.
+   * Parses an admin-entered score, returning empty if blank or invalid. Uses {@link BigDecimal}
+   * instead of {@link Double#parseDouble} so malicious input like "NaN", "Infinity", or hex/suffix
+   * forms can't sneak through; the finite check also catches values that overflow to infinity.
    */
   private static Optional<Double> parseScore(String scoreAsString) {
     if (isBlank(scoreAsString)) {

--- a/server/app/mapping/admin/questions/QuestionFormPageMapper.java
+++ b/server/app/mapping/admin/questions/QuestionFormPageMapper.java
@@ -28,6 +28,7 @@ public final class QuestionFormPageMapper {
       MapQuestionSettingsPartialViewModel mapSettings,
       boolean apiBridgeEnabled,
       boolean enumeratorImprovementsEnabled,
+      boolean answerOptionScoringEnabled,
       ReadOnlyQuestionService readOnlyQuestionService,
       Optional<String> errorMessage) {
     // Build enumerator options
@@ -51,6 +52,7 @@ public final class QuestionFormPageMapper {
             mapSettings,
             apiBridgeEnabled,
             enumeratorImprovementsEnabled,
+            answerOptionScoringEnabled,
             readOnlyQuestionService,
             errorMessage)
         .editMode(false)
@@ -67,6 +69,7 @@ public final class QuestionFormPageMapper {
       MapQuestionSettingsPartialViewModel mapSettings,
       boolean apiBridgeEnabled,
       boolean enumeratorImprovementsEnabled,
+      boolean answerOptionScoringEnabled,
       ReadOnlyQuestionService readOnlyQuestionService,
       Optional<String> errorMessage) {
     String enumeratorDisplayName =
@@ -77,6 +80,7 @@ public final class QuestionFormPageMapper {
             mapSettings,
             apiBridgeEnabled,
             enumeratorImprovementsEnabled,
+            answerOptionScoringEnabled,
             readOnlyQuestionService,
             errorMessage)
         .editMode(true)
@@ -92,6 +96,7 @@ public final class QuestionFormPageMapper {
       MapQuestionSettingsPartialViewModel mapSettings,
       boolean apiBridgeEnabled,
       boolean enumeratorImprovementsEnabled,
+      boolean answerOptionScoringEnabled,
       ReadOnlyQuestionService readOnlyQuestionService,
       Optional<String> errorMessage) {
     QuestionType questionType = questionForm.getQuestionType();
@@ -150,6 +155,8 @@ public final class QuestionFormPageMapper {
             questionType.equals(QuestionType.YES_NO)
                 ? YesNoConfigMapper.buildYesNoConfig((MultiOptionQuestionForm) questionForm)
                 : null)
+        .showScores(
+            answerOptionScoringEnabled && QuestionType.supportsOptionScores(questionType))
         .errorMessage(errorToastMessage)
         .errorToastId(errorToastMessage.isPresent() ? UUID.randomUUID().toString() : null);
   }

--- a/server/app/mapping/admin/questions/QuestionFormPageMapper.java
+++ b/server/app/mapping/admin/questions/QuestionFormPageMapper.java
@@ -155,8 +155,7 @@ public final class QuestionFormPageMapper {
             questionType.equals(QuestionType.YES_NO)
                 ? YesNoConfigMapper.buildYesNoConfig((MultiOptionQuestionForm) questionForm)
                 : null)
-        .showScores(
-            answerOptionScoringEnabled && QuestionType.supportsOptionScores(questionType))
+        .showScores(answerOptionScoringEnabled && QuestionType.supportsOptionScores(questionType))
         .errorMessage(errorToastMessage)
         .errorToastId(errorToastMessage.isPresent() ? UUID.randomUUID().toString() : null);
   }

--- a/server/app/views/admin/questions/QuestionConfig.java
+++ b/server/app/views/admin/questions/QuestionConfig.java
@@ -28,6 +28,7 @@ import j2html.tags.specialized.DivTag;
 import j2html.tags.specialized.FieldsetTag;
 import j2html.tags.specialized.InputTag;
 import j2html.tags.specialized.LabelTag;
+import java.util.List;
 import java.util.Optional;
 import java.util.OptionalLong;
 import play.i18n.Messages;
@@ -39,6 +40,7 @@ import services.question.LocalizedQuestionOption;
 import services.question.YesNoQuestionOption;
 import services.question.types.DateQuestionDefinition.DateValidationOption;
 import services.question.types.DateQuestionDefinition.DateValidationOption.DateType;
+import services.question.types.QuestionType;
 import services.settings.SettingsManifest;
 import views.BaseView;
 import views.BaseViewModel;
@@ -70,6 +72,11 @@ public final class QuestionConfig {
       SettingsManifest settingsManifest,
       Request request) {
     QuestionConfig config = new QuestionConfig();
+    // Score inputs render only when the scoring flag is on and the type supports option scores;
+    // Yes/No questions use a separate renderer and never show scores.
+    boolean showScores =
+        settingsManifest.getAnswerOptionScoringEnabled(request)
+            && QuestionType.supportsOptionScores(questionForm.getQuestionType());
     switch (questionForm.getQuestionType()) {
       case ADDRESS:
         return Optional.of(
@@ -78,7 +85,7 @@ public final class QuestionConfig {
         MultiOptionQuestionForm form = (MultiOptionQuestionForm) questionForm;
         return Optional.of(
             config
-                .addMultiOptionQuestionFields(form, messages)
+                .addMultiOptionQuestionFields(form, messages, showScores)
                 .addMultiSelectQuestionValidation(form)
                 .getContainer());
       case ENUMERATOR:
@@ -106,7 +113,8 @@ public final class QuestionConfig {
       case RADIO_BUTTON:
         return Optional.of(
             config
-                .addMultiOptionQuestionFields((MultiOptionQuestionForm) questionForm, messages)
+                .addMultiOptionQuestionFields(
+                    (MultiOptionQuestionForm) questionForm, messages, showScores)
                 .getContainer());
       case FILEUPLOAD:
         return Optional.of(
@@ -312,8 +320,13 @@ public final class QuestionConfig {
    * Creates a template text field where an admin can enter a single multi-option question answer,
    * along with a button to remove the option.
    */
-  public static DivTag multiOptionQuestionFieldTemplate(Messages messages) {
-    return multiOptionQuestionField(Optional.empty(), messages, /* isForNewOption= */ true);
+  public static DivTag multiOptionQuestionFieldTemplate(Messages messages, boolean showScores) {
+    return multiOptionQuestionField(
+        Optional.empty(),
+        messages,
+        /* isForNewOption= */ true,
+        /* scoreValue= */ Optional.empty(),
+        showScores);
   }
 
   /**
@@ -321,7 +334,11 @@ public final class QuestionConfig {
    * answer, along with a button to remove the option.
    */
   private static DivTag multiOptionQuestionField(
-      Optional<LocalizedQuestionOption> existingOption, Messages messages, boolean isForNewOption) {
+      Optional<LocalizedQuestionOption> existingOption,
+      Messages messages,
+      boolean isForNewOption,
+      Optional<String> scoreValue,
+      boolean showScores) {
     DivTag optionAdminName =
         FieldWithLabel.input()
             .setFieldName(isForNewOption ? "newOptionAdminNames[]" : "optionAdminNames[]")
@@ -403,26 +420,57 @@ public final class QuestionConfig {
                 "col-start-8",
                 "row-span-2")
             .attr("aria-label", "delete");
-    return div()
-        .withClasses(
-            ReferenceClasses.MULTI_OPTION_QUESTION_OPTION,
-            ReferenceClasses.MULTI_OPTION_QUESTION_OPTION_EDITABLE,
-            "grid",
-            "grid-cols-8",
-            "grid-rows-4",
-            "items-center",
-            "mb-4")
-        .with(
-            optionIndexInput,
-            optionAdminName,
-            moveUpButton,
-            moveDownButton,
-            optionInput,
-            removeOptionButton);
+    DivTag row =
+        div()
+            .withClasses(
+                ReferenceClasses.MULTI_OPTION_QUESTION_OPTION,
+                ReferenceClasses.MULTI_OPTION_QUESTION_OPTION_EDITABLE,
+                "grid",
+                "grid-cols-8",
+                showScores ? "grid-rows-6" : "grid-rows-4",
+                "items-center",
+                "mb-4")
+            .with(
+                optionIndexInput,
+                optionAdminName,
+                moveUpButton,
+                moveDownButton,
+                optionInput,
+                removeOptionButton);
+    if (showScores) {
+      // FieldWithLabel's numeric value plumbing is long-only, so decimal values are set directly
+      // on the input's value attribute.
+      FieldWithLabel scoreField =
+          FieldWithLabel.number()
+              .setFieldName(isForNewOption ? "newOptionScores[]" : "optionScores[]")
+              .setLabelText("Score")
+              .addReferenceClass(ReferenceClasses.MULTI_OPTION_SCORE_INPUT);
+      scoreValueForDisplay(scoreValue).ifPresent(value -> scoreField.setAttribute("value", value));
+      row.with(
+          scoreField
+              .getNumberTag()
+              .withClasses(
+                  ReferenceClasses.MULTI_OPTION_SCORE_INPUT,
+                  "col-start-1",
+                  "col-span-5",
+                  "mb-2",
+                  "ml-2",
+                  "row-start-5",
+                  "row-span-2"));
+    }
+    return row;
+  }
+
+  private static Optional<String> scoreValueForDisplay(Optional<String> scoreValue) {
+    return scoreValue.flatMap(MultiOptionQuestionForm::formatScoreForDisplay);
+  }
+
+  private static Optional<String> scoreAt(List<String> scores, int index) {
+    return index < scores.size() ? Optional.of(scores.get(index)) : Optional.empty();
   }
 
   private QuestionConfig addMultiOptionQuestionFields(
-      MultiOptionQuestionForm multiOptionQuestionForm, Messages messages) {
+      MultiOptionQuestionForm multiOptionQuestionForm, Messages messages, boolean showScores) {
     Preconditions.checkState(
         multiOptionQuestionForm.getOptionIds().size()
             == multiOptionQuestionForm.getOptions().size(),
@@ -441,7 +489,9 @@ public final class QuestionConfig {
                       /* displayInAnswerOptions= */ Optional.of(true),
                       LocalizedStrings.DEFAULT_LOCALE)),
               messages,
-              /* isForNewOption= */ false));
+              /* isForNewOption= */ false,
+              scoreAt(multiOptionQuestionForm.getOptionScores(), i),
+              showScores));
       optionIndex++;
     }
 
@@ -457,7 +507,9 @@ public final class QuestionConfig {
                       /* displayInAnswerOptions= */ Optional.of(true),
                       LocalizedStrings.DEFAULT_LOCALE)),
               messages,
-              /* isForNewOption= */ true));
+              /* isForNewOption= */ true,
+              scoreAt(multiOptionQuestionForm.getNewOptionScores(), i),
+              showScores));
       optionIndex++;
     }
 

--- a/server/app/views/admin/questions/QuestionEditView.java
+++ b/server/app/views/admin/questions/QuestionEditView.java
@@ -164,7 +164,7 @@ public final class QuestionEditView extends BaseHtmlView {
         String.format("New %s question", questionType.getLabel().toLowerCase(Locale.ROOT));
 
     DivTag formContent =
-        buildQuestionContainer(title)
+        buildQuestionContainer(title, showScores(request, questionType))
             .with(
                 buildNewQuestionForm(questionForm, enumeratorQuestionDefinitions, request)
                     .with(makeCsrfTokenInputTag(request)));
@@ -223,7 +223,7 @@ public final class QuestionEditView extends BaseHtmlView {
         String.format("Edit %s question", questionType.getLabel().toLowerCase(Locale.ROOT));
 
     DivTag formContent =
-        buildQuestionContainer(title)
+        buildQuestionContainer(title, showScores(request, questionType))
             .with(
                 buildEditQuestionForm(
                         id,
@@ -274,7 +274,7 @@ public final class QuestionEditView extends BaseHtmlView {
         questionForm, enumeratorOptions, /* submittable= */ true, forCreate, request);
   }
 
-  private DivTag buildQuestionContainer(String title) {
+  private DivTag buildQuestionContainer(String title, boolean showScores) {
     return div()
         .withId("question-form")
         .attr("hx-ext", "response-targets")
@@ -290,25 +290,34 @@ public final class QuestionEditView extends BaseHtmlView {
             "relative",
             "w-2/5")
         .with(renderHeader(title))
-        .with(multiOptionQuestionField());
+        .with(multiOptionQuestionField(showScores));
   }
 
   // A <template> holding the markup for a new multi-option answer. The id lives
   // on the <template> so the JS can clone its content (see MultiOptionQuestion);
   // the cloned row is shown when appended, so it is not hidden here.
-  private TemplateTag multiOptionQuestionField() {
+  private TemplateTag multiOptionQuestionField(boolean showScores) {
     return template()
         .withId("multi-option-question-answer-template")
         .with(
-            QuestionConfig.multiOptionQuestionFieldTemplate(messages)
+            QuestionConfig.multiOptionQuestionFieldTemplate(messages, showScores)
                 .withClasses(
                     ReferenceClasses.MULTI_OPTION_QUESTION_OPTION,
                     ReferenceClasses.MULTI_OPTION_QUESTION_OPTION_EDITABLE,
                     "grid",
                     "grid-cols-8",
-                    "grid-rows-4",
+                    showScores ? "grid-rows-6" : "grid-rows-4",
                     "items-center",
                     "mb-4"));
+  }
+
+  /**
+   * Whether score inputs should render for this request and question type: the scoring flag is on
+   * and the type supports option scores (which excludes Yes/No).
+   */
+  private boolean showScores(Request request, QuestionType questionType) {
+    return settingsManifest.getAnswerOptionScoringEnabled(request)
+        && QuestionType.supportsOptionScores(questionType);
   }
 
   private FormTag buildNewQuestionForm(

--- a/server/app/views/admin/questions/QuestionEditView.java
+++ b/server/app/views/admin/questions/QuestionEditView.java
@@ -312,8 +312,9 @@ public final class QuestionEditView extends BaseHtmlView {
   }
 
   /**
-   * Whether score inputs should render for this request and question type: the scoring flag is on
-   * and the type supports option scores (which excludes Yes/No).
+   * Whether score inputs should render for this request and question type. Score inputs should
+   * render if the ANSWER_OPTION_SCORING_ENABLED flag is on and the type supports option scores (all
+   * multi-option question types except Yes/No questions).
    */
   private boolean showScores(Request request, QuestionType questionType) {
     return settingsManifest.getAnswerOptionScoringEnabled(request)

--- a/server/app/views/admin/questions/QuestionFormPage.html
+++ b/server/app/views/admin/questions/QuestionFormPage.html
@@ -13,7 +13,7 @@
     <!--/* Markup cloned by the client when adding a new multi-option answer. */-->
     <template id="multi-option-question-answer-template">
       <div
-        th:replace="~{admin/questions/fragments/MultiOptionRow :: multiOptionRow(true, '', '', '', ${model.randomFieldId()}, ${model.randomFieldId()}, ${model.randomFieldId()})}"
+        th:replace="~{admin/questions/fragments/MultiOptionRow :: multiOptionRow(true, '', '', '', ${model.randomFieldId()}, ${model.randomFieldId()}, ${model.randomFieldId()}, ${model.showScores}, null, ${model.randomFieldId()})}"
       ></div>
     </template>
 

--- a/server/app/views/admin/questions/QuestionFormPageViewModel.java
+++ b/server/app/views/admin/questions/QuestionFormPageViewModel.java
@@ -4,6 +4,7 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 
 import com.google.common.collect.ImmutableList;
 import controllers.admin.routes;
+import forms.questions.MultiOptionQuestionForm;
 import forms.questions.QuestionForm;
 import java.util.List;
 import java.util.Locale;
@@ -94,6 +95,10 @@ public final class QuestionFormPageViewModel implements BaseViewModel {
   // YES_NO: the option rows to render. Null for other question types.
   private final YesNoConfig yesNoConfig;
 
+  // CHECKBOX / DROPDOWN / RADIO_BUTTON: whether the per-option score inputs render (the
+  // answer-option-scoring flag is on and the question type supports scores).
+  private final boolean showScores;
+
   // Error message shown as a toast (already carries the "Error: " prefix)
   private final Optional<String> errorMessage;
   // Random id for the toast container. Null when there is no error message.
@@ -133,6 +138,18 @@ public final class QuestionFormPageViewModel implements BaseViewModel {
    */
   public String randomFieldId() {
     return RandomStringUtils.randomAlphabetic(8);
+  }
+
+  /**
+   * The display value for the score input at {@code index} of a bound score list, formatted
+   * without trailing zeros. Null (attribute omitted) when the entry is missing, blank, or
+   * unparseable; a null-padded or short list from a sparse crafted post is tolerated.
+   */
+  public String scoreDisplayValue(List<String> scores, int index) {
+    if (index >= scores.size()) {
+      return null;
+    }
+    return MultiOptionQuestionForm.formatScoreForDisplay(scores.get(index)).orElse(null);
   }
 
   /** Whether there is a type-specific question config section. */

--- a/server/app/views/admin/questions/QuestionFormPageViewModel.java
+++ b/server/app/views/admin/questions/QuestionFormPageViewModel.java
@@ -96,7 +96,7 @@ public final class QuestionFormPageViewModel implements BaseViewModel {
   private final YesNoConfig yesNoConfig;
 
   // CHECKBOX / DROPDOWN / RADIO_BUTTON: whether the per-option score inputs render (the
-  // answer-option-scoring flag is on and the question type supports scores).
+  // ANSWER_OPTION_SCORING_ENABLED flag is on and the question type supports scores).
   private final boolean showScores;
 
   // Error message shown as a toast (already carries the "Error: " prefix)
@@ -141,9 +141,8 @@ public final class QuestionFormPageViewModel implements BaseViewModel {
   }
 
   /**
-   * The display value for the score input at {@code index} of a bound score list, formatted
-   * without trailing zeros. Null (attribute omitted) when the entry is missing, blank, or
-   * unparseable; a null-padded or short list from a sparse crafted post is tolerated.
+   * The display value for the score input at {@code index} of a bound score list, formatted without
+   * trailing zeros. Null (attribute omitted) when the entry is missing, blank, or unparseable.
    */
   public String scoreDisplayValue(List<String> scores, int index) {
     if (index >= scores.size()) {

--- a/server/app/views/admin/questions/fragments/MultiOptionContainerFragment.html
+++ b/server/app/views/admin/questions/fragments/MultiOptionContainerFragment.html
@@ -8,12 +8,12 @@
   <div id="multi-option-container">
     <th:block th:each="optionText, stat : ${questionForm.getOptions()}">
       <div
-        th:replace="~{admin/questions/fragments/MultiOptionRow :: multiOptionRow(false, ${questionForm.getOptionIds().get(stat.index)}, ${questionForm.getOptionAdminNames().get(stat.index)}, ${optionText}, ${model.randomFieldId()}, ${model.randomFieldId()}, ${model.randomFieldId()})}"
+        th:replace="~{admin/questions/fragments/MultiOptionRow :: multiOptionRow(false, ${questionForm.getOptionIds().get(stat.index)}, ${questionForm.getOptionAdminNames().get(stat.index)}, ${optionText}, ${model.randomFieldId()}, ${model.randomFieldId()}, ${model.randomFieldId()}, ${model.showScores}, ${model.scoreDisplayValue(questionForm.getOptionScores(), stat.index)}, ${model.randomFieldId()})}"
       ></div>
     </th:block>
     <th:block th:each="newOptionText, stat : ${questionForm.getNewOptions()}">
       <div
-        th:replace="~{admin/questions/fragments/MultiOptionRow :: multiOptionRow(true, '', ${questionForm.getNewOptionAdminNames().get(stat.index)}, ${newOptionText}, ${model.randomFieldId()}, ${model.randomFieldId()}, ${model.randomFieldId()})}"
+        th:replace="~{admin/questions/fragments/MultiOptionRow :: multiOptionRow(true, '', ${questionForm.getNewOptionAdminNames().get(stat.index)}, ${newOptionText}, ${model.randomFieldId()}, ${model.randomFieldId()}, ${model.randomFieldId()}, ${model.showScores}, ${model.scoreDisplayValue(questionForm.getNewOptionScores(), stat.index)}, ${model.randomFieldId()})}"
       ></div>
     </th:block>
   </div>

--- a/server/app/views/admin/questions/fragments/MultiOptionRow.html
+++ b/server/app/views/admin/questions/fragments/MultiOptionRow.html
@@ -5,11 +5,16 @@
   options are also readonly on the Admin ID.
 
   Callers pass the label/input ids in (optionIdFieldId, adminNameFieldId,
-  optionTextFieldId), generating them with ${model.randomFieldId()} so
-  labels stay associated with inputs. Icons live in LegacySvgFragments.html.
+  optionTextFieldId, scoreFieldId), generating them with
+  ${model.randomFieldId()} so labels stay associated with inputs. When
+  showScores is true (the answer-option-scoring flag is on and the type
+  supports scores) the row grows to six grid rows and renders a score input
+  posting to newOptionScores[] / optionScores[]; scoreValue is the
+  pre-formatted display value or null. Icons live in LegacySvgFragments.html.
 */-->
 <div
-  th:fragment="multiOptionRow(isForNewOption, optionId, adminName, optionText, optionIdFieldId, adminNameFieldId, optionTextFieldId)"
+  th:fragment="multiOptionRow(isForNewOption, optionId, adminName, optionText, optionIdFieldId, adminNameFieldId, optionTextFieldId, showScores, scoreValue, scoreFieldId)"
+  th:class="|cf-multi-option-question-option cf-multi-option-question-option-editable grid grid-cols-8 ${showScores ? 'grid-rows-6' : 'grid-rows-4'} items-center mb-4|"
   class="cf-multi-option-question-option cf-multi-option-question-option-editable grid grid-cols-8 grid-rows-4 items-center mb-4"
 >
   <div th:if="${isForNewOption}"></div>
@@ -123,4 +128,32 @@
       th:replace="~{admin/shared/LegacySvgFragments :: iconDelete('w-6 h-6')}"
     ></svg>
   </button>
+  <div
+    th:if="${showScores}"
+    class="cf-multi-option-score-input col-start-1 col-span-5 mb-2 ml-2 row-start-5 row-span-2"
+  >
+    <label
+      th:for="${scoreFieldId}"
+      class="pointer-events-none text-gray-600 text-base px-1 py-2"
+      >Score<span
+        th:replace="~{admin/shared/LegacyFieldWithLabel/RequiredIndicator :: requiredIndicator(false)}"
+      ></span
+    ></label>
+    <div class="flex flex-col">
+      <input
+        type="number"
+        inputmode="decimal"
+        step="any"
+        th:value="${scoreValue}"
+        maxlength="10000"
+        th:id="${scoreFieldId}"
+        th:name="${isForNewOption} ? 'newOptionScores[]' : 'optionScores[]'"
+        class="px-3 bg-white text-black text-lg py-2 block outline-none box-border m-auto border border-gray-500 rounded-lg w-full focus:border-civiform-blue placeholder-gray-500"
+      />
+      <div
+        th:id="|${scoreFieldId}-errors|"
+        class="text-red-600 text-xs p-1 hidden"
+      ></div>
+    </div>
+  </div>
 </div>

--- a/server/app/views/admin/questions/fragments/MultiOptionRow.html
+++ b/server/app/views/admin/questions/fragments/MultiOptionRow.html
@@ -7,7 +7,7 @@
   Callers pass the label/input ids in (optionIdFieldId, adminNameFieldId,
   optionTextFieldId, scoreFieldId), generating them with
   ${model.randomFieldId()} so labels stay associated with inputs. When
-  showScores is true (the answer-option-scoring flag is on and the type
+  showScores is true (the ANSWER_OPTION_SCORING_ENABLED flag is on and the type
   supports scores) the row grows to six grid rows and renders a score input
   posting to newOptionScores[] / optionScores[]; scoreValue is the
   pre-formatted display value or null. Icons live in LegacySvgFragments.html.

--- a/server/app/views/style/ReferenceClasses.java
+++ b/server/app/views/style/ReferenceClasses.java
@@ -82,6 +82,7 @@ public final class ReferenceClasses {
       "cf-multi-option-question-option-editable";
   public static final String MULTI_OPTION_INPUT = "cf-multi-option-input";
   public static final String MULTI_OPTION_ADMIN_INPUT = "cf-multi-option-admin-input";
+  public static final String MULTI_OPTION_SCORE_INPUT = "cf-multi-option-score-input";
 
   // Keep these values in sync with app/assets/javascript/file_upload.ts.
   public static final String FILEUPLOAD_TOO_LARGE_ERROR_ID = "cf-fileupload-too-large-error";

--- a/server/test/controllers/admin/AdminQuestionControllerTest.java
+++ b/server/test/controllers/admin/AdminQuestionControllerTest.java
@@ -1296,6 +1296,146 @@ public class AdminQuestionControllerTest extends ResetPostgres {
   }
 
   @Test
+  public void create_thymeleafQuestionForm_withOptionScores_savesScores() {
+    ImmutableMap<String, String> formData =
+        ImmutableMap.<String, String>builder()
+            .put("questionName", "thymeleaf scored dropdown")
+            .put("questionDescription", "desc")
+            .put("questionType", "DROPDOWN")
+            .put("questionText", "Pick one")
+            .put("questionHelpText", "help")
+            .put("newOptions[0]", "first")
+            .put("newOptions[1]", "second")
+            .put("newOptionAdminNames[0]", "first_admin")
+            .put("newOptionAdminNames[1]", "second_admin")
+            .put("newOptionScores[0]", "5.5")
+            .put("newOptionScores[1]", "")
+            .build();
+    RequestBuilder requestBuilder =
+        fakeRequestBuilder()
+            .addCiviFormSetting("ANSWER_OPTION_SCORING_ENABLED", "true")
+            .addCiviFormSetting("ADMIN_UI_MIGRATION_J2HTML_TO_THYMELEAF_SC_ENABLED", "true")
+            .bodyForm(formData);
+
+    ImmutableSet<Long> questionIdsBefore = retrieveAllQuestionIds();
+    Result result = controller.create(requestBuilder.build(), "dropdown");
+
+    assertThat(result.status()).isEqualTo(SEE_OTHER);
+    ImmutableSet<Long> questionIdsAfter = retrieveAllQuestionIds();
+    Long newQuestionId = Sets.difference(questionIdsAfter, questionIdsBefore).iterator().next();
+    MultiOptionQuestionDefinition definition =
+        (MultiOptionQuestionDefinition)
+            questionRepo
+                .lookupQuestion(newQuestionId)
+                .toCompletableFuture()
+                .join()
+                .get()
+                .getQuestionDefinition();
+    assertThat(definition.getOptions().stream().map(QuestionOption::score))
+        .containsExactly(Optional.of(5.5), Optional.empty());
+  }
+
+  @Test
+  public void update_thymeleafQuestionForm_withOptionScores_savesScores() {
+    QuestionDefinition definition = createScoredDropdownDefinition();
+    QuestionModel question = testQuestionBank.maybeSave(definition, LifecycleStage.DRAFT);
+
+    ImmutableMap<String, String> formData =
+        ImmutableMap.<String, String>builder()
+            .put("questionName", definition.getName())
+            .put("questionDescription", definition.getDescription())
+            .put("questionType", definition.getQuestionType().name())
+            .put("questionText", "new question text")
+            .put("questionHelpText", "new help text")
+            .put("options[0]", "chocolate")
+            .put("options[1]", "strawberry")
+            .put("optionIds[0]", "1")
+            .put("optionIds[1]", "2")
+            .put("optionAdminNames[0]", "chocolate_admin")
+            .put("optionAdminNames[1]", "strawberry_admin")
+            .put("optionScores[0]", "")
+            .put("optionScores[1]", "-1.25")
+            .put("nextAvailableId", "3")
+            .put("questionExportState", "NON_DEMOGRAPHIC")
+            .put("concurrencyToken", question.getConcurrencyToken().toString())
+            .build();
+    RequestBuilder requestBuilder =
+        fakeRequestBuilder()
+            .addCiviFormSetting("ANSWER_OPTION_SCORING_ENABLED", "true")
+            .addCiviFormSetting("ADMIN_UI_MIGRATION_J2HTML_TO_THYMELEAF_SC_ENABLED", "true")
+            .bodyForm(formData);
+
+    Result result =
+        controller.update(
+            requestBuilder.build(), question.id, definition.getQuestionType().toString());
+
+    assertThat(result.status()).isEqualTo(SEE_OTHER);
+    MultiOptionQuestionDefinition found =
+        (MultiOptionQuestionDefinition)
+            questionRepo
+                .lookupQuestion(question.id)
+                .toCompletableFuture()
+                .join()
+                .get()
+                .getQuestionDefinition();
+    assertThat(found.getOptions().stream().map(QuestionOption::score))
+        .containsExactly(Optional.empty(), Optional.of(-1.25));
+  }
+
+  @Test
+  public void update_thymeleafQuestionForm_invalidScore_rendersScoreInputsWithErrorWithoutSaving() {
+    QuestionDefinition definition = createScoredDropdownDefinition();
+    QuestionModel question = testQuestionBank.maybeSave(definition, LifecycleStage.DRAFT);
+
+    ImmutableMap<String, String> formData =
+        ImmutableMap.<String, String>builder()
+            .put("questionName", definition.getName())
+            .put("questionDescription", definition.getDescription())
+            .put("questionType", definition.getQuestionType().name())
+            .put("questionText", "new question text")
+            .put("questionHelpText", "new help text")
+            .put("options[0]", "chocolate")
+            .put("options[1]", "strawberry")
+            .put("optionIds[0]", "1")
+            .put("optionIds[1]", "2")
+            .put("optionAdminNames[0]", "chocolate_admin")
+            .put("optionAdminNames[1]", "strawberry_admin")
+            .put("optionScores[0]", "junk")
+            .put("optionScores[1]", "")
+            .put("nextAvailableId", "3")
+            .put("questionExportState", "NON_DEMOGRAPHIC")
+            .put("concurrencyToken", question.getConcurrencyToken().toString())
+            .build();
+    Request request =
+        fakeRequestBuilder()
+            .addCSRFToken()
+            .addCiviFormSetting("ANSWER_OPTION_SCORING_ENABLED", "true")
+            .addCiviFormSetting("ADMIN_UI_MIGRATION_J2HTML_TO_THYMELEAF_SC_ENABLED", "true")
+            .bodyForm(formData)
+            .build();
+
+    Result result =
+        controller.update(request, question.id, definition.getQuestionType().toString());
+
+    // The error re-render honors the migration flag: the Thymeleaf page comes back with the
+    // score inputs so the admin can correct and resubmit.
+    assertThat(result.status()).isEqualTo(OK);
+    String unescaped = StringEscapeUtils.unescapeHtml4(contentAsString(result));
+    assertThat(unescaped).contains("Option score 'junk' must be a number");
+    assertThat(unescaped).contains("name=\"optionScores[]\"");
+    MultiOptionQuestionDefinition found =
+        (MultiOptionQuestionDefinition)
+            questionRepo
+                .lookupQuestion(question.id)
+                .toCompletableFuture()
+                .join()
+                .get()
+                .getQuestionDefinition();
+    assertThat(found.getOptions().stream().map(QuestionOption::score))
+        .containsExactly(Optional.of(3.5), Optional.empty());
+  }
+
+  @Test
   public void update_withInvalidScore_flagEnabled_rendersErrorWithoutSaving_nonNumeric() {
     QuestionDefinition definition = createScoredDropdownDefinition();
     QuestionModel question = testQuestionBank.maybeSave(definition, LifecycleStage.DRAFT);
@@ -1392,6 +1532,37 @@ public class AdminQuestionControllerTest extends ResetPostgres {
                 .getQuestionDefinition();
     assertThat(found.getOptions().stream().map(QuestionOption::score))
         .containsExactly(Optional.of(3.5), Optional.of(5.0));
+  }
+
+  @Test
+  public void edit_scoredQuestion_flagEnabled_rendersScoreInputsWithValues() {
+    QuestionModel question =
+        testQuestionBank.maybeSave(createScoredDropdownDefinition(), LifecycleStage.DRAFT);
+    Request request =
+        fakeRequestBuilder()
+            .addCSRFToken()
+            .addCiviFormSetting("ANSWER_OPTION_SCORING_ENABLED", "true")
+            .build();
+
+    Result result =
+        controller.edit(request, question.id, /* redirectUrl= */ "").toCompletableFuture().join();
+
+    assertThat(result.status()).isEqualTo(OK);
+    assertThat(contentAsString(result))
+        .containsPattern("name=\"optionScores\\[\\]\"[^>]*value=\"3.5\"");
+  }
+
+  @Test
+  public void edit_scoredQuestion_flagDisabled_rendersNoScoreInputs() {
+    QuestionModel question =
+        testQuestionBank.maybeSave(createScoredDropdownDefinition(), LifecycleStage.DRAFT);
+    Request request = fakeRequestBuilder().addCSRFToken().build();
+
+    Result result =
+        controller.edit(request, question.id, /* redirectUrl= */ "").toCompletableFuture().join();
+
+    assertThat(result.status()).isEqualTo(OK);
+    assertThat(contentAsString(result)).doesNotContain("optionScores[]");
   }
 
   private MultiOptionQuestionDefinition createScoredDropdownDefinition() {

--- a/server/test/controllers/admin/AdminQuestionControllerTest.java
+++ b/server/test/controllers/admin/AdminQuestionControllerTest.java
@@ -1309,7 +1309,7 @@ public class AdminQuestionControllerTest extends ResetPostgres {
             .put("newOptionAdminNames[0]", "first_admin")
             .put("newOptionAdminNames[1]", "second_admin")
             .put("newOptionScores[0]", "5.5")
-            .put("newOptionScores[1]", "")
+            .put("newOptionScores[1]", "7.0")
             .build();
     RequestBuilder requestBuilder =
         fakeRequestBuilder()
@@ -1332,7 +1332,7 @@ public class AdminQuestionControllerTest extends ResetPostgres {
                 .get()
                 .getQuestionDefinition();
     assertThat(definition.getOptions().stream().map(QuestionOption::score))
-        .containsExactly(Optional.of(5.5), Optional.empty());
+        .containsExactly(Optional.of(5.5), Optional.of(7.0));
   }
 
   @Test
@@ -1353,7 +1353,7 @@ public class AdminQuestionControllerTest extends ResetPostgres {
             .put("optionIds[1]", "2")
             .put("optionAdminNames[0]", "chocolate_admin")
             .put("optionAdminNames[1]", "strawberry_admin")
-            .put("optionScores[0]", "")
+            .put("optionScores[0]", "0")
             .put("optionScores[1]", "-1.25")
             .put("nextAvailableId", "3")
             .put("questionExportState", "NON_DEMOGRAPHIC")
@@ -1380,59 +1380,6 @@ public class AdminQuestionControllerTest extends ResetPostgres {
                 .getQuestionDefinition();
     assertThat(found.getOptions().stream().map(QuestionOption::score))
         .containsExactly(Optional.empty(), Optional.of(-1.25));
-  }
-
-  @Test
-  public void update_thymeleafQuestionForm_invalidScore_rendersScoreInputsWithErrorWithoutSaving() {
-    QuestionDefinition definition = createScoredDropdownDefinition();
-    QuestionModel question = testQuestionBank.maybeSave(definition, LifecycleStage.DRAFT);
-
-    ImmutableMap<String, String> formData =
-        ImmutableMap.<String, String>builder()
-            .put("questionName", definition.getName())
-            .put("questionDescription", definition.getDescription())
-            .put("questionType", definition.getQuestionType().name())
-            .put("questionText", "new question text")
-            .put("questionHelpText", "new help text")
-            .put("options[0]", "chocolate")
-            .put("options[1]", "strawberry")
-            .put("optionIds[0]", "1")
-            .put("optionIds[1]", "2")
-            .put("optionAdminNames[0]", "chocolate_admin")
-            .put("optionAdminNames[1]", "strawberry_admin")
-            .put("optionScores[0]", "junk")
-            .put("optionScores[1]", "")
-            .put("nextAvailableId", "3")
-            .put("questionExportState", "NON_DEMOGRAPHIC")
-            .put("concurrencyToken", question.getConcurrencyToken().toString())
-            .build();
-    Request request =
-        fakeRequestBuilder()
-            .addCSRFToken()
-            .addCiviFormSetting("ANSWER_OPTION_SCORING_ENABLED", "true")
-            .addCiviFormSetting("ADMIN_UI_MIGRATION_J2HTML_TO_THYMELEAF_SC_ENABLED", "true")
-            .bodyForm(formData)
-            .build();
-
-    Result result =
-        controller.update(request, question.id, definition.getQuestionType().toString());
-
-    // The error re-render honors the migration flag: the Thymeleaf page comes back with the
-    // score inputs so the admin can correct and resubmit.
-    assertThat(result.status()).isEqualTo(OK);
-    String unescaped = StringEscapeUtils.unescapeHtml4(contentAsString(result));
-    assertThat(unescaped).contains("Option score 'junk' must be a number");
-    assertThat(unescaped).contains("name=\"optionScores[]\"");
-    MultiOptionQuestionDefinition found =
-        (MultiOptionQuestionDefinition)
-            questionRepo
-                .lookupQuestion(question.id)
-                .toCompletableFuture()
-                .join()
-                .get()
-                .getQuestionDefinition();
-    assertThat(found.getOptions().stream().map(QuestionOption::score))
-        .containsExactly(Optional.of(3.5), Optional.empty());
   }
 
   @Test
@@ -1549,7 +1496,7 @@ public class AdminQuestionControllerTest extends ResetPostgres {
 
     assertThat(result.status()).isEqualTo(OK);
     assertThat(contentAsString(result))
-        .containsPattern("name=\"optionScores\\[\\]\"[^>]*value=\"3.5\"");
+        .containsPattern("value=\"3.5\"[^>]*name=\"optionScores\\[\\]\"");
   }
 
   @Test

--- a/server/test/controllers/admin/AdminQuestionControllerTest.java
+++ b/server/test/controllers/admin/AdminQuestionControllerTest.java
@@ -1103,7 +1103,7 @@ public class AdminQuestionControllerTest extends ResetPostgres {
     assertThat(result.status()).isEqualTo(OK);
     String unescaped = StringEscapeUtils.unescapeHtml4(contentAsString(result));
     assertThat(unescaped)
-        .contains("When creating a scored question, all options must include scores.");
+        .contains("When creating a scored question, all options must include scores");
     assertThat(retrieveAllQuestionIds().size()).isEqualTo(questionIdsBefore.size());
   }
 
@@ -1379,7 +1379,7 @@ public class AdminQuestionControllerTest extends ResetPostgres {
                 .get()
                 .getQuestionDefinition();
     assertThat(found.getOptions().stream().map(QuestionOption::score))
-        .containsExactly(Optional.empty(), Optional.of(-1.25));
+        .containsExactly(Optional.of(0.0), Optional.of(-1.25));
   }
 
   @Test
@@ -1468,7 +1468,7 @@ public class AdminQuestionControllerTest extends ResetPostgres {
     assertThat(result.status()).isEqualTo(OK);
     String unescaped = StringEscapeUtils.unescapeHtml4(contentAsString(result));
     assertThat(unescaped)
-        .contains("When creating a scored question, all options must include scores.");
+        .contains("When creating a scored question, all options must include scores");
     MultiOptionQuestionDefinition found =
         (MultiOptionQuestionDefinition)
             questionRepo

--- a/server/test/forms/questions/MultiOptionQuestionFormTest.java
+++ b/server/test/forms/questions/MultiOptionQuestionFormTest.java
@@ -349,8 +349,7 @@ public class MultiOptionQuestionFormTest {
     assertThat(form.getOptionScoreErrors())
         .extracting(CiviFormError::message)
         .containsExactly(
-            "When creating a scored question, all options must include scoresWhen creating a scored"
-                + " question, all options must include scores",
+            "When creating a scored question, all options must include scores",
             "The number of option scores must match the number of options");
   }
 

--- a/server/test/forms/questions/MultiOptionQuestionFormTest.java
+++ b/server/test/forms/questions/MultiOptionQuestionFormTest.java
@@ -349,7 +349,8 @@ public class MultiOptionQuestionFormTest {
     assertThat(form.getOptionScoreErrors())
         .extracting(CiviFormError::message)
         .containsExactly(
-            "When creating a scored question, all options must include scores.",
+            "When creating a scored question, all options must include scoresWhen creating a scored"
+                + " question, all options must include scores",
             "The number of option scores must match the number of options");
   }
 

--- a/server/test/mapping/admin/questions/QuestionFormPageMapperTest.java
+++ b/server/test/mapping/admin/questions/QuestionFormPageMapperTest.java
@@ -5,8 +5,11 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
+import forms.questions.DropdownQuestionForm;
 import forms.questions.TextQuestionForm;
 import forms.questions.YesNoQuestionForm;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 import org.junit.Before;
 import org.junit.Test;
@@ -33,6 +36,7 @@ public final class QuestionFormPageMapperTest {
         null,
         /* apiBridgeEnabled= */ false,
         /* enumeratorImprovementsEnabled= */ false,
+        /* answerOptionScoringEnabled= */ false,
         readOnlyQuestionService,
         Optional.empty());
   }
@@ -45,6 +49,7 @@ public final class QuestionFormPageMapperTest {
         null,
         /* apiBridgeEnabled= */ false,
         /* enumeratorImprovementsEnabled= */ false,
+        /* answerOptionScoringEnabled= */ false,
         readOnlyQuestionService,
         Optional.empty());
   }
@@ -174,12 +179,85 @@ public final class QuestionFormPageMapperTest {
             null,
             /* apiBridgeEnabled= */ false,
             /* enumeratorImprovementsEnabled= */ false,
+            /* answerOptionScoringEnabled= */ false,
             readOnlyQuestionService,
             Optional.empty());
 
     assertThat(result.getYesNoConfig()).isNotNull();
     assertThat(result.getYesNoConfig().showLabel()).isTrue();
     assertThat(result.getYesNoConfig().options()).hasSize(4);
+  }
+
+  @Test
+  public void mapNew_scoringEnabledSupportedType_showsScores() {
+    QuestionFormPageViewModel result =
+        mapper.mapNew(
+            new DropdownQuestionForm(),
+            ImmutableList.of(),
+            null,
+            /* apiBridgeEnabled= */ false,
+            /* enumeratorImprovementsEnabled= */ false,
+            /* answerOptionScoringEnabled= */ true,
+            readOnlyQuestionService,
+            Optional.empty());
+
+    assertThat(result.isShowScores()).isTrue();
+  }
+
+  @Test
+  public void mapNew_scoringDisabled_hidesScores() {
+    QuestionFormPageViewModel result =
+        mapper.mapNew(
+            new DropdownQuestionForm(),
+            ImmutableList.of(),
+            null,
+            /* apiBridgeEnabled= */ false,
+            /* enumeratorImprovementsEnabled= */ false,
+            /* answerOptionScoringEnabled= */ false,
+            readOnlyQuestionService,
+            Optional.empty());
+
+    assertThat(result.isShowScores()).isFalse();
+  }
+
+  @Test
+  public void mapNew_scoringEnabledUnsupportedTypes_hidesScores() {
+    QuestionFormPageViewModel yesNoResult =
+        mapper.mapNew(
+            new YesNoQuestionForm(),
+            ImmutableList.of(),
+            null,
+            /* apiBridgeEnabled= */ false,
+            /* enumeratorImprovementsEnabled= */ false,
+            /* answerOptionScoringEnabled= */ true,
+            readOnlyQuestionService,
+            Optional.empty());
+    QuestionFormPageViewModel textResult =
+        mapper.mapNew(
+            new TextQuestionForm(),
+            ImmutableList.of(),
+            null,
+            /* apiBridgeEnabled= */ false,
+            /* enumeratorImprovementsEnabled= */ false,
+            /* answerOptionScoringEnabled= */ true,
+            readOnlyQuestionService,
+            Optional.empty());
+
+    assertThat(yesNoResult.isShowScores()).isFalse();
+    assertThat(textResult.isShowScores()).isFalse();
+  }
+
+  @Test
+  public void scoreDisplayValue_formatsAndToleratesBlankInvalidAndSparseEntries() {
+    QuestionFormPageViewModel model = mapNewTextForm(new TextQuestionForm());
+
+    assertThat(model.scoreDisplayValue(List.of("2.0"), 0)).isEqualTo("2");
+    assertThat(model.scoreDisplayValue(List.of("1.50"), 0)).isEqualTo("1.5");
+    assertThat(model.scoreDisplayValue(List.of("-0.50"), 0)).isEqualTo("-0.5");
+    assertThat(model.scoreDisplayValue(List.of(""), 0)).isNull();
+    assertThat(model.scoreDisplayValue(List.of("junk"), 0)).isNull();
+    assertThat(model.scoreDisplayValue(List.of(), 0)).isNull();
+    assertThat(model.scoreDisplayValue(Arrays.asList((String) null), 0)).isNull();
   }
 
   @Test
@@ -193,6 +271,7 @@ public final class QuestionFormPageMapperTest {
             null,
             /* apiBridgeEnabled= */ false,
             /* enumeratorImprovementsEnabled= */ false,
+            /* answerOptionScoringEnabled= */ false,
             readOnlyQuestionService,
             Optional.of("Something went wrong"));
 
@@ -230,6 +309,7 @@ public final class QuestionFormPageMapperTest {
             null,
             /* apiBridgeEnabled= */ true,
             /* enumeratorImprovementsEnabled= */ false,
+            /* answerOptionScoringEnabled= */ false,
             readOnlyQuestionService,
             Optional.empty());
 
@@ -275,6 +355,7 @@ public final class QuestionFormPageMapperTest {
             null,
             /* apiBridgeEnabled= */ false,
             /* enumeratorImprovementsEnabled= */ false,
+            /* answerOptionScoringEnabled= */ false,
             readOnlyQuestionService,
             Optional.empty());
 
@@ -313,6 +394,7 @@ public final class QuestionFormPageMapperTest {
             null,
             /* apiBridgeEnabled= */ false,
             /* enumeratorImprovementsEnabled= */ false,
+            /* answerOptionScoringEnabled= */ false,
             readOnlyQuestionService,
             Optional.empty());
 
@@ -331,6 +413,7 @@ public final class QuestionFormPageMapperTest {
             null,
             /* apiBridgeEnabled= */ false,
             /* enumeratorImprovementsEnabled= */ false,
+            /* answerOptionScoringEnabled= */ false,
             readOnlyQuestionService,
             Optional.of("Error occurred"));
 

--- a/server/test/resources/thymeleaf/admin/questions/legacyQuestionFragments/multiOptionRowExisting.thtest
+++ b/server/test/resources/thymeleaf/admin/questions/legacyQuestionFragments/multiOptionRowExisting.thtest
@@ -6,7 +6,7 @@ adminValidation.multiOptionAdminError=Admin names can only contain lowercase let
 adminValidation.multiOptionEmpty=Multi option questions cannot have blank options.
 # ----------------------------------------------------------------------
 %INPUT
-<div th:replace="~{admin/questions/fragments/MultiOptionRow :: multiOptionRow(false, '42', 'option_one', 'Option one', 'field-1', 'field-2', 'field-3')}"></div>
+<div th:replace="~{admin/questions/fragments/MultiOptionRow :: multiOptionRow(false, '42', 'option_one', 'Option one', 'field-1', 'field-2', 'field-3', false, null, 'field-4')}"></div>
 # ----------------------------------------------------------------------
 %OUTPUT
 <div

--- a/server/test/resources/thymeleaf/admin/questions/legacyQuestionFragments/multiOptionRowScored.thtest
+++ b/server/test/resources/thymeleaf/admin/questions/legacyQuestionFragments/multiOptionRowScored.thtest
@@ -1,4 +1,4 @@
-%NAME multiOptionRow - new option posts to the newOptions fields and has no optionIds field
+%NAME multiOptionRow - showScores grows the grid and renders an editable score input
 %TEMPLATE_MODE HTML
 %MESSAGES
 toast.errorMessageOutline=Error: {0}
@@ -6,13 +6,28 @@ adminValidation.multiOptionAdminError=Admin names can only contain lowercase let
 adminValidation.multiOptionEmpty=Multi option questions cannot have blank options.
 # ----------------------------------------------------------------------
 %INPUT
-<div th:replace="~{admin/questions/fragments/MultiOptionRow :: multiOptionRow(true, null, '', '', 'field-1', 'field-2', 'field-3', false, null, 'field-4')}"></div>
+<div th:replace="~{admin/questions/fragments/MultiOptionRow :: multiOptionRow(false, '42', 'option_one', 'Option one', 'field-1', 'field-2', 'field-3', true, '2.5', 'field-4')}"></div>
 # ----------------------------------------------------------------------
 %OUTPUT
 <div
-  class="cf-multi-option-question-option cf-multi-option-question-option-editable grid grid-cols-8 grid-rows-4 items-center mb-4"
+  class="cf-multi-option-question-option cf-multi-option-question-option-editable grid grid-cols-8 grid-rows-6 items-center mb-4"
 >
-  <div></div>
+  <div class="hidden">
+    <label for="field-1" class="sr-only"
+      >option ids<span class="usa-hint--required hidden" aria-hidden="true">&nbsp;*</span></label
+    >
+    <div class="flex flex-col">
+      <input
+        type="text"
+        value="42"
+        maxlength="10000"
+        id="field-1"
+        name="optionIds[]"
+        class="px-3 bg-white text-black text-lg py-2 block outline-none box-border m-auto border border-gray-500 rounded-lg w-full focus:border-civiform-blue placeholder-gray-500"
+      />
+      <div id="field-1-errors" class="text-red-600 text-xs p-1 hidden"></div>
+    </div>
+  </div>
   <div
     class="cf-multi-option-admin-input col-start-1 col-span-5 mb-2 ml-2 row-start-1 row-span-2"
   >
@@ -24,12 +39,13 @@ adminValidation.multiOptionEmpty=Multi option questions cannot have blank option
     <div class="flex flex-col">
       <input
         type="text"
-        value=""
+        value="option_one"
         maxlength="10000"
         aria-required="true"
         id="field-2"
-        name="newOptionAdminNames[]"
-        class="px-3 bg-white text-black text-lg py-2 block outline-none box-border m-auto border border-gray-500 rounded-lg w-full focus:border-civiform-blue placeholder-gray-500"
+        name="optionAdminNames[]"
+        readonly="readonly"
+        class="px-3 bg-white text-black text-lg py-2 block outline-none box-border m-auto border border-gray-500 rounded-lg w-full focus:border-civiform-blue placeholder-gray-500 read-only:text-gray-500 read-only:bg-gray-100"
       />
       <div
         id="field-2-errors"
@@ -82,11 +98,11 @@ adminValidation.multiOptionEmpty=Multi option questions cannot have blank option
     <div class="flex flex-col">
       <input
         type="text"
-        value=""
+        value="Option one"
         maxlength="10000"
         aria-required="true"
         id="field-3"
-        name="newOptions[]"
+        name="options[]"
         class="px-3 bg-white text-black text-lg py-2 block outline-none box-border m-auto border border-gray-500 rounded-lg w-full focus:border-civiform-blue placeholder-gray-500"
       />
       <div
@@ -139,4 +155,26 @@ adminValidation.multiOptionEmpty=Multi option questions cannot have blank option
       ></path>
     </svg>
   </button>
+  <div
+    class="cf-multi-option-score-input col-start-1 col-span-5 mb-2 ml-2 row-start-5 row-span-2"
+  >
+    <label
+      for="field-4"
+      class="pointer-events-none text-gray-600 text-base px-1 py-2"
+      >Score<span class="usa-hint--required hidden" aria-hidden="true">&nbsp;*</span></label
+    >
+    <div class="flex flex-col">
+      <input
+        type="number"
+        inputmode="decimal"
+        step="any"
+        value="2.5"
+        maxlength="10000"
+        id="field-4"
+        name="optionScores[]"
+        class="px-3 bg-white text-black text-lg py-2 block outline-none box-border m-auto border border-gray-500 rounded-lg w-full focus:border-civiform-blue placeholder-gray-500"
+      />
+      <div id="field-4-errors" class="text-red-600 text-xs p-1 hidden"></div>
+    </div>
+  </div>
 </div>

--- a/server/test/views/admin/question/QuestionConfigTest.java
+++ b/server/test/views/admin/question/QuestionConfigTest.java
@@ -193,10 +193,8 @@ public class QuestionConfigTest extends ResetPostgres {
     assertThat(result).contains("Score");
     assertThat(result).contains("cf-multi-option-score-input");
     assertThat(result).contains("grid-rows-6");
-    assertThat(result)
-        .containsPattern("name=\"optionScores\\[\\]\"[^>]*value=\"4.25\"");
-    assertThat(result)
-        .containsPattern("name=\"newOptionScores\\[\\]\"[^>]*value=\"-2.5\"");
+    assertThat(result).containsPattern("name=\"optionScores\\[\\]\"[^>]*value=\"4.25\"");
+    assertThat(result).containsPattern("name=\"newOptionScores\\[\\]\"[^>]*value=\"-2.5\"");
     // The unscored option renders an empty score input, keeping the lists parallel.
     Matcher scoreInputs = Pattern.compile("name=\"optionScores\\[\\]\"").matcher(result);
     assertThat(scoreInputs.results().count()).isEqualTo(2);

--- a/server/test/views/admin/question/QuestionConfigTest.java
+++ b/server/test/views/admin/question/QuestionConfigTest.java
@@ -179,7 +179,7 @@ public class QuestionConfigTest extends ResetPostgres {
     form.setOptions(ImmutableList.of("option-a", "option-b"));
     form.setOptionAdminNames(ImmutableList.of("option-admin-a", "option-admin-b"));
     form.setOptionIds(ImmutableList.of(1L, 2L));
-    form.setOptionScores(ImmutableList.of("4.25", ""));
+    form.setOptionScores(ImmutableList.of("4.25"));
     form.setNewOptions(ImmutableList.of("option-c"));
     form.setNewOptionAdminNames(ImmutableList.of("option-admin-c"));
     // Trailing zeros are stripped for display: -2.50 renders as -2.5.
@@ -193,8 +193,8 @@ public class QuestionConfigTest extends ResetPostgres {
     assertThat(result).contains("Score");
     assertThat(result).contains("cf-multi-option-score-input");
     assertThat(result).contains("grid-rows-6");
-    assertThat(result).containsPattern("name=\"optionScores\\[\\]\"[^>]*value=\"4.25\"");
-    assertThat(result).containsPattern("name=\"newOptionScores\\[\\]\"[^>]*value=\"-2.5\"");
+    assertThat(result).containsPattern("value=\"4.25\"[^>]*name=\"optionScores\\[\\]\"");
+    assertThat(result).containsPattern("value=\"*-2.5\"[^>]*name=\"newOptionScores\\[\\]\"");
     // The unscored option renders an empty score input, keeping the lists parallel.
     Matcher scoreInputs = Pattern.compile("name=\"optionScores\\[\\]\"").matcher(result);
     assertThat(scoreInputs.results().count()).isEqualTo(2);

--- a/server/test/views/admin/question/QuestionConfigTest.java
+++ b/server/test/views/admin/question/QuestionConfigTest.java
@@ -3,6 +3,7 @@ package views.admin.question;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static play.test.Helpers.stubMessagesApi;
 
 import com.google.common.collect.ImmutableList;
@@ -169,6 +170,67 @@ public class QuestionConfigTest extends ResetPostgres {
     assertThat(result).contains("existing-option-admin-b");
     assertThat(result).contains("new-option-admin-c");
     assertThat(result).contains("new-option-admin-d");
+  }
+
+  @Test
+  public void checkboxForm_scoringFlagEnabled_rendersScoreInputsWithValues() {
+    when(settingsManifest.getAnswerOptionScoringEnabled(request)).thenReturn(true);
+    CheckboxQuestionForm form = new CheckboxQuestionForm();
+    form.setOptions(ImmutableList.of("option-a", "option-b"));
+    form.setOptionAdminNames(ImmutableList.of("option-admin-a", "option-admin-b"));
+    form.setOptionIds(ImmutableList.of(1L, 2L));
+    form.setOptionScores(ImmutableList.of("4.25", ""));
+    form.setNewOptions(ImmutableList.of("option-c"));
+    form.setNewOptionAdminNames(ImmutableList.of("option-admin-c"));
+    // Trailing zeros are stripped for display: -2.50 renders as -2.5.
+    form.setNewOptionScores(ImmutableList.of("-2.50"));
+
+    Optional<DivTag> maybeConfig =
+        QuestionConfig.buildQuestionConfig(form, messages, settingsManifest, request);
+    assertThat(maybeConfig).isPresent();
+    String result = maybeConfig.get().renderFormatted();
+
+    assertThat(result).contains("Score");
+    assertThat(result).contains("cf-multi-option-score-input");
+    assertThat(result).contains("grid-rows-6");
+    assertThat(result)
+        .containsPattern("name=\"optionScores\\[\\]\"[^>]*value=\"4.25\"");
+    assertThat(result)
+        .containsPattern("name=\"newOptionScores\\[\\]\"[^>]*value=\"-2.5\"");
+    // The unscored option renders an empty score input, keeping the lists parallel.
+    Matcher scoreInputs = Pattern.compile("name=\"optionScores\\[\\]\"").matcher(result);
+    assertThat(scoreInputs.results().count()).isEqualTo(2);
+  }
+
+  @Test
+  public void checkboxForm_scoringFlagDisabled_rendersNoScoreInputs() {
+    CheckboxQuestionForm form = new CheckboxQuestionForm();
+    form.setOptions(ImmutableList.of("option-a"));
+    form.setOptionAdminNames(ImmutableList.of("option-admin-a"));
+    form.setOptionIds(ImmutableList.of(1L));
+
+    Optional<DivTag> maybeConfig =
+        QuestionConfig.buildQuestionConfig(form, messages, settingsManifest, request);
+    assertThat(maybeConfig).isPresent();
+    String result = maybeConfig.get().renderFormatted();
+
+    assertThat(result).doesNotContain("optionScores[]");
+    assertThat(result).doesNotContain("cf-multi-option-score-input");
+    assertThat(result).contains("grid-rows-4");
+  }
+
+  @Test
+  public void yesNoForm_scoringFlagEnabled_rendersNoScoreInputs() {
+    when(settingsManifest.getAnswerOptionScoringEnabled(request)).thenReturn(true);
+    YesNoQuestionForm form = new YesNoQuestionForm();
+
+    Optional<DivTag> maybeConfig =
+        QuestionConfig.buildQuestionConfig(form, messages, settingsManifest, request);
+    assertThat(maybeConfig).isPresent();
+    String result = maybeConfig.get().renderFormatted();
+
+    assertThat(result).doesNotContain("optionScores[]");
+    assertThat(result).doesNotContain("cf-multi-option-score-input");
   }
 
   @Test

--- a/server/test/views/admin/questions/LegacyQuestionFragmentsTest.java
+++ b/server/test/views/admin/questions/LegacyQuestionFragmentsTest.java
@@ -95,4 +95,14 @@ public class LegacyQuestionFragmentsTest {
   public void multiOptionRow_existingOption() {
     ThymeleafFragmentTester.run(DIR + "multiOptionRowExisting.thtest");
   }
+
+  /**
+   * With showScores on (the answer-option-scoring flag and a supported question type), the row
+   * grows to six grid rows and renders a never-readonly score input posting to optionScores[],
+   * with the pre-formatted display value.
+   */
+  @Test
+  public void multiOptionRow_scoredOption() {
+    ThymeleafFragmentTester.run(DIR + "multiOptionRowScored.thtest");
+  }
 }

--- a/server/test/views/admin/questions/LegacyQuestionFragmentsTest.java
+++ b/server/test/views/admin/questions/LegacyQuestionFragmentsTest.java
@@ -98,8 +98,8 @@ public class LegacyQuestionFragmentsTest {
 
   /**
    * With showScores on (the answer-option-scoring flag and a supported question type), the row
-   * grows to six grid rows and renders a never-readonly score input posting to optionScores[],
-   * with the pre-formatted display value.
+   * grows to six grid rows and renders a never-readonly score input posting to optionScores[], with
+   * the pre-formatted display value.
    */
   @Test
   public void multiOptionRow_scoredOption() {


### PR DESCRIPTION
### Description

Add optional score input boxes on the admin question create/edit page for radio, checkbox, and dropdown type questions. Includes changes to both the new Thymeleaf admin frontend and legacy j2html frontend. New fields are only visible when the `ANSWER_OPTION_SCORING_ENABLED` flag is set to true.

Assisted-by: Claude Code:claude-fable-5

<img width="550" height="660" alt="image" src="https://github.com/user-attachments/assets/8fab7481-3b42-4666-a3fa-0d3b2f4486af" />

### Checklist

Remove any sections below that do not apply to your PR. For sections that do apply, complete all of the appropriate checklist items and check them off. If a checklist item doesn't apply to your PR, leave it unchecked but do not delete it.

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [ ] Added an additional reviewer as required if changes potentially affect the security of the application.
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [x] Noted in the PR description which, if any, code in this PR was generated by AI.

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/helper/feature-flags.conf`
- [x] Conditioned new functionality on a [FeatureFlag](https://github.com/civiform/civiform/wiki/Feature-Flags)
- [x] Wrote browser tests with the feature flag off and on, etc.

### Instructions for manual testing

1. As a CiviForm admin, turn on the `ANSWER_OPTION_SCORING_ENABLED` flag
2. Create a new checkbox, radio, and/or dropdown type question, see new score fields
3. Enter scores into the score fields -- confirm they save
4. Edit the question and confirm scores are still shown
5. Test error handling -- attempt to enter a non-numeric value or leave one of the scores blank, should see error
6. Remove all the scores and save -- should save successfully
7. Confirm scores are maintained even with flag off: Toggle the flag off and edit the question -- score fields should not show. Toggle the flag back on and edit the question -- score fields should show again with previously saved values.

### Issue(s) this completes

Fixes #13831 
