### PR TITLE
Fix TI data access issue

### DIFF
--- a/server/app/controllers/applicant/ApplicantProgramsController.java
+++ b/server/app/controllers/applicant/ApplicantProgramsController.java
@@ -209,8 +209,21 @@ public final class ApplicantProgramsController extends CiviFormController {
       return CompletableFuture.completedFuture(redirectToHome());
     } else {
       CiviFormProfile profile = profileUtils.currentUserProfile(request);
-      return programSlugHandler.showProgramWithApplicantId(
-          this, request, programName, applicantId, profile);
+      return checkApplicantAuthorization(request, applicantId)
+          .thenComposeAsync(
+              v ->
+                  programSlugHandler.showProgramWithApplicantId(
+                      this, request, programName, applicantId, profile),
+              classLoaderExecutionContext.current())
+          .exceptionally(
+              ex -> {
+                if (ex instanceof CompletionException) {
+                  if (ex.getCause() instanceof SecurityException) {
+                    return redirectToHome();
+                  }
+                }
+                throw new RuntimeException(ex);
+              });
     }
   }
 

--- a/server/test/auth/CiviFormProfileTest.java
+++ b/server/test/auth/CiviFormProfileTest.java
@@ -111,10 +111,10 @@ public class CiviFormProfileTest extends ResetPostgres {
     clientAccount.setManagedByGroup(tiGroupWithClientAccess);
     clientAccount.save();
 
-    TrustedIntermediaryGroupModel tiGroupWithoutClientAcccess =
+    TrustedIntermediaryGroupModel tiGroupWithoutClientAccess =
         resourceCreator.insertTrustedIntermediaryGroup();
     AccountModel tiAccountWithoutClientAccess = resourceCreator.insertAccount();
-    tiAccountWithoutClientAccess.setMemberOfGroup(tiGroupWithoutClientAcccess);
+    tiAccountWithoutClientAccess.setMemberOfGroup(tiGroupWithoutClientAccess);
     tiAccountWithoutClientAccess.save();
 
     CiviFormProfile tiProfile = profileTestFactory.wrapTi(tiAccountWithoutClientAccess);

--- a/server/test/auth/CiviFormProfileTest.java
+++ b/server/test/auth/CiviFormProfileTest.java
@@ -8,6 +8,7 @@ import static support.FakeRequestBuilder.fakeRequestBuilder;
 import com.google.common.collect.ImmutableList;
 import models.AccountModel;
 import models.ApplicantModel;
+import models.TrustedIntermediaryGroupModel;
 import org.junit.Before;
 import org.junit.Test;
 import play.mvc.Http.Request;
@@ -72,6 +73,57 @@ public class CiviFormProfileTest extends ResetPostgres {
     CiviFormProfile profile = profileFactory.wrapProfileData(data);
 
     assertThatThrownBy(() -> profile.checkAuthorization(1234L).join())
+        .hasCauseInstanceOf(SecurityException.class);
+  }
+
+  @Test
+  public void checkAuthorization_ti_passesForManagedClientId() {
+    ApplicantModel client = resourceCreator.insertApplicant();
+    AccountModel clientAccount = resourceCreator.insertAccount();
+    client.setAccount(clientAccount);
+    client.save();
+
+    TrustedIntermediaryGroupModel group = resourceCreator.insertTrustedIntermediaryGroup();
+    clientAccount.setManagedByGroup(group);
+    clientAccount.save();
+
+    AccountModel tiAccount = resourceCreator.insertAccount();
+    tiAccount.setMemberOfGroup(group);
+    tiAccount.save();
+
+    CiviFormProfile tiProfile = profileTestFactory.wrapTi(tiAccount);
+
+    tiProfile.checkAuthorization(client.id).join(); // should not throw
+  }
+
+  @Test
+  public void checkAuthorization_ti_failsForUnmanagedClientId() {
+    ApplicantModel clientOne = resourceCreator.insertApplicant();
+    AccountModel clientOneAccount = resourceCreator.insertAccount();
+    clientOne.setAccount(clientOneAccount);
+    clientOne.save();
+
+    TrustedIntermediaryGroupModel tiGroupOne = resourceCreator.insertTrustedIntermediaryGroup();
+    clientOneAccount.setManagedByGroup(tiGroupOne);
+    clientOneAccount.save();
+    AccountModel tiAccountOne = resourceCreator.insertAccount();
+    tiAccountOne.setMemberOfGroup(tiGroupOne);
+    tiAccountOne.save();
+
+    ApplicantModel clientTwo = resourceCreator.insertApplicant();
+    AccountModel clientTwoAccount = resourceCreator.insertAccount();
+    clientTwo.setAccount(clientTwoAccount);
+    clientTwo.save();
+
+    TrustedIntermediaryGroupModel tiGroupTwo = resourceCreator.insertTrustedIntermediaryGroup();
+    clientOneAccount.setManagedByGroup(tiGroupTwo);
+    clientOneAccount.save();
+    AccountModel tiAccountTwo = resourceCreator.insertAccount();
+    tiAccountTwo.setMemberOfGroup(tiGroupTwo);
+    tiAccountTwo.save();
+
+    CiviFormProfile tiProfile = profileTestFactory.wrapTi(tiAccountOne);
+    assertThatThrownBy(() -> tiProfile.checkAuthorization(clientTwo.id).join())
         .hasCauseInstanceOf(SecurityException.class);
   }
 

--- a/server/test/auth/CiviFormProfileTest.java
+++ b/server/test/auth/CiviFormProfileTest.java
@@ -98,32 +98,27 @@ public class CiviFormProfileTest extends ResetPostgres {
 
   @Test
   public void checkAuthorization_ti_failsForUnmanagedClientId() {
-    ApplicantModel clientOne = resourceCreator.insertApplicant();
-    AccountModel clientOneAccount = resourceCreator.insertAccount();
-    clientOne.setAccount(clientOneAccount);
-    clientOne.save();
+    ApplicantModel client = resourceCreator.insertApplicant();
+    AccountModel clientAccount = resourceCreator.insertAccount();
+    client.setAccount(clientAccount);
+    client.save();
 
-    TrustedIntermediaryGroupModel tiGroupOne = resourceCreator.insertTrustedIntermediaryGroup();
-    clientOneAccount.setManagedByGroup(tiGroupOne);
-    clientOneAccount.save();
-    AccountModel tiAccountOne = resourceCreator.insertAccount();
-    tiAccountOne.setMemberOfGroup(tiGroupOne);
-    tiAccountOne.save();
+    TrustedIntermediaryGroupModel tiGroupWithClientAccess =
+        resourceCreator.insertTrustedIntermediaryGroup();
+    AccountModel tiAccountWithClientAccess = resourceCreator.insertAccount();
+    tiAccountWithClientAccess.setMemberOfGroup(tiGroupWithClientAccess);
+    tiAccountWithClientAccess.save();
+    clientAccount.setManagedByGroup(tiGroupWithClientAccess);
+    clientAccount.save();
 
-    ApplicantModel clientTwo = resourceCreator.insertApplicant();
-    AccountModel clientTwoAccount = resourceCreator.insertAccount();
-    clientTwo.setAccount(clientTwoAccount);
-    clientTwo.save();
+    TrustedIntermediaryGroupModel tiGroupWithoutClientAcccess =
+        resourceCreator.insertTrustedIntermediaryGroup();
+    AccountModel tiAccountWithoutClientAccess = resourceCreator.insertAccount();
+    tiAccountWithoutClientAccess.setMemberOfGroup(tiGroupWithoutClientAcccess);
+    tiAccountWithoutClientAccess.save();
 
-    TrustedIntermediaryGroupModel tiGroupTwo = resourceCreator.insertTrustedIntermediaryGroup();
-    clientOneAccount.setManagedByGroup(tiGroupTwo);
-    clientOneAccount.save();
-    AccountModel tiAccountTwo = resourceCreator.insertAccount();
-    tiAccountTwo.setMemberOfGroup(tiGroupTwo);
-    tiAccountTwo.save();
-
-    CiviFormProfile tiProfile = profileTestFactory.wrapTi(tiAccountOne);
-    assertThatThrownBy(() -> tiProfile.checkAuthorization(clientTwo.id).join())
+    CiviFormProfile tiProfile = profileTestFactory.wrapTi(tiAccountWithoutClientAccess);
+    assertThatThrownBy(() -> tiProfile.checkAuthorization(client.id).join())
         .hasCauseInstanceOf(SecurityException.class);
   }
 

--- a/server/test/controllers/applicant/ApplicantProgramsControllerTest.java
+++ b/server/test/controllers/applicant/ApplicantProgramsControllerTest.java
@@ -420,6 +420,28 @@ public class ApplicantProgramsControllerTest extends WithMockedProfiles {
   }
 
   @Test
+  public void showWithApplicantId_redirectsUnauthorizedTi() {
+    ProgramModel program = resourceCreator().insertActiveProgram("program");
+
+    ApplicantModel applicantOne = createApplicant();
+    // create a TI that manages applicantOne
+    createTIWithMockedProfile(applicantOne);
+
+    ApplicantModel applicantTwo = createApplicant();
+    // create a TI that does not manage applicantOne. This is the current logged in user.
+    createTIWithMockedProfile(applicantTwo);
+
+    Result result =
+        controller
+            .showWithApplicantId(fakeRequest(), applicantOne.id, program.getSlug())
+            .toCompletableFuture()
+            .join();
+
+    assertThat(result.status()).isEqualTo(SEE_OTHER);
+    assertThat(result.redirectLocation()).hasValue("/");
+  }
+
+  @Test
   public void showInfoDisabledProgram() {
     resourceCreator.insertActiveDisabledProgram("disabledProgram");
 


### PR DESCRIPTION
### Description

Fixes TI data access issue.

I confirmed this is not an issue anywhere else in our code base by doing a manual check of everywhere we use `@Secure(authorizers = Authorizers.Labels.TI_OR_CIVIFORM_ADMIN)` and confirming we call `checkApplicantAuthorization` before rendering data. I also asked Claude to do an audit to find any potential further vulnerabilities.

I used Claude to help me figure out some testing syntax. Claude suggested adding the tests to CiviFormProfileTest because we had a gap in testing for TI authorization.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [x] Added an additional reviewer as required if changes potentially affect the security of the application.
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [x] Noted in the PR description which, if any, code in this PR was generated by AI.

### Issue(s) this completes

Fixes #13930 
