### PR TITLE
[Translation Management Improvement] Enable translations improvements by default

### DIFF
--- a/browser-test/src/admin/admin_question_translation_legacy.test.ts
+++ b/browser-test/src/admin/admin_question_translation_legacy.test.ts
@@ -1,7 +1,6 @@
 import {test, expect} from '../support/civiform_fixtures'
 import {
   disableFeatureFlag,
-  enableFeatureFlag,
   isLocalDevEnvironment,
   loginAsAdmin,
   validateScreenshot,
@@ -176,7 +175,6 @@ test.describe('Admin can manage question translations', () => {
     adminPrograms,
     adminTranslations,
   }) => {
-    await enableFeatureFlag(page, 'translation_management_improvement_enabled')
     await loginAsAdmin(page)
     const questionName = 'name-translated'
 

--- a/server/app/services/settings/SettingsManifest.java
+++ b/server/app/services/settings/SettingsManifest.java
@@ -1096,8 +1096,8 @@ public final class SettingsManifest extends AbstractSettingsManifest {
   }
 
   /** Enables translation management improvement phase one */
-  public boolean getTranslationManagementImprovementEnabled(RequestHeader request) {
-    return getBool("TRANSLATION_MANAGEMENT_IMPROVEMENT_ENABLED", request);
+  public boolean getTranslationManagementImprovementEnabled() {
+    return getBool("TRANSLATION_MANAGEMENT_IMPROVEMENT_ENABLED");
   }
 
   /** (NOT FOR PRODUCTION USE) Use program slugs instead of program IDs in URLs. */
@@ -2390,7 +2390,7 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                           "Enables translation management improvement phase one",
                           /* isRequired= */ false,
                           SettingType.BOOLEAN,
-                          SettingMode.ADMIN_WRITEABLE))))
+                          SettingMode.ADMIN_READABLE))))
           .put(
               "Experimental",
               SettingsSection.create(

--- a/server/app/views/admin/programs/ProgramAdministratorProgramListView.java
+++ b/server/app/views/admin/programs/ProgramAdministratorProgramListView.java
@@ -64,7 +64,7 @@ public final class ProgramAdministratorProgramListView extends BaseHtmlView {
                         .filter(program -> authorizedPrograms.contains(program.adminName()))
                         .map(p -> buildCardData(p, civiformProfile))
                         .sorted(ProgramCardFactory.programTypeThenLastModifiedThenNameComparator())
-                        .map(cardData -> programCardFactory.renderCard(cardData, request))));
+                        .map(cardData -> programCardFactory.renderCard(cardData))));
 
     HtmlBundle htmlBundle = layout.getBundle(request).setTitle(title).addMainContent(contentDiv);
     return layout.renderCentered(htmlBundle);

--- a/server/app/views/admin/programs/ProgramIndexView.java
+++ b/server/app/views/admin/programs/ProgramIndexView.java
@@ -181,7 +181,7 @@ public final class ProgramIndexView extends BaseHtmlView {
                                     publishSingleProgramModals,
                                     universalQuestionIds))
                         .sorted(ProgramCardFactory.programTypeThenLastModifiedThenNameComparator())
-                        .map(cardData -> programCardFactory.renderCard(cardData, request)))));
+                        .map(cardData -> programCardFactory.renderCard(cardData)))));
 
     HtmlBundle htmlBundle =
         layout
@@ -543,7 +543,7 @@ public final class ProgramIndexView extends BaseHtmlView {
         activeRowExtraActions.add(
             renderEditLink(/* isActive= */ true, activeProgram.get(), request));
 
-        if (settingsManifest.getTranslationManagementImprovementEnabled(request)) {
+        if (settingsManifest.getTranslationManagementImprovementEnabled()) {
           maybeRenderManageTranslationsLink(activeProgram.get())
               .ifPresent(activeRowExtraActions::add);
         }

--- a/server/app/views/admin/questions/QuestionsListView.java
+++ b/server/app/views/admin/questions/QuestionsListView.java
@@ -376,7 +376,7 @@ public final class QuestionsListView extends BaseHtmlView {
                     .withClasses("ml-4", StyleUtils.responsiveXLarge("ml-10"))
                     .with(viewUtils.renderEditOnText("Edited on ", question.getLastModifiedTime()))
                     .condWith(
-                        settingsManifest.getTranslationManagementImprovementEnabled(request),
+                        settingsManifest.getTranslationManagementImprovementEnabled(),
                         generateTranslationCompleteText(question).orElse(div())))
             .with(actionsCellAndModal.getLeft());
 
@@ -716,9 +716,7 @@ public final class QuestionsListView extends BaseHtmlView {
         modals.add(discardDraftButtonAndModal.getRight());
       }
     }
-    if (isActive
-        && isEditable
-        && settingsManifest.getTranslationManagementImprovementEnabled(request)) {
+    if (isActive && isEditable && settingsManifest.getTranslationManagementImprovementEnabled()) {
       Optional<ButtonTag> maybeTranslationLink = renderQuestionTranslationLink(question);
       maybeTranslationLink.ifPresent(extraActions::add);
     }

--- a/server/app/views/components/ProgramCardFactory.java
+++ b/server/app/views/components/ProgramCardFactory.java
@@ -18,7 +18,6 @@ import java.util.Comparator;
 import java.util.Locale;
 import java.util.Optional;
 import javax.inject.Inject;
-import play.mvc.Http;
 import services.program.ProgramDefinition;
 import services.program.ProgramType;
 import services.settings.SettingsManifest;
@@ -42,7 +41,7 @@ public final class ProgramCardFactory {
     this.settingsManifest = checkNotNull(settingsManifest);
   }
 
-  public DivTag renderCard(ProgramCardData cardData, Http.Request request) {
+  public DivTag renderCard(ProgramCardData cardData) {
     ProgramDefinition displayProgram = getDisplayProgram(cardData);
 
     String programTitleText = displayProgram.localizedName().getDefault();
@@ -64,8 +63,7 @@ public final class ProgramCardFactory {
               renderProgramRow(
                   cardData.isCiviFormAdmin(),
                   /* isActive= */ false,
-                  cardData.draftProgram().get(),
-                  request));
+                  cardData.draftProgram().get()));
     }
 
     if (cardData.activeProgram().isPresent()) {
@@ -75,7 +73,6 @@ public final class ProgramCardFactory {
                   cardData.isCiviFormAdmin(),
                   /* isActive= */ true,
                   cardData.activeProgram().get(),
-                  request,
                   cardData.draftProgram().isPresent() ? "border-t" : ""));
     }
 
