### PR TITLE
Rockycodes/programs score field

### DIFF
--- a/server/app/controllers/admin/AdminQuestionController.java
+++ b/server/app/controllers/admin/AdminQuestionController.java
@@ -242,9 +242,27 @@ public final class AdminQuestionController extends CiviFormController {
       return badRequest(invalidQuestionTypeMessage(questionType));
     }
 
+    boolean scoringEnabled = settingsManifest.getAnswerOptionScoringEnabled(request);
+
+    // Invalid scores surface as form validation errors and re-render the form, rather than being
+    // silently dropped by the builder below.
+    ImmutableSet<CiviFormError> scoreErrors = getOptionScoreErrors(questionForm, scoringEnabled);
+    if (!scoreErrors.isEmpty()) {
+      ToastMessage errorMessage = ToastMessage.errorNonLocalized(joinErrors(scoreErrors));
+      ImmutableList<EnumeratorQuestionDefinition> enumeratorQuestionDefinitions =
+          service
+              .getReadOnlyQuestionService()
+              .toCompletableFuture()
+              .join()
+              .getUpToDateEnumeratorQuestions();
+      return ok(
+          editView.renderNewQuestionForm(
+              request, questionForm, enumeratorQuestionDefinitions, errorMessage));
+    }
+
     QuestionDefinition questionDefinition;
     try {
-      questionDefinition = questionForm.getBuilder().build();
+      questionDefinition = getBuilder(questionForm, scoringEnabled).build();
     } catch (UnsupportedQuestionTypeException e) {
       // Valid question type that is not yet fully supported.
       return badRequest(e.getMessage());
@@ -428,9 +446,25 @@ public final class AdminQuestionController extends CiviFormController {
 
     Optional<QuestionDefinition> maybeExisting = Optional.of(roService.getQuestionDefinition(id));
 
+    boolean scoringEnabled = settingsManifest.getAnswerOptionScoringEnabled(request);
+
+    // Invalid scores surface as form validation errors and re-render the form, rather than being
+    // silently dropped by the builder below.
+    ImmutableSet<CiviFormError> scoreErrors = getOptionScoreErrors(questionForm, scoringEnabled);
+    if (!scoreErrors.isEmpty()) {
+      return ok(
+          editView.renderEditQuestionForm(
+              request,
+              id,
+              questionForm,
+              maybeGetEnumerationQuestion(roService, maybeExisting.get()),
+              ToastMessage.errorNonLocalized(joinErrors(scoreErrors))));
+    }
+
     QuestionDefinition questionDefinition;
     try {
-      questionDefinition = getBuilder(maybeExisting, questionForm).setId(id).build();
+      questionDefinition =
+          getBuilder(maybeExisting, questionForm, scoringEnabled).setId(id).build();
     } catch (UnsupportedQuestionTypeException e) {
       // Failed while trying to update a question that was already created for the given question
       // type
@@ -496,12 +530,37 @@ public final class AdminQuestionController extends CiviFormController {
     return result;
   }
 
+  /**
+   * Builds the {@link QuestionDefinitionBuilder} for a form response, threading the scoring flag
+   * into multi-option forms. When the flag is off, submitted scores are discarded.
+   */
+  private QuestionDefinitionBuilder getBuilder(QuestionForm questionForm, boolean scoringEnabled) {
+    if (questionForm instanceof MultiOptionQuestionForm multiOptionQuestionForm) {
+      return multiOptionQuestionForm.getBuilder(scoringEnabled);
+    }
+    return questionForm.getBuilder();
+  }
+
+  /**
+   * Returns validation errors for submitted option scores. Only relevant when the scoring flag is
+   * on and the question type supports scores; crafted score fields on other requests are ignored.
+   */
+  private ImmutableSet<CiviFormError> getOptionScoreErrors(
+      QuestionForm questionForm, boolean scoringEnabled) {
+    if (!scoringEnabled
+        || !(questionForm instanceof MultiOptionQuestionForm multiOptionQuestionForm)
+        || !QuestionType.supportsOptionScores(questionForm.getQuestionType())) {
+      return ImmutableSet.of();
+    }
+    return multiOptionQuestionForm.getOptionScoreErrors();
+  }
+
   private QuestionDefinitionBuilder getBuilder(
-      Optional<QuestionDefinition> existing, QuestionForm questionForm) {
-    QuestionDefinitionBuilder updated = questionForm.getBuilder();
+      Optional<QuestionDefinition> existing, QuestionForm questionForm, boolean scoringEnabled) {
+    QuestionDefinitionBuilder updated = getBuilder(questionForm, scoringEnabled);
 
     if (existing.isPresent()) {
-      updateDefaultLocalizations(existing.get(), updated, questionForm);
+      updateDefaultLocalizations(existing.get(), updated, questionForm, scoringEnabled);
     }
 
     return updated;
@@ -514,7 +573,8 @@ public final class AdminQuestionController extends CiviFormController {
   private void updateDefaultLocalizations(
       QuestionDefinition currentQuestionDefinition,
       QuestionDefinitionBuilder updatedQuestionDefinitionBuilder,
-      QuestionForm questionForm) {
+      QuestionForm questionForm,
+      boolean scoringEnabled) {
     // Instead of overwriting all localizations, we just want to overwrite the one
     // for the default locale (the only one possible to change in the edit form).
     updatedQuestionDefinitionBuilder.setQuestionText(
@@ -553,7 +613,8 @@ public final class AdminQuestionController extends CiviFormController {
       updateDefaultLocalizationForOptions(
           updatedQuestionDefinitionBuilder,
           (MultiOptionQuestionDefinition) currentQuestionDefinition,
-          updatedQuestionOptions);
+          updatedQuestionOptions,
+          scoringEnabled);
     }
 
     if (questionForm instanceof MapQuestionForm) {
@@ -590,7 +651,15 @@ public final class AdminQuestionController extends CiviFormController {
   private void updateDefaultLocalizationForOptions(
       QuestionDefinitionBuilder updatedQuestionDefinitionBuilder,
       MultiOptionQuestionDefinition currentQuestionDefinition,
-      ImmutableList<QuestionOption> updatedQuestionOptions) {
+      ImmutableList<QuestionOption> updatedQuestionOptions,
+      boolean scoringEnabled) {
+
+    // When scores don't apply to this edit (flag off or unsupported type), existing options keep
+    // their stored score via toBuilder() below, so an edit made while the flag is off cannot drop
+    // a stored score, and crafted score fields are discarded.
+    boolean applyScores =
+        scoringEnabled
+            && QuestionType.supportsOptionScores(currentQuestionDefinition.getQuestionType());
 
     var existingOptions = currentQuestionDefinition.getOptions();
     ImmutableList.Builder<QuestionOption> newOptionsListBuilder = ImmutableList.builder();
@@ -610,24 +679,31 @@ public final class AdminQuestionController extends CiviFormController {
               .equals(updatedQuestionOptionText.getDefault())) {
         // If there's an existing option with the same ID and same default locale text, then use it
         // and only update the displayOrder, preserving the adminName and translations.
-        newOptionsListBuilder.add(
+        QuestionOption.Builder optionBuilder =
             maybeExistingOptionWithSameId.get().toBuilder()
                 .setDisplayOrder(updatedQuestionOption.displayOrder())
-                .setDisplayInAnswerOptions(updatedQuestionOption.displayInAnswerOptions())
-                .build());
+                .setDisplayInAnswerOptions(updatedQuestionOption.displayInAnswerOptions());
+        if (applyScores) {
+          optionBuilder.setScore(updatedQuestionOption.score());
+        }
+        newOptionsListBuilder.add(optionBuilder.build());
       } else if (maybeExistingOptionWithSameId.isPresent()) {
         // If there's an existing option with the same ID but different text, then use it
         // and update the displayOrder and default locale text, preserving the adminName but
         // clearing any existing translations.
-        newOptionsListBuilder.add(
+        QuestionOption.Builder optionBuilder =
             maybeExistingOptionWithSameId.get().toBuilder()
                 .setDisplayOrder(updatedQuestionOption.displayOrder())
                 .setOptionText(updatedQuestionOptionText)
-                .setDisplayInAnswerOptions(updatedQuestionOption.displayInAnswerOptions())
-                .build());
+                .setDisplayInAnswerOptions(updatedQuestionOption.displayInAnswerOptions());
+        if (applyScores) {
+          optionBuilder.setScore(updatedQuestionOption.score());
+        }
+        newOptionsListBuilder.add(optionBuilder.build());
       } else {
         // If there wasn't an option with the same ID, treat it as a new
-        // option with a new adminName, displayOrder, and text.
+        // option with a new adminName, displayOrder, and text. Its score is already stripped by
+        // the form builder when scores don't apply.
         newOptionsListBuilder.add(updatedQuestionOption);
       }
     }

--- a/server/app/controllers/admin/AdminQuestionController.java
+++ b/server/app/controllers/admin/AdminQuestionController.java
@@ -207,6 +207,7 @@ public final class AdminQuestionController extends CiviFormController {
                     mapSettings,
                     settingsManifest.getApiBridgeEnabled(request),
                     settingsManifest.getEnumeratorImprovementsEnabled(request),
+                    settingsManifest.getAnswerOptionScoringEnabled(request),
                     roService,
                     Optional.empty());
         return ok(questionFormPageView.render(request, model)).as(Http.MimeTypes.HTML);
@@ -248,16 +249,7 @@ public final class AdminQuestionController extends CiviFormController {
     // silently dropped by the builder below.
     ImmutableSet<CiviFormError> scoreErrors = getOptionScoreErrors(questionForm, scoringEnabled);
     if (!scoreErrors.isEmpty()) {
-      ToastMessage errorMessage = ToastMessage.errorNonLocalized(joinErrors(scoreErrors));
-      ImmutableList<EnumeratorQuestionDefinition> enumeratorQuestionDefinitions =
-          service
-              .getReadOnlyQuestionService()
-              .toCompletableFuture()
-              .join()
-              .getUpToDateEnumeratorQuestions();
-      return ok(
-          editView.renderNewQuestionForm(
-              request, questionForm, enumeratorQuestionDefinitions, errorMessage));
+      return renderNewQuestionFormWithError(request, questionForm, joinErrors(scoreErrors));
     }
 
     QuestionDefinition questionDefinition;
@@ -274,31 +266,7 @@ public final class AdminQuestionController extends CiviFormController {
     ErrorAnd<QuestionDefinition, CiviFormError> result =
         service.create(questionDefinition, enumeratorImprovementsEnabled);
     if (result.isError()) {
-      String errorText = joinErrors(result.getErrors());
-      ReadOnlyQuestionService roService =
-          service.getReadOnlyQuestionService().toCompletableFuture().join();
-      ImmutableList<EnumeratorQuestionDefinition> enumeratorQuestionDefinitions =
-          roService.getUpToDateEnumeratorQuestions();
-
-      if (settingsManifest.getAdminUiMigrationJ2htmlToThymeleafScEnabled(request)) {
-        MapQuestionSettingsPartialViewModel mapSettings = buildMapSettingsViewModel(questionForm);
-        QuestionFormPageViewModel model =
-            new QuestionFormPageMapper()
-                .mapNew(
-                    questionForm,
-                    enumeratorQuestionDefinitions,
-                    mapSettings,
-                    settingsManifest.getApiBridgeEnabled(request),
-                    settingsManifest.getEnumeratorImprovementsEnabled(request),
-                    roService,
-                    Optional.of(errorText));
-        return ok(questionFormPageView.render(request, model)).as(Http.MimeTypes.HTML);
-      }
-
-      ToastMessage errorMessage = ToastMessage.errorNonLocalized(errorText);
-      return ok(
-          editView.renderNewQuestionForm(
-              request, questionForm, enumeratorQuestionDefinitions, errorMessage));
+      return renderNewQuestionFormWithError(request, questionForm, joinErrors(result.getErrors()));
     }
 
     try {
@@ -452,13 +420,13 @@ public final class AdminQuestionController extends CiviFormController {
     // silently dropped by the builder below.
     ImmutableSet<CiviFormError> scoreErrors = getOptionScoreErrors(questionForm, scoringEnabled);
     if (!scoreErrors.isEmpty()) {
-      return ok(
-          editView.renderEditQuestionForm(
-              request,
-              id,
-              questionForm,
-              maybeGetEnumerationQuestion(roService, maybeExisting.get()),
-              ToastMessage.errorNonLocalized(joinErrors(scoreErrors))));
+      return renderEditQuestionFormWithError(
+          request,
+          id,
+          questionForm,
+          maybeGetEnumerationQuestion(roService, maybeExisting.get()),
+          roService,
+          joinErrors(scoreErrors));
     }
 
     QuestionDefinition questionDefinition;
@@ -491,26 +459,13 @@ public final class AdminQuestionController extends CiviFormController {
     }
 
     if (errorAndUpdatedQuestionDefinition.isError()) {
-      String errorText = joinErrors(errorAndUpdatedQuestionDefinition.getErrors());
-      Optional<QuestionDefinition> maybeEnumerationQuestion =
-          maybeGetEnumerationQuestion(roService, questionDefinition);
-
-      if (settingsManifest.getAdminUiMigrationJ2htmlToThymeleafScEnabled(request)) {
-        QuestionFormPageViewModel model =
-            buildEditQuestionPageModel(
-                id,
-                questionForm,
-                maybeEnumerationQuestion,
-                roService,
-                request,
-                Optional.of(errorText));
-        return ok(questionFormPageView.render(request, model)).as(Http.MimeTypes.HTML);
-      }
-
-      ToastMessage errorMessage = ToastMessage.errorNonLocalized(errorText);
-      return ok(
-          editView.renderEditQuestionForm(
-              request, id, questionForm, maybeEnumerationQuestion, errorMessage));
+      return renderEditQuestionFormWithError(
+          request,
+          id,
+          questionForm,
+          maybeGetEnumerationQuestion(roService, questionDefinition),
+          roService,
+          joinErrors(errorAndUpdatedQuestionDefinition.getErrors()));
     }
     try {
       service.setExportState(
@@ -539,6 +494,68 @@ public final class AdminQuestionController extends CiviFormController {
       return multiOptionQuestionForm.getBuilder(scoringEnabled);
     }
     return questionForm.getBuilder();
+  }
+
+  /**
+   * Re-renders the new-question form with a form-level error, honoring the j2html-to-Thymeleaf
+   * migration flag.
+   */
+  private Result renderNewQuestionFormWithError(
+      Request request, QuestionForm questionForm, String errorText) {
+    ReadOnlyQuestionService roService =
+        service.getReadOnlyQuestionService().toCompletableFuture().join();
+    ImmutableList<EnumeratorQuestionDefinition> enumeratorQuestionDefinitions =
+        roService.getUpToDateEnumeratorQuestions();
+
+    if (settingsManifest.getAdminUiMigrationJ2htmlToThymeleafScEnabled(request)) {
+      MapQuestionSettingsPartialViewModel mapSettings = buildMapSettingsViewModel(questionForm);
+      QuestionFormPageViewModel model =
+          new QuestionFormPageMapper()
+              .mapNew(
+                  questionForm,
+                  enumeratorQuestionDefinitions,
+                  mapSettings,
+                  settingsManifest.getApiBridgeEnabled(request),
+                  settingsManifest.getEnumeratorImprovementsEnabled(request),
+                  settingsManifest.getAnswerOptionScoringEnabled(request),
+                  roService,
+                  Optional.of(errorText));
+      return ok(questionFormPageView.render(request, model)).as(Http.MimeTypes.HTML);
+    }
+
+    ToastMessage errorMessage = ToastMessage.errorNonLocalized(errorText);
+    return ok(
+        editView.renderNewQuestionForm(
+            request, questionForm, enumeratorQuestionDefinitions, errorMessage));
+  }
+
+  /**
+   * Re-renders the edit-question form with a form-level error, honoring the j2html-to-Thymeleaf
+   * migration flag.
+   */
+  private Result renderEditQuestionFormWithError(
+      Request request,
+      Long id,
+      QuestionForm questionForm,
+      Optional<QuestionDefinition> maybeEnumerationQuestion,
+      ReadOnlyQuestionService roService,
+      String errorText) {
+    if (settingsManifest.getAdminUiMigrationJ2htmlToThymeleafScEnabled(request)) {
+      QuestionFormPageViewModel model =
+          buildEditQuestionPageModel(
+              id,
+              questionForm,
+              maybeEnumerationQuestion,
+              roService,
+              request,
+              Optional.of(errorText));
+      return ok(questionFormPageView.render(request, model)).as(Http.MimeTypes.HTML);
+    }
+
+    ToastMessage errorMessage = ToastMessage.errorNonLocalized(errorText);
+    return ok(
+        editView.renderEditQuestionForm(
+            request, id, questionForm, maybeEnumerationQuestion, errorMessage));
   }
 
   /**
@@ -810,6 +827,7 @@ public final class AdminQuestionController extends CiviFormController {
             mapSettings,
             settingsManifest.getApiBridgeEnabled(request),
             settingsManifest.getEnumeratorImprovementsEnabled(request),
+            settingsManifest.getAnswerOptionScoringEnabled(request),
             readOnlyQuestionService,
             errorMessage);
   }

--- a/server/app/forms/questions/MultiOptionQuestionForm.java
+++ b/server/app/forms/questions/MultiOptionQuestionForm.java
@@ -2,12 +2,16 @@ package forms.questions;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
+import services.CiviFormError;
 import services.LocalizedStrings;
 import services.TranslationNotFoundException;
 import services.question.LocalizedQuestionOption;
@@ -30,6 +34,10 @@ public abstract class MultiOptionQuestionForm extends QuestionForm {
   private List<Long> optionIds;
   private List<String> optionAdminNames;
   private List<String> newOptionAdminNames;
+  // Optional per-option scores, parallel to options/newOptions. Stored as strings so that blank
+  // (unscored), 0, and invalid input are distinguishable; see parseScore.
+  private List<String> optionScores;
+  private List<String> newOptionScores;
 
   // The IDs of option types which have been selected by the admin to be included in the question's
   // answer options.
@@ -50,6 +58,8 @@ public abstract class MultiOptionQuestionForm extends QuestionForm {
     this.optionIds = new ArrayList<>();
     this.optionAdminNames = new ArrayList<>();
     this.newOptionAdminNames = new ArrayList<>();
+    this.optionScores = new ArrayList<>();
+    this.newOptionScores = new ArrayList<>();
     this.displayedOptionIds = new ArrayList<>();
     this.minChoicesRequired = OptionalInt.empty();
     this.maxChoicesAllowed = OptionalInt.empty();
@@ -71,7 +81,16 @@ public abstract class MultiOptionQuestionForm extends QuestionForm {
     this.optionIds = new ArrayList<>();
     this.optionAdminNames = new ArrayList<>();
     this.newOptionAdminNames = new ArrayList<>();
+    this.optionScores = new ArrayList<>();
+    this.newOptionScores = new ArrayList<>();
     this.displayedOptionIds = new ArrayList<>();
+
+    // Scores live on QuestionOption only (never on the applicant-facing LocalizedQuestionOption),
+    // so resolve them by option id.
+    ImmutableMap<Long, QuestionOption> optionsById =
+        qd.getOptions().stream()
+            .collect(
+                ImmutableMap.toImmutableMap(QuestionOption::id, option -> option, (a, b) -> a));
 
     try {
       // The first time a question is created, we only create for the default locale. The admin can
@@ -84,6 +103,11 @@ public abstract class MultiOptionQuestionForm extends QuestionForm {
                   options.add(option.optionText());
                   optionIds.add(option.id());
                   optionAdminNames.add(option.adminName());
+                  optionScores.add(
+                      Optional.ofNullable(optionsById.get(option.id()))
+                          .flatMap(QuestionOption::score)
+                          .map(QuestionOption::formatScore)
+                          .orElse(""));
                   if (getQuestionType() == QuestionType.YES_NO) {
                     if (option.displayInAnswerOptions().isPresent()
                         && option.displayInAnswerOptions().get()) {
@@ -144,6 +168,22 @@ public abstract class MultiOptionQuestionForm extends QuestionForm {
     this.newOptionAdminNames = newOptionAdminNames;
   }
 
+  public List<String> getOptionScores() {
+    return this.optionScores;
+  }
+
+  public void setOptionScores(List<String> optionScores) {
+    this.optionScores = optionScores;
+  }
+
+  public List<String> getNewOptionScores() {
+    return this.newOptionScores;
+  }
+
+  public void setNewOptionScores(List<String> newOptionScores) {
+    this.newOptionScores = newOptionScores;
+  }
+
   public List<Long> getDisplayedOptionIds() {
     return this.displayedOptionIds;
   }
@@ -195,13 +235,93 @@ public abstract class MultiOptionQuestionForm extends QuestionForm {
   }
 
   /**
+   * Returns validation problems with the submitted option scores, as form errors rather than
+   * exceptions so the edit view can re-render with a message.
+   *
+   * <p>Each score list must be parallel to its option list, and every non-blank entry must parse
+   * as a finite decimal number. The cardinality check is unconditional: callers only validate
+   * scores when the score inputs were rendered, so a missing or short list is a crafted post (or
+   * a mid-edit flag flip) and must error rather than silently build unscored options — for an
+   * existing question that would wipe its stored scores.
+   */
+  public ImmutableSet<CiviFormError> getOptionScoreErrors() {
+    ImmutableSet.Builder<CiviFormError> errors = ImmutableSet.builder();
+    if (optionScores.size() != options.size()) {
+      errors.add(
+          CiviFormError.of("The number of option scores does not match the number of options"));
+    }
+    if (newOptionScores.size() != newOptions.size()) {
+      errors.add(
+          CiviFormError.of(
+              "The number of new option scores does not match the number of new options"));
+    }
+    for (String scoreAsString : optionScores) {
+      addParseErrorIfInvalid(errors, scoreAsString);
+    }
+    for (String scoreAsString : newOptionScores) {
+      addParseErrorIfInvalid(errors, scoreAsString);
+    }
+    return errors.build();
+  }
+
+  private static void addParseErrorIfInvalid(
+      ImmutableSet.Builder<CiviFormError> errors, String scoreAsString) {
+    if (!isBlank(scoreAsString) && parseScore(scoreAsString).isEmpty()) {
+      errors.add(
+          CiviFormError.of(
+              String.format("Option score '%s' must be a number", scoreAsString.trim())));
+    }
+  }
+
+  private static boolean isBlank(String scoreAsString) {
+    return scoreAsString == null || scoreAsString.isBlank();
+  }
+
+  /**
+   * Parses an admin-entered score. Blank means unscored. Parsing goes through {@link BigDecimal}
+   * rather than {@link Double#parseDouble} as a server-side backstop against crafted posts: it
+   * accepts plain and exponent decimal notation but rejects the NaN/Infinity/hex/suffix forms
+   * Double.parseDouble tolerates, and the finite check rejects double-overflowing exponents.
+   * Invalid input surfaces as empty here and as errors in {@link #getOptionScoreErrors}.
+   */
+  private static Optional<Double> parseScore(String scoreAsString) {
+    if (isBlank(scoreAsString)) {
+      return Optional.empty();
+    }
+    try {
+      double score = new BigDecimal(scoreAsString.trim()).doubleValue();
+      return Double.isFinite(score) ? Optional.of(score) : Optional.empty();
+    } catch (NumberFormatException e) {
+      return Optional.empty();
+    }
+  }
+
+  private static Optional<Double> scoreAt(List<String> scores, int index) {
+    return index < scores.size() ? parseScore(scores.get(index)) : Optional.empty();
+  }
+
+  /**
    * Build a {@link QuestionDefinitionBuilder} from this QuestionForm, for handling the form
-   * response.
+   * response. Option scores are never applied through this overload; callers with the scoring
+   * feature flag in hand use {@link #getBuilder(boolean)}.
    *
    * @return a {@link QuestionDefinitionBuilder} with the values from this QuestionForm
    */
   @Override
   public QuestionDefinitionBuilder getBuilder() {
+    return getBuilder(/* scoringEnabled= */ false);
+  }
+
+  /**
+   * Build a {@link QuestionDefinitionBuilder} from this QuestionForm, for handling the form
+   * response.
+   *
+   * @param scoringEnabled whether the answer-option-scoring feature flag is on for this request;
+   *     when false (or the question type does not support scores), submitted scores are discarded
+   *     and options are built unscored
+   * @return a {@link QuestionDefinitionBuilder} with the values from this QuestionForm
+   */
+  public QuestionDefinitionBuilder getBuilder(boolean scoringEnabled) {
     MultiOptionQuestionDefinition.MultiOptionValidationPredicates.Builder predicateBuilder =
         MultiOptionQuestionDefinition.MultiOptionValidationPredicates.builder();
 
@@ -222,6 +342,10 @@ public abstract class MultiOptionQuestionForm extends QuestionForm {
         this.optionAdminNames.size() == this.options.size(),
         "Option admin names and options are not the same size.");
 
+    // Scores only apply when the feature flag is on and the type supports them; this inherently
+    // excludes Yes/No questions.
+    boolean applyScores = scoringEnabled && QuestionType.supportsOptionScores(getQuestionType());
+
     // Note: the question edit form only sets or updates the default locale.
     for (int i = 0; i < options.size(); i++) {
       // Yes/No questions have optional question options; all other question types should write
@@ -236,7 +360,8 @@ public abstract class MultiOptionQuestionForm extends QuestionForm {
               /* displayOrder= */ i,
               /* adminName= */ optionAdminNames.get(i),
               /* optionText= */ LocalizedStrings.withDefaultValue(options.get(i)),
-              /* displayInAnswerOptions= */ Optional.of(displayInAnswerOptions)));
+              /* displayInAnswerOptions= */ Optional.of(displayInAnswerOptions),
+              /* score= */ applyScores ? scoreAt(optionScores, i) : Optional.empty()));
     }
 
     // Get the next available ID, from either the max of the option IDs in the response or the
@@ -251,7 +376,8 @@ public abstract class MultiOptionQuestionForm extends QuestionForm {
               /* displayOrder= */ options.size() + i,
               /* adminName= */ newOptionAdminNames.get(i),
               /* optionText= */ LocalizedStrings.withDefaultValue(newOptions.get(i)),
-              /* displayInAnswerOptions= */ Optional.of(true)));
+              /* displayInAnswerOptions= */ Optional.of(true),
+              /* score= */ applyScores ? scoreAt(newOptionScores, i) : Optional.empty()));
     }
     ImmutableList<QuestionOption> questionOptions = questionOptionsBuilder.build();
 

--- a/server/app/forms/questions/MultiOptionQuestionForm.java
+++ b/server/app/forms/questions/MultiOptionQuestionForm.java
@@ -278,6 +278,15 @@ public abstract class MultiOptionQuestionForm extends QuestionForm {
   }
 
   /**
+   * Converts a bound score string to its input display value, formatted without trailing zeros.
+   * Blank (unscored) and unparseable values render an empty input; invalid submissions are
+   * re-rendered alongside a form-level error from {@link #getOptionScoreErrors}.
+   */
+  public static Optional<String> formatScoreForDisplay(String scoreAsString) {
+    return parseScore(scoreAsString).map(QuestionOption::formatScore);
+  }
+
+  /**
    * Parses an admin-entered score. Blank means unscored. Parsing goes through {@link BigDecimal}
    * rather than {@link Double#parseDouble} as a server-side backstop against crafted posts: it
    * accepts plain and exponent decimal notation but rejects the NaN/Infinity/hex/suffix forms

--- a/server/app/mapping/admin/questions/QuestionFormPageMapper.java
+++ b/server/app/mapping/admin/questions/QuestionFormPageMapper.java
@@ -28,6 +28,7 @@ public final class QuestionFormPageMapper {
       MapQuestionSettingsPartialViewModel mapSettings,
       boolean apiBridgeEnabled,
       boolean enumeratorImprovementsEnabled,
+      boolean answerOptionScoringEnabled,
       ReadOnlyQuestionService readOnlyQuestionService,
       Optional<String> errorMessage) {
     // Build enumerator options
@@ -51,6 +52,7 @@ public final class QuestionFormPageMapper {
             mapSettings,
             apiBridgeEnabled,
             enumeratorImprovementsEnabled,
+            answerOptionScoringEnabled,
             readOnlyQuestionService,
             errorMessage)
         .editMode(false)
@@ -67,6 +69,7 @@ public final class QuestionFormPageMapper {
       MapQuestionSettingsPartialViewModel mapSettings,
       boolean apiBridgeEnabled,
       boolean enumeratorImprovementsEnabled,
+      boolean answerOptionScoringEnabled,
       ReadOnlyQuestionService readOnlyQuestionService,
       Optional<String> errorMessage) {
     String enumeratorDisplayName =
@@ -77,6 +80,7 @@ public final class QuestionFormPageMapper {
             mapSettings,
             apiBridgeEnabled,
             enumeratorImprovementsEnabled,
+            answerOptionScoringEnabled,
             readOnlyQuestionService,
             errorMessage)
         .editMode(true)
@@ -92,6 +96,7 @@ public final class QuestionFormPageMapper {
       MapQuestionSettingsPartialViewModel mapSettings,
       boolean apiBridgeEnabled,
       boolean enumeratorImprovementsEnabled,
+      boolean answerOptionScoringEnabled,
       ReadOnlyQuestionService readOnlyQuestionService,
       Optional<String> errorMessage) {
     QuestionType questionType = questionForm.getQuestionType();
@@ -150,6 +155,8 @@ public final class QuestionFormPageMapper {
             questionType.equals(QuestionType.YES_NO)
                 ? YesNoConfigMapper.buildYesNoConfig((MultiOptionQuestionForm) questionForm)
                 : null)
+        .showScores(
+            answerOptionScoringEnabled && QuestionType.supportsOptionScores(questionType))
         .errorMessage(errorToastMessage)
         .errorToastId(errorToastMessage.isPresent() ? UUID.randomUUID().toString() : null);
   }

--- a/server/app/models/ProgramModel.java
+++ b/server/app/models/ProgramModel.java
@@ -70,6 +70,9 @@ public class ProgramModel extends BaseModel {
   /** If the program is for logged in applicants only. */
   @Constraints.Required private Boolean loginOnly;
 
+  /** If true, the program applies answer-option scores to submitted applications. */
+  @Constraints.Required private Boolean usesScoring;
+
   /** The notification preferences for this program */
   @Constraints.Required
   private @DbArray List<ProgramNotificationPreference> notificationPreferences;
@@ -195,6 +198,7 @@ public class ProgramModel extends BaseModel {
     this.notificationPreferences = new ArrayList<>(definition.notificationPreferences());
     this.programType = definition.programType();
     this.eligibilityIsGating = definition.eligibilityIsGating();
+    this.usesScoring = definition.usesScoring();
     this.acls = definition.acls();
 
     // Ebeans needs to manage the collection so add categories instead of
@@ -216,6 +220,49 @@ public class ProgramModel extends BaseModel {
 
   /**
    * Construct a new Program object with the given program name, description, and block definitions.
+   * Includes program categories. The program does not use answer-option scoring.
+   */
+  public ProgramModel(
+      String adminName,
+      String adminDescription,
+      String defaultDisplayName,
+      String defaultDisplayDescription,
+      String defaultShortDescription,
+      String defaultConfirmationMessage,
+      String externalLink,
+      String displayMode,
+      ImmutableList<ProgramNotificationPreference> notificationPreferences,
+      ImmutableList<BlockDefinition> blockDefinitions,
+      VersionModel associatedVersion,
+      ProgramType programType,
+      boolean eligibilityIsGating,
+      boolean loginOnly,
+      ProgramAcls programAcls,
+      ImmutableList<CategoryModel> categories,
+      ImmutableList<ApplicationStep> applicationSteps) {
+    this(
+        adminName,
+        adminDescription,
+        defaultDisplayName,
+        defaultDisplayDescription,
+        defaultShortDescription,
+        defaultConfirmationMessage,
+        externalLink,
+        displayMode,
+        notificationPreferences,
+        blockDefinitions,
+        associatedVersion,
+        programType,
+        eligibilityIsGating,
+        loginOnly,
+        /* usesScoring= */ false,
+        programAcls,
+        categories,
+        applicationSteps);
+  }
+
+  /**
+   * Construct a new Program object with the given program name, description, and block definitions.
    * Includes program categories.
    */
   public ProgramModel(
@@ -233,6 +280,7 @@ public class ProgramModel extends BaseModel {
       ProgramType programType,
       boolean eligibilityIsGating,
       boolean loginOnly,
+      boolean usesScoring,
       ProgramAcls programAcls,
       ImmutableList<CategoryModel> categories,
       ImmutableList<ApplicationStep> applicationSteps) {
@@ -253,6 +301,7 @@ public class ProgramModel extends BaseModel {
     this.programType = programType;
     this.eligibilityIsGating = eligibilityIsGating;
     this.loginOnly = loginOnly;
+    this.usesScoring = usesScoring;
     this.acls = programAcls;
 
     // Ebeans needs to manage the collection so add categories instead of
@@ -280,6 +329,7 @@ public class ProgramModel extends BaseModel {
     programType = programDefinition.programType();
     eligibilityIsGating = programDefinition.eligibilityIsGating();
     loginOnly = programDefinition.loginOnly();
+    usesScoring = programDefinition.usesScoring();
     acls = programDefinition.acls();
     localizedSummaryImageDescription =
         programDefinition.localizedSummaryImageDescription().orElse(null);
@@ -318,6 +368,8 @@ public class ProgramModel extends BaseModel {
             .setProgramType(programType)
             .setEligibilityIsGating(eligibilityIsGating)
             .setLoginOnly(loginOnly)
+            // Rows created before the uses_scoring evolution may load a null column value.
+            .setUsesScoring(usesScoring != null && usesScoring)
             .setAcls(acls)
             .setCategories(ImmutableList.copyOf(categories))
             .setApplicationSteps(ImmutableList.copyOf(applicationSteps))

--- a/server/app/services/question/QuestionOption.java
+++ b/server/app/services/question/QuestionOption.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableMap;
+import java.math.BigDecimal;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.OptionalLong;
@@ -39,6 +40,13 @@ public abstract class QuestionOption {
   public abstract Optional<Boolean> displayInAnswerOptions();
 
   /**
+   * The score this option contributes to a submitted application, for programs that use scoring.
+   * Never shown to applicants. Absent means unscored, which is distinct from a score of 0.
+   */
+  @JsonProperty("score")
+  public abstract Optional<Double> score();
+
+  /**
    * Create a QuestionOption, used for JSON mapping to account for the legacy `optionText`.
    *
    * <p>Legacy QuestionOptions from before early May 2021 will not have `localizedOptionText`.
@@ -50,16 +58,20 @@ public abstract class QuestionOption {
       @JsonProperty("adminName") String adminName,
       @JsonProperty("localizedOptionText") LocalizedStrings localizedOptionText,
       @JsonProperty("optionText") ImmutableMap<Locale, String> legacyOptionText,
-      @JsonProperty("displayInAnswerOptions") Optional<Boolean> displayInAnswerOptions) {
+      @JsonProperty("displayInAnswerOptions") Optional<Boolean> displayInAnswerOptions,
+      @JsonProperty("score") Optional<Double> score) {
     if (displayOrder == -1) {
       displayOrder = id;
     }
     if (localizedOptionText != null) {
       return QuestionOption.create(
-          id, displayOrder, adminName, localizedOptionText, displayInAnswerOptions);
+          id, displayOrder, adminName, localizedOptionText, displayInAnswerOptions, score);
     }
     return QuestionOption.create(
-        id, displayOrder, adminName, LocalizedStrings.create(legacyOptionText));
+            id, displayOrder, adminName, LocalizedStrings.create(legacyOptionText))
+        .toBuilder()
+        .setScore(score)
+        .build();
   }
 
   /**
@@ -123,6 +135,44 @@ public abstract class QuestionOption {
         .build();
   }
 
+  /**
+   * Create a {@link QuestionOption}.
+   *
+   * @param id the option id
+   * @param displayOrder the option display
+   * @param adminName the option's immutable admin name, exposed via the API
+   * @param optionText the option's user-facing text
+   * @param displayInAnswerOptions whether to show the option to the applicant
+   * @param score the score the option contributes to a scored application, absent if unscored
+   * @return the {@link QuestionOption}
+   */
+  public static QuestionOption create(
+      long id,
+      long displayOrder,
+      String adminName,
+      LocalizedStrings optionText,
+      Optional<Boolean> displayInAnswerOptions,
+      Optional<Double> score) {
+    return QuestionOption.builder()
+        .setId(id)
+        .setAdminName(adminName)
+        .setOptionText(optionText)
+        .setDisplayOrder(OptionalLong.of(displayOrder))
+        .setDisplayInAnswerOptions(displayInAnswerOptions)
+        .setScore(score)
+        .build();
+  }
+
+  /**
+   * Canonical admin-facing rendering of a score value: plain decimal notation with trailing
+   * zeros stripped, so {@code 2.0} renders as {@code 2} and {@code 1.50} as {@code 1.5}. Used
+   * everywhere a score is displayed (question form inputs, PDFs, CSV cells); JSON output emits
+   * raw numbers instead.
+   */
+  public static String formatScore(double score) {
+    return BigDecimal.valueOf(score).stripTrailingZeros().toPlainString();
+  }
+
   public LocalizedQuestionOption localize(Locale locale) {
     if (!optionText().hasTranslationFor(locale)) {
       throw new RuntimeException(
@@ -180,6 +230,13 @@ public abstract class QuestionOption {
 
     @JsonProperty("displayInAnswerOptions")
     public abstract Builder setDisplayInAnswerOptions(Optional<Boolean> displayInAnswerOptions);
+
+    @JsonProperty("score")
+    public abstract Builder setScore(Optional<Double> score);
+
+    public Builder setScore(double score) {
+      return setScore(Optional.of(score));
+    }
 
     public abstract QuestionOption build();
   }

--- a/server/app/services/question/types/QuestionType.java
+++ b/server/app/services/question/types/QuestionType.java
@@ -1,5 +1,6 @@
 package services.question.types;
 
+import com.google.common.collect.ImmutableSet;
 import java.util.List;
 import java.util.Locale;
 import services.applicant.question.AbstractQuestion;
@@ -48,6 +49,9 @@ public enum QuestionType {
   private static final List<QuestionType> QUESTION_TYPES_SUPPORTING_SETTINGS =
       List.of(QuestionType.MAP);
 
+  private static final ImmutableSet<QuestionType> QUESTION_TYPES_SUPPORTING_OPTION_SCORES =
+      ImmutableSet.of(QuestionType.CHECKBOX, QuestionType.DROPDOWN, QuestionType.RADIO_BUTTON);
+
   QuestionType(String label, Class<? extends AbstractQuestion> supportedQuestion) {
     this.label = label;
     this.supportedQuestion = supportedQuestion;
@@ -61,6 +65,19 @@ public enum QuestionType {
    */
   public static boolean supportsQuestionSettings(QuestionType questionType) {
     return QUESTION_TYPES_SUPPORTING_SETTINGS.contains(questionType);
+  }
+
+  /**
+   * Determines if a {@link QuestionType} supports optional scores on its answer options.
+   *
+   * <p>This is deliberately narrower than {@link #isMultiOptionType()}: Yes/No questions are
+   * multi-option but must never carry scores.
+   *
+   * @param questionType a {@link QuestionType}
+   * @return boolean to indicate whether the question type supports option scores
+   */
+  public static boolean supportsOptionScores(QuestionType questionType) {
+    return QUESTION_TYPES_SUPPORTING_OPTION_SCORES.contains(questionType);
   }
 
   /**

--- a/server/app/services/settings/SettingsManifest.java
+++ b/server/app/services/settings/SettingsManifest.java
@@ -1149,6 +1149,14 @@ public final class SettingsManifest extends AbstractSettingsManifest {
     return getBool("NEW_APPLICANT_GUEST_MERGING_STRATEGY_DRY_RUN_ENABLED");
   }
 
+  /**
+   * (NOT FOR PRODUCTION USE) Enables optional scores on multi-option question answer options and
+   * score output on submitted applications for programs that opt in.
+   */
+  public boolean getAnswerOptionScoringEnabled(RequestHeader request) {
+    return getBool("ANSWER_OPTION_SCORING_ENABLED", request);
+  }
+
   private static final ImmutableMap<String, SettingsSection> GENERATED_SECTIONS =
       ImmutableMap.<String, SettingsSection>builder()
           .put(
@@ -2441,7 +2449,15 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                               + " applicant-guest merging strategy.",
                           /* isRequired= */ false,
                           SettingType.BOOLEAN,
-                          SettingMode.ADMIN_READABLE))))
+                          SettingMode.ADMIN_READABLE),
+                      SettingDescription.create(
+                          "ANSWER_OPTION_SCORING_ENABLED",
+                          "(NOT FOR PRODUCTION USE) Enables optional scores on multi-option"
+                              + " question answer options and score output on submitted"
+                              + " applications for programs that opt in.",
+                          /* isRequired= */ false,
+                          SettingType.BOOLEAN,
+                          SettingMode.ADMIN_WRITEABLE))))
           .put(
               "Miscellaneous",
               SettingsSection.create(

--- a/server/app/views/admin/questions/QuestionConfig.java
+++ b/server/app/views/admin/questions/QuestionConfig.java
@@ -28,6 +28,7 @@ import j2html.tags.specialized.DivTag;
 import j2html.tags.specialized.FieldsetTag;
 import j2html.tags.specialized.InputTag;
 import j2html.tags.specialized.LabelTag;
+import java.util.List;
 import java.util.Optional;
 import java.util.OptionalLong;
 import play.i18n.Messages;
@@ -39,6 +40,7 @@ import services.question.LocalizedQuestionOption;
 import services.question.YesNoQuestionOption;
 import services.question.types.DateQuestionDefinition.DateValidationOption;
 import services.question.types.DateQuestionDefinition.DateValidationOption.DateType;
+import services.question.types.QuestionType;
 import services.settings.SettingsManifest;
 import views.BaseView;
 import views.BaseViewModel;
@@ -70,6 +72,11 @@ public final class QuestionConfig {
       SettingsManifest settingsManifest,
       Request request) {
     QuestionConfig config = new QuestionConfig();
+    // Score inputs render only when the scoring flag is on and the type supports option scores;
+    // Yes/No questions use a separate renderer and never show scores.
+    boolean showScores =
+        settingsManifest.getAnswerOptionScoringEnabled(request)
+            && QuestionType.supportsOptionScores(questionForm.getQuestionType());
     switch (questionForm.getQuestionType()) {
       case ADDRESS:
         return Optional.of(
@@ -78,7 +85,7 @@ public final class QuestionConfig {
         MultiOptionQuestionForm form = (MultiOptionQuestionForm) questionForm;
         return Optional.of(
             config
-                .addMultiOptionQuestionFields(form, messages)
+                .addMultiOptionQuestionFields(form, messages, showScores)
                 .addMultiSelectQuestionValidation(form)
                 .getContainer());
       case ENUMERATOR:
@@ -106,7 +113,8 @@ public final class QuestionConfig {
       case RADIO_BUTTON:
         return Optional.of(
             config
-                .addMultiOptionQuestionFields((MultiOptionQuestionForm) questionForm, messages)
+                .addMultiOptionQuestionFields(
+                    (MultiOptionQuestionForm) questionForm, messages, showScores)
                 .getContainer());
       case FILEUPLOAD:
         return Optional.of(
@@ -312,8 +320,13 @@ public final class QuestionConfig {
    * Creates a template text field where an admin can enter a single multi-option question answer,
    * along with a button to remove the option.
    */
-  public static DivTag multiOptionQuestionFieldTemplate(Messages messages) {
-    return multiOptionQuestionField(Optional.empty(), messages, /* isForNewOption= */ true);
+  public static DivTag multiOptionQuestionFieldTemplate(Messages messages, boolean showScores) {
+    return multiOptionQuestionField(
+        Optional.empty(),
+        messages,
+        /* isForNewOption= */ true,
+        /* scoreValue= */ Optional.empty(),
+        showScores);
   }
 
   /**
@@ -321,7 +334,11 @@ public final class QuestionConfig {
    * answer, along with a button to remove the option.
    */
   private static DivTag multiOptionQuestionField(
-      Optional<LocalizedQuestionOption> existingOption, Messages messages, boolean isForNewOption) {
+      Optional<LocalizedQuestionOption> existingOption,
+      Messages messages,
+      boolean isForNewOption,
+      Optional<String> scoreValue,
+      boolean showScores) {
     DivTag optionAdminName =
         FieldWithLabel.input()
             .setFieldName(isForNewOption ? "newOptionAdminNames[]" : "optionAdminNames[]")
@@ -403,26 +420,57 @@ public final class QuestionConfig {
                 "col-start-8",
                 "row-span-2")
             .attr("aria-label", "delete");
-    return div()
-        .withClasses(
-            ReferenceClasses.MULTI_OPTION_QUESTION_OPTION,
-            ReferenceClasses.MULTI_OPTION_QUESTION_OPTION_EDITABLE,
-            "grid",
-            "grid-cols-8",
-            "grid-rows-4",
-            "items-center",
-            "mb-4")
-        .with(
-            optionIndexInput,
-            optionAdminName,
-            moveUpButton,
-            moveDownButton,
-            optionInput,
-            removeOptionButton);
+    DivTag row =
+        div()
+            .withClasses(
+                ReferenceClasses.MULTI_OPTION_QUESTION_OPTION,
+                ReferenceClasses.MULTI_OPTION_QUESTION_OPTION_EDITABLE,
+                "grid",
+                "grid-cols-8",
+                showScores ? "grid-rows-6" : "grid-rows-4",
+                "items-center",
+                "mb-4")
+            .with(
+                optionIndexInput,
+                optionAdminName,
+                moveUpButton,
+                moveDownButton,
+                optionInput,
+                removeOptionButton);
+    if (showScores) {
+      // FieldWithLabel's numeric value plumbing is long-only, so decimal values are set directly
+      // on the input's value attribute.
+      FieldWithLabel scoreField =
+          FieldWithLabel.number()
+              .setFieldName(isForNewOption ? "newOptionScores[]" : "optionScores[]")
+              .setLabelText("Score")
+              .addReferenceClass(ReferenceClasses.MULTI_OPTION_SCORE_INPUT);
+      scoreValueForDisplay(scoreValue).ifPresent(value -> scoreField.setAttribute("value", value));
+      row.with(
+          scoreField
+              .getNumberTag()
+              .withClasses(
+                  ReferenceClasses.MULTI_OPTION_SCORE_INPUT,
+                  "col-start-1",
+                  "col-span-5",
+                  "mb-2",
+                  "ml-2",
+                  "row-start-5",
+                  "row-span-2"));
+    }
+    return row;
+  }
+
+  private static Optional<String> scoreValueForDisplay(Optional<String> scoreValue) {
+    return scoreValue.flatMap(MultiOptionQuestionForm::formatScoreForDisplay);
+  }
+
+  private static Optional<String> scoreAt(List<String> scores, int index) {
+    return index < scores.size() ? Optional.of(scores.get(index)) : Optional.empty();
   }
 
   private QuestionConfig addMultiOptionQuestionFields(
-      MultiOptionQuestionForm multiOptionQuestionForm, Messages messages) {
+      MultiOptionQuestionForm multiOptionQuestionForm, Messages messages, boolean showScores) {
     Preconditions.checkState(
         multiOptionQuestionForm.getOptionIds().size()
             == multiOptionQuestionForm.getOptions().size(),
@@ -441,7 +489,9 @@ public final class QuestionConfig {
                       /* displayInAnswerOptions= */ Optional.of(true),
                       LocalizedStrings.DEFAULT_LOCALE)),
               messages,
-              /* isForNewOption= */ false));
+              /* isForNewOption= */ false,
+              scoreAt(multiOptionQuestionForm.getOptionScores(), i),
+              showScores));
       optionIndex++;
     }
 
@@ -457,7 +507,9 @@ public final class QuestionConfig {
                       /* displayInAnswerOptions= */ Optional.of(true),
                       LocalizedStrings.DEFAULT_LOCALE)),
               messages,
-              /* isForNewOption= */ true));
+              /* isForNewOption= */ true,
+              scoreAt(multiOptionQuestionForm.getNewOptionScores(), i),
+              showScores));
       optionIndex++;
     }
 

--- a/server/app/views/admin/questions/QuestionEditView.java
+++ b/server/app/views/admin/questions/QuestionEditView.java
@@ -162,7 +162,7 @@ public final class QuestionEditView extends BaseHtmlView {
         String.format("New %s question", questionType.getLabel().toLowerCase(Locale.ROOT));
 
     DivTag formContent =
-        buildQuestionContainer(title)
+        buildQuestionContainer(title, showScores(request, questionType))
             .with(
                 buildNewQuestionForm(questionForm, enumeratorQuestionDefinitions, request)
                     .with(makeCsrfTokenInputTag(request)));
@@ -221,7 +221,7 @@ public final class QuestionEditView extends BaseHtmlView {
         String.format("Edit %s question", questionType.getLabel().toLowerCase(Locale.ROOT));
 
     DivTag formContent =
-        buildQuestionContainer(title)
+        buildQuestionContainer(title, showScores(request, questionType))
             .with(
                 buildEditQuestionForm(
                         id,
@@ -272,7 +272,7 @@ public final class QuestionEditView extends BaseHtmlView {
         questionForm, enumeratorOptions, /* submittable= */ true, forCreate, request);
   }
 
-  private DivTag buildQuestionContainer(String title) {
+  private DivTag buildQuestionContainer(String title, boolean showScores) {
     return div()
         .withId("question-form")
         .attr("hx-ext", "response-targets")
@@ -288,25 +288,34 @@ public final class QuestionEditView extends BaseHtmlView {
             "relative",
             "w-2/5")
         .with(renderHeader(title))
-        .with(multiOptionQuestionField());
+        .with(multiOptionQuestionField(showScores));
   }
 
   // A <template> holding the markup for a new multi-option answer. The id lives
   // on the <template> so the JS can clone its content (see MultiOptionQuestion);
   // the cloned row is shown when appended, so it is not hidden here.
-  private TemplateTag multiOptionQuestionField() {
+  private TemplateTag multiOptionQuestionField(boolean showScores) {
     return template()
         .withId("multi-option-question-answer-template")
         .with(
-            QuestionConfig.multiOptionQuestionFieldTemplate(messages)
+            QuestionConfig.multiOptionQuestionFieldTemplate(messages, showScores)
                 .withClasses(
                     ReferenceClasses.MULTI_OPTION_QUESTION_OPTION,
                     ReferenceClasses.MULTI_OPTION_QUESTION_OPTION_EDITABLE,
                     "grid",
                     "grid-cols-8",
-                    "grid-rows-4",
+                    showScores ? "grid-rows-6" : "grid-rows-4",
                     "items-center",
                     "mb-4"));
+  }
+
+  /**
+   * Whether score inputs should render for this request and question type: the scoring flag is on
+   * and the type supports option scores (which excludes Yes/No).
+   */
+  private boolean showScores(Request request, QuestionType questionType) {
+    return settingsManifest.getAnswerOptionScoringEnabled(request)
+        && QuestionType.supportsOptionScores(questionType);
   }
 
   private FormTag buildNewQuestionForm(

--- a/server/app/views/admin/questions/QuestionFormPage.html
+++ b/server/app/views/admin/questions/QuestionFormPage.html
@@ -13,7 +13,7 @@
     <!--/* Markup cloned by the client when adding a new multi-option answer. */-->
     <template id="multi-option-question-answer-template">
       <div
-        th:replace="~{admin/questions/fragments/MultiOptionRow :: multiOptionRow(true, '', '', '', ${model.randomFieldId()}, ${model.randomFieldId()}, ${model.randomFieldId()})}"
+        th:replace="~{admin/questions/fragments/MultiOptionRow :: multiOptionRow(true, '', '', '', ${model.randomFieldId()}, ${model.randomFieldId()}, ${model.randomFieldId()}, ${model.showScores}, null, ${model.randomFieldId()})}"
       ></div>
     </template>
 

--- a/server/app/views/admin/questions/QuestionFormPageViewModel.java
+++ b/server/app/views/admin/questions/QuestionFormPageViewModel.java
@@ -4,6 +4,7 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 
 import com.google.common.collect.ImmutableList;
 import controllers.admin.routes;
+import forms.questions.MultiOptionQuestionForm;
 import forms.questions.QuestionForm;
 import java.util.List;
 import java.util.Locale;
@@ -94,6 +95,10 @@ public final class QuestionFormPageViewModel implements BaseViewModel {
   // YES_NO: the option rows to render. Null for other question types.
   private final YesNoConfig yesNoConfig;
 
+  // CHECKBOX / DROPDOWN / RADIO_BUTTON: whether the per-option score inputs render (the
+  // answer-option-scoring flag is on and the question type supports scores).
+  private final boolean showScores;
+
   // Error message shown as a toast (already carries the "Error: " prefix)
   private final Optional<String> errorMessage;
   // Random id for the toast container. Null when there is no error message.
@@ -133,6 +138,18 @@ public final class QuestionFormPageViewModel implements BaseViewModel {
    */
   public String randomFieldId() {
     return RandomStringUtils.randomAlphabetic(8);
+  }
+
+  /**
+   * The display value for the score input at {@code index} of a bound score list, formatted
+   * without trailing zeros. Null (attribute omitted) when the entry is missing, blank, or
+   * unparseable; a null-padded or short list from a sparse crafted post is tolerated.
+   */
+  public String scoreDisplayValue(List<String> scores, int index) {
+    if (index >= scores.size()) {
+      return null;
+    }
+    return MultiOptionQuestionForm.formatScoreForDisplay(scores.get(index)).orElse(null);
   }
 
   /** Whether there is a type-specific question config section. */

--- a/server/app/views/admin/questions/fragments/MultiOptionContainerFragment.html
+++ b/server/app/views/admin/questions/fragments/MultiOptionContainerFragment.html
@@ -8,12 +8,12 @@
   <div id="multi-option-container">
     <th:block th:each="optionText, stat : ${questionForm.getOptions()}">
       <div
-        th:replace="~{admin/questions/fragments/MultiOptionRow :: multiOptionRow(false, ${questionForm.getOptionIds().get(stat.index)}, ${questionForm.getOptionAdminNames().get(stat.index)}, ${optionText}, ${model.randomFieldId()}, ${model.randomFieldId()}, ${model.randomFieldId()})}"
+        th:replace="~{admin/questions/fragments/MultiOptionRow :: multiOptionRow(false, ${questionForm.getOptionIds().get(stat.index)}, ${questionForm.getOptionAdminNames().get(stat.index)}, ${optionText}, ${model.randomFieldId()}, ${model.randomFieldId()}, ${model.randomFieldId()}, ${model.showScores}, ${model.scoreDisplayValue(questionForm.getOptionScores(), stat.index)}, ${model.randomFieldId()})}"
       ></div>
     </th:block>
     <th:block th:each="newOptionText, stat : ${questionForm.getNewOptions()}">
       <div
-        th:replace="~{admin/questions/fragments/MultiOptionRow :: multiOptionRow(true, '', ${questionForm.getNewOptionAdminNames().get(stat.index)}, ${newOptionText}, ${model.randomFieldId()}, ${model.randomFieldId()}, ${model.randomFieldId()})}"
+        th:replace="~{admin/questions/fragments/MultiOptionRow :: multiOptionRow(true, '', ${questionForm.getNewOptionAdminNames().get(stat.index)}, ${newOptionText}, ${model.randomFieldId()}, ${model.randomFieldId()}, ${model.randomFieldId()}, ${model.showScores}, ${model.scoreDisplayValue(questionForm.getNewOptionScores(), stat.index)}, ${model.randomFieldId()})}"
       ></div>
     </th:block>
   </div>

--- a/server/app/views/admin/questions/fragments/MultiOptionRow.html
+++ b/server/app/views/admin/questions/fragments/MultiOptionRow.html
@@ -5,11 +5,16 @@
   options are also readonly on the Admin ID.
 
   Callers pass the label/input ids in (optionIdFieldId, adminNameFieldId,
-  optionTextFieldId), generating them with ${model.randomFieldId()} so
-  labels stay associated with inputs. Icons live in LegacySvgFragments.html.
+  optionTextFieldId, scoreFieldId), generating them with
+  ${model.randomFieldId()} so labels stay associated with inputs. When
+  showScores is true (the answer-option-scoring flag is on and the type
+  supports scores) the row grows to six grid rows and renders a score input
+  posting to newOptionScores[] / optionScores[]; scoreValue is the
+  pre-formatted display value or null. Icons live in LegacySvgFragments.html.
 */-->
 <div
-  th:fragment="multiOptionRow(isForNewOption, optionId, adminName, optionText, optionIdFieldId, adminNameFieldId, optionTextFieldId)"
+  th:fragment="multiOptionRow(isForNewOption, optionId, adminName, optionText, optionIdFieldId, adminNameFieldId, optionTextFieldId, showScores, scoreValue, scoreFieldId)"
+  th:class="|cf-multi-option-question-option cf-multi-option-question-option-editable grid grid-cols-8 ${showScores ? 'grid-rows-6' : 'grid-rows-4'} items-center mb-4|"
   class="cf-multi-option-question-option cf-multi-option-question-option-editable grid grid-cols-8 grid-rows-4 items-center mb-4"
 >
   <div th:if="${isForNewOption}"></div>
@@ -123,4 +128,32 @@
       th:replace="~{admin/shared/LegacySvgFragments :: iconDelete('w-6 h-6')}"
     ></svg>
   </button>
+  <div
+    th:if="${showScores}"
+    class="cf-multi-option-score-input col-start-1 col-span-5 mb-2 ml-2 row-start-5 row-span-2"
+  >
+    <label
+      th:for="${scoreFieldId}"
+      class="pointer-events-none text-gray-600 text-base px-1 py-2"
+      >Score<span
+        th:replace="~{admin/shared/LegacyFieldWithLabel/RequiredIndicator :: requiredIndicator(false)}"
+      ></span
+    ></label>
+    <div class="flex flex-col">
+      <input
+        type="number"
+        inputmode="decimal"
+        step="any"
+        th:value="${scoreValue}"
+        maxlength="10000"
+        th:id="${scoreFieldId}"
+        th:name="${isForNewOption} ? 'newOptionScores[]' : 'optionScores[]'"
+        class="px-3 bg-white text-black text-lg py-2 block outline-none box-border m-auto border border-gray-500 rounded-lg w-full focus:border-civiform-blue placeholder-gray-500"
+      />
+      <div
+        th:id="|${scoreFieldId}-errors|"
+        class="text-red-600 text-xs p-1 hidden"
+      ></div>
+    </div>
+  </div>
 </div>

--- a/server/app/views/style/ReferenceClasses.java
+++ b/server/app/views/style/ReferenceClasses.java
@@ -82,6 +82,7 @@ public final class ReferenceClasses {
       "cf-multi-option-question-option-editable";
   public static final String MULTI_OPTION_INPUT = "cf-multi-option-input";
   public static final String MULTI_OPTION_ADMIN_INPUT = "cf-multi-option-admin-input";
+  public static final String MULTI_OPTION_SCORE_INPUT = "cf-multi-option-score-input";
 
   // Keep these values in sync with app/assets/javascript/file_upload.ts.
   public static final String FILEUPLOAD_TOO_LARGE_ERROR_ID = "cf-fileupload-too-large-error";

--- a/server/conf/env-var-docs.json
+++ b/server/conf/env-var-docs.json
@@ -1010,6 +1010,12 @@
         "description": "(NOT FOR PRODUCTION USE) Enable dry run logging for the new applicant-guest merging strategy.",
         "type": "bool",
         "required": false
+      },
+      "ANSWER_OPTION_SCORING_ENABLED": {
+        "mode": "ADMIN_WRITEABLE",
+        "description": "(NOT FOR PRODUCTION USE) Enables optional scores on multi-option question answer options and score output on submitted applications for programs that opt in.",
+        "type": "bool",
+        "required": false
       }
     }
   }

--- a/server/conf/evolutions/default/97.sql
+++ b/server/conf/evolutions/default/97.sql
@@ -1,0 +1,8 @@
+# --- Whether the program applies answer-option scores to submitted applications
+# --- !Ups
+ALTER TABLE IF EXISTS programs
+ADD COLUMN IF NOT EXISTS uses_scoring boolean DEFAULT FALSE NOT NULL;
+
+# --- !Downs
+ALTER TABLE IF EXISTS programs
+DROP COLUMN IF EXISTS uses_scoring;

--- a/server/conf/helper/feature-flags.conf
+++ b/server/conf/helper/feature-flags.conf
@@ -102,3 +102,7 @@ file_upload_question_improvements_enabled = ${?FILE_UPLOAD_QUESTION_IMPROVEMENTS
 # Session timeout based on inactivity and maximum session duration
 session_timeout_enabled = true
 session_timeout_enabled = ${?SESSION_TIMEOUT_ENABLED}
+
+# Enables optional scores on multi-option question answer options
+answer_option_scoring_enabled = false
+answer_option_scoring_enabled = ${?ANSWER_OPTION_SCORING_ENABLED}

--- a/server/test/controllers/admin/AdminQuestionControllerTest.java
+++ b/server/test/controllers/admin/AdminQuestionControllerTest.java
@@ -1178,6 +1178,146 @@ public class AdminQuestionControllerTest extends ResetPostgres {
   }
 
   @Test
+  public void create_thymeleafQuestionForm_withOptionScores_savesScores() {
+    ImmutableMap<String, String> formData =
+        ImmutableMap.<String, String>builder()
+            .put("questionName", "thymeleaf scored dropdown")
+            .put("questionDescription", "desc")
+            .put("questionType", "DROPDOWN")
+            .put("questionText", "Pick one")
+            .put("questionHelpText", "help")
+            .put("newOptions[0]", "first")
+            .put("newOptions[1]", "second")
+            .put("newOptionAdminNames[0]", "first_admin")
+            .put("newOptionAdminNames[1]", "second_admin")
+            .put("newOptionScores[0]", "5.5")
+            .put("newOptionScores[1]", "")
+            .build();
+    RequestBuilder requestBuilder =
+        fakeRequestBuilder()
+            .addCiviFormSetting("ANSWER_OPTION_SCORING_ENABLED", "true")
+            .addCiviFormSetting("ADMIN_UI_MIGRATION_J2HTML_TO_THYMELEAF_SC_ENABLED", "true")
+            .bodyForm(formData);
+
+    ImmutableSet<Long> questionIdsBefore = retrieveAllQuestionIds();
+    Result result = controller.create(requestBuilder.build(), "dropdown");
+
+    assertThat(result.status()).isEqualTo(SEE_OTHER);
+    ImmutableSet<Long> questionIdsAfter = retrieveAllQuestionIds();
+    Long newQuestionId = Sets.difference(questionIdsAfter, questionIdsBefore).iterator().next();
+    MultiOptionQuestionDefinition definition =
+        (MultiOptionQuestionDefinition)
+            questionRepo
+                .lookupQuestion(newQuestionId)
+                .toCompletableFuture()
+                .join()
+                .get()
+                .getQuestionDefinition();
+    assertThat(definition.getOptions().stream().map(QuestionOption::score))
+        .containsExactly(Optional.of(5.5), Optional.empty());
+  }
+
+  @Test
+  public void update_thymeleafQuestionForm_withOptionScores_savesScores() {
+    QuestionDefinition definition = createScoredDropdownDefinition();
+    QuestionModel question = testQuestionBank.maybeSave(definition, LifecycleStage.DRAFT);
+
+    ImmutableMap<String, String> formData =
+        ImmutableMap.<String, String>builder()
+            .put("questionName", definition.getName())
+            .put("questionDescription", definition.getDescription())
+            .put("questionType", definition.getQuestionType().name())
+            .put("questionText", "new question text")
+            .put("questionHelpText", "new help text")
+            .put("options[0]", "chocolate")
+            .put("options[1]", "strawberry")
+            .put("optionIds[0]", "1")
+            .put("optionIds[1]", "2")
+            .put("optionAdminNames[0]", "chocolate_admin")
+            .put("optionAdminNames[1]", "strawberry_admin")
+            .put("optionScores[0]", "")
+            .put("optionScores[1]", "-1.25")
+            .put("nextAvailableId", "3")
+            .put("questionExportState", "NON_DEMOGRAPHIC")
+            .put("concurrencyToken", question.getConcurrencyToken().toString())
+            .build();
+    RequestBuilder requestBuilder =
+        fakeRequestBuilder()
+            .addCiviFormSetting("ANSWER_OPTION_SCORING_ENABLED", "true")
+            .addCiviFormSetting("ADMIN_UI_MIGRATION_J2HTML_TO_THYMELEAF_SC_ENABLED", "true")
+            .bodyForm(formData);
+
+    Result result =
+        controller.update(
+            requestBuilder.build(), question.id, definition.getQuestionType().toString());
+
+    assertThat(result.status()).isEqualTo(SEE_OTHER);
+    MultiOptionQuestionDefinition found =
+        (MultiOptionQuestionDefinition)
+            questionRepo
+                .lookupQuestion(question.id)
+                .toCompletableFuture()
+                .join()
+                .get()
+                .getQuestionDefinition();
+    assertThat(found.getOptions().stream().map(QuestionOption::score))
+        .containsExactly(Optional.empty(), Optional.of(-1.25));
+  }
+
+  @Test
+  public void update_thymeleafQuestionForm_invalidScore_rendersScoreInputsWithErrorWithoutSaving() {
+    QuestionDefinition definition = createScoredDropdownDefinition();
+    QuestionModel question = testQuestionBank.maybeSave(definition, LifecycleStage.DRAFT);
+
+    ImmutableMap<String, String> formData =
+        ImmutableMap.<String, String>builder()
+            .put("questionName", definition.getName())
+            .put("questionDescription", definition.getDescription())
+            .put("questionType", definition.getQuestionType().name())
+            .put("questionText", "new question text")
+            .put("questionHelpText", "new help text")
+            .put("options[0]", "chocolate")
+            .put("options[1]", "strawberry")
+            .put("optionIds[0]", "1")
+            .put("optionIds[1]", "2")
+            .put("optionAdminNames[0]", "chocolate_admin")
+            .put("optionAdminNames[1]", "strawberry_admin")
+            .put("optionScores[0]", "junk")
+            .put("optionScores[1]", "")
+            .put("nextAvailableId", "3")
+            .put("questionExportState", "NON_DEMOGRAPHIC")
+            .put("concurrencyToken", question.getConcurrencyToken().toString())
+            .build();
+    Request request =
+        fakeRequestBuilder()
+            .addCSRFToken()
+            .addCiviFormSetting("ANSWER_OPTION_SCORING_ENABLED", "true")
+            .addCiviFormSetting("ADMIN_UI_MIGRATION_J2HTML_TO_THYMELEAF_SC_ENABLED", "true")
+            .bodyForm(formData)
+            .build();
+
+    Result result =
+        controller.update(request, question.id, definition.getQuestionType().toString());
+
+    // The error re-render honors the migration flag: the Thymeleaf page comes back with the
+    // score inputs so the admin can correct and resubmit.
+    assertThat(result.status()).isEqualTo(OK);
+    String unescaped = StringEscapeUtils.unescapeHtml4(contentAsString(result));
+    assertThat(unescaped).contains("Option score 'junk' must be a number");
+    assertThat(unescaped).contains("name=\"optionScores[]\"");
+    MultiOptionQuestionDefinition found =
+        (MultiOptionQuestionDefinition)
+            questionRepo
+                .lookupQuestion(question.id)
+                .toCompletableFuture()
+                .join()
+                .get()
+                .getQuestionDefinition();
+    assertThat(found.getOptions().stream().map(QuestionOption::score))
+        .containsExactly(Optional.of(3.5), Optional.empty());
+  }
+
+  @Test
   public void update_withInvalidScore_flagEnabled_rendersErrorWithoutSaving() {
     QuestionDefinition definition = createScoredDropdownDefinition();
     QuestionModel question = testQuestionBank.maybeSave(definition, LifecycleStage.DRAFT);
@@ -1224,6 +1364,37 @@ public class AdminQuestionControllerTest extends ResetPostgres {
                 .getQuestionDefinition();
     assertThat(found.getOptions().stream().map(QuestionOption::score))
         .containsExactly(Optional.of(3.5), Optional.empty());
+  }
+
+  @Test
+  public void edit_scoredQuestion_flagEnabled_rendersScoreInputsWithValues() {
+    QuestionModel question =
+        testQuestionBank.maybeSave(createScoredDropdownDefinition(), LifecycleStage.DRAFT);
+    Request request =
+        fakeRequestBuilder()
+            .addCSRFToken()
+            .addCiviFormSetting("ANSWER_OPTION_SCORING_ENABLED", "true")
+            .build();
+
+    Result result =
+        controller.edit(request, question.id, /* redirectUrl= */ "").toCompletableFuture().join();
+
+    assertThat(result.status()).isEqualTo(OK);
+    assertThat(contentAsString(result))
+        .containsPattern("name=\"optionScores\\[\\]\"[^>]*value=\"3.5\"");
+  }
+
+  @Test
+  public void edit_scoredQuestion_flagDisabled_rendersNoScoreInputs() {
+    QuestionModel question =
+        testQuestionBank.maybeSave(createScoredDropdownDefinition(), LifecycleStage.DRAFT);
+    Request request = fakeRequestBuilder().addCSRFToken().build();
+
+    Result result =
+        controller.edit(request, question.id, /* redirectUrl= */ "").toCompletableFuture().join();
+
+    assertThat(result.status()).isEqualTo(OK);
+    assertThat(contentAsString(result)).doesNotContain("optionScores[]");
   }
 
   private MultiOptionQuestionDefinition createScoredDropdownDefinition() {

--- a/server/test/controllers/admin/AdminQuestionControllerTest.java
+++ b/server/test/controllers/admin/AdminQuestionControllerTest.java
@@ -935,6 +935,326 @@ public class AdminQuestionControllerTest extends ResetPostgres {
   }
 
   @Test
+  public void create_withOptionScores_flagEnabled_savesScores() {
+    ImmutableMap<String, String> formData =
+        ImmutableMap.<String, String>builder()
+            .put("questionName", "scored dropdown")
+            .put("questionDescription", "desc")
+            .put("questionType", "DROPDOWN")
+            .put("questionText", "Pick one")
+            .put("questionHelpText", "help")
+            .put("newOptions[0]", "first")
+            .put("newOptions[1]", "second")
+            .put("newOptionAdminNames[0]", "first_admin")
+            .put("newOptionAdminNames[1]", "second_admin")
+            .put("newOptionScores[0]", "5.5")
+            .put("newOptionScores[1]", "")
+            .build();
+    RequestBuilder requestBuilder =
+        fakeRequestBuilder()
+            .addCiviFormSetting("ANSWER_OPTION_SCORING_ENABLED", "true")
+            .bodyForm(formData);
+
+    ImmutableSet<Long> questionIdsBefore = retrieveAllQuestionIds();
+    Result result = controller.create(requestBuilder.build(), "dropdown");
+
+    assertThat(result.status()).isEqualTo(SEE_OTHER);
+    ImmutableSet<Long> questionIdsAfter = retrieveAllQuestionIds();
+    Long newQuestionId = Sets.difference(questionIdsAfter, questionIdsBefore).iterator().next();
+    MultiOptionQuestionDefinition definition =
+        (MultiOptionQuestionDefinition)
+            questionRepo
+                .lookupQuestion(newQuestionId)
+                .toCompletableFuture()
+                .join()
+                .get()
+                .getQuestionDefinition();
+    assertThat(definition.getOptions().stream().map(QuestionOption::score))
+        .containsExactly(Optional.of(5.5), Optional.empty());
+  }
+
+  @Test
+  public void create_withOptionScores_flagDisabled_ignoresCraftedScores() {
+    ImmutableMap<String, String> formData =
+        ImmutableMap.<String, String>builder()
+            .put("questionName", "crafted dropdown")
+            .put("questionDescription", "desc")
+            .put("questionType", "DROPDOWN")
+            .put("questionText", "Pick one")
+            .put("questionHelpText", "help")
+            .put("newOptions[0]", "first")
+            .put("newOptionAdminNames[0]", "first_admin")
+            .put("newOptionScores[0]", "5")
+            .build();
+    RequestBuilder requestBuilder = fakeRequestBuilder().bodyForm(formData);
+
+    ImmutableSet<Long> questionIdsBefore = retrieveAllQuestionIds();
+    Result result = controller.create(requestBuilder.build(), "dropdown");
+
+    assertThat(result.status()).isEqualTo(SEE_OTHER);
+    ImmutableSet<Long> questionIdsAfter = retrieveAllQuestionIds();
+    Long newQuestionId = Sets.difference(questionIdsAfter, questionIdsBefore).iterator().next();
+    MultiOptionQuestionDefinition definition =
+        (MultiOptionQuestionDefinition)
+            questionRepo
+                .lookupQuestion(newQuestionId)
+                .toCompletableFuture()
+                .join()
+                .get()
+                .getQuestionDefinition();
+    assertThat(definition.getOptions().stream().map(QuestionOption::score))
+        .containsExactly(Optional.empty());
+  }
+
+  @Test
+  public void create_withInvalidScore_flagEnabled_rendersErrorWithoutSaving() {
+    ImmutableMap<String, String> formData =
+        ImmutableMap.<String, String>builder()
+            .put("questionName", "invalid score dropdown")
+            .put("questionDescription", "desc")
+            .put("questionType", "DROPDOWN")
+            .put("questionText", "Pick one")
+            .put("questionHelpText", "help")
+            .put("newOptions[0]", "first")
+            .put("newOptionAdminNames[0]", "first_admin")
+            .put("newOptionScores[0]", "junk")
+            .build();
+    Request request =
+        fakeRequestBuilder()
+            .addCSRFToken()
+            .addCiviFormSetting("ANSWER_OPTION_SCORING_ENABLED", "true")
+            .bodyForm(formData)
+            .build();
+
+    ImmutableSet<Long> questionIdsBefore = retrieveAllQuestionIds();
+    Result result = controller.create(request, "dropdown");
+
+    assertThat(result.status()).isEqualTo(OK);
+    String unescaped = StringEscapeUtils.unescapeHtml4(contentAsString(result));
+    assertThat(unescaped).contains("Option score 'junk' must be a number");
+    assertThat(retrieveAllQuestionIds().size()).isEqualTo(questionIdsBefore.size());
+  }
+
+  @Test
+  public void update_withOptionScores_flagEnabled_savesScores() {
+    QuestionDefinition definition = createScoredDropdownDefinition();
+    QuestionModel question = testQuestionBank.maybeSave(definition, LifecycleStage.DRAFT);
+
+    ImmutableMap<String, String> formData =
+        ImmutableMap.<String, String>builder()
+            .put("questionName", definition.getName())
+            .put("questionDescription", definition.getDescription())
+            .put("questionType", definition.getQuestionType().name())
+            .put("questionText", "new question text")
+            .put("questionHelpText", "new help text")
+            .put("options[0]", "chocolate")
+            .put("options[1]", "strawberry")
+            .put("optionIds[0]", "1")
+            .put("optionIds[1]", "2")
+            .put("optionAdminNames[0]", "chocolate_admin")
+            .put("optionAdminNames[1]", "strawberry_admin")
+            .put("optionScores[0]", "9.75")
+            .put("optionScores[1]", "")
+            .put("nextAvailableId", "3")
+            .put("questionExportState", "NON_DEMOGRAPHIC")
+            .put("concurrencyToken", question.getConcurrencyToken().toString())
+            .build();
+    RequestBuilder requestBuilder =
+        fakeRequestBuilder()
+            .addCiviFormSetting("ANSWER_OPTION_SCORING_ENABLED", "true")
+            .bodyForm(formData);
+
+    Result result =
+        controller.update(
+            requestBuilder.build(), question.id, definition.getQuestionType().toString());
+
+    assertThat(result.status()).isEqualTo(SEE_OTHER);
+    MultiOptionQuestionDefinition found =
+        (MultiOptionQuestionDefinition)
+            questionRepo
+                .lookupQuestion(question.id)
+                .toCompletableFuture()
+                .join()
+                .get()
+                .getQuestionDefinition();
+    // Option 1's score is updated; option 2's blank input clears its stored score.
+    assertThat(found.getOptions().stream().map(QuestionOption::score))
+        .containsExactly(Optional.of(9.75), Optional.empty());
+  }
+
+  @Test
+  public void update_flagDisabled_preservesStoredScoresAndIgnoresCraftedScores() {
+    QuestionDefinition definition = createScoredDropdownDefinition();
+    QuestionModel question = testQuestionBank.maybeSave(definition, LifecycleStage.DRAFT);
+
+    ImmutableMap<String, String> formData =
+        ImmutableMap.<String, String>builder()
+            .put("questionName", definition.getName())
+            .put("questionDescription", definition.getDescription())
+            .put("questionType", definition.getQuestionType().name())
+            .put("questionText", "new question text")
+            .put("questionHelpText", "new help text")
+            .put("options[0]", "chocolate")
+            .put("options[1]", "strawberry")
+            .put("optionIds[0]", "1")
+            .put("optionIds[1]", "2")
+            .put("optionAdminNames[0]", "chocolate_admin")
+            .put("optionAdminNames[1]", "strawberry_admin")
+            // Crafted scores; the score inputs are not rendered while the flag is off.
+            .put("optionScores[0]", "1000")
+            .put("optionScores[1]", "1000")
+            .put("nextAvailableId", "3")
+            .put("questionExportState", "NON_DEMOGRAPHIC")
+            .put("concurrencyToken", question.getConcurrencyToken().toString())
+            .build();
+    RequestBuilder requestBuilder = fakeRequestBuilder().bodyForm(formData);
+
+    Result result =
+        controller.update(
+            requestBuilder.build(), question.id, definition.getQuestionType().toString());
+
+    assertThat(result.status()).isEqualTo(SEE_OTHER);
+    MultiOptionQuestionDefinition found =
+        (MultiOptionQuestionDefinition)
+            questionRepo
+                .lookupQuestion(question.id)
+                .toCompletableFuture()
+                .join()
+                .get()
+                .getQuestionDefinition();
+    // The stored scores survive the flag-off edit; the crafted values are discarded.
+    assertThat(found.getOptions().stream().map(QuestionOption::score))
+        .containsExactly(Optional.of(3.5), Optional.empty());
+  }
+
+  @Test
+  public void update_withoutScoreFields_flagEnabled_rendersErrorWithoutWipingScores() {
+    // A crafted post omitting optionScores[] entirely (the rendered form always submits them)
+    // must fail cardinality validation, not silently rebuild every option unscored.
+    QuestionDefinition definition = createScoredDropdownDefinition();
+    QuestionModel question = testQuestionBank.maybeSave(definition, LifecycleStage.DRAFT);
+
+    ImmutableMap<String, String> formData =
+        ImmutableMap.<String, String>builder()
+            .put("questionName", definition.getName())
+            .put("questionDescription", definition.getDescription())
+            .put("questionType", definition.getQuestionType().name())
+            .put("questionText", "new question text")
+            .put("questionHelpText", "new help text")
+            .put("options[0]", "chocolate")
+            .put("options[1]", "strawberry")
+            .put("optionIds[0]", "1")
+            .put("optionIds[1]", "2")
+            .put("optionAdminNames[0]", "chocolate_admin")
+            .put("optionAdminNames[1]", "strawberry_admin")
+            .put("nextAvailableId", "3")
+            .put("questionExportState", "NON_DEMOGRAPHIC")
+            .put("concurrencyToken", question.getConcurrencyToken().toString())
+            .build();
+    Request request =
+        fakeRequestBuilder()
+            .addCSRFToken()
+            .addCiviFormSetting("ANSWER_OPTION_SCORING_ENABLED", "true")
+            .bodyForm(formData)
+            .build();
+
+    Result result =
+        controller.update(request, question.id, definition.getQuestionType().toString());
+
+    assertThat(result.status()).isEqualTo(OK);
+    String unescaped = StringEscapeUtils.unescapeHtml4(contentAsString(result));
+    assertThat(unescaped)
+        .contains("The number of option scores does not match the number of options");
+    MultiOptionQuestionDefinition found =
+        (MultiOptionQuestionDefinition)
+            questionRepo
+                .lookupQuestion(question.id)
+                .toCompletableFuture()
+                .join()
+                .get()
+                .getQuestionDefinition();
+    assertThat(found.getOptions().stream().map(QuestionOption::score))
+        .containsExactly(Optional.of(3.5), Optional.empty());
+  }
+
+  @Test
+  public void update_withInvalidScore_flagEnabled_rendersErrorWithoutSaving() {
+    QuestionDefinition definition = createScoredDropdownDefinition();
+    QuestionModel question = testQuestionBank.maybeSave(definition, LifecycleStage.DRAFT);
+
+    ImmutableMap<String, String> formData =
+        ImmutableMap.<String, String>builder()
+            .put("questionName", definition.getName())
+            .put("questionDescription", definition.getDescription())
+            .put("questionType", definition.getQuestionType().name())
+            .put("questionText", "new question text")
+            .put("questionHelpText", "new help text")
+            .put("options[0]", "chocolate")
+            .put("options[1]", "strawberry")
+            .put("optionIds[0]", "1")
+            .put("optionIds[1]", "2")
+            .put("optionAdminNames[0]", "chocolate_admin")
+            .put("optionAdminNames[1]", "strawberry_admin")
+            .put("optionScores[0]", "NaN")
+            .put("optionScores[1]", "")
+            .put("nextAvailableId", "3")
+            .put("questionExportState", "NON_DEMOGRAPHIC")
+            .put("concurrencyToken", question.getConcurrencyToken().toString())
+            .build();
+    Request request =
+        fakeRequestBuilder()
+            .addCSRFToken()
+            .addCiviFormSetting("ANSWER_OPTION_SCORING_ENABLED", "true")
+            .bodyForm(formData)
+            .build();
+
+    Result result =
+        controller.update(request, question.id, definition.getQuestionType().toString());
+
+    assertThat(result.status()).isEqualTo(OK);
+    String unescaped = StringEscapeUtils.unescapeHtml4(contentAsString(result));
+    assertThat(unescaped).contains("Option score 'NaN' must be a number");
+    MultiOptionQuestionDefinition found =
+        (MultiOptionQuestionDefinition)
+            questionRepo
+                .lookupQuestion(question.id)
+                .toCompletableFuture()
+                .join()
+                .get()
+                .getQuestionDefinition();
+    assertThat(found.getOptions().stream().map(QuestionOption::score))
+        .containsExactly(Optional.of(3.5), Optional.empty());
+  }
+
+  private MultiOptionQuestionDefinition createScoredDropdownDefinition() {
+    QuestionDefinitionConfig config =
+        QuestionDefinitionConfig.builder()
+            .setName("scored ice cream")
+            .setDescription("Select your favorite ice cream flavor")
+            .setQuestionText(LocalizedStrings.of(Locale.US, "Ice cream?"))
+            .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help"))
+            .build();
+    ImmutableList<QuestionOption> questionOptions =
+        ImmutableList.of(
+            QuestionOption.create(
+                /* id= */ 1L,
+                /* displayOrder= */ 0,
+                /* adminName= */ "chocolate_admin",
+                /* optionText= */ LocalizedStrings.of(Locale.US, "chocolate"),
+                /* displayInAnswerOptions= */ Optional.of(true),
+                /* score= */ Optional.of(3.5)),
+            QuestionOption.create(
+                /* id= */ 2L,
+                /* displayOrder= */ 1,
+                /* adminName= */ "strawberry_admin",
+                /* optionText= */ LocalizedStrings.of(Locale.US, "strawberry"),
+                /* displayInAnswerOptions= */ Optional.of(true),
+                /* score= */ Optional.empty()));
+    return new MultiOptionQuestionDefinition(
+        config, questionOptions, MultiOptionQuestionType.DROPDOWN);
+  }
+
+  @Test
   public void update_failsWithErrorMessageAndPopulatedFields() {
     QuestionModel question = testQuestionBank.textApplicantFavoriteColor();
     ImmutableMap.Builder<String, String> formData = ImmutableMap.builder();

--- a/server/test/forms/questions/MultiOptionQuestionFormBindingTest.java
+++ b/server/test/forms/questions/MultiOptionQuestionFormBindingTest.java
@@ -1,0 +1,93 @@
+package forms.questions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static support.FakeRequestBuilder.fakeRequestBuilder;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.Before;
+import org.junit.Test;
+import play.data.FormFactory;
+import play.mvc.Http.Request;
+import repository.ResetPostgres;
+import services.CiviFormError;
+
+/**
+ * Proves Play's binding of the parallel score string lists on a real {@link FormFactory}, in
+ * particular that a blank trailing score row still binds so the lists stay parallel to the option
+ * lists.
+ */
+public class MultiOptionQuestionFormBindingTest extends ResetPostgres {
+
+  private FormFactory formFactory;
+
+  @Before
+  public void setup() {
+    formFactory = instanceOf(FormFactory.class);
+  }
+
+  @Test
+  public void bindFromRequest_bindsParallelScoreLists_includingTrailingBlank() {
+    Request request =
+        fakeRequestBuilder()
+            .bodyForm(
+                ImmutableMap.<String, String>builder()
+                    .put("questionName", "binding test")
+                    .put("questionDescription", "desc")
+                    .put("questionText", "question text")
+                    .put("questionHelpText", "help text")
+                    .put("options[0]", "one")
+                    .put("options[1]", "two")
+                    .put("optionAdminNames[0]", "one_admin")
+                    .put("optionAdminNames[1]", "two_admin")
+                    .put("optionIds[0]", "1")
+                    .put("optionIds[1]", "2")
+                    .put("optionScores[0]", "10.5")
+                    // A trailing blank score row must still bind an entry.
+                    .put("optionScores[1]", "")
+                    .put("newOptions[0]", "three")
+                    .put("newOptionAdminNames[0]", "three_admin")
+                    .put("newOptionScores[0]", "")
+                    .put("nextAvailableId", "3")
+                    .build())
+            .build();
+
+    CheckboxQuestionForm form =
+        formFactory.form(CheckboxQuestionForm.class).bindFromRequest(request).get();
+
+    assertThat(form.getOptions()).containsExactly("one", "two");
+    assertThat(form.getOptionScores()).containsExactly("10.5", "");
+    assertThat(form.getNewOptions()).containsExactly("three");
+    assertThat(form.getNewOptionScores()).containsExactly("");
+    assertThat(form.getOptionScoreErrors()).isEmpty();
+  }
+
+  @Test
+  public void bindFromRequest_missingScoreFields_bindsEmptyLists() {
+    Request request =
+        fakeRequestBuilder()
+            .bodyForm(
+                ImmutableMap.<String, String>builder()
+                    .put("questionName", "binding test")
+                    .put("questionDescription", "desc")
+                    .put("questionText", "question text")
+                    .put("questionHelpText", "help text")
+                    .put("options[0]", "one")
+                    .put("optionAdminNames[0]", "one_admin")
+                    .put("optionIds[0]", "1")
+                    .put("nextAvailableId", "2")
+                    .build())
+            .build();
+
+    CheckboxQuestionForm form =
+        formFactory.form(CheckboxQuestionForm.class).bindFromRequest(request).get();
+
+    assertThat(form.getOptionScores()).isEmpty();
+    assertThat(form.getNewOptionScores()).isEmpty();
+    // Missing score fields bind as empty lists, which fail cardinality validation: the rendered
+    // form always submits a score input per option, so this shape is a crafted post and must not
+    // silently build unscored options.
+    assertThat(form.getOptionScoreErrors())
+        .extracting(CiviFormError::message)
+        .containsExactly("The number of option scores does not match the number of options");
+  }
+}

--- a/server/test/forms/questions/MultiOptionQuestionFormTest.java
+++ b/server/test/forms/questions/MultiOptionQuestionFormTest.java
@@ -4,9 +4,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import java.util.Locale;
+import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.UUID;
 import org.junit.Test;
+import services.CiviFormError;
 import services.LocalizedStrings;
 import services.question.QuestionOption;
 import services.question.types.MultiOptionQuestionDefinition;
@@ -210,5 +212,203 @@ public class MultiOptionQuestionFormTest {
 
     assertThat(questionDefinition.getOptionAdminNames())
         .containsExactly("one admin", "two admin", "three admin", "four admin");
+  }
+
+  private static MultiOptionQuestionDefinition definitionWithScoredOptions() {
+    QuestionDefinitionConfig config =
+        QuestionDefinitionConfig.builder()
+            .setName("name")
+            .setDescription("description")
+            .setQuestionText(LocalizedStrings.of(Locale.US, "What is the question text?"))
+            .setQuestionHelpText(LocalizedStrings.of(Locale.US, "help text"))
+            .setConcurrencyToken(UUID.randomUUID())
+            .build();
+    return new MultiOptionQuestionDefinition(
+        config,
+        ImmutableList.of(
+            QuestionOption.create(
+                /* id= */ 1L,
+                /* displayOrder= */ 0L,
+                /* adminName= */ "one admin",
+                /* optionText= */ LocalizedStrings.of(Locale.US, "option 1"),
+                /* displayInAnswerOptions= */ Optional.of(true),
+                /* score= */ Optional.of(3.5)),
+            QuestionOption.create(
+                /* id= */ 2L,
+                /* displayOrder= */ 1L,
+                /* adminName= */ "two admin",
+                /* optionText= */ LocalizedStrings.of(Locale.US, "option 2"),
+                /* displayInAnswerOptions= */ Optional.of(true),
+                /* score= */ Optional.empty()),
+            QuestionOption.create(
+                /* id= */ 5L,
+                /* displayOrder= */ 2L,
+                /* adminName= */ "five admin",
+                /* optionText= */ LocalizedStrings.of(Locale.US, "option 5"),
+                /* displayInAnswerOptions= */ Optional.of(true),
+                /* score= */ Optional.of(-2.0))),
+        MultiOptionQuestionType.CHECKBOX);
+  }
+
+  @Test
+  public void constructor_withQd_populatesOptionScoresInDisplayOrder() {
+    MultiOptionQuestionForm form = new CheckboxQuestionForm(definitionWithScoredOptions());
+
+    // Blank means unscored; scores are parallel to options.
+    assertThat(form.getOptions()).containsExactly("option 1", "option 2", "option 5");
+    // Whole values populate without a trailing .0 (formatScore).
+    assertThat(form.getOptionScores()).containsExactly("3.5", "", "-2");
+  }
+
+  @Test
+  public void getBuilder_scoringEnabled_appliesScores() throws Exception {
+    MultiOptionQuestionForm form = new CheckboxQuestionForm();
+    form.setQuestionName("name");
+    form.setQuestionDescription("description");
+    form.setQuestionText("What is the question text?");
+    form.setQuestionHelpText("help text");
+    form.setMinChoicesRequired("");
+    form.setMaxChoicesAllowed("");
+    form.setOptions(ImmutableList.of("one", "two", "three"));
+    form.setOptionAdminNames(ImmutableList.of("one admin", "two admin", "three admin"));
+    form.setOptionIds(ImmutableList.of(1L, 2L, 3L));
+    form.setOptionScores(ImmutableList.of("4", "", "0"));
+    form.setNewOptions(ImmutableList.of("four"));
+    form.setNewOptionAdminNames(ImmutableList.of("four admin"));
+    form.setNewOptionScores(ImmutableList.of("-7.25"));
+
+    MultiOptionQuestionDefinition questionDefinition =
+        (MultiOptionQuestionDefinition) form.getBuilder(/* scoringEnabled= */ true).build();
+
+    assertThat(questionDefinition.getOptions().stream().map(QuestionOption::score))
+        .containsExactly(
+            Optional.of(4.0), Optional.empty(), Optional.of(0.0), Optional.of(-7.25));
+  }
+
+  @Test
+  public void getBuilder_scoringDisabled_discardsSubmittedScores() throws Exception {
+    MultiOptionQuestionForm form = new CheckboxQuestionForm();
+    form.setQuestionName("name");
+    form.setQuestionDescription("description");
+    form.setQuestionText("What is the question text?");
+    form.setQuestionHelpText("help text");
+    form.setMinChoicesRequired("");
+    form.setMaxChoicesAllowed("");
+    form.setOptions(ImmutableList.of("one", "two"));
+    form.setOptionAdminNames(ImmutableList.of("one admin", "two admin"));
+    form.setOptionIds(ImmutableList.of(1L, 2L));
+    form.setOptionScores(ImmutableList.of("4", "5"));
+
+    MultiOptionQuestionDefinition viaDefaultOverload =
+        (MultiOptionQuestionDefinition) form.getBuilder().build();
+    MultiOptionQuestionDefinition viaExplicitFalse =
+        (MultiOptionQuestionDefinition) form.getBuilder(/* scoringEnabled= */ false).build();
+
+    assertThat(viaDefaultOverload.getOptions().stream().map(QuestionOption::score))
+        .containsExactly(Optional.empty(), Optional.empty());
+    assertThat(viaExplicitFalse.getOptions().stream().map(QuestionOption::score))
+        .containsExactly(Optional.empty(), Optional.empty());
+  }
+
+  @Test
+  public void getOptionScoreErrors_missingScoreLists_returnsError() {
+    // Score validation only runs when the score inputs were rendered, so a post with options but
+    // no score fields at all is a crafted post; it must error rather than silently build unscored
+    // options, which for an existing question would wipe its stored scores.
+    MultiOptionQuestionForm form = new CheckboxQuestionForm();
+    form.setQuestionName("name");
+    form.setQuestionDescription("description");
+    form.setQuestionText("What is the question text?");
+    form.setQuestionHelpText("help text");
+    form.setMinChoicesRequired("");
+    form.setMaxChoicesAllowed("");
+    form.setOptions(ImmutableList.of("one", "two"));
+    form.setOptionAdminNames(ImmutableList.of("one admin", "two admin"));
+    form.setOptionIds(ImmutableList.of(1L, 2L));
+
+    assertThat(form.getOptionScoreErrors())
+        .extracting(CiviFormError::message)
+        .containsExactly("The number of option scores does not match the number of options");
+  }
+
+  @Test
+  public void getOptionScoreErrors_noOptionsAndNoScores_empty() {
+    // Zero options with zero scores is parallel, not a mismatch.
+    MultiOptionQuestionForm form = new CheckboxQuestionForm();
+    form.setNewOptions(ImmutableList.of("one"));
+    form.setNewOptionAdminNames(ImmutableList.of("one admin"));
+    form.setNewOptionScores(ImmutableList.of("2.5"));
+
+    assertThat(form.getOptionScoreErrors()).isEmpty();
+  }
+
+  @Test
+  public void getBuilder_yesNoForm_neverAppliesScores() throws Exception {
+    MultiOptionQuestionForm form = new YesNoQuestionForm();
+    form.setQuestionName("name");
+    form.setQuestionDescription("description");
+    form.setQuestionText("What is the question text?");
+    form.setQuestionHelpText("help text");
+    form.setOptions(ImmutableList.of("Yes", "No"));
+    form.setOptionAdminNames(ImmutableList.of("yes", "no"));
+    form.setOptionIds(ImmutableList.of(1L, 0L));
+    form.setDisplayedOptionIds(ImmutableList.of(1L, 0L));
+    // Crafted scores on a Yes/No question must be discarded even with the flag on.
+    form.setOptionScores(ImmutableList.of("4", "5"));
+
+    MultiOptionQuestionDefinition questionDefinition =
+        (MultiOptionQuestionDefinition) form.getBuilder(/* scoringEnabled= */ true).build();
+
+    assertThat(questionDefinition.getOptions().stream().map(QuestionOption::score))
+        .containsExactly(Optional.empty(), Optional.empty());
+  }
+
+  @Test
+  public void getOptionScoreErrors_validScores_empty() {
+    MultiOptionQuestionForm form = new CheckboxQuestionForm();
+    form.setOptions(ImmutableList.of("one", "two", "three"));
+    form.setOptionAdminNames(ImmutableList.of("one admin", "two admin", "three admin"));
+    form.setOptionIds(ImmutableList.of(1L, 2L, 3L));
+    // Fractional, exponent-notation, and beyond-32-bit values are all valid decimals; blank
+    // stays "unscored".
+    form.setOptionScores(ImmutableList.of("1.5", "", "2147483648"));
+    form.setNewOptions(ImmutableList.of("four"));
+    form.setNewOptionAdminNames(ImmutableList.of("four admin"));
+    form.setNewOptionScores(ImmutableList.of("-0.125"));
+
+    assertThat(form.getOptionScoreErrors()).isEmpty();
+  }
+
+  @Test
+  public void getOptionScoreErrors_invalidScores_returnsErrorsNotExceptions() {
+    MultiOptionQuestionForm form = new CheckboxQuestionForm();
+    form.setOptions(ImmutableList.of("one", "two", "three", "four"));
+    form.setOptionAdminNames(
+        ImmutableList.of("one admin", "two admin", "three admin", "four admin"));
+    form.setOptionIds(ImmutableList.of(1L, 2L, 3L, 4L));
+    // Junk, NaN, Infinity, and a double-overflowing exponent are all rejected.
+    form.setOptionScores(ImmutableList.of("junk", "NaN", "Infinity", "1e999"));
+
+    assertThat(form.getOptionScoreErrors())
+        .hasSize(4)
+        .allSatisfy(error -> assertThat(error.message()).contains("must be a number"));
+  }
+
+  @Test
+  public void getOptionScoreErrors_cardinalityMismatch_returnsError() {
+    MultiOptionQuestionForm form = new CheckboxQuestionForm();
+    form.setOptions(ImmutableList.of("one", "two"));
+    form.setOptionAdminNames(ImmutableList.of("one admin", "two admin"));
+    form.setOptionIds(ImmutableList.of(1L, 2L));
+    form.setOptionScores(ImmutableList.of("4"));
+    form.setNewOptions(ImmutableList.of("three"));
+    form.setNewOptionAdminNames(ImmutableList.of("three admin"));
+    form.setNewOptionScores(ImmutableList.of("1", "2"));
+
+    assertThat(form.getOptionScoreErrors())
+        .extracting(CiviFormError::message)
+        .containsExactlyInAnyOrder(
+            "The number of option scores does not match the number of options",
+            "The number of new option scores does not match the number of new options");
   }
 }

--- a/server/test/forms/translation/MultiOptionQuestionTranslationFormTest.java
+++ b/server/test/forms/translation/MultiOptionQuestionTranslationFormTest.java
@@ -79,4 +79,36 @@ public class MultiOptionQuestionTranslationFormTest {
                 /* displayInAnswerOptions= */ Optional.empty(),
                 /* locale= */ Locale.FRANCE));
   }
+
+  @Test
+  public void buildsQuestion_preservesOptionScores() throws Exception {
+    QuestionDefinitionConfig config =
+        QuestionDefinitionConfig.builder()
+            .setName("test")
+            .setDescription("desc")
+            .setQuestionText(LocalizedStrings.empty())
+            .setQuestionHelpText(LocalizedStrings.empty())
+            .build();
+    QuestionDefinition question =
+        new MultiOptionQuestionDefinition(
+            config,
+            ImmutableList.of(
+                QuestionOption.create(
+                    /* id= */ 1L,
+                    /* displayOrder= */ 0L,
+                    /* adminName= */ "opt1",
+                    /* optionText= */ LocalizedStrings.withDefaultValue("other"),
+                    /* displayInAnswerOptions= */ Optional.of(true),
+                    /* score= */ Optional.of(7.5))),
+            MultiOptionQuestionType.RADIO_BUTTON);
+
+    MultiOptionQuestionTranslationForm form = new MultiOptionQuestionTranslationForm();
+    form.setOptions(ImmutableList.of("new"));
+    MultiOptionQuestionDefinition updated =
+        (MultiOptionQuestionDefinition) form.builderWithUpdates(question, Locale.CHINA).build();
+
+    // A translation-only edit must not drop stored scores.
+    assertThat(updated.getOptions().stream().map(QuestionOption::score))
+        .containsExactly(Optional.of(7.5));
+  }
 }

--- a/server/test/mapping/admin/questions/QuestionFormPageMapperTest.java
+++ b/server/test/mapping/admin/questions/QuestionFormPageMapperTest.java
@@ -5,8 +5,11 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
+import forms.questions.DropdownQuestionForm;
 import forms.questions.TextQuestionForm;
 import forms.questions.YesNoQuestionForm;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 import org.junit.Before;
 import org.junit.Test;
@@ -33,6 +36,7 @@ public final class QuestionFormPageMapperTest {
         null,
         /* apiBridgeEnabled= */ false,
         /* enumeratorImprovementsEnabled= */ false,
+        /* answerOptionScoringEnabled= */ false,
         readOnlyQuestionService,
         Optional.empty());
   }
@@ -45,6 +49,7 @@ public final class QuestionFormPageMapperTest {
         null,
         /* apiBridgeEnabled= */ false,
         /* enumeratorImprovementsEnabled= */ false,
+        /* answerOptionScoringEnabled= */ false,
         readOnlyQuestionService,
         Optional.empty());
   }
@@ -174,12 +179,85 @@ public final class QuestionFormPageMapperTest {
             null,
             /* apiBridgeEnabled= */ false,
             /* enumeratorImprovementsEnabled= */ false,
+            /* answerOptionScoringEnabled= */ false,
             readOnlyQuestionService,
             Optional.empty());
 
     assertThat(result.getYesNoConfig()).isNotNull();
     assertThat(result.getYesNoConfig().showLabel()).isTrue();
     assertThat(result.getYesNoConfig().options()).hasSize(4);
+  }
+
+  @Test
+  public void mapNew_scoringEnabledSupportedType_showsScores() {
+    QuestionFormPageViewModel result =
+        mapper.mapNew(
+            new DropdownQuestionForm(),
+            ImmutableList.of(),
+            null,
+            /* apiBridgeEnabled= */ false,
+            /* enumeratorImprovementsEnabled= */ false,
+            /* answerOptionScoringEnabled= */ true,
+            readOnlyQuestionService,
+            Optional.empty());
+
+    assertThat(result.isShowScores()).isTrue();
+  }
+
+  @Test
+  public void mapNew_scoringDisabled_hidesScores() {
+    QuestionFormPageViewModel result =
+        mapper.mapNew(
+            new DropdownQuestionForm(),
+            ImmutableList.of(),
+            null,
+            /* apiBridgeEnabled= */ false,
+            /* enumeratorImprovementsEnabled= */ false,
+            /* answerOptionScoringEnabled= */ false,
+            readOnlyQuestionService,
+            Optional.empty());
+
+    assertThat(result.isShowScores()).isFalse();
+  }
+
+  @Test
+  public void mapNew_scoringEnabledUnsupportedTypes_hidesScores() {
+    QuestionFormPageViewModel yesNoResult =
+        mapper.mapNew(
+            new YesNoQuestionForm(),
+            ImmutableList.of(),
+            null,
+            /* apiBridgeEnabled= */ false,
+            /* enumeratorImprovementsEnabled= */ false,
+            /* answerOptionScoringEnabled= */ true,
+            readOnlyQuestionService,
+            Optional.empty());
+    QuestionFormPageViewModel textResult =
+        mapper.mapNew(
+            new TextQuestionForm(),
+            ImmutableList.of(),
+            null,
+            /* apiBridgeEnabled= */ false,
+            /* enumeratorImprovementsEnabled= */ false,
+            /* answerOptionScoringEnabled= */ true,
+            readOnlyQuestionService,
+            Optional.empty());
+
+    assertThat(yesNoResult.isShowScores()).isFalse();
+    assertThat(textResult.isShowScores()).isFalse();
+  }
+
+  @Test
+  public void scoreDisplayValue_formatsAndToleratesBlankInvalidAndSparseEntries() {
+    QuestionFormPageViewModel model = mapNewTextForm(new TextQuestionForm());
+
+    assertThat(model.scoreDisplayValue(List.of("2.0"), 0)).isEqualTo("2");
+    assertThat(model.scoreDisplayValue(List.of("1.50"), 0)).isEqualTo("1.5");
+    assertThat(model.scoreDisplayValue(List.of("-0.50"), 0)).isEqualTo("-0.5");
+    assertThat(model.scoreDisplayValue(List.of(""), 0)).isNull();
+    assertThat(model.scoreDisplayValue(List.of("junk"), 0)).isNull();
+    assertThat(model.scoreDisplayValue(List.of(), 0)).isNull();
+    assertThat(model.scoreDisplayValue(Arrays.asList((String) null), 0)).isNull();
   }
 
   @Test
@@ -193,6 +271,7 @@ public final class QuestionFormPageMapperTest {
             null,
             /* apiBridgeEnabled= */ false,
             /* enumeratorImprovementsEnabled= */ false,
+            /* answerOptionScoringEnabled= */ false,
             readOnlyQuestionService,
             Optional.of("Something went wrong"));
 
@@ -230,6 +309,7 @@ public final class QuestionFormPageMapperTest {
             null,
             /* apiBridgeEnabled= */ true,
             /* enumeratorImprovementsEnabled= */ false,
+            /* answerOptionScoringEnabled= */ false,
             readOnlyQuestionService,
             Optional.empty());
 
@@ -275,6 +355,7 @@ public final class QuestionFormPageMapperTest {
             null,
             /* apiBridgeEnabled= */ false,
             /* enumeratorImprovementsEnabled= */ false,
+            /* answerOptionScoringEnabled= */ false,
             readOnlyQuestionService,
             Optional.empty());
 
@@ -313,6 +394,7 @@ public final class QuestionFormPageMapperTest {
             null,
             /* apiBridgeEnabled= */ false,
             /* enumeratorImprovementsEnabled= */ false,
+            /* answerOptionScoringEnabled= */ false,
             readOnlyQuestionService,
             Optional.empty());
 
@@ -331,6 +413,7 @@ public final class QuestionFormPageMapperTest {
             null,
             /* apiBridgeEnabled= */ false,
             /* enumeratorImprovementsEnabled= */ false,
+            /* answerOptionScoringEnabled= */ false,
             readOnlyQuestionService,
             Optional.of("Error occurred"));
 

--- a/server/test/models/ProgramModelTest.java
+++ b/server/test/models/ProgramModelTest.java
@@ -47,6 +47,20 @@ public class ProgramModelTest extends ResetPostgres {
   }
 
   @Test
+  public void usesScoring_roundTripsThroughDatabase() {
+    ProgramModel scoringProgram =
+        support.ProgramBuilder.newDraftProgram("scoring program").withUsesScoring(true).build();
+    ProgramModel plainProgram = support.ProgramBuilder.newDraftProgram("plain program").build();
+
+    ProgramModel foundScoring =
+        repo.lookupProgram(scoringProgram.id).toCompletableFuture().join().get();
+    ProgramModel foundPlain = repo.lookupProgram(plainProgram.id).toCompletableFuture().join().get();
+
+    assertThat(foundScoring.getProgramDefinition().usesScoring()).isTrue();
+    assertThat(foundPlain.getProgramDefinition().usesScoring()).isFalse();
+  }
+
+  @Test
   public void canSaveProgram() throws UnsupportedQuestionTypeException {
     QuestionDefinition questionDefinition =
         new QuestionDefinitionBuilder()

--- a/server/test/resources/thymeleaf/admin/questions/legacyQuestionFragments/multiOptionRowExisting.thtest
+++ b/server/test/resources/thymeleaf/admin/questions/legacyQuestionFragments/multiOptionRowExisting.thtest
@@ -6,7 +6,7 @@ adminValidation.multiOptionAdminError=Admin names can only contain lowercase let
 adminValidation.multiOptionEmpty=Multi option questions cannot have blank options.
 # ----------------------------------------------------------------------
 %INPUT
-<div th:replace="~{admin/questions/fragments/MultiOptionRow :: multiOptionRow(false, '42', 'option_one', 'Option one', 'field-1', 'field-2', 'field-3')}"></div>
+<div th:replace="~{admin/questions/fragments/MultiOptionRow :: multiOptionRow(false, '42', 'option_one', 'Option one', 'field-1', 'field-2', 'field-3', false, null, 'field-4')}"></div>
 # ----------------------------------------------------------------------
 %OUTPUT
 <div

--- a/server/test/resources/thymeleaf/admin/questions/legacyQuestionFragments/multiOptionRowScored.thtest
+++ b/server/test/resources/thymeleaf/admin/questions/legacyQuestionFragments/multiOptionRowScored.thtest
@@ -1,4 +1,4 @@
-%NAME multiOptionRow - new option posts to the newOptions fields and has no optionIds field
+%NAME multiOptionRow - showScores grows the grid and renders an editable score input
 %TEMPLATE_MODE HTML
 %MESSAGES
 toast.errorMessageOutline=Error: {0}
@@ -6,13 +6,28 @@ adminValidation.multiOptionAdminError=Admin names can only contain lowercase let
 adminValidation.multiOptionEmpty=Multi option questions cannot have blank options.
 # ----------------------------------------------------------------------
 %INPUT
-<div th:replace="~{admin/questions/fragments/MultiOptionRow :: multiOptionRow(true, null, '', '', 'field-1', 'field-2', 'field-3', false, null, 'field-4')}"></div>
+<div th:replace="~{admin/questions/fragments/MultiOptionRow :: multiOptionRow(false, '42', 'option_one', 'Option one', 'field-1', 'field-2', 'field-3', true, '2.5', 'field-4')}"></div>
 # ----------------------------------------------------------------------
 %OUTPUT
 <div
-  class="cf-multi-option-question-option cf-multi-option-question-option-editable grid grid-cols-8 grid-rows-4 items-center mb-4"
+  class="cf-multi-option-question-option cf-multi-option-question-option-editable grid grid-cols-8 grid-rows-6 items-center mb-4"
 >
-  <div></div>
+  <div class="hidden">
+    <label for="field-1" class="sr-only"
+      >option ids<span class="usa-hint--required hidden" aria-hidden="true">&nbsp;*</span></label
+    >
+    <div class="flex flex-col">
+      <input
+        type="text"
+        value="42"
+        maxlength="10000"
+        id="field-1"
+        name="optionIds[]"
+        class="px-3 bg-white text-black text-lg py-2 block outline-none box-border m-auto border border-gray-500 rounded-lg w-full focus:border-civiform-blue placeholder-gray-500"
+      />
+      <div id="field-1-errors" class="text-red-600 text-xs p-1 hidden"></div>
+    </div>
+  </div>
   <div
     class="cf-multi-option-admin-input col-start-1 col-span-5 mb-2 ml-2 row-start-1 row-span-2"
   >
@@ -24,12 +39,13 @@ adminValidation.multiOptionEmpty=Multi option questions cannot have blank option
     <div class="flex flex-col">
       <input
         type="text"
-        value=""
+        value="option_one"
         maxlength="10000"
         aria-required="true"
         id="field-2"
-        name="newOptionAdminNames[]"
-        class="px-3 bg-white text-black text-lg py-2 block outline-none box-border m-auto border border-gray-500 rounded-lg w-full focus:border-civiform-blue placeholder-gray-500"
+        name="optionAdminNames[]"
+        readonly="readonly"
+        class="px-3 bg-white text-black text-lg py-2 block outline-none box-border m-auto border border-gray-500 rounded-lg w-full focus:border-civiform-blue placeholder-gray-500 read-only:text-gray-500 read-only:bg-gray-100"
       />
       <div
         id="field-2-errors"
@@ -82,11 +98,11 @@ adminValidation.multiOptionEmpty=Multi option questions cannot have blank option
     <div class="flex flex-col">
       <input
         type="text"
-        value=""
+        value="Option one"
         maxlength="10000"
         aria-required="true"
         id="field-3"
-        name="newOptions[]"
+        name="options[]"
         class="px-3 bg-white text-black text-lg py-2 block outline-none box-border m-auto border border-gray-500 rounded-lg w-full focus:border-civiform-blue placeholder-gray-500"
       />
       <div
@@ -139,4 +155,26 @@ adminValidation.multiOptionEmpty=Multi option questions cannot have blank option
       ></path>
     </svg>
   </button>
+  <div
+    class="cf-multi-option-score-input col-start-1 col-span-5 mb-2 ml-2 row-start-5 row-span-2"
+  >
+    <label
+      for="field-4"
+      class="pointer-events-none text-gray-600 text-base px-1 py-2"
+      >Score<span class="usa-hint--required hidden" aria-hidden="true">&nbsp;*</span></label
+    >
+    <div class="flex flex-col">
+      <input
+        type="number"
+        inputmode="decimal"
+        step="any"
+        value="2.5"
+        maxlength="10000"
+        id="field-4"
+        name="optionScores[]"
+        class="px-3 bg-white text-black text-lg py-2 block outline-none box-border m-auto border border-gray-500 rounded-lg w-full focus:border-civiform-blue placeholder-gray-500"
+      />
+      <div id="field-4-errors" class="text-red-600 text-xs p-1 hidden"></div>
+    </div>
+  </div>
 </div>

--- a/server/test/services/question/types/QuestionOptionTest.java
+++ b/server/test/services/question/types/QuestionOptionTest.java
@@ -3,15 +3,21 @@ package services.question.types;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.collect.ImmutableMap;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.OptionalLong;
 import org.junit.Test;
 import services.LocalizedStrings;
+import services.ObjectMapperSingleton;
 import services.question.LocalizedQuestionOption;
 import services.question.QuestionOption;
 
 public class QuestionOptionTest {
+
+  private static final ObjectMapper mapper = ObjectMapperSingleton.instance();
 
   @Test
   public void localize_unsupportedLocale_throws() {
@@ -113,5 +119,149 @@ public class QuestionOptionTest {
     assertThat(localizedNo.order()).isEqualTo(1L); // displayOrder=1, not id=0
     assertThat(localizedNotSure.order()).isEqualTo(2L); // displayOrder=2, same as id=2
     assertThat(localizedMaybe.order()).isEqualTo(3L); // displayOrder=3, same as id=3
+  }
+
+  @Test
+  public void serde_roundTrip_preservesScore() throws Exception {
+    QuestionOption option =
+        QuestionOption.create(
+            /* id= */ 1L,
+            /* displayOrder= */ 0L,
+            /* adminName= */ "scored",
+            /* optionText= */ LocalizedStrings.of(Locale.US, "scored option"),
+            /* displayInAnswerOptions= */ Optional.of(true),
+            /* score= */ Optional.of(5.0));
+
+    QuestionOption deserialized =
+        mapper.readValue(mapper.writeValueAsString(option), QuestionOption.class);
+
+    assertThat(deserialized).isEqualTo(option);
+    assertThat(deserialized.score()).isEqualTo(Optional.of(5.0));
+  }
+
+  @Test
+  public void serde_roundTrip_preservesNegativeScore() throws Exception {
+    QuestionOption option =
+        QuestionOption.create(
+            /* id= */ 1L,
+            /* displayOrder= */ 0L,
+            /* adminName= */ "negative",
+            /* optionText= */ LocalizedStrings.of(Locale.US, "negative option"),
+            /* displayInAnswerOptions= */ Optional.of(true),
+            /* score= */ Optional.of(-3.5));
+
+    QuestionOption deserialized =
+        mapper.readValue(mapper.writeValueAsString(option), QuestionOption.class);
+
+    assertThat(deserialized.score()).isEqualTo(Optional.of(-3.5));
+  }
+
+  @Test
+  public void deserialize_integralScoreJson_readsEquivalentDouble() throws Exception {
+    // Stored rows written while scores were whole numbers hold integral JSON values; they
+    // deserialize to the equivalent double.
+    QuestionOption option =
+        QuestionOption.create(
+            /* id= */ 1L,
+            /* displayOrder= */ 0L,
+            /* adminName= */ "integral",
+            /* optionText= */ LocalizedStrings.of(Locale.US, "integral option"),
+            /* displayInAnswerOptions= */ Optional.of(true));
+    ObjectNode node = (ObjectNode) mapper.readTree(mapper.writeValueAsString(option));
+    node.put("score", 6);
+
+    QuestionOption deserialized = mapper.readValue(node.toString(), QuestionOption.class);
+
+    assertThat(deserialized.score()).isEqualTo(Optional.of(6.0));
+  }
+
+  @Test
+  public void formatScore_stripsTrailingZerosAndUsesPlainNotation() {
+    assertThat(QuestionOption.formatScore(2.0)).isEqualTo("2");
+    assertThat(QuestionOption.formatScore(1.5)).isEqualTo("1.5");
+    assertThat(QuestionOption.formatScore(-0.5)).isEqualTo("-0.5");
+    assertThat(QuestionOption.formatScore(0.0)).isEqualTo("0");
+    assertThat(QuestionOption.formatScore(1234567.25)).isEqualTo("1234567.25");
+  }
+
+  @Test
+  public void serde_roundTrip_absentScore() throws Exception {
+    QuestionOption option =
+        QuestionOption.create(
+            /* id= */ 1L,
+            /* displayOrder= */ 0L,
+            /* adminName= */ "unscored",
+            /* optionText= */ LocalizedStrings.of(Locale.US, "unscored option"),
+            /* displayInAnswerOptions= */ Optional.of(true));
+
+    QuestionOption deserialized =
+        mapper.readValue(mapper.writeValueAsString(option), QuestionOption.class);
+
+    assertThat(deserialized).isEqualTo(option);
+    assertThat(deserialized.score()).isEmpty();
+  }
+
+  @Test
+  public void deserialize_storedJsonWithoutScoreField_readsEmptyScore() throws Exception {
+    // Simulates a pre-feature stored row: no `score` property at all.
+    QuestionOption option =
+        QuestionOption.create(
+            /* id= */ 1L,
+            /* displayOrder= */ 0L,
+            /* adminName= */ "pre-feature",
+            /* optionText= */ LocalizedStrings.of(Locale.US, "pre-feature option"),
+            /* displayInAnswerOptions= */ Optional.of(true));
+    ObjectNode node = (ObjectNode) mapper.readTree(mapper.writeValueAsString(option));
+    node.remove("score");
+
+    QuestionOption deserialized = mapper.readValue(node.toString(), QuestionOption.class);
+
+    assertThat(deserialized).isEqualTo(option);
+    assertThat(deserialized.score()).isEmpty();
+  }
+
+  @Test
+  public void deserialize_explicitNullScore_readsEmptyScore() throws Exception {
+    QuestionOption option =
+        QuestionOption.create(
+            /* id= */ 1L,
+            /* displayOrder= */ 0L,
+            /* adminName= */ "null-score",
+            /* optionText= */ LocalizedStrings.of(Locale.US, "null score option"),
+            /* displayInAnswerOptions= */ Optional.of(true));
+    ObjectNode node = (ObjectNode) mapper.readTree(mapper.writeValueAsString(option));
+    node.putNull("score");
+
+    QuestionOption deserialized = mapper.readValue(node.toString(), QuestionOption.class);
+
+    assertThat(deserialized.score()).isEmpty();
+  }
+
+  @Test
+  public void deserialize_legacyOptionTextJson_preservesScore() throws Exception {
+    // Legacy rows (pre-May 2021) have `optionText` instead of `localizedOptionText`.
+    String legacyJson =
+        "{\"id\": 1, \"displayOrder\": 2, \"adminName\": \"legacy\","
+            + " \"optionText\": {\"en_US\": \"legacy option\"}, \"score\": 7.5}";
+
+    QuestionOption deserialized = mapper.readValue(legacyJson, QuestionOption.class);
+
+    assertThat(deserialized.optionText().get(Locale.US)).isEqualTo("legacy option");
+    assertThat(deserialized.score()).isEqualTo(Optional.of(7.5));
+  }
+
+  @Test
+  public void jsonCreator_legacyBranch_preservesScore() {
+    QuestionOption option =
+        QuestionOption.jsonCreator(
+            /* id= */ 1L,
+            /* displayOrder= */ 2L,
+            /* adminName= */ "legacy",
+            /* localizedOptionText= */ null,
+            /* legacyOptionText= */ ImmutableMap.of(Locale.US, "legacy option"),
+            /* displayInAnswerOptions= */ Optional.empty(),
+            /* score= */ Optional.of(4.5));
+
+    assertThat(option.score()).isEqualTo(Optional.of(4.5));
   }
 }

--- a/server/test/services/question/types/QuestionTypeTest.java
+++ b/server/test/services/question/types/QuestionTypeTest.java
@@ -41,4 +41,30 @@ public class QuestionTypeTest {
   public void of_lowercase() throws InvalidQuestionTypeException {
     assertThat(QuestionType.of("text")).isEqualTo(QuestionType.TEXT);
   }
+
+  @Test
+  public void supportsOptionScores_trueForCheckboxDropdownRadio() {
+    assertThat(QuestionType.supportsOptionScores(QuestionType.CHECKBOX)).isTrue();
+    assertThat(QuestionType.supportsOptionScores(QuestionType.DROPDOWN)).isTrue();
+    assertThat(QuestionType.supportsOptionScores(QuestionType.RADIO_BUTTON)).isTrue();
+  }
+
+  @Test
+  public void supportsOptionScores_falseForYesNo() {
+    // Yes/No is a multi-option type but must never support scoring.
+    assertThat(QuestionType.YES_NO.isMultiOptionType()).isTrue();
+    assertThat(QuestionType.supportsOptionScores(QuestionType.YES_NO)).isFalse();
+  }
+
+  @Test
+  public void supportsOptionScores_falseForAllOtherTypes() {
+    for (QuestionType type : QuestionType.values()) {
+      if (type == QuestionType.CHECKBOX
+          || type == QuestionType.DROPDOWN
+          || type == QuestionType.RADIO_BUTTON) {
+        continue;
+      }
+      assertThat(QuestionType.supportsOptionScores(type)).isFalse();
+    }
+  }
 }

--- a/server/test/views/admin/question/QuestionConfigTest.java
+++ b/server/test/views/admin/question/QuestionConfigTest.java
@@ -3,6 +3,7 @@ package views.admin.question;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static play.test.Helpers.stubMessagesApi;
 
 import com.google.common.collect.ImmutableList;
@@ -166,6 +167,67 @@ public class QuestionConfigTest extends ResetPostgres {
     assertThat(result).contains("existing-option-admin-b");
     assertThat(result).contains("new-option-admin-c");
     assertThat(result).contains("new-option-admin-d");
+  }
+
+  @Test
+  public void checkboxForm_scoringFlagEnabled_rendersScoreInputsWithValues() {
+    when(settingsManifest.getAnswerOptionScoringEnabled(request)).thenReturn(true);
+    CheckboxQuestionForm form = new CheckboxQuestionForm();
+    form.setOptions(ImmutableList.of("option-a", "option-b"));
+    form.setOptionAdminNames(ImmutableList.of("option-admin-a", "option-admin-b"));
+    form.setOptionIds(ImmutableList.of(1L, 2L));
+    form.setOptionScores(ImmutableList.of("4.25", ""));
+    form.setNewOptions(ImmutableList.of("option-c"));
+    form.setNewOptionAdminNames(ImmutableList.of("option-admin-c"));
+    // Trailing zeros are stripped for display: -2.50 renders as -2.5.
+    form.setNewOptionScores(ImmutableList.of("-2.50"));
+
+    Optional<DivTag> maybeConfig =
+        QuestionConfig.buildQuestionConfig(form, messages, settingsManifest, request);
+    assertThat(maybeConfig).isPresent();
+    String result = maybeConfig.get().renderFormatted();
+
+    assertThat(result).contains("Score");
+    assertThat(result).contains("cf-multi-option-score-input");
+    assertThat(result).contains("grid-rows-6");
+    assertThat(result)
+        .containsPattern("name=\"optionScores\\[\\]\"[^>]*value=\"4.25\"");
+    assertThat(result)
+        .containsPattern("name=\"newOptionScores\\[\\]\"[^>]*value=\"-2.5\"");
+    // The unscored option renders an empty score input, keeping the lists parallel.
+    Matcher scoreInputs = Pattern.compile("name=\"optionScores\\[\\]\"").matcher(result);
+    assertThat(scoreInputs.results().count()).isEqualTo(2);
+  }
+
+  @Test
+  public void checkboxForm_scoringFlagDisabled_rendersNoScoreInputs() {
+    CheckboxQuestionForm form = new CheckboxQuestionForm();
+    form.setOptions(ImmutableList.of("option-a"));
+    form.setOptionAdminNames(ImmutableList.of("option-admin-a"));
+    form.setOptionIds(ImmutableList.of(1L));
+
+    Optional<DivTag> maybeConfig =
+        QuestionConfig.buildQuestionConfig(form, messages, settingsManifest, request);
+    assertThat(maybeConfig).isPresent();
+    String result = maybeConfig.get().renderFormatted();
+
+    assertThat(result).doesNotContain("optionScores[]");
+    assertThat(result).doesNotContain("cf-multi-option-score-input");
+    assertThat(result).contains("grid-rows-4");
+  }
+
+  @Test
+  public void yesNoForm_scoringFlagEnabled_rendersNoScoreInputs() {
+    when(settingsManifest.getAnswerOptionScoringEnabled(request)).thenReturn(true);
+    YesNoQuestionForm form = new YesNoQuestionForm();
+
+    Optional<DivTag> maybeConfig =
+        QuestionConfig.buildQuestionConfig(form, messages, settingsManifest, request);
+    assertThat(maybeConfig).isPresent();
+    String result = maybeConfig.get().renderFormatted();
+
+    assertThat(result).doesNotContain("optionScores[]");
+    assertThat(result).doesNotContain("cf-multi-option-score-input");
   }
 
   @Test

--- a/server/test/views/admin/questions/LegacyQuestionFragmentsTest.java
+++ b/server/test/views/admin/questions/LegacyQuestionFragmentsTest.java
@@ -95,4 +95,14 @@ public class LegacyQuestionFragmentsTest {
   public void multiOptionRow_existingOption() {
     ThymeleafFragmentTester.run(DIR + "multiOptionRowExisting.thtest");
   }
+
+  /**
+   * With showScores on (the answer-option-scoring flag and a supported question type), the row
+   * grows to six grid rows and renders a never-readonly score input posting to optionScores[],
+   * with the pre-formatted display value.
+   */
+  @Test
+  public void multiOptionRow_scoredOption() {
+    ThymeleafFragmentTester.run(DIR + "multiOptionRowScored.thtest");
+  }
 }


### PR DESCRIPTION
### Description

Please explain the changes you made here.

## Release notes

Remove this section if the feature is still under development or if title of the pull request can be used as the default release notes description. If more detail is needed to communicate to partners the scope of the PR's changes, use this release notes section (and remove this placeholder text).

When the Release engineer creates Release Notes, they will not look for this section for Under Development tagged PRs, and will use it if present for all other PRs included in the Release Notes.

### Checklist

Remove any sections below that do not apply to your PR. For sections that do apply, complete all of the appropriate checklist items and check them off. If a checklist item doesn't apply to your PR, leave it unchecked but do not delete it.

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [ ] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [ ] Added an additional reviewer as required if changes potentially affect the security of the application.
- [ ] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

#### Database evolutions

Read the guidelines [here](https://github.com/civiform/civiform/wiki/Database#writing-database-evolutions)

- [ ] Assigned two reviewers
- [ ] Guarded against already existing resources using `IF NOT EXISTS` and `IF EXISTS`
- [ ] Downs created to undo changes in Ups
- [ ] Every comment in script should begin with -- and not # --- unless it denotes Ups or Downs. See [here](https://www.playframework.com/documentation/2.9.x/Evolutions) for details.
- [ ] Tested both the Downs and the Ups scripts manually (When testing, include all comments from the evolution in your test script to ensure any syntax errors in the comments are caught.)
- [ ] Data migrations aren't being done (please use a [Durable Job](https://github.com/civiform/civiform/wiki/Database#durable-jobs-for-data-updates) if doing a data migration)
- [ ] Update the model documentation in our [wiki](https://github.com/civiform/civiform/wiki/Database) if necessary

#### Durable jobs

Read the docs [here](https://github.com/civiform/civiform/wiki/Database#durable-jobs-for-data-updates)

- [ ] Assigned two reviewers
- [ ] Included a rollback plan and a job to undo the data changes if appropriate

#### User visible changes

- [ ] Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
  - [ ] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [ ] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order
- [ ] Performed manual accessibility tests for any applicant-facing changes or any new admin-facing features. See [manual-accessibility-testing](https://github.com/civiform/civiform/wiki/Accessibility#manual-accessibility-testing)
- [ ] Manually tested with a right-to-left language

#### New Features

- [ ] Add new FeatureFlag env vars to `server/conf/helper/feature-flags.conf`
- [ ] Conditioned new functionality on a [FeatureFlag](https://github.com/civiform/civiform/wiki/Feature-Flags)
- [ ] Wrote browser tests with the feature flag off and on, etc.

### Instructions for manual testing

If instructions are needed for manual testing by reviewers, include them here.

### Issue(s) this completes

Fixes #<issue_number>; Fixes #<issue_number>...
