### PR TITLE
Update SECURITY.md to use GitHub private vulnerability reporting

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,7 @@ All production deployments are encouraged to deploy weekly and keep in regular c
 
 ## Reporting a Vulnerability
 
-To report a vulnerability, please email civiform-escalations@googlegroups.com
+Please report vulnerabilities privately through GitHub's ["Report a vulnerability" form](https://github.com/civiform/civiform/security/advisories/new). This goes directly to the maintainers and lets us coordinate a fix with you before disclosure.
 
 Please include the docker image tag for the version in which you have found the vulnerability, or a link to code on GitHub if that is more appropriate.
 


### PR DESCRIPTION
### Description

The email address listed in SECURITY.md for reporting vulnerabilities (civiform-escalations@googlegroups.com) is no longer receiving mail, so reports sent there bounce. This points reporters at GitHub's private vulnerability reporting form instead, which routes directly to the maintainers and supports private coordination before disclosure.

Documentation-only change; no code in this PR, so no AI-generated code.

### Checklist

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): ignore-for-release
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [x] Added an additional reviewer as required if changes potentially affect the security of the application.
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [x] Noted in the PR description which, if any, code in this PR was generated by AI.

### Instructions for manual testing

Open the ["Report a vulnerability" link](https://github.com/civiform/civiform/security/advisories/new) and confirm the private advisory form loads.

### Issue(s) this completes

N/A