### PR TITLE
Fix Renovate Update Failures

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -11,6 +11,16 @@
   labels: ["dependencies"],
   // Amount of time to wait after a release before opening a PR, to avoid chasing yanked or broken releases.
   minimumReleaseAge: "3 days",
+
+  // Throttle requests to Maven Central to reduce the chance of hitting its rate limits.
+  hostRules: [
+    {
+      matchHost: "repo.maven.apache.org",
+      concurrentRequestLimit: 2,
+      maxRequestsPerSecond: 1,
+    },
+  ],
+
   // These files deviate from standard compose naming convention. 
   // This makes sure renovate finds them.
   "docker-compose": {
@@ -24,6 +34,18 @@
     ],
   },
   packageRules: [
+    {
+      // These are locally-built images, not images published to Docker Hub.
+      // Prevent Renovate from attempting Docker Hub lookups for them.
+      matchDatasources: ["docker"],
+      matchPackageNames: [
+        "civiform",
+        "civiform-dev",
+        "civiform-mock-web-services",
+        "civiform-oidc-provider",
+      ],
+      enabled: false,
+    },
     {
       groupName: "autovalue",
       matchPackageNames: ["com.google.auto.value:{/,}**"],


### PR DESCRIPTION
This PR deals with two failures Renovate has been having.

#### One

For a while I have noticed Renovate has been intermittently been getting http 429 errors when trying to update dependencies from the Maven repository. When renovate hits this issue it causes the entire scan to fail. We then have to wait for the Maven server to start allowing the IP of the Renovate server.

Renovate is on the free hosted plan and we are limited in the ways we can control how it runs. Further worsening the issue is the hosted server is a shared resource so other projects could also be contributing to the issue.

This change will throttle calls to Maven to 2 concurrent calls down from 16 hopefully giving it enough space to keep things flowing.

#### Two

Renovate has internal timeouts trying to resolve docker images we build locally. These are built or aliased locally and will never directly resolve on docker hub:

- civiform
- civiform-dev
- civiform-mock-web-services
- civiform-oidc-provider

These are now ignored for the update. Anything with the`civiform/` prefix would remain unaffected as that is on docker hub.


### Checklist

Remove any sections below that do not apply to your PR. For sections that do apply, complete all of the appropriate checklist items and check them off. If a checklist item doesn't apply to your PR, leave it unchecked but do not delete it.

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [ ] Added an additional reviewer as required if changes potentially affect the security of the application.
- [ ] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.
