### PR TITLE
Post formatter fixes as suggested changes on PRs

### DIFF
--- a/.github/scripts/post-format-suggestions.js
+++ b/.github/scripts/post-format-suggestions.js
@@ -1,0 +1,181 @@
+// Posts the fixes that bin/fmt and bin/fmt-sbt left in the working tree
+// back onto the pull request as one-click suggested-change review
+// comments. Invoked from .github/workflows/format.yaml via
+// actions/github-script. The working tree is left untouched, so the
+// diff check that follows still fails.
+
+// GitHub rejects comment bodies over this size, and one bad comment
+// rejects the whole review.
+const MAX_BODY_LENGTH = 65536
+
+// The review API caps out well before this, and a wall of suggestions
+// stops being helpful anyway; the review body discloses the rest.
+const MAX_COMMENTS = 50
+
+// Parses `git diff -U0` output into {path, hunks} entries, where each
+// hunk carries its old-file start line and count plus the replacement
+// (lines) and replaced (oldLines) content. Zero context lines matter:
+// each suggestion must anchor on exactly the lines it replaces. Any
+// wider range sweeps in the PR diff's deleted lines, and GitHub refuses
+// to apply suggestions whose range includes deleted lines.
+function parseDiff(diff) {
+  const files = []
+  let file = null
+  let inHeader = false
+  for (const line of diff.split('\n')) {
+    // With -U0 every content line starts with '+', '-', or '\', so a
+    // bare 'diff --git ' line is always a real file boundary.
+    // '+++ b/...' alone is not: an added content line beginning
+    // '++ b/...' renders exactly the same way, so header lines only
+    // count between 'diff --git ' and the file's first '@@ '.
+    if (line.startsWith('diff --git ')) {
+      inHeader = true
+      file = null
+    } else if (inHeader && line.startsWith('+++ b/')) {
+      // Headers for paths with special characters arrive quoted
+      // ('+++ "b/..."') and fail this match, skipping the file; the
+      // API couldn't anchor on the quoted form anyway. A path
+      // containing spaces carries a literal trailing tab.
+      file = {path: line.slice(6).replace(/\t$/, ''), hunks: []}
+      files.push(file)
+    } else if (line.startsWith('@@ ')) {
+      inHeader = false
+      if (file) {
+        const match = line.match(/^@@ -(\d+)(?:,(\d+))? /)
+        file.hunks.push({
+          start: Number(match[1]),
+          count: match[2] === undefined ? 1 : Number(match[2]),
+          lines: [],
+          oldLines: [],
+        })
+      }
+    } else if (file && !inHeader && file.hunks.length > 0) {
+      const hunk = file.hunks[file.hunks.length - 1]
+      if (line.startsWith('+')) {
+        hunk.lines.push(line.slice(1))
+      } else if (line.startsWith('-')) {
+        hunk.oldLines.push(line.slice(1))
+      }
+    }
+  }
+  return files
+}
+
+// Turns parsed hunks into createReview comment payloads. Returns the
+// comments plus a count of fixes that exist in the diff but can't be
+// expressed as an applyable suggestion.
+function buildComments(files) {
+  const comments = []
+  let skipped = 0
+  for (const {path, hunks} of files) {
+    for (const {start, count, lines, oldLines} of hunks) {
+      // A pure insertion has no existing line to anchor on, and a hunk
+      // whose only change is the trailing-newline marker yields a
+      // suggestion identical to the existing text, which GitHub can't
+      // apply.
+      if (count === 0 || lines.join('\n') === oldLines.join('\n')) {
+        skipped++
+        continue
+      }
+      // The fence must be longer than any backtick run in the content,
+      // or a ``` line (common in Markdown files) would close the
+      // suggestion block early. No replacement lines means delete the
+      // range; an empty suggestion block does that, a blank line would
+      // not.
+      const runs = lines.join('\n').match(/`+/g) || []
+      const fence = '`'.repeat(
+        runs.reduce((max, run) => Math.max(max, run.length + 1), 3),
+      )
+      const body =
+        fence + 'suggestion\n' + lines.map((l) => l + '\n').join('') + fence
+      if (body.length > MAX_BODY_LENGTH) {
+        skipped++
+        continue
+      }
+      comments.push({
+        path,
+        line: start + count - 1,
+        side: 'RIGHT',
+        ...(count > 1 && {start_line: start, start_side: 'RIGHT'}),
+        body,
+      })
+    }
+  }
+  return {comments, skipped}
+}
+
+async function postSuggestions({github, context, core, exec}) {
+  const {stdout: diff} = await exec.getExecOutput('git', ['diff', '-U0'], {
+    silent: true,
+  })
+  if (!diff.trim()) return
+
+  const {comments, skipped} = buildComments(parseDiff(diff))
+  if (comments.length === 0 && skipped === 0) return
+
+  const capped = comments.slice(0, MAX_COMMENTS)
+  const pr = context.payload.pull_request
+  const parts = []
+  if (capped.length > 0) {
+    parts.push(
+      'bin/fmt would make these changes. Apply them with "Commit suggestion", or run bin/fmt locally.',
+    )
+    if (comments.length > MAX_COMMENTS) {
+      parts.push(`(Showing ${MAX_COMMENTS} of ${comments.length} fixes.)`)
+    }
+    if (skipped > 0) {
+      parts.push(
+        `${skipped} more can't be shown as suggestions; the failing check's diff has everything.`,
+      )
+    }
+  } else {
+    parts.push(
+      "bin/fmt would make changes that can't be shown as suggestions; run bin/fmt locally or see the failing check's diff.",
+    )
+  }
+  try {
+    await github.rest.pulls.createReview({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      pull_number: pr.number,
+      commit_id: pr.head.sha,
+      event: 'COMMENT',
+      body: parts.join(' '),
+      ...(capped.length > 0 && {comments: capped}),
+    })
+  } catch (error) {
+    // A 422 means GitHub refused a specific comment, usually a hunk
+    // outside the PR's own diff, which rejects the whole review; retry
+    // one comment at a time and drop the ones GitHub refuses. Anything
+    // else (rate limit, permissions, network) would doom the
+    // per-comment retries too, so don't compound the failure with up to
+    // 50 more calls.
+    if (error.status !== 422) {
+      core.warning(`Could not post formatter suggestions: ${error.message}`)
+      return
+    }
+    let posted = 0
+    for (const comment of capped) {
+      try {
+        await github.rest.pulls.createReviewComment({
+          owner: context.repo.owner,
+          repo: context.repo.repo,
+          pull_number: pr.number,
+          commit_id: pr.head.sha,
+          ...comment,
+        })
+        posted++
+      } catch (err) {
+        // A refused comment sits on lines the PR didn't touch; the
+        // diff step's output still shows it. Any other failure applies
+        // to the remaining calls too.
+        if (err.status !== 422) break
+      }
+    }
+    core.warning(
+      `Posted ${posted} of ${capped.length} formatter suggestions individually: ${error.message}`,
+    )
+  }
+}
+
+module.exports = {parseDiff, buildComments, postSuggestions}