@@ -142,7 +139,6 @@ public final class ProgramCardFactory {
       boolean isCiviFormAdmin,
       boolean isActive,
       ProgramCardData.ProgramRow programRow,
-      Http.Request request,
       String... extraStyles) {
     ProgramDefinition program = programRow.program();
     String updatedPrefix = isActive ? "Published on " : "Edited on ";
@@ -168,7 +164,7 @@ public final class ProgramCardFactory {
             StyleUtils.responsiveXLarge("ml-8"));
 
     boolean isTranslationManagementImprovementEnabled =
-        settingsManifest.getTranslationManagementImprovementEnabled(request);
+        settingsManifest.getTranslationManagementImprovementEnabled();
 
     return div()
         // This is used to provide the uniqueness needed for Playwright to locate

--- a/server/conf/application.dev.conf
+++ b/server/conf/application.dev.conf
@@ -106,4 +106,3 @@ session_inactivity_timeout_minutes= 5760
 # Feature flags
 name_suffix_dropdown_enabled = true
 new_applicant_guest_merging_strategy_enabled = true
-translation_management_improvement_enabled = true

--- a/server/conf/env-var-docs.json
+++ b/server/conf/env-var-docs.json
@@ -953,7 +953,7 @@
         "required": false
       },
       "TRANSLATION_MANAGEMENT_IMPROVEMENT_ENABLED": {
-        "mode": "ADMIN_WRITEABLE",
+        "mode": "ADMIN_READABLE",
         "description": "Enables translation management improvement phase one",
         "type": "bool",
         "required": false

--- a/server/conf/helper/feature-flags.conf
+++ b/server/conf/helper/feature-flags.conf
@@ -52,7 +52,7 @@ program_slug_urls_enabled = false
 program_slug_urls_enabled = ${?PROGRAM_SLUG_URLS_ENABLED}
 
 # Enables translation management improvement phase one
-translation_management_improvement_enabled = false
+translation_management_improvement_enabled = true
 translation_management_improvement_enabled = ${?TRANSLATION_MANAGEMENT_IMPROVEMENT_ENABLED}
 
 # Enables api bridge support


### PR DESCRIPTION
### Description

Make the TRANSLATION_MANAGEMENT_IMPROVEMENT_ENABLED flag admin-readable and enable it by default for all environments. Removed the `request` object from the `SettingsManifest` method and removed calls to toggle feature flag in browser tests.

## Release notes

TRANSLATION_MANAGEMENT_IMPROVEMENT_ENABLED is now enabled by default. If you had not previously enabled this flag, admin will now see a couple of improvements to translations management. See the recording [here](https://drive.google.com/file/d/17CApUkfBhlsiaCPc4o4WBqMrrFd8LbR-/view?usp=sharing) for more information on this feature. To disabled this flag, set TRANSLATION_MANAGEMENT_IMPROVEMENT_ENABLED to false in your deployment config. Please note that this option will be deprecated in a future release.

### Checklist

#### General

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [ ] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [ ] Added an additional reviewer as required if changes potentially affect the security of the application.
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

### Instructions for manual testing

1. Login as an admin
2. Confirm translations complete/incomplete flag shows up on the programs list page
3. Confirm translations complete/incomplete flag shows up on the questions list page
4. Confirm translations are marked complete when all translations are entered for all languages
5. Confirm you can edit translations from an active program

### Issue(s) this completes

Related to #13769 