### PR TITLE
[Scored Questions] Add new uses_scoring field onto programs model

### DIFF
--- a/server/app/models/ProgramModel.java
+++ b/server/app/models/ProgramModel.java
@@ -220,49 +220,6 @@ public class ProgramModel extends BaseModel {
 
   /**
    * Construct a new Program object with the given program name, description, and block definitions.
-   * Includes program categories. The program does not use answer-option scoring.
-   */
-  public ProgramModel(
-      String adminName,
-      String adminDescription,
-      String defaultDisplayName,
-      String defaultDisplayDescription,
-      String defaultShortDescription,
-      String defaultConfirmationMessage,
-      String externalLink,
-      String displayMode,
-      ImmutableList<ProgramNotificationPreference> notificationPreferences,
-      ImmutableList<BlockDefinition> blockDefinitions,
-      VersionModel associatedVersion,
-      ProgramType programType,
-      boolean eligibilityIsGating,
-      boolean loginOnly,
-      ProgramAcls programAcls,
-      ImmutableList<CategoryModel> categories,
-      ImmutableList<ApplicationStep> applicationSteps) {
-    this(
-        adminName,
-        adminDescription,
-        defaultDisplayName,
-        defaultDisplayDescription,
-        defaultShortDescription,
-        defaultConfirmationMessage,
-        externalLink,
-        displayMode,
-        notificationPreferences,
-        blockDefinitions,
-        associatedVersion,
-        programType,
-        eligibilityIsGating,
-        loginOnly,
-        /* usesScoring= */ false,
-        programAcls,
-        categories,
-        applicationSteps);
-  }
-
-  /**
-   * Construct a new Program object with the given program name, description, and block definitions.
    * Includes program categories.
    */
   public ProgramModel(

--- a/server/app/models/ProgramModel.java
+++ b/server/app/models/ProgramModel.java
@@ -368,8 +368,7 @@ public class ProgramModel extends BaseModel {
             .setProgramType(programType)
             .setEligibilityIsGating(eligibilityIsGating)
             .setLoginOnly(loginOnly)
-            // Rows created before the uses_scoring evolution may load a null column value.
-            .setUsesScoring(usesScoring != null && usesScoring)
+            .setUsesScoring(usesScoring)
             .setAcls(acls)
             .setCategories(ImmutableList.copyOf(categories))
             .setApplicationSteps(ImmutableList.copyOf(applicationSteps))

--- a/server/app/models/ProgramModel.java
+++ b/server/app/models/ProgramModel.java
@@ -70,6 +70,9 @@ public class ProgramModel extends BaseModel {
   /** If the program is for logged in applicants only. */
   @Constraints.Required private Boolean loginOnly;
 
+  /** If true, the program applies answer-option scores to submitted applications. */
+  @Constraints.Required private Boolean usesScoring;
+
   /** The notification preferences for this program */
   @Constraints.Required
   private @DbArray List<ProgramNotificationPreference> notificationPreferences;
@@ -195,6 +198,7 @@ public class ProgramModel extends BaseModel {
     this.notificationPreferences = new ArrayList<>(definition.notificationPreferences());
     this.programType = definition.programType();
     this.eligibilityIsGating = definition.eligibilityIsGating();
+    this.usesScoring = definition.usesScoring();
     this.acls = definition.acls();
 
     // Ebeans needs to manage the collection so add categories instead of
@@ -216,6 +220,49 @@ public class ProgramModel extends BaseModel {
 
   /**
    * Construct a new Program object with the given program name, description, and block definitions.
+   * Includes program categories. The program does not use answer-option scoring.
+   */
+  public ProgramModel(
+      String adminName,
+      String adminDescription,
+      String defaultDisplayName,
+      String defaultDisplayDescription,
+      String defaultShortDescription,
+      String defaultConfirmationMessage,
+      String externalLink,
+      String displayMode,
+      ImmutableList<ProgramNotificationPreference> notificationPreferences,
+      ImmutableList<BlockDefinition> blockDefinitions,
+      VersionModel associatedVersion,
+      ProgramType programType,
+      boolean eligibilityIsGating,
+      boolean loginOnly,
+      ProgramAcls programAcls,
+      ImmutableList<CategoryModel> categories,
+      ImmutableList<ApplicationStep> applicationSteps) {
+    this(
+        adminName,
+        adminDescription,
+        defaultDisplayName,
+        defaultDisplayDescription,
+        defaultShortDescription,
+        defaultConfirmationMessage,
+        externalLink,
+        displayMode,
+        notificationPreferences,
+        blockDefinitions,
+        associatedVersion,
+        programType,
+        eligibilityIsGating,
+        loginOnly,
+        /* usesScoring= */ false,
+        programAcls,
+        categories,
+        applicationSteps);
+  }
+
+  /**
+   * Construct a new Program object with the given program name, description, and block definitions.
    * Includes program categories.
    */
   public ProgramModel(
@@ -233,6 +280,7 @@ public class ProgramModel extends BaseModel {
       ProgramType programType,
       boolean eligibilityIsGating,
       boolean loginOnly,
+      boolean usesScoring,
       ProgramAcls programAcls,
       ImmutableList<CategoryModel> categories,
       ImmutableList<ApplicationStep> applicationSteps) {
@@ -253,6 +301,7 @@ public class ProgramModel extends BaseModel {
     this.programType = programType;
     this.eligibilityIsGating = eligibilityIsGating;
     this.loginOnly = loginOnly;
+    this.usesScoring = usesScoring;
     this.acls = programAcls;
 
     // Ebeans needs to manage the collection so add categories instead of
@@ -280,6 +329,7 @@ public class ProgramModel extends BaseModel {
     programType = programDefinition.programType();
     eligibilityIsGating = programDefinition.eligibilityIsGating();
     loginOnly = programDefinition.loginOnly();
+    usesScoring = programDefinition.usesScoring();
     acls = programDefinition.acls();
     localizedSummaryImageDescription =
         programDefinition.localizedSummaryImageDescription().orElse(null);
@@ -318,6 +368,8 @@ public class ProgramModel extends BaseModel {
             .setProgramType(programType)
             .setEligibilityIsGating(eligibilityIsGating)
             .setLoginOnly(loginOnly)
+            // Rows created before the uses_scoring evolution may load a null column value.
+            .setUsesScoring(usesScoring != null && usesScoring)
             .setAcls(acls)
             .setCategories(ImmutableList.copyOf(categories))
             .setApplicationSteps(ImmutableList.copyOf(applicationSteps))

--- a/server/app/services/program/ProgramDefinition.java
+++ b/server/app/services/program/ProgramDefinition.java
@@ -141,6 +141,20 @@ public abstract class ProgramDefinition {
   @JsonProperty("eligibilityIsGating")
   public abstract boolean eligibilityIsGating();
 
+  /**
+   * Internal storage for {@link #usesScoring()}. Optional so that program exports created before
+   * the property existed still deserialize; a missing property reads as false. Use {@link
+   * #usesScoring()} instead.
+   */
+  @JsonProperty("usesScoring")
+  abstract Optional<Boolean> usesScoringInternal();
+
+  /** Whether the program applies answer-option scores to submitted applications. */
+  @JsonIgnore
+  public final boolean usesScoring() {
+    return usesScoringInternal().orElse(false);
+  }
+
   @JsonProperty("acls")
   public abstract ProgramAcls acls();
 
@@ -910,6 +924,13 @@ public abstract class ProgramDefinition {
 
     @JsonProperty("eligibilityIsGating")
     public abstract Builder setEligibilityIsGating(boolean eligibilityIsGating);
+
+    @JsonProperty("usesScoring")
+    abstract Builder setUsesScoringInternal(Optional<Boolean> usesScoring);
+
+    public final Builder setUsesScoring(boolean usesScoring) {
+      return setUsesScoringInternal(Optional.of(usesScoring));
+    }
 
     @JsonProperty("loginOnly")
     public abstract Builder setLoginOnly(boolean loginOnly);

--- a/server/app/services/program/ProgramService.java
+++ b/server/app/services/program/ProgramService.java
@@ -459,6 +459,7 @@ public final class ProgramService {
             programType,
             eligibilityIsGating,
             loginOnly,
+            /* usesScoring= */ false,
             programAcls,
             categoryRepository.findCategoriesByIds(categoryIds),
             applicationSteps);

--- a/server/conf/evolutions/default/98.sql
+++ b/server/conf/evolutions/default/98.sql
@@ -1,4 +1,4 @@
-# --- Whether the program applies answer-option scores to submitted applications
+-- Whether the program applies answer-option scores to submitted applications
 # --- !Ups
 ALTER TABLE IF EXISTS programs
 ADD COLUMN IF NOT EXISTS uses_scoring boolean DEFAULT FALSE NOT NULL;

--- a/server/conf/evolutions/default/98.sql
+++ b/server/conf/evolutions/default/98.sql
@@ -1,0 +1,8 @@
+# --- Whether the program applies answer-option scores to submitted applications
+# --- !Ups
+ALTER TABLE IF EXISTS programs
+ADD COLUMN IF NOT EXISTS uses_scoring boolean DEFAULT FALSE NOT NULL;
+
+# --- !Downs
+ALTER TABLE IF EXISTS programs
+DROP COLUMN IF EXISTS uses_scoring;

--- a/server/test/actions/ProgramDisabledActionTest.java
+++ b/server/test/actions/ProgramDisabledActionTest.java
@@ -61,6 +61,7 @@ public class ProgramDisabledActionTest extends ResetPostgres {
             /* programType */ ProgramType.DEFAULT,
             /* eligibilityIsGating= */ true,
             /* loginOnly= */ false,
+            /* usesScoring= */ false,
             /* ProgramAcls */ new ProgramAcls(),
             /* categories */ ImmutableList.of(),
             /* applicationSteps */ ImmutableList.of(new ApplicationStep("title", "description")));

--- a/server/test/models/ProgramModelTest.java
+++ b/server/test/models/ProgramModelTest.java
@@ -47,6 +47,21 @@ public class ProgramModelTest extends ResetPostgres {
   }
 
   @Test
+  public void usesScoring_roundTripsThroughDatabase() {
+    ProgramModel scoringProgram =
+        support.ProgramBuilder.newDraftProgram("scoring program").withUsesScoring(true).build();
+    ProgramModel plainProgram = support.ProgramBuilder.newDraftProgram("plain program").build();
+
+    ProgramModel foundScoring =
+        repo.lookupProgram(scoringProgram.id).toCompletableFuture().join().get();
+    ProgramModel foundPlain =
+        repo.lookupProgram(plainProgram.id).toCompletableFuture().join().get();
+
+    assertThat(foundScoring.getProgramDefinition().usesScoring()).isTrue();
+    assertThat(foundPlain.getProgramDefinition().usesScoring()).isFalse();
+  }
+
+  @Test
   public void canSaveProgram() throws UnsupportedQuestionTypeException {
     QuestionDefinition questionDefinition =
         new QuestionDefinitionBuilder()

--- a/server/test/models/VersionModelTest.java
+++ b/server/test/models/VersionModelTest.java
@@ -42,6 +42,7 @@ public class VersionModelTest extends ResetPostgres {
             ProgramType.DEFAULT,
             /* eligibilityIsGating= */ true,
             /* loginOnly= */ false,
+            /* usesScoring= */ false,
             new ProgramAcls(),
             /* categories= */ ImmutableList.of(),
             ImmutableList.of(new ApplicationStep("title", "description")));

--- a/server/test/repository/ApplicationRepositoryTest.java
+++ b/server/test/repository/ApplicationRepositoryTest.java
@@ -636,6 +636,7 @@ public class ApplicationRepositoryTest extends ResetPostgres {
             ProgramType.DEFAULT,
             /* eligibilityIsGating= */ true,
             /* loginOnly= */ false,
+            /* usesScoring= */ false,
             new ProgramAcls(),
             /* categories= */ ImmutableList.of(),
             ImmutableList.of(new ApplicationStep("title", "description")));

--- a/server/test/repository/ProgramRepositoryTest.java
+++ b/server/test/repository/ProgramRepositoryTest.java
@@ -272,6 +272,7 @@ public class ProgramRepositoryTest extends ResetPostgres {
             ProgramType.DEFAULT,
             /* eligibilityIsGating= */ true,
             /* loginOnly= */ false,
+            /* usesScoring= */ false,
             new ProgramAcls(),
             /* categories= */ ImmutableList.of(),
             ImmutableList.of(new ApplicationStep("title", "description")));
@@ -293,6 +294,7 @@ public class ProgramRepositoryTest extends ResetPostgres {
             ProgramType.DEFAULT,
             /* eligibilityIsGating= */ true,
             /* loginOnly= */ false,
+            /* usesScoring= */ false,
             new ProgramAcls(),
             /* categories= */ ImmutableList.of(),
             ImmutableList.of(new ApplicationStep("title", "description")));
@@ -320,6 +322,7 @@ public class ProgramRepositoryTest extends ResetPostgres {
             ProgramType.DEFAULT,
             /* eligibilityIsGating= */ true,
             /* loginOnly= */ false,
+            /* usesScoring= */ false,
             new ProgramAcls(),
             /* categories= */ ImmutableList.of(),
             ImmutableList.of(new ApplicationStep("title", "description")));

--- a/server/test/services/program/ProgramDefinitionTest.java
+++ b/server/test/services/program/ProgramDefinitionTest.java
@@ -1909,37 +1909,6 @@ public class ProgramDefinitionTest extends ResetPostgres {
         .containsExactly(expectedBlockA, expectedBlockB, expectedBlockC, expectedBlockD);
   }
 
-  private ProgramDefinition minimalProgramDefinition(boolean usesScoring) {
-    ProgramDefinition.Builder builder =
-        ProgramDefinition.builder()
-            .setId(123L)
-            .setAdminName("uses-scoring-test")
-            .setAdminDescription("Admin description")
-            .setLocalizedName(LocalizedStrings.of(Locale.US, "The Program"))
-            .setLocalizedDescription(LocalizedStrings.of(Locale.US, "This program is for testing."))
-            .setLocalizedShortDescription(
-                LocalizedStrings.of(Locale.US, "This program is for testing."))
-            .setLocalizedConfirmationMessage(LocalizedStrings.withEmptyDefault())
-            .setExternalLink("")
-            .setDisplayMode(DisplayMode.PUBLIC)
-            .setBlockDefinitions(ImmutableList.of())
-            .setProgramType(ProgramType.DEFAULT)
-            .setEligibilityIsGating(true)
-            .setLoginOnly(false)
-            .setAcls(new ProgramAcls())
-            .setCategories(ImmutableList.of())
-            .setApplicationSteps(ImmutableList.of(new ApplicationStep("title", "description")))
-            .setBridgeDefinitions(ImmutableMap.of());
-    if (usesScoring) {
-      builder.setUsesScoring(true);
-    }
-    return builder.build();
-  }
-
-  private static ObjectMapper migrationStyleObjectMapper() {
-    return new ObjectMapper().registerModule(new GuavaModule()).registerModule(new Jdk8Module());
-  }
-
   @Test
   public void usesScoring_unset_buildsAndReadsFalse() {
     // Builders that never call setUsesScoring must still build (deserialization-safe default).
@@ -1983,5 +1952,36 @@ public class ProgramDefinitionTest extends ResetPostgres {
     ProgramDefinition result = objectMapper.readValue(node.toString(), ProgramDefinition.class);
 
     assertThat(result.usesScoring()).isFalse();
+  }
+
+  private ProgramDefinition minimalProgramDefinition(boolean usesScoring) {
+    ProgramDefinition.Builder builder =
+        ProgramDefinition.builder()
+            .setId(123L)
+            .setAdminName("uses-scoring-test")
+            .setAdminDescription("Admin description")
+            .setLocalizedName(LocalizedStrings.of(Locale.US, "The Program"))
+            .setLocalizedDescription(LocalizedStrings.of(Locale.US, "This program is for testing."))
+            .setLocalizedShortDescription(
+                LocalizedStrings.of(Locale.US, "This program is for testing."))
+            .setLocalizedConfirmationMessage(LocalizedStrings.withEmptyDefault())
+            .setExternalLink("")
+            .setDisplayMode(DisplayMode.PUBLIC)
+            .setBlockDefinitions(ImmutableList.of())
+            .setProgramType(ProgramType.DEFAULT)
+            .setEligibilityIsGating(true)
+            .setLoginOnly(false)
+            .setAcls(new ProgramAcls())
+            .setCategories(ImmutableList.of())
+            .setApplicationSteps(ImmutableList.of(new ApplicationStep("title", "description")))
+            .setBridgeDefinitions(ImmutableMap.of());
+    if (usesScoring) {
+      builder.setUsesScoring(true);
+    }
+    return builder.build();
+  }
+
+  private static ObjectMapper migrationStyleObjectMapper() {
+    return new ObjectMapper().registerModule(new GuavaModule()).registerModule(new Jdk8Module());
   }
 }

--- a/server/test/services/program/ProgramDefinitionTest.java
+++ b/server/test/services/program/ProgramDefinitionTest.java
@@ -7,6 +7,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import auth.ProgramAcls;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.google.common.collect.ImmutableList;
@@ -1906,5 +1907,81 @@ public class ProgramDefinitionTest extends ResetPostgres {
             .build();
     assertThat(result.blockDefinitions())
         .containsExactly(expectedBlockA, expectedBlockB, expectedBlockC, expectedBlockD);
+  }
+
+  private ProgramDefinition minimalProgramDefinition(boolean usesScoring) {
+    ProgramDefinition.Builder builder =
+        ProgramDefinition.builder()
+            .setId(123L)
+            .setAdminName("uses-scoring-test")
+            .setAdminDescription("Admin description")
+            .setLocalizedName(LocalizedStrings.of(Locale.US, "The Program"))
+            .setLocalizedDescription(LocalizedStrings.of(Locale.US, "This program is for testing."))
+            .setLocalizedShortDescription(
+                LocalizedStrings.of(Locale.US, "This program is for testing."))
+            .setLocalizedConfirmationMessage(LocalizedStrings.withEmptyDefault())
+            .setExternalLink("")
+            .setDisplayMode(DisplayMode.PUBLIC)
+            .setBlockDefinitions(ImmutableList.of())
+            .setProgramType(ProgramType.DEFAULT)
+            .setEligibilityIsGating(true)
+            .setLoginOnly(false)
+            .setAcls(new ProgramAcls())
+            .setCategories(ImmutableList.of())
+            .setApplicationSteps(ImmutableList.of(new ApplicationStep("title", "description")))
+            .setBridgeDefinitions(ImmutableMap.of());
+    if (usesScoring) {
+      builder.setUsesScoring(true);
+    }
+    return builder.build();
+  }
+
+  private static ObjectMapper migrationStyleObjectMapper() {
+    return new ObjectMapper().registerModule(new GuavaModule()).registerModule(new Jdk8Module());
+  }
+
+  @Test
+  public void usesScoring_unset_buildsAndReadsFalse() {
+    // Builders that never call setUsesScoring must still build (deserialization-safe default).
+    assertThat(minimalProgramDefinition(/* usesScoring= */ false).usesScoring()).isFalse();
+  }
+
+  @Test
+  public void serde_usesScoringTrue_roundTrips() throws JsonProcessingException {
+    ObjectMapper objectMapper = migrationStyleObjectMapper();
+
+    String json = objectMapper.writeValueAsString(minimalProgramDefinition(true));
+    ProgramDefinition result = objectMapper.readValue(json, ProgramDefinition.class);
+
+    assertThat(json).contains("\"usesScoring\"");
+    assertThat(result.usesScoring()).isTrue();
+  }
+
+  @Test
+  public void deserialize_preFeatureExportWithoutUsesScoring_readsFalse()
+      throws JsonProcessingException {
+    ObjectMapper objectMapper = migrationStyleObjectMapper();
+    // Simulate a program export created before the property existed.
+    ObjectNode node =
+        (ObjectNode)
+            objectMapper.readTree(objectMapper.writeValueAsString(minimalProgramDefinition(true)));
+    node.remove("usesScoring");
+
+    ProgramDefinition result = objectMapper.readValue(node.toString(), ProgramDefinition.class);
+
+    assertThat(result.usesScoring()).isFalse();
+  }
+
+  @Test
+  public void deserialize_explicitNullUsesScoring_readsFalse() throws JsonProcessingException {
+    ObjectMapper objectMapper = migrationStyleObjectMapper();
+    ObjectNode node =
+        (ObjectNode)
+            objectMapper.readTree(objectMapper.writeValueAsString(minimalProgramDefinition(true)));
+    node.putNull("usesScoring");
+
+    ProgramDefinition result = objectMapper.readValue(node.toString(), ProgramDefinition.class);
+
+    assertThat(result.usesScoring()).isFalse();
   }
 }

--- a/server/test/support/ProgramBuilder.java
+++ b/server/test/support/ProgramBuilder.java
@@ -154,6 +154,7 @@ public class ProgramBuilder {
             ProgramType.DEFAULT,
             /* eligibilityIsGating= */ true,
             /* loginOnly= */ false,
+            /* usesScoring= */ false,
             new ProgramAcls(),
             /* categories= */ ImmutableList.of(),
             ImmutableList.of(new ApplicationStep("title", "description")));
@@ -272,6 +273,7 @@ public class ProgramBuilder {
             /* programType */ programType,
             /* eligibilityIsGating= */ true,
             /* loginOnly= */ false,
+            /* usesScoring= */ false,
             /* ProgramAcls */ new ProgramAcls(),
             /* categories= */ ImmutableList.of(),
             /* appplicationSteps */ ImmutableList.of(new ApplicationStep("title", "description")));
@@ -304,6 +306,7 @@ public class ProgramBuilder {
             ProgramType.DEFAULT,
             /* eligibilityIsGating= */ true,
             /* loginOnly= */ false,
+            /* usesScoring= */ false,
             new ProgramAcls(),
             /* categories= */ ImmutableList.of(),
             ImmutableList.of(new ApplicationStep("title", "description")));

--- a/server/test/support/ProgramBuilder.java
+++ b/server/test/support/ProgramBuilder.java
@@ -386,6 +386,11 @@ public class ProgramBuilder {
     return this;
   }
 
+  public ProgramBuilder withUsesScoring(boolean usesScoring) {
+    builder.setUsesScoring(usesScoring);
+    return this;
+  }
+
   /**
    * Creates a {@link BlockBuilder} with this {@link ProgramBuilder} with empty name and
    * description.


### PR DESCRIPTION
### Description

Adds a `uses_scoring` column to the `programs` table and corresponding `usesScoring` field to `ProgramModel.java` and `ProgramDefinition.java`. The field is not null and defaults to false.

Future work will surface a checkbox on the program create/edit metadata page that allows admins to indicate that options scoring should be used on a program and will set this field to `true`.

Updated the [wiki documentation for the `programs` table](https://github.com/civiform/civiform/wiki/Database/_compare/0b90da0899c0e358b1793f4135e029e3f0c9e9de...23018aaca64be3fa074ee04e855f9319c791e12e).

Assisted-by: Claude Code:claude-fable-5

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [ ] Added an additional reviewer as required if changes potentially affect the security of the application.
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [x] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [x] Noted in the PR description which, if any, code in this PR was generated by AI.

#### Database evolutions

Read the guidelines [here](https://github.com/civiform/civiform/wiki/Database#writing-database-evolutions)

- [x] Assigned two reviewers
- [x] Guarded against already existing resources using `IF NOT EXISTS` and `IF EXISTS`
- [x] Downs created to undo changes in Ups
- [x] Every comment in script should begin with -- and not # --- unless it denotes Ups or Downs. See [here](https://www.playframework.com/documentation/2.9.x/Evolutions) for details.
- [x] Tested both the Downs and the Ups scripts manually (When testing, include all comments from the evolution in your test script to ensure any syntax errors in the comments are caught.)
- [x] Data migrations aren't being done (please use a [Durable Job](https://github.com/civiform/civiform/wiki/Database#durable-jobs-for-data-updates) if doing a data migration)
- [x] Update the model documentation in our [wiki](https://github.com/civiform/civiform/wiki/Database) if necessary

### Instructions for manual testing

Ensure creating, editing, exporting, and importing programs works as normal.

### Issue(s) this completes

Fixes #13835;