--- a/.github/scripts/post-format-suggestions.js
+++ b/.github/scripts/post-format-suggestions.js
@@ -14,10 +14,12 @@ const MAX_COMMENTS = 50
 
 // Parses `git diff -U0` output into {path, hunks} entries, where each
 // hunk carries its old-file start line and count plus the replacement
-// (lines) and replaced (oldLines) content. Zero context lines matter:
-// each suggestion must anchor on exactly the lines it replaces. Any
-// wider range sweeps in the PR diff's deleted lines, and GitHub refuses
-// to apply suggestions whose range includes deleted lines.
+// (newLines) and replaced (oldLines) content. -U0 tells git to emit no
+// unchanged context lines around a hunk, so each hunk spans exactly the
+// lines it replaces and the suggestion anchors on just those. With
+// context included, the anchor range would be wider and could take in
+// lines the PR's own diff deletes, and GitHub refuses to apply a
+// suggestion whose range includes a deleted line.
 function parseDiff(diff) {
   const files = []
   let file = null
@@ -25,13 +27,14 @@ function parseDiff(diff) {
   for (const line of diff.split('\n')) {
     // With -U0 every content line starts with '+', '-', or '\', so a
     // bare 'diff --git ' line is always a real file boundary.
-    // '+++ b/...' alone is not: an added content line beginning
-    // '++ b/...' renders exactly the same way, so header lines only
-    // count between 'diff --git ' and the file's first '@@ '.
+    // '+++ b/...' alone is not a file boundary because an added content
+    // line beginning '++ b/...' renders exactly the same way, so header
+    // lines only count between 'diff --git ' and the file's first '@@ '.
     if (line.startsWith('diff --git ')) {
       inHeader = true
       file = null
     } else if (inHeader && line.startsWith('+++ b/')) {
+      // Grab the filename from the '+++ b/' header line.
       // Headers for paths with special characters arrive quoted
       // ('+++ "b/..."') and fail this match, skipping the file; the
       // API couldn't anchor on the quoted form anyway. A path
@@ -45,14 +48,14 @@ function parseDiff(diff) {
         file.hunks.push({
           start: Number(match[1]),
           count: match[2] === undefined ? 1 : Number(match[2]),
-          lines: [],
+          newLines: [],
           oldLines: [],
         })
       }
     } else if (file && !inHeader && file.hunks.length > 0) {
       const hunk = file.hunks[file.hunks.length - 1]
       if (line.startsWith('+')) {
-        hunk.lines.push(line.slice(1))
+        hunk.newLines.push(line.slice(1))
       } else if (line.startsWith('-')) {
         hunk.oldLines.push(line.slice(1))
       }
@@ -68,12 +71,12 @@ function buildComments(files) {
   const comments = []
   let skipped = 0
   for (const {path, hunks} of files) {
-    for (const {start, count, lines, oldLines} of hunks) {
+    for (const {start, count, newLines, oldLines} of hunks) {
       // A pure insertion has no existing line to anchor on, and a hunk
       // whose only change is the trailing-newline marker yields a
       // suggestion identical to the existing text, which GitHub can't
       // apply.
-      if (count === 0 || lines.join('\n') === oldLines.join('\n')) {
+      if (count === 0 || newLines.join('\n') === oldLines.join('\n')) {
         skipped++
         continue
       }
@@ -82,16 +85,22 @@ function buildComments(files) {
       // suggestion block early. No replacement lines means delete the
       // range; an empty suggestion block does that, a blank line would
       // not.
-      const runs = lines.join('\n').match(/`+/g) || []
+      const runs = newLines.join('\n').match(/`+/g) || []
       const fence = '`'.repeat(
         runs.reduce((max, run) => Math.max(max, run.length + 1), 3),
       )
       const body =
-        fence + 'suggestion\n' + lines.map((l) => l + '\n').join('') + fence
+        fence + 'suggestion\n' + newLines.map((l) => l + '\n').join('') + fence
+      // Ensure the final body, suggestion fencing included, is not too
+      // long for the API.
       if (body.length > MAX_BODY_LENGTH) {
         skipped++
         continue
       }
+      // The API describes a multi-line comment's range as start_line
+      // through line, where line is the range's LAST line, so a hunk
+      // anchored at start ends at start + count - 1. See
+      // https://docs.github.com/en/rest/pulls/comments#create-a-review-comment-for-a-pull-request
       comments.push({
         path,
         line: start + count - 1,

--- a/.github/scripts/post-format-suggestions.test.js
+++ b/.github/scripts/post-format-suggestions.test.js
@@ -1,0 +1,197 @@
+// Run with `node --test .github/scripts` (a step in format.yaml does).
+const {test} = require('node:test')
+const assert = require('node:assert/strict')
+const {parseDiff, buildComments} = require('./post-format-suggestions.js')
+
+function suggestion(files) {
+  return buildComments(parseDiff(files))
+}
+
+test('anchors each hunk on exactly the replaced lines', () => {
+  const diff = [
+    'diff --git a/src/a.ts b/src/a.ts',
+    'index 1111111..2222222 100644',
+    '--- a/src/a.ts',
+    '+++ b/src/a.ts',
+    '@@ -5,2 +5,2 @@ class A {',
+    '-  x = "1";',
+    '-  y = "2";',
+    "+  x = '1'",
+    "+  y = '2'",
+    '@@ -9 +9 @@ class A {',
+    '-        z()',
+    '+    z()',
+    '',
+  ].join('\n')
+  const {comments, skipped} = suggestion(diff)
+  assert.equal(skipped, 0)
+  assert.deepEqual(comments, [
+    {
+      path: 'src/a.ts',
+      line: 6,
+      side: 'RIGHT',
+      start_line: 5,
+      start_side: 'RIGHT',
+      body: "```suggestion\n  x = '1'\n  y = '2'\n```",
+    },
+    {
+      path: 'src/a.ts',
+      line: 9,
+      side: 'RIGHT',
+      body: '```suggestion\n    z()\n```',
+    },
+  ])
+})
+
+test('added content that renders as "+++ b/..." is not a file boundary', () => {
+  const diff = [
+    'diff --git a/doc.md b/doc.md',
+    '--- a/doc.md',
+    '+++ b/doc.md',
+    '@@ -3 +3,2 @@',
+    '-old',
+    '+new',
+    '+++ b/evil',
+    '',
+  ].join('\n')
+  const {comments} = suggestion(diff)
+  assert.equal(comments.length, 1)
+  assert.equal(comments[0].path, 'doc.md')
+  assert.equal(comments[0].body, '```suggestion\nnew\n++ b/evil\n```')
+})
+
+test('fence outgrows backtick runs in the content', () => {
+  const diff = [
+    'diff --git a/doc.md b/doc.md',
+    '--- a/doc.md',
+    '+++ b/doc.md',
+    '@@ -1 +1,3 @@',
+    '-x',
+    '+a',
+    '+```',
+    '+b',
+    '',
+  ].join('\n')
+  const {comments} = suggestion(diff)
+  assert.equal(comments[0].body, '````suggestion\na\n```\nb\n````')
+})
+
+test('deletion-only hunk emits an empty suggestion block', () => {
+  const diff = [
+    'diff --git a/a.ts b/a.ts',
+    '--- a/a.ts',
+    '+++ b/a.ts',
+    '@@ -4,2 +3,0 @@',
+    '-a',
+    '-b',
+    '',
+  ].join('\n')
+  const {comments} = suggestion(diff)
+  assert.deepEqual(comments, [
+    {
+      path: 'a.ts',
+      line: 5,
+      side: 'RIGHT',
+      start_line: 4,
+      start_side: 'RIGHT',
+      body: '```suggestion\n```',
+    },
+  ])
+})
+
+test('skips pure insertions, which have no line to anchor on', () => {
+  const diff = [
+    'diff --git a/a.ts b/a.ts',
+    '--- a/a.ts',
+    '+++ b/a.ts',
+    '@@ -4,0 +5,2 @@',
+    '+a',
+    '+b',
+    '',
+  ].join('\n')
+  const {comments, skipped} = suggestion(diff)
+  assert.equal(comments.length, 0)
+  assert.equal(skipped, 1)
+})
+
+test('skips trailing-newline-only changes, which GitHub cannot apply', () => {
+  const diff = [
+    'diff --git a/a.ts b/a.ts',
+    '--- a/a.ts',
+    '+++ b/a.ts',
+    '@@ -3 +3 @@',
+    '-last',
+    '\\ No newline at end of file',
+    '+last',
+    '',
+  ].join('\n')
+  const {comments, skipped} = suggestion(diff)
+  assert.equal(comments.length, 0)
+  assert.equal(skipped, 1)
+})
+
+test('skips bodies over the API limit instead of dooming the review', () => {
+  const diff = [
+    'diff --git a/a.ts b/a.ts',
+    '--- a/a.ts',
+    '+++ b/a.ts',
+    '@@ -1 +1 @@',
+    '-x',
+    '+' + 'y'.repeat(70000),
+    '',
+  ].join('\n')
+  const {comments, skipped} = suggestion(diff)
+  assert.equal(comments.length, 0)
+  assert.equal(skipped, 1)
+})
+
+test('strips the trailing tab from paths containing spaces', () => {
+  const diff = [
+    'diff --git "a/my file.ts" "b/my file.ts"',
+    '--- "a/my file.ts"',
+    '+++ b/my file.ts\t',
+    '@@ -1 +1 @@',
+    '-x',
+    '+y',
+    '',
+  ].join('\n')
+  const {comments} = suggestion(diff)
+  assert.equal(comments[0].path, 'my file.ts')
+})
+
+test('skips quoted special-character paths but keeps parsing later files', () => {
+  const diff = [
+    'diff --git "a/we\\tird.ts" "b/we\\tird.ts"',
+    '--- "a/we\\tird.ts"',
+    '+++ "b/we\\tird.ts"',
+    '@@ -1 +1 @@',
+    '-x',
+    '+y',
+    'diff --git a/plain.ts b/plain.ts',
+    '--- a/plain.ts',
+    '+++ b/plain.ts',
+    '@@ -2 +2 @@',
+    '-p',
+    '+q',
+    '',
+  ].join('\n')
+  const {comments} = suggestion(diff)
+  assert.equal(comments.length, 1)
+  assert.equal(comments[0].path, 'plain.ts')
+  assert.equal(comments[0].line, 2)
+})
+
+test('binary and mode-only entries produce no comments', () => {
+  const diff = [
+    'diff --git a/img.png b/img.png',
+    'index 1111111..2222222 100644',
+    'Binary files a/img.png and b/img.png differ',
+    'diff --git a/run.sh b/run.sh',
+    'old mode 100644',
+    'new mode 100755',
+    '',
+  ].join('\n')
+  const {comments, skipped} = suggestion(diff)
+  assert.equal(comments.length, 0)
+  assert.equal(skipped, 0)
+})

--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -52,13 +52,98 @@ jobs:
       - name: Post formatter fixes as suggested changes
         # Forked PRs get a read-only token, so suggestions can't be posted there.
         if: ${{ !github.event.pull_request.head.repo.fork }}
-        uses: reviewdog/action-suggester@2558ba17e65a9039e73764a73009fc05fef28a46 # v1.24.3
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
-          tool_name: bin/fmt
-          # Keep the formatter's working-tree changes so the diff check below
-          # still fails the job when files need formatting.
-          cleanup: false
-          fail_level: none
+          script: |
+            // The formatters above rewrite files in place, and the working
+            // tree now holds the fixes that the diff check below will fail
+            // on. Post that diff back as one-click suggested changes first.
+            // The working tree is left untouched so the check still fails.
+            const {stdout: diff} = await exec.getExecOutput(
+              'git',
+              ['diff', '-U1'],
+              {silent: true},
+            )
+            if (!diff.trim()) return
+
+            const files = []
+            let file = null
+            for (const line of diff.split('\n')) {
+              if (line.startsWith('+++ b/')) {
+                file = {path: line.slice(6), hunks: []}
+                files.push(file)
+              } else if (line.startsWith('+++ ')) {
+                file = null
+              } else if (file && line.startsWith('@@ ')) {
+                const match = line.match(/^@@ -(\d+)(?:,(\d+))? /)
+                file.hunks.push({
+                  start: Number(match[1]),
+                  count: match[2] === undefined ? 1 : Number(match[2]),
+                  lines: [],
+                })
+              } else if (file && file.hunks.length > 0 && /^[+ ]/.test(line)) {
+                // '+' and ' ' lines together are the post-format content.
+                file.hunks[file.hunks.length - 1].lines.push(line.slice(1))
+              }
+            }
+
+            const comments = []
+            for (const {path, hunks} of files) {
+              for (const {start, count, lines} of hunks) {
+                // A pure insertion has no existing line to anchor on.
+                if (count === 0) continue
+                comments.push({
+                  path,
+                  line: start + count - 1,
+                  side: 'RIGHT',
+                  ...(count > 1 && {start_line: start, start_side: 'RIGHT'}),
+                  body: '```suggestion\n' + lines.join('\n') + '\n```',
+                })
+              }
+            }
+            if (comments.length === 0) return
+
+            const limit = 50
+            const capped = comments.slice(0, limit)
+            const pr = context.payload.pull_request
+            const intro =
+              'bin/fmt would make these changes. Apply them with "Commit suggestion", or run bin/fmt locally.' +
+              (comments.length > limit
+                ? ` (Showing ${limit} of ${comments.length} fixes.)`
+                : '')
+            try {
+              await github.rest.pulls.createReview({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pr.number,
+                commit_id: pr.head.sha,
+                event: 'COMMENT',
+                body: intro,
+                comments: capped,
+              })
+            } catch (error) {
+              // One hunk outside the PR's own diff rejects the whole review;
+              // retry one comment at a time and drop the ones GitHub refuses.
+              let posted = 0
+              for (const comment of capped) {
+                try {
+                  await github.rest.pulls.createReviewComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    pull_number: pr.number,
+                    commit_id: pr.head.sha,
+                    ...comment,
+                  })
+                  posted++
+                } catch {
+                  // This fix sits on lines the PR didn't touch; the diff
+                  // step's output still shows it.
+                }
+              }
+              core.warning(
+                `Posted ${posted} of ${capped.length} formatter suggestions individually: ${error.message}`,
+              )
+            }
 
       - name: show bin/fmt and bin/fmt-sbt diff
         run: git add .; git diff --exit-code HEAD

--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -54,7 +54,9 @@ jobs:
         run: bin/fmt-sbt
 
       - name: Test workflow scripts
-        run: node --test .github/scripts
+        # The shell expands the glob; handing node the directory instead
+        # works on some Node versions and not others.
+        run: node --test .github/scripts/*.test.js
 
       - name: Post formatter fixes as suggested changes
         # The formatters above rewrite files in place, and the working

--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -53,7 +53,15 @@ jobs:
         if: contains(toJSON(steps.file_changes.outputs.all_changed_files), '.sbt') || contains(toJSON(steps.file_changes.outputs.all_changed_files), '.scala') || contains(toJSON(steps.file_changes.outputs.all_changed_files), '.github/workflows/format.yaml') || contains(toJSON(steps.file_changes.outputs.all_changed_files), 'fmt-sbt')
         run: bin/fmt-sbt
 
+      - name: Test workflow scripts
+        run: node --test .github/scripts
+
       - name: Post formatter fixes as suggested changes
+        # The formatters above rewrite files in place, and the working
+        # tree now holds the fixes that the diff check below will fail
+        # on. Post that diff back as one-click suggested changes first;
+        # the working tree is left untouched so the check still fails.
+        #
         # Forked PRs get a read-only token, so suggestions can't be posted
         # there. Comparing full_name (rather than checking head.repo.fork)
         # also covers deleted forks, where head.repo is null and a bare
@@ -62,171 +70,8 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
-            // The formatters above rewrite files in place, and the working
-            // tree now holds the fixes that the diff check below will fail
-            // on. Post that diff back as one-click suggested changes first.
-            // The working tree is left untouched so the check still fails.
-            // Zero context lines: each suggestion must anchor on exactly the
-            // lines it replaces. Any wider range sweeps in the PR diff's
-            // deleted lines, and GitHub refuses to apply suggestions whose
-            // range includes deleted lines.
-            const {stdout: diff} = await exec.getExecOutput(
-              'git',
-              ['diff', '-U0'],
-              {silent: true},
-            )
-            if (!diff.trim()) return
-
-            const files = []
-            let file = null
-            let inHeader = false
-            for (const line of diff.split('\n')) {
-              // With -U0 every content line starts with '+', '-', or '\',
-              // so a bare 'diff --git ' line is always a real file
-              // boundary. '+++ b/...' alone is not: an added content line
-              // beginning '++ b/...' renders exactly the same way, so
-              // header lines only count between 'diff --git ' and the
-              // file's first '@@ '.
-              if (line.startsWith('diff --git ')) {
-                inHeader = true
-                file = null
-              } else if (inHeader && line.startsWith('+++ b/')) {
-                // Headers for paths with special characters arrive quoted
-                // ('+++ "b/..."') and fail this match, skipping the file;
-                // the API couldn't anchor on the quoted form anyway. A
-                // path containing spaces carries a literal trailing tab.
-                file = {path: line.slice(6).replace(/\t$/, ''), hunks: []}
-                files.push(file)
-              } else if (line.startsWith('@@ ')) {
-                inHeader = false
-                if (file) {
-                  const match = line.match(/^@@ -(\d+)(?:,(\d+))? /)
-                  file.hunks.push({
-                    start: Number(match[1]),
-                    count: match[2] === undefined ? 1 : Number(match[2]),
-                    lines: [],
-                    oldLines: [],
-                  })
-                }
-              } else if (file && !inHeader && file.hunks.length > 0) {
-                const hunk = file.hunks[file.hunks.length - 1]
-                if (line.startsWith('+')) {
-                  hunk.lines.push(line.slice(1))
-                } else if (line.startsWith('-')) {
-                  hunk.oldLines.push(line.slice(1))
-                }
-              }
-            }
-
-            const comments = []
-            let skipped = 0
-            for (const {path, hunks} of files) {
-              for (const {start, count, lines, oldLines} of hunks) {
-                // A pure insertion has no existing line to anchor on, and
-                // a hunk whose only change is the trailing-newline marker
-                // yields a suggestion identical to the existing text,
-                // which GitHub can't apply.
-                if (count === 0 || lines.join('\n') === oldLines.join('\n')) {
-                  skipped++
-                  continue
-                }
-                // The fence must be longer than any backtick run in the
-                // content, or a ``` line (common in Markdown files) would
-                // close the suggestion block early. No replacement lines
-                // means delete the range; an empty suggestion block does
-                // that, a blank line would not.
-                const runs = lines.join('\n').match(/`+/g) || []
-                const fence = '`'.repeat(
-                  runs.reduce((max, run) => Math.max(max, run.length + 1), 3),
-                )
-                const body =
-                  fence +
-                  'suggestion\n' +
-                  lines.map((l) => l + '\n').join('') +
-                  fence
-                // GitHub rejects comment bodies over 65536 characters, and
-                // one bad comment rejects the whole review.
-                if (body.length > 65536) {
-                  skipped++
-                  continue
-                }
-                comments.push({
-                  path,
-                  line: start + count - 1,
-                  side: 'RIGHT',
-                  ...(count > 1 && {start_line: start, start_side: 'RIGHT'}),
-                  body,
-                })
-              }
-            }
-            if (comments.length === 0 && skipped === 0) return
-
-            const limit = 50
-            const capped = comments.slice(0, limit)
-            const pr = context.payload.pull_request
-            const parts = []
-            if (capped.length > 0) {
-              parts.push(
-                'bin/fmt would make these changes. Apply them with "Commit suggestion", or run bin/fmt locally.',
-              )
-              if (comments.length > limit) {
-                parts.push(`(Showing ${limit} of ${comments.length} fixes.)`)
-              }
-              if (skipped > 0) {
-                parts.push(
-                  `${skipped} more can't be shown as suggestions; the failing check's diff has everything.`,
-                )
-              }
-            } else {
-              parts.push(
-                "bin/fmt would make changes that can't be shown as suggestions; run bin/fmt locally or see the failing check's diff.",
-              )
-            }
-            try {
-              await github.rest.pulls.createReview({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: pr.number,
-                commit_id: pr.head.sha,
-                event: 'COMMENT',
-                body: parts.join(' '),
-                ...(capped.length > 0 && {comments: capped}),
-              })
-            } catch (error) {
-              // A 422 means GitHub refused a specific comment, usually a
-              // hunk outside the PR's own diff, which rejects the whole
-              // review; retry one comment at a time and drop the ones
-              // GitHub refuses. Anything else (rate limit, permissions,
-              // network) would doom the per-comment retries too, so don't
-              // compound the failure with up to 50 more calls.
-              if (error.status !== 422) {
-                core.warning(
-                  `Could not post formatter suggestions: ${error.message}`,
-                )
-                return
-              }
-              let posted = 0
-              for (const comment of capped) {
-                try {
-                  await github.rest.pulls.createReviewComment({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    pull_number: pr.number,
-                    commit_id: pr.head.sha,
-                    ...comment,
-                  })
-                  posted++
-                } catch (err) {
-                  // A refused comment sits on lines the PR didn't touch;
-                  // the diff step's output still shows it. Any other
-                  // failure applies to the remaining calls too.
-                  if (err.status !== 422) break
-                }
-              }
-              core.warning(
-                `Posted ${posted} of ${capped.length} formatter suggestions individually: ${error.message}`,
-              )
-            }
+            const {postSuggestions} = require('./.github/scripts/post-format-suggestions.js')
+            await postSuggestions({github, context, core, exec})
 
       - name: show bin/fmt and bin/fmt-sbt diff
         run: git add .; git diff --exit-code HEAD

--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -59,9 +59,13 @@ jobs:
             // tree now holds the fixes that the diff check below will fail
             // on. Post that diff back as one-click suggested changes first.
             // The working tree is left untouched so the check still fails.
+            // Zero context lines: each suggestion must anchor on exactly the
+            // lines it replaces. Any wider range sweeps in the PR diff's
+            // deleted lines, and GitHub refuses to apply suggestions whose
+            // range includes deleted lines.
             const {stdout: diff} = await exec.getExecOutput(
               'git',
-              ['diff', '-U1'],
+              ['diff', '-U0'],
               {silent: true},
             )
             if (!diff.trim()) return
@@ -81,8 +85,7 @@ jobs:
                   count: match[2] === undefined ? 1 : Number(match[2]),
                   lines: [],
                 })
-              } else if (file && file.hunks.length > 0 && /^[+ ]/.test(line)) {
-                // '+' and ' ' lines together are the post-format content.
+              } else if (file && file.hunks.length > 0 && line.startsWith('+')) {
                 file.hunks[file.hunks.length - 1].lines.push(line.slice(1))
               }
             }
@@ -97,7 +100,11 @@ jobs:
                   line: start + count - 1,
                   side: 'RIGHT',
                   ...(count > 1 && {start_line: start, start_side: 'RIGHT'}),
-                  body: '```suggestion\n' + lines.join('\n') + '\n```',
+                  // No replacement lines means delete the range; an empty
+                  // suggestion block does that, a blank line would not.
+                  body: lines.length
+                    ? '```suggestion\n' + lines.join('\n') + '\n```'
+                    : '```suggestion\n```',
                 })
               }
             }

--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -16,6 +16,10 @@ permissions: read-all
 jobs:
   formatting:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # Allows posting formatter fixes as suggested-change review comments.
+      pull-requests: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -44,6 +48,18 @@ jobs:
           DOCKER_BUILDKIT: 1
         if: contains(toJSON(steps.file_changes.outputs.all_changed_files), '.sbt') || contains(toJSON(steps.file_changes.outputs.all_changed_files), '.scala') || contains(toJSON(steps.file_changes.outputs.all_changed_files), '.github/workflows/format.yaml') || contains(toJSON(steps.file_changes.outputs.all_changed_files), 'fmt-sbt')
         run: bin/fmt-sbt
+
+      - name: Post formatter fixes as suggested changes
+        # Forked PRs get a read-only token, so suggestions can't be posted there.
+        if: ${{ !github.event.pull_request.head.repo.fork }}
+        uses: reviewdog/action-suggester@2558ba17e65a9039e73764a73009fc05fef28a46 # v1.24.3
+        with:
+          tool_name: bin/fmt
+          # Keep the formatter's working-tree changes so the diff check below
+          # still fails the job when files need formatting.
+          cleanup: false
+          fail_level: none
+
       - name: show bin/fmt and bin/fmt-sbt diff
         run: git add .; git diff --exit-code HEAD
 

--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -24,6 +24,10 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
+          # Nothing here pushes or fetches after checkout, so don't leave
+          # the (now write-scoped) token on the runner for later steps,
+          # which execute PR-controlled scripts.
+          persist-credentials: false
 
       - id: file_changes
         uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62 # v47
@@ -50,8 +54,11 @@ jobs:
         run: bin/fmt-sbt
 
       - name: Post formatter fixes as suggested changes
-        # Forked PRs get a read-only token, so suggestions can't be posted there.
-        if: ${{ !github.event.pull_request.head.repo.fork }}
+        # Forked PRs get a read-only token, so suggestions can't be posted
+        # there. Comparing full_name (rather than checking head.repo.fork)
+        # also covers deleted forks, where head.repo is null and a bare
+        # .fork check would fail open.
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
@@ -72,52 +79,109 @@ jobs:
 
             const files = []
             let file = null
+            let inHeader = false
             for (const line of diff.split('\n')) {
-              if (line.startsWith('+++ b/')) {
-                file = {path: line.slice(6), hunks: []}
-                files.push(file)
-              } else if (line.startsWith('+++ ')) {
+              // With -U0 every content line starts with '+', '-', or '\',
+              // so a bare 'diff --git ' line is always a real file
+              // boundary. '+++ b/...' alone is not: an added content line
+              // beginning '++ b/...' renders exactly the same way, so
+              // header lines only count between 'diff --git ' and the
+              // file's first '@@ '.
+              if (line.startsWith('diff --git ')) {
+                inHeader = true
                 file = null
-              } else if (file && line.startsWith('@@ ')) {
-                const match = line.match(/^@@ -(\d+)(?:,(\d+))? /)
-                file.hunks.push({
-                  start: Number(match[1]),
-                  count: match[2] === undefined ? 1 : Number(match[2]),
-                  lines: [],
-                })
-              } else if (file && file.hunks.length > 0 && line.startsWith('+')) {
-                file.hunks[file.hunks.length - 1].lines.push(line.slice(1))
+              } else if (inHeader && line.startsWith('+++ b/')) {
+                // Headers for paths with special characters arrive quoted
+                // ('+++ "b/..."') and fail this match, skipping the file;
+                // the API couldn't anchor on the quoted form anyway. A
+                // path containing spaces carries a literal trailing tab.
+                file = {path: line.slice(6).replace(/\t$/, ''), hunks: []}
+                files.push(file)
+              } else if (line.startsWith('@@ ')) {
+                inHeader = false
+                if (file) {
+                  const match = line.match(/^@@ -(\d+)(?:,(\d+))? /)
+                  file.hunks.push({
+                    start: Number(match[1]),
+                    count: match[2] === undefined ? 1 : Number(match[2]),
+                    lines: [],
+                    oldLines: [],
+                  })
+                }
+              } else if (file && !inHeader && file.hunks.length > 0) {
+                const hunk = file.hunks[file.hunks.length - 1]
+                if (line.startsWith('+')) {
+                  hunk.lines.push(line.slice(1))
+                } else if (line.startsWith('-')) {
+                  hunk.oldLines.push(line.slice(1))
+                }
               }
             }
 
             const comments = []
+            let skipped = 0
             for (const {path, hunks} of files) {
-              for (const {start, count, lines} of hunks) {
-                // A pure insertion has no existing line to anchor on.
-                if (count === 0) continue
+              for (const {start, count, lines, oldLines} of hunks) {
+                // A pure insertion has no existing line to anchor on, and
+                // a hunk whose only change is the trailing-newline marker
+                // yields a suggestion identical to the existing text,
+                // which GitHub can't apply.
+                if (count === 0 || lines.join('\n') === oldLines.join('\n')) {
+                  skipped++
+                  continue
+                }
+                // The fence must be longer than any backtick run in the
+                // content, or a ``` line (common in Markdown files) would
+                // close the suggestion block early. No replacement lines
+                // means delete the range; an empty suggestion block does
+                // that, a blank line would not.
+                const runs = lines.join('\n').match(/`+/g) || []
+                const fence = '`'.repeat(
+                  runs.reduce((max, run) => Math.max(max, run.length + 1), 3),
+                )
+                const body =
+                  fence +
+                  'suggestion\n' +
+                  lines.map((l) => l + '\n').join('') +
+                  fence
+                // GitHub rejects comment bodies over 65536 characters, and
+                // one bad comment rejects the whole review.
+                if (body.length > 65536) {
+                  skipped++
+                  continue
+                }
                 comments.push({
                   path,
                   line: start + count - 1,
                   side: 'RIGHT',
                   ...(count > 1 && {start_line: start, start_side: 'RIGHT'}),
-                  // No replacement lines means delete the range; an empty
-                  // suggestion block does that, a blank line would not.
-                  body: lines.length
-                    ? '```suggestion\n' + lines.join('\n') + '\n```'
-                    : '```suggestion\n```',
+                  body,
                 })
               }
             }
-            if (comments.length === 0) return
+            if (comments.length === 0 && skipped === 0) return
 
             const limit = 50
             const capped = comments.slice(0, limit)
             const pr = context.payload.pull_request
-            const intro =
-              'bin/fmt would make these changes. Apply them with "Commit suggestion", or run bin/fmt locally.' +
-              (comments.length > limit
-                ? ` (Showing ${limit} of ${comments.length} fixes.)`
-                : '')
+            const parts = []
+            if (capped.length > 0) {
+              parts.push(
+                'bin/fmt would make these changes. Apply them with "Commit suggestion", or run bin/fmt locally.',
+              )
+              if (comments.length > limit) {
+                parts.push(`(Showing ${limit} of ${comments.length} fixes.)`)
+              }
+              if (skipped > 0) {
+                parts.push(
+                  `${skipped} more can't be shown as suggestions; the failing check's diff has everything.`,
+                )
+              }
+            } else {
+              parts.push(
+                "bin/fmt would make changes that can't be shown as suggestions; run bin/fmt locally or see the failing check's diff.",
+              )
+            }
             try {
               await github.rest.pulls.createReview({
                 owner: context.repo.owner,
@@ -125,12 +189,22 @@ jobs:
                 pull_number: pr.number,
                 commit_id: pr.head.sha,
                 event: 'COMMENT',
-                body: intro,
-                comments: capped,
+                body: parts.join(' '),
+                ...(capped.length > 0 && {comments: capped}),
               })
             } catch (error) {
-              // One hunk outside the PR's own diff rejects the whole review;
-              // retry one comment at a time and drop the ones GitHub refuses.
+              // A 422 means GitHub refused a specific comment, usually a
+              // hunk outside the PR's own diff, which rejects the whole
+              // review; retry one comment at a time and drop the ones
+              // GitHub refuses. Anything else (rate limit, permissions,
+              // network) would doom the per-comment retries too, so don't
+              // compound the failure with up to 50 more calls.
+              if (error.status !== 422) {
+                core.warning(
+                  `Could not post formatter suggestions: ${error.message}`,
+                )
+                return
+              }
               let posted = 0
               for (const comment of capped) {
                 try {
@@ -142,9 +216,11 @@ jobs:
                     ...comment,
                   })
                   posted++
-                } catch {
-                  // This fix sits on lines the PR didn't touch; the diff
-                  // step's output still shows it.
+                } catch (err) {
+                  // A refused comment sits on lines the PR didn't touch;
+                  // the diff step's output still shows it. Any other
+                  // failure applies to the remaining calls too.
+                  if (err.status !== 422) break
                 }
               }
               core.warning(

--- a/formatter/fmt
+++ b/formatter/fmt
@@ -95,6 +95,19 @@ function get_modified_sql_files() {
   ) | grep -E ".+\.(sql)$"
 }
 
+function get_modified_workflow_script_files() {
+  # JavaScript run by GitHub workflows. Deliberately not all .js files:
+  # some tracked .js files predate prettier coverage, and formatting
+  # them here would surprise unrelated PRs that happen to touch them.
+  #
+  # Zero matches in grep returns a 1, but we want to treat as empty which is
+  # why the `|| true` is there
+  (
+    get_tracked_modified_files
+    get_untracked_files
+  ) | grep -E "^\.github/scripts/.+\.js$" || true
+}
+
 # Returns list of files that should be formatted by prettier
 function get_modified_prettier_files() {
   (
@@ -103,6 +116,7 @@ function get_modified_prettier_files() {
     get_modified_md_files
     get_modified_html_files
     get_modified_scss_files
+    get_modified_workflow_script_files
   )
 }
 

--- a/server/app/assets/javascripts/admin_export_view.ts
+++ b/server/app/assets/javascripts/admin_export_view.ts
@@ -6,7 +6,7 @@ class AdminExportView {
   private static COPY_BUTTON_ID = 'copy-json-button'
 
   constructor() {
-        this.addClickListenerToCopyButton()
+    this.addClickListenerToCopyButton()
   }
 
   addClickListenerToCopyButton() {

--- a/server/app/assets/javascripts/admin_export_view.ts
+++ b/server/app/assets/javascripts/admin_export_view.ts
@@ -2,8 +2,8 @@ import {assertNotNull} from '@/util'
 
 class AdminExportView {
   // These values should be kept in sync with views/admin/migration/AdminExportView.java.
-  private static PROGRAM_JSON_ID = "program-json";
-  private static COPY_BUTTON_ID = "copy-json-button";
+  private static PROGRAM_JSON_ID = 'program-json'
+  private static COPY_BUTTON_ID = 'copy-json-button'
 
   constructor() {
         this.addClickListenerToCopyButton()

--- a/server/app/assets/javascripts/admin_export_view.ts
+++ b/server/app/assets/javascripts/admin_export_view.ts
@@ -2,11 +2,11 @@ import {assertNotNull} from '@/util'
 
 class AdminExportView {
   // These values should be kept in sync with views/admin/migration/AdminExportView.java.
-  private static PROGRAM_JSON_ID = 'program-json'
-  private static COPY_BUTTON_ID = 'copy-json-button'
+  private static PROGRAM_JSON_ID = "program-json";
+  private static COPY_BUTTON_ID = "copy-json-button";
 
   constructor() {
-    this.addClickListenerToCopyButton()
+        this.addClickListenerToCopyButton()
   }
 
   addClickListenerToCopyButton() {


### PR DESCRIPTION
### Description

When the formatting check fails, the fixed files already exist on the runner: `bin/fmt` and `bin/fmt-sbt` write them to disk, and the workflow diffs and discards them. This adds an `actions/github-script` step that posts that diff back on the PR as inline one-click suggested changes, so authors can apply the fix from the PR page without running anything locally.

Motivating case: two template PRs edited through the web UI (#13933, #13932) failed formatting with no self-serve way out, and each needed a fix commit pushed by someone else. The Slack discussion settled on suggestions rather than auto-committing, so nothing modifies a branch unless the author clicks.

Behavior:

- The check still fails exactly as it does today. The new step only reads the working tree and posts review comments; the existing `git diff --exit-code` step still decides pass/fail.
- Nothing is pushed to the branch, so no PAT or App token is needed and there is no stale-check re-trigger problem. The job gains `pull-requests: write` (it previously opted down to `read-all`).
- Skipped on forked PRs, where the token is read-only.
- Implementation note: the first cut used `reviewdog/action-suggester`, but this repo's Actions policy only allows GitHub-owned actions plus a short allowlist, so the workflow failed at startup. Rather than widening the allowlist, this uses `actions/github-script` at the same pinned version already used elsewhere in this repo. The logic lives in `.github/scripts/post-format-suggestions.js` (the step itself is a two-line `require()`), with unit tests for the diff-parsing edge cases run by a `node --test` workflow step; `bin/fmt` now runs prettier over `.github/scripts/*.js` so the suggester's own code is formatter-covered.
- Known limitation: GitHub suggestions only attach to lines inside the PR's diff. If a whole batch includes such a hunk the step falls back to posting suggestions one at a time and drops only the ones GitHub refuses; the check's own diff output still shows everything.

AI disclosure: the workflow change and this description were drafted with Claude and reviewed by me.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [ ] Added an additional reviewer as required if changes potentially affect the security of the application.
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [x] Noted in the PR description which, if any, code in this PR was generated by AI.

### Instructions for manual testing

Already demonstrated end-to-end on this PR: the `DEMO ONLY` commit deliberately misformatted `admin_export_view.ts`, the Format run posted the fixes as one-click suggestions while the check still failed as usual, and applying them via "Commit suggestion" restored the file to match main and turned the check green — so the revert itself was performed by the feature under review. (An earlier iteration used `-U1` diff context, which produced suggestions GitHub refused to apply because their ranges included deleted lines; the `-U0` anchoring in the final version is the fix.) The demo and suggestion commits disappear at squash merge.

