### PR TITLE
[Enumerators] Cascade initial question new-draft to its enumerator

### DIFF
--- a/server/app/repository/QuestionRepository.java
+++ b/server/app/repository/QuestionRepository.java
@@ -77,15 +77,16 @@ public final class QuestionRepository {
   }
 
   public CompletionStage<Optional<QuestionModel>> lookupQuestion(long id) {
-    return supplyAsync(
-        () ->
-            database
-                .find(QuestionModel.class)
-                .setLabel("QuestionModel.findById")
-                .setProfileLocation(queryProfileLocationBuilder.create("lookupQuestion"))
-                .setId(id)
-                .findOneOrEmpty(),
-        dbExecutionContext);
+    return supplyAsync(() -> lookupQuestionSync(id));
+  }
+
+  public Optional<QuestionModel> lookupQuestionSync(long id) {
+    return database
+        .find(QuestionModel.class)
+        .setLabel("QuestionModel.findById")
+        .setProfileLocation(queryProfileLocationBuilder.create("lookupQuestion"))
+        .setId(id)
+        .findOneOrEmpty();
   }
 
   /**
@@ -146,6 +147,13 @@ public final class QuestionRepository {
       if (definition.isEnumerator()) {
         transaction.setNestedUseSavepoint();
         updateAllRepeatedQuestions(newDraftQuestion.id, definition.getId());
+      }
+      // Update the enumerator for an initial question.
+      if (definition.getEnumeratorId().isPresent()) {
+        updateEnumeratorQuestion(
+            definition.getEnumeratorId().get(),
+            /* newInitialQuestionId= */ newDraftQuestion.id,
+            /* oldInitialQuestionId= */ definition.getId());
       }
 
       // Update programs that reference the previous question. A bit round about but this will
@@ -270,6 +278,19 @@ public final class QuestionRepository {
         .values()
         // Update to the new enumerator ID.
         .forEach(qd -> createOrUpdateDraft(updateEnumeratorId(qd, newEnumeratorId)));
+  }
+
+  /**
+   * Updates the enumerator to use {@code newInitialQuestionId} if it currently points to {@code
+   * oldInitialQuestionId} .
+   */
+  public void updateEnumeratorQuestion(
+      long enumeratorId, long newInitialQuestionId, long oldInitialQuestionId) {
+    lookupQuestionSync(enumeratorId)
+        .map(QuestionModel::getQuestionDefinition)
+        .filter(qd -> qd.getEnumeratorInitialQuestionId().equals(Optional.of(oldInitialQuestionId)))
+        .map(qd -> updateEnumeratorInitialQuestionId(qd, newInitialQuestionId))
+        .ifPresent(this::createOrUpdateDraft);
   }
 
   public QuestionDefinition updateEnumeratorId(

--- a/server/test/repository/QuestionRepositoryTest.java
+++ b/server/test/repository/QuestionRepositoryTest.java
@@ -748,7 +748,11 @@ public class QuestionRepositoryTest extends ResetPostgres {
     assertThat(enumeratorAfter.getEnumeratorInitialQuestionId()).hasValue(firstDraft.id);
   }
 
-  /** Container for the entities made in {@code newEnumeratorFixture}. */
+  /** Container for the entities made in {@code newEnumeratorFixture}.
+   *
+   * The default context is that items are for the new enumerator flow, and
+   * ones in the old flow are indicated with 'old'.
+  */
   private record EnumeratorFixture(
       long enumeratorId,
       long initialQuestionId,

--- a/server/test/repository/QuestionRepositoryTest.java
+++ b/server/test/repository/QuestionRepositoryTest.java
@@ -537,26 +537,46 @@ public class QuestionRepositoryTest extends ResetPostgres {
             .setDescription("updated")
             .build());
 
-    QuestionDefinition newInitialQuestion = latestDefinition(fixture.initialQuestionId());
-    var newInitialQuestionId = newInitialQuestion.getId();
-    assertThat(newInitialQuestionId).isNotEqualTo(fixture.initialQuestionId());
+    QuestionDefinition initialQuestionAfter = latestDefinition(fixture.initialQuestionId());
+    var initialQuestionAfterId = initialQuestionAfter.getId();
+    assertThat(initialQuestionAfterId).isNotEqualTo(fixture.initialQuestionId());
     // A draft of the enumerator now points at the initial question's new draft...
     QuestionDefinition enumeratorAfter = latestDefinition(fixture.enumeratorId());
     assertThat(enumeratorAfter.getId()).isNotEqualTo(fixture.enumeratorId());
-    assertThat(enumeratorAfter.getEnumeratorInitialQuestionId()).hasValue(newInitialQuestionId);
-    // Both repeated questions point back at the enumerator's new draft. These have to be re-read:
-    // the model returned above predates the cascade that repointed its row.
-    QuestionDefinition newRepeatedQuestion = latestDefinition(fixture.repeatedQuestionId());
-    assertThat(newInitialQuestion.getEnumeratorId()).hasValue(enumeratorAfter.getId());
-    assertThat(newRepeatedQuestion.getEnumeratorId()).hasValue(enumeratorAfter.getId());
+    assertThat(enumeratorAfter.getEnumeratorInitialQuestionId()).hasValue(initialQuestionAfterId);
+    // Both repeated questions point back at the enumerator's new draft.
+    QuestionDefinition repeatedQuestionAfter = latestDefinition(fixture.repeatedQuestionId());
+    assertThat(initialQuestionAfter.getEnumeratorId()).hasValue(enumeratorAfter.getId());
+    assertThat(repeatedQuestionAfter.getEnumeratorId()).hasValue(enumeratorAfter.getId());
     // ...while the published enumerator keeps pointing at the published initial question.
     assertThat(lookupDefinition(fixture.enumeratorId()).getEnumeratorInitialQuestionId())
         .hasValue(fixture.initialQuestionId());
-    // Every block follows its questions to their new revisions.
+    // Blocks 1 and 2 follow their questions to their new revisions.
     assertThat(blockQuestionIds(fixture.program(), 1L))
-        .containsExactly(enumeratorAfter.getId(), newInitialDraft.id);
+        .containsExactly(enumeratorAfter.getId(), initialQuestionAfterId);
     assertThat(blockQuestionIds(fixture.program(), 2L))
-        .containsExactly(latestDefinition(fixture.repeatedQuestionId()).getId());
+        .containsExactly(repeatedQuestionAfter.getId());
+
+    // Block 3's new-flow cluster was not drafted, and its mutual references are intact.
+    QuestionDefinition newEnumerator = latestDefinition(fixture.newEnumeratorId());
+    QuestionDefinition newRepeatedQuestion = latestDefinition(fixture.newRepeatedQuestionId());
+    assertThat(newEnumerator.getId()).isEqualTo(fixture.newEnumeratorId());
+    assertThat(newEnumerator.getEnumeratorInitialQuestionId())
+        .hasValue(fixture.newRepeatedQuestionId());
+    assertThat(newRepeatedQuestion.getId()).isEqualTo(fixture.newRepeatedQuestionId());
+    assertThat(newRepeatedQuestion.getEnumeratorId()).hasValue(fixture.newEnumeratorId());
+    assertThat(blockQuestionIds(fixture.program(), 3L))
+        .containsExactly(fixture.newEnumeratorId(), fixture.newRepeatedQuestionId());
+
+    // Block 4's old-flow cluster was not drafted, and no back reference was invented for it.
+    QuestionDefinition oldEnumerator = latestDefinition(fixture.oldEnumeratorId());
+    QuestionDefinition oldRepeatedQuestion = latestDefinition(fixture.oldRepeatedQuestionId());
+    assertThat(oldEnumerator.getId()).isEqualTo(fixture.oldEnumeratorId());
+    assertThat(oldEnumerator.getEnumeratorInitialQuestionId()).isEmpty();
+    assertThat(oldRepeatedQuestion.getId()).isEqualTo(fixture.oldRepeatedQuestionId());
+    assertThat(oldRepeatedQuestion.getEnumeratorId()).hasValue(fixture.oldEnumeratorId());
+    assertThat(blockQuestionIds(fixture.program(), 4L))
+        .containsExactly(fixture.oldEnumeratorId(), fixture.oldRepeatedQuestionId());
   }
 
   @Test
@@ -586,34 +606,42 @@ public class QuestionRepositoryTest extends ResetPostgres {
 
   /** Container for the entities made in {@code newEnumeratorFixture}. */
   private record EnumeratorFixture(
-      long enumeratorId, long initialQuestionId, long repeatedQuestionId, ProgramModel program) {}
+      long enumeratorId,
+      long initialQuestionId,
+      long repeatedQuestionId,
+      long newEnumeratorId,
+      long newRepeatedQuestionId,
+      long oldEnumeratorId,
+      long oldRepeatedQuestionId,
+      ProgramModel program) {}
 
   /**
-   * Builds a draft program with two blocks and three ACTIVE questions.
+   * Builds a draft program with four blocks and seven ACTIVE questions.
    *
    * <p>Block 1 holds the enumerator and its initial question, which point at each other. Block 2
    * repeats on block 1 and holds a third question whose enumerator id is the block 1 enumerator.
+   *
+   * <p>Blocks 3 and 4 are controls that nothing done to the block 1 cluster may touch. Block 3 holds
+   * a new-flow enumerator and its initial question, which point at each other. Block 4 holds an
+   * old-flow enumerator and a repeated question, where only the repeated question points at the
+   * enumerator.
    */
   private EnumeratorFixture newEnumeratorFixture() {
     QuestionModel enumerator =
-        testQuestionBank.maybeSave(
-            new EnumeratorQuestionDefinition(
-                QuestionDefinitionConfig.builder()
-                    .setName("household members")
-                    .setDescription("The applicant's household members")
-                    .setQuestionText(LocalizedStrings.of(Locale.US, "Who is in your household?"))
-                    .build(),
-                LocalizedStrings.empty()),
-            LifecycleStage.ACTIVE);
+        saveActiveEnumerator("household members", "Who is in your household?");
     QuestionModel initialQuestion = saveActiveRepeatedQuestion("household member name", enumerator);
-    // Complete the mutual reference in place, so no draft is created.
-    new QuestionModel(
-            repo.updateEnumeratorInitialQuestionId(
-                enumerator.getQuestionDefinition(), initialQuestion.id))
-        .update();
-    enumerator.refresh();
+    pointAtInitialQuestion(enumerator, initialQuestion);
     QuestionModel repeatedQuestion =
         saveActiveRepeatedQuestion("household member nickname", enumerator);
+
+    QuestionModel newEnumerator = saveActiveEnumerator("new enumerator", "Where have you worked?");
+    QuestionModel newRepeatedQuestion =
+        saveActiveRepeatedQuestion("new repeated question", newEnumerator);
+    pointAtInitialQuestion(newEnumerator, newRepeatedQuestion);
+
+    QuestionModel oldEnumerator = saveActiveEnumerator("old enumerator", "Where have you lived?");
+    QuestionModel oldRepeatedQuestion =
+        saveActiveRepeatedQuestion("old repeated question", oldEnumerator);
 
     ProgramModel program =
         ProgramBuilder.newDraftProgram("enumerator program")
@@ -622,8 +650,43 @@ public class QuestionRepositoryTest extends ResetPostgres {
             .withRequiredQuestion(initialQuestion)
             .withRepeatedBlock("block 2")
             .withRequiredQuestion(repeatedQuestion)
+            .withBlock("block 3")
+            .withRequiredQuestion(newEnumerator)
+            .withRequiredQuestion(newRepeatedQuestion)
+            .withBlock("block 4")
+            .withRequiredQuestion(oldEnumerator)
+            .withRequiredQuestion(oldRepeatedQuestion)
             .build();
-    return new EnumeratorFixture(enumerator.id, initialQuestion.id, repeatedQuestion.id, program);
+    return new EnumeratorFixture(
+        enumerator.id,
+        initialQuestion.id,
+        repeatedQuestion.id,
+        newEnumerator.id,
+        newRepeatedQuestion.id,
+        oldEnumerator.id,
+        oldRepeatedQuestion.id,
+        program);
+  }
+
+  private QuestionModel saveActiveEnumerator(String name, String questionText) {
+    return testQuestionBank.maybeSave(
+        new EnumeratorQuestionDefinition(
+            QuestionDefinitionConfig.builder()
+                .setName(name)
+                .setDescription(name)
+                .setQuestionText(LocalizedStrings.of(Locale.US, questionText))
+                .build(),
+            LocalizedStrings.empty()),
+        LifecycleStage.ACTIVE);
+  }
+
+  /** Completes the mutual reference in place, so no draft is created. */
+  private void pointAtInitialQuestion(QuestionModel enumerator, QuestionModel initialQuestion) {
+    new QuestionModel(
+            repo.updateEnumeratorInitialQuestionId(
+                enumerator.getQuestionDefinition(), initialQuestion.id))
+        .update();
+    enumerator.refresh();
   }
 
   private QuestionModel saveActiveRepeatedQuestion(String name, QuestionModel enumerator) {

--- a/server/test/repository/QuestionRepositoryTest.java
+++ b/server/test/repository/QuestionRepositoryTest.java
@@ -532,32 +532,49 @@ public class QuestionRepositoryTest extends ResetPostgres {
       throws ProgramBlockDefinitionNotFoundException, UnsupportedQuestionTypeException {
     EnumeratorFixture fixture = newEnumeratorFixture();
 
-    repo.createOrUpdateDraft(
-        new QuestionDefinitionBuilder(lookupDefinition(fixture.initialQuestionId()))
-            .setDescription("updated")
-            .build());
+    draftInitialQuestion(fixture);
 
     QuestionDefinition initialQuestionAfter = latestDefinition(fixture.initialQuestionId());
-    var initialQuestionAfterId = initialQuestionAfter.getId();
-    assertThat(initialQuestionAfterId).isNotEqualTo(fixture.initialQuestionId());
+    assertThat(initialQuestionAfter.getId()).isNotEqualTo(fixture.initialQuestionId());
     // A draft of the enumerator now points at the initial question's new draft...
     QuestionDefinition enumeratorAfter = latestDefinition(fixture.enumeratorId());
     assertThat(enumeratorAfter.getId()).isNotEqualTo(fixture.enumeratorId());
-    assertThat(enumeratorAfter.getEnumeratorInitialQuestionId()).hasValue(initialQuestionAfterId);
-    // Both repeated questions point back at the enumerator's new draft.
-    QuestionDefinition repeatedQuestionAfter = latestDefinition(fixture.repeatedQuestionId());
+    assertThat(enumeratorAfter.getEnumeratorInitialQuestionId())
+        .hasValue(initialQuestionAfter.getId());
     assertThat(initialQuestionAfter.getEnumeratorId()).hasValue(enumeratorAfter.getId());
-    assertThat(repeatedQuestionAfter.getEnumeratorId()).hasValue(enumeratorAfter.getId());
     // ...while the published enumerator keeps pointing at the published initial question.
     assertThat(lookupDefinition(fixture.enumeratorId()).getEnumeratorInitialQuestionId())
         .hasValue(fixture.initialQuestionId());
-    // Blocks 1 and 2 follow their questions to their new revisions.
+    // Block 1 follows both questions to their new revisions.
     assertThat(blockQuestionIds(fixture.program(), 1L))
-        .containsExactly(enumeratorAfter.getId(), initialQuestionAfterId);
+        .containsExactly(enumeratorAfter.getId(), initialQuestionAfter.getId());
+  }
+
+  @Test
+  public void createOrUpdateDraft_draftingInitialQuestion_repointsSiblingRepeatedQuestion()
+      throws ProgramBlockDefinitionNotFoundException, UnsupportedQuestionTypeException {
+    // The repeated question in block 2 is not the initial question, but it is repeated on the same
+    // enumerator, so drafting the enumerator has to carry it forward too.
+    EnumeratorFixture fixture = newEnumeratorFixture();
+
+    draftInitialQuestion(fixture);
+
+    QuestionDefinition repeatedQuestionAfter = latestDefinition(fixture.repeatedQuestionId());
+    assertThat(repeatedQuestionAfter.getId()).isNotEqualTo(fixture.repeatedQuestionId());
+    assertThat(repeatedQuestionAfter.getEnumeratorId())
+        .hasValue(latestDefinition(fixture.enumeratorId()).getId());
     assertThat(blockQuestionIds(fixture.program(), 2L))
         .containsExactly(repeatedQuestionAfter.getId());
+  }
 
-    // Block 3's new-flow cluster was not drafted, and its mutual references are intact.
+  @Test
+  public void createOrUpdateDraft_draftingInitialQuestion_leavesOtherNewFlowEnumeratorAlone()
+      throws ProgramBlockDefinitionNotFoundException, UnsupportedQuestionTypeException {
+    // Block 3's cluster was not drafted, and its mutual references are intact.
+    EnumeratorFixture fixture = newEnumeratorFixture();
+
+    draftInitialQuestion(fixture);
+
     QuestionDefinition newEnumerator = latestDefinition(fixture.newEnumeratorId());
     QuestionDefinition newRepeatedQuestion = latestDefinition(fixture.newRepeatedQuestionId());
     assertThat(newEnumerator.getId()).isEqualTo(fixture.newEnumeratorId());
@@ -567,8 +584,16 @@ public class QuestionRepositoryTest extends ResetPostgres {
     assertThat(newRepeatedQuestion.getEnumeratorId()).hasValue(fixture.newEnumeratorId());
     assertThat(blockQuestionIds(fixture.program(), 3L))
         .containsExactly(fixture.newEnumeratorId(), fixture.newRepeatedQuestionId());
+  }
 
-    // Block 4's old-flow cluster was not drafted, and no back reference was invented for it.
+  @Test
+  public void createOrUpdateDraft_draftingInitialQuestion_leavesOldFlowEnumeratorWithoutBackRef()
+      throws ProgramBlockDefinitionNotFoundException, UnsupportedQuestionTypeException {
+    // Block 4's cluster was not drafted, and no back reference was invented for its enumerator.
+    EnumeratorFixture fixture = newEnumeratorFixture();
+
+    draftInitialQuestion(fixture);
+
     QuestionDefinition oldEnumerator = latestDefinition(fixture.oldEnumeratorId());
     QuestionDefinition oldRepeatedQuestion = latestDefinition(fixture.oldRepeatedQuestionId());
     assertThat(oldEnumerator.getId()).isEqualTo(fixture.oldEnumeratorId());
@@ -577,6 +602,15 @@ public class QuestionRepositoryTest extends ResetPostgres {
     assertThat(oldRepeatedQuestion.getEnumeratorId()).hasValue(fixture.oldEnumeratorId());
     assertThat(blockQuestionIds(fixture.program(), 4L))
         .containsExactly(fixture.oldEnumeratorId(), fixture.oldRepeatedQuestionId());
+  }
+
+  /** Creates a new draft revision of the block 1 initial question. */
+  private void draftInitialQuestion(EnumeratorFixture fixture)
+      throws UnsupportedQuestionTypeException {
+    repo.createOrUpdateDraft(
+        new QuestionDefinitionBuilder(lookupDefinition(fixture.initialQuestionId()))
+            .setDescription("updated")
+            .build());
   }
 
   @Test

--- a/server/test/repository/QuestionRepositoryTest.java
+++ b/server/test/repository/QuestionRepositoryTest.java
@@ -530,22 +530,26 @@ public class QuestionRepositoryTest extends ResetPostgres {
   @Test
   public void createOrUpdateDraft_draftingInitialQuestion_repointsEnumeratorAtNewDraft()
       throws ProgramBlockDefinitionNotFoundException, UnsupportedQuestionTypeException {
+    // Creating a draft of an initial question creates an updated draft of its
+    // enumerator.
     EnumeratorFixture fixture = newEnumeratorFixture();
 
     draftInitialQuestion(fixture);
 
     QuestionDefinition initialQuestionAfter = latestDefinition(fixture.initialQuestionId());
+    // There's a new initial question.
     assertThat(initialQuestionAfter.getId()).isNotEqualTo(fixture.initialQuestionId());
-    // A draft of the enumerator now points at the initial question's new draft...
+    // There's a new enumerator which now points at the new initial question.
     QuestionDefinition enumeratorAfter = latestDefinition(fixture.enumeratorId());
     assertThat(enumeratorAfter.getId()).isNotEqualTo(fixture.enumeratorId());
     assertThat(enumeratorAfter.getEnumeratorInitialQuestionId())
         .hasValue(initialQuestionAfter.getId());
+    // The new initial question points at the new enumerator.
     assertThat(initialQuestionAfter.getEnumeratorId()).hasValue(enumeratorAfter.getId());
-    // ...while the published enumerator keeps pointing at the published initial question.
+    // The previous active enumerator has not changed.
     assertThat(lookupDefinition(fixture.enumeratorId()).getEnumeratorInitialQuestionId())
         .hasValue(fixture.initialQuestionId());
-    // Block 1 follows both questions to their new revisions.
+    // Block 1 contains both of the new questions.
     assertThat(blockQuestionIds(fixture.program(), 1L))
         .containsExactly(enumeratorAfter.getId(), initialQuestionAfter.getId());
   }
@@ -553,16 +557,19 @@ public class QuestionRepositoryTest extends ResetPostgres {
   @Test
   public void createOrUpdateDraft_draftingInitialQuestion_repointsSiblingRepeatedQuestion()
       throws ProgramBlockDefinitionNotFoundException, UnsupportedQuestionTypeException {
-    // The repeated question in block 2 is not the initial question, but it is repeated on the same
-    // enumerator, so drafting the enumerator has to carry it forward too.
+    // Creating a draft of an initial question creates an updated draft of the other questions
+    // repeated on its enumerator.
     EnumeratorFixture fixture = newEnumeratorFixture();
 
     draftInitialQuestion(fixture);
 
     QuestionDefinition repeatedQuestionAfter = latestDefinition(fixture.repeatedQuestionId());
+    // There's a new repeated question.
     assertThat(repeatedQuestionAfter.getId()).isNotEqualTo(fixture.repeatedQuestionId());
+    // The new repeated question points at the new enumerator.
     assertThat(repeatedQuestionAfter.getEnumeratorId())
         .hasValue(latestDefinition(fixture.enumeratorId()).getId());
+    // Block 2 contains the new repeated question.
     assertThat(blockQuestionIds(fixture.program(), 2L))
         .containsExactly(repeatedQuestionAfter.getId());
   }
@@ -570,18 +577,22 @@ public class QuestionRepositoryTest extends ResetPostgres {
   @Test
   public void createOrUpdateDraft_draftingInitialQuestion_leavesOtherNewFlowEnumeratorAlone()
       throws ProgramBlockDefinitionNotFoundException, UnsupportedQuestionTypeException {
-    // Block 3's cluster was not drafted, and its mutual references are intact.
+    // Creating a draft of an initial question leaves an unrelated enumerator and its own initial
+    // question alone.
     EnumeratorFixture fixture = newEnumeratorFixture();
 
     draftInitialQuestion(fixture);
 
     QuestionDefinition newEnumerator = latestDefinition(fixture.newEnumeratorId());
     QuestionDefinition newRepeatedQuestion = latestDefinition(fixture.newRepeatedQuestionId());
+    // There's no new enumerator, and it still points at the same initial question.
     assertThat(newEnumerator.getId()).isEqualTo(fixture.newEnumeratorId());
     assertThat(newEnumerator.getEnumeratorInitialQuestionId())
         .hasValue(fixture.newRepeatedQuestionId());
+    // There's no new initial question, and it still points at the same enumerator.
     assertThat(newRepeatedQuestion.getId()).isEqualTo(fixture.newRepeatedQuestionId());
     assertThat(newRepeatedQuestion.getEnumeratorId()).hasValue(fixture.newEnumeratorId());
+    // Block 3 still contains the original questions.
     assertThat(blockQuestionIds(fixture.program(), 3L))
         .containsExactly(fixture.newEnumeratorId(), fixture.newRepeatedQuestionId());
   }
@@ -589,17 +600,118 @@ public class QuestionRepositoryTest extends ResetPostgres {
   @Test
   public void createOrUpdateDraft_draftingInitialQuestion_leavesOldFlowEnumeratorWithoutBackRef()
       throws ProgramBlockDefinitionNotFoundException, UnsupportedQuestionTypeException {
-    // Block 4's cluster was not drafted, and no back reference was invented for its enumerator.
+    // Creating a draft of an initial question leaves an old flow enumerator, which has no initial
+    // question of its own, and its repeated question alone.
     EnumeratorFixture fixture = newEnumeratorFixture();
 
     draftInitialQuestion(fixture);
 
     QuestionDefinition oldEnumerator = latestDefinition(fixture.oldEnumeratorId());
     QuestionDefinition oldRepeatedQuestion = latestDefinition(fixture.oldRepeatedQuestionId());
+    // There's no new enumerator, and it still has no initial question.
     assertThat(oldEnumerator.getId()).isEqualTo(fixture.oldEnumeratorId());
     assertThat(oldEnumerator.getEnumeratorInitialQuestionId()).isEmpty();
+    // There's no new repeated question, and it still points at the same enumerator.
     assertThat(oldRepeatedQuestion.getId()).isEqualTo(fixture.oldRepeatedQuestionId());
     assertThat(oldRepeatedQuestion.getEnumeratorId()).hasValue(fixture.oldEnumeratorId());
+    // Block 4 still contains the original questions.
+    assertThat(blockQuestionIds(fixture.program(), 4L))
+        .containsExactly(fixture.oldEnumeratorId(), fixture.oldRepeatedQuestionId());
+  }
+
+  @Test
+  public void createOrUpdateDraft_draftingEnumerator_repointsBackReferenceAtCascadedDraft()
+      throws ProgramBlockDefinitionNotFoundException, UnsupportedQuestionTypeException {
+    // Creating a draft of an enumerator creates an updated draft of its initial question, and the
+    // enumerator draft points at that new initial question rather than the published one.
+    EnumeratorFixture fixture = newEnumeratorFixture();
+
+    draftEnumerator(fixture);
+
+    QuestionDefinition enumeratorAfter = latestDefinition(fixture.enumeratorId());
+    // There's a new enumerator, and it kept the edit that created it.
+    assertThat(enumeratorAfter.getId()).isNotEqualTo(fixture.enumeratorId());
+    assertThat(enumeratorAfter.getDescription()).isEqualTo("updated");
+    QuestionDefinition initialQuestionAfter = latestDefinition(fixture.initialQuestionId());
+    // There's a new initial question.
+    assertThat(initialQuestionAfter.getId()).isNotEqualTo(fixture.initialQuestionId());
+    // The new enumerator points at the new initial question.
+    assertThat(enumeratorAfter.getEnumeratorInitialQuestionId())
+        .hasValue(initialQuestionAfter.getId());
+    // The new initial question points at the new enumerator.
+    assertThat(initialQuestionAfter.getEnumeratorId()).hasValue(enumeratorAfter.getId());
+    // The previous active enumerator has not changed.
+    assertThat(lookupDefinition(fixture.enumeratorId()).getEnumeratorInitialQuestionId())
+        .hasValue(fixture.initialQuestionId());
+    // Block 1 contains both of the new questions.
+    assertThat(blockQuestionIds(fixture.program(), 1L))
+        .containsExactly(enumeratorAfter.getId(), initialQuestionAfter.getId());
+  }
+
+  @Test
+  public void createOrUpdateDraft_draftingEnumerator_carriesSiblingRepeatedQuestionForward()
+      throws ProgramBlockDefinitionNotFoundException, UnsupportedQuestionTypeException {
+    // Creating a draft of an enumerator creates an updated draft of the other questions repeated
+    // on it, and those do not take over its initial question reference.
+    EnumeratorFixture fixture = newEnumeratorFixture();
+
+    draftEnumerator(fixture);
+
+    QuestionDefinition enumeratorAfter = latestDefinition(fixture.enumeratorId());
+    QuestionDefinition repeatedQuestionAfter = latestDefinition(fixture.repeatedQuestionId());
+    // There's a new repeated question.
+    assertThat(repeatedQuestionAfter.getId()).isNotEqualTo(fixture.repeatedQuestionId());
+    // The new repeated question points at the new enumerator.
+    assertThat(repeatedQuestionAfter.getEnumeratorId()).hasValue(enumeratorAfter.getId());
+    // The new enumerator does not point at it, because it is not the initial question.
+    assertThat(enumeratorAfter.getEnumeratorInitialQuestionId().orElseThrow())
+        .isNotEqualTo(repeatedQuestionAfter.getId());
+    // Block 2 contains the new repeated question.
+    assertThat(blockQuestionIds(fixture.program(), 2L))
+        .containsExactly(repeatedQuestionAfter.getId());
+  }
+
+  @Test
+  public void createOrUpdateDraft_draftingEnumerator_leavesOtherNewFlowEnumeratorAlone()
+      throws ProgramBlockDefinitionNotFoundException, UnsupportedQuestionTypeException {
+    // Creating a draft of an enumerator leaves an unrelated enumerator and its own initial
+    // question alone.
+    EnumeratorFixture fixture = newEnumeratorFixture();
+
+    draftEnumerator(fixture);
+
+    QuestionDefinition newEnumerator = latestDefinition(fixture.newEnumeratorId());
+    QuestionDefinition newRepeatedQuestion = latestDefinition(fixture.newRepeatedQuestionId());
+    // There's no new enumerator, and it still points at the same initial question.
+    assertThat(newEnumerator.getId()).isEqualTo(fixture.newEnumeratorId());
+    assertThat(newEnumerator.getEnumeratorInitialQuestionId())
+        .hasValue(fixture.newRepeatedQuestionId());
+    // There's no new initial question, and it still points at the same enumerator.
+    assertThat(newRepeatedQuestion.getId()).isEqualTo(fixture.newRepeatedQuestionId());
+    assertThat(newRepeatedQuestion.getEnumeratorId()).hasValue(fixture.newEnumeratorId());
+    // Block 3 still contains the original questions.
+    assertThat(blockQuestionIds(fixture.program(), 3L))
+        .containsExactly(fixture.newEnumeratorId(), fixture.newRepeatedQuestionId());
+  }
+
+  @Test
+  public void createOrUpdateDraft_draftingEnumerator_leavesOldFlowEnumeratorWithoutBackRef()
+      throws ProgramBlockDefinitionNotFoundException, UnsupportedQuestionTypeException {
+    // Creating a draft of an enumerator leaves an old flow enumerator, which has no initial
+    // question of its own, and its repeated question alone.
+    EnumeratorFixture fixture = newEnumeratorFixture();
+
+    draftEnumerator(fixture);
+
+    QuestionDefinition oldEnumerator = latestDefinition(fixture.oldEnumeratorId());
+    QuestionDefinition oldRepeatedQuestion = latestDefinition(fixture.oldRepeatedQuestionId());
+    // There's no new enumerator, and it still has no initial question.
+    assertThat(oldEnumerator.getId()).isEqualTo(fixture.oldEnumeratorId());
+    assertThat(oldEnumerator.getEnumeratorInitialQuestionId()).isEmpty();
+    // There's no new repeated question, and it still points at the same enumerator.
+    assertThat(oldRepeatedQuestion.getId()).isEqualTo(fixture.oldRepeatedQuestionId());
+    assertThat(oldRepeatedQuestion.getEnumeratorId()).hasValue(fixture.oldEnumeratorId());
+    // Block 4 still contains the original questions.
     assertThat(blockQuestionIds(fixture.program(), 4L))
         .containsExactly(fixture.oldEnumeratorId(), fixture.oldRepeatedQuestionId());
   }
@@ -609,6 +721,14 @@ public class QuestionRepositoryTest extends ResetPostgres {
       throws UnsupportedQuestionTypeException {
     repo.createOrUpdateDraft(
         new QuestionDefinitionBuilder(lookupDefinition(fixture.initialQuestionId()))
+            .setDescription("updated")
+            .build());
+  }
+
+  /** Creates a new draft revision of the block 1 enumerator. */
+  private void draftEnumerator(EnumeratorFixture fixture) throws UnsupportedQuestionTypeException {
+    repo.createOrUpdateDraft(
+        new QuestionDefinitionBuilder(lookupDefinition(fixture.enumeratorId()))
             .setDescription("updated")
             .build());
   }
@@ -655,9 +775,9 @@ public class QuestionRepositoryTest extends ResetPostgres {
    * <p>Block 1 holds the enumerator and its initial question, which point at each other. Block 2
    * repeats on block 1 and holds a third question whose enumerator id is the block 1 enumerator.
    *
-   * <p>Blocks 3 and 4 are controls that nothing done to the block 1 cluster may touch. Block 3 holds
-   * a new-flow enumerator and its initial question, which point at each other. Block 4 holds an
-   * old-flow enumerator and a repeated question, where only the repeated question points at the
+   * <p>Blocks 3 and 4 are controls that nothing done to the block 1 cluster may touch. Block 3
+   * holds a new-flow enumerator and its initial question, which point at each other. Block 4 holds
+   * an old-flow enumerator and a repeated question, where only the repeated question points at the
    * enumerator.
    */
   private EnumeratorFixture newEnumeratorFixture() {

--- a/server/test/repository/QuestionRepositoryTest.java
+++ b/server/test/repository/QuestionRepositoryTest.java
@@ -12,17 +12,23 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import models.LifecycleStage;
+import models.ProgramModel;
 import models.QuestionModel;
 import models.QuestionTag;
 import org.junit.Before;
 import org.junit.Test;
 import services.LocalizedStrings;
+import services.program.ProgramBlockDefinitionNotFoundException;
+import services.program.ProgramQuestionDefinition;
 import services.question.PrimaryApplicantInfoTag;
 import services.question.exceptions.UnsupportedQuestionTypeException;
+import services.question.types.EnumeratorQuestionDefinition;
 import services.question.types.QuestionDefinition;
 import services.question.types.QuestionDefinitionBuilder;
 import services.question.types.QuestionDefinitionConfig;
 import services.question.types.TextQuestionDefinition;
+import support.ProgramBuilder;
 import support.TestQuestionBank;
 
 public class QuestionRepositoryTest extends ResetPostgres {
@@ -519,6 +525,143 @@ public class QuestionRepositoryTest extends ResetPostgres {
 
     assertThat(savedQuestions).hasSize(2);
     assertThat(repo.listQuestions().toCompletableFuture().join()).hasSize(2);
+  }
+
+  @Test
+  public void createOrUpdateDraft_draftingInitialQuestion_repointsEnumeratorAtNewDraft()
+      throws ProgramBlockDefinitionNotFoundException, UnsupportedQuestionTypeException {
+    EnumeratorFixture fixture = newEnumeratorFixture();
+
+    repo.createOrUpdateDraft(
+        new QuestionDefinitionBuilder(lookupDefinition(fixture.initialQuestionId()))
+            .setDescription("updated")
+            .build());
+
+    QuestionDefinition newInitialQuestion = latestDefinition(fixture.initialQuestionId());
+    var newInitialQuestionId = newInitialQuestion.getId();
+    assertThat(newInitialQuestionId).isNotEqualTo(fixture.initialQuestionId());
+    // A draft of the enumerator now points at the initial question's new draft...
+    QuestionDefinition enumeratorAfter = latestDefinition(fixture.enumeratorId());
+    assertThat(enumeratorAfter.getId()).isNotEqualTo(fixture.enumeratorId());
+    assertThat(enumeratorAfter.getEnumeratorInitialQuestionId()).hasValue(newInitialQuestionId);
+    // Both repeated questions point back at the enumerator's new draft. These have to be re-read:
+    // the model returned above predates the cascade that repointed its row.
+    QuestionDefinition newRepeatedQuestion = latestDefinition(fixture.repeatedQuestionId());
+    assertThat(newInitialQuestion.getEnumeratorId()).hasValue(enumeratorAfter.getId());
+    assertThat(newRepeatedQuestion.getEnumeratorId()).hasValue(enumeratorAfter.getId());
+    // ...while the published enumerator keeps pointing at the published initial question.
+    assertThat(lookupDefinition(fixture.enumeratorId()).getEnumeratorInitialQuestionId())
+        .hasValue(fixture.initialQuestionId());
+    // Every block follows its questions to their new revisions.
+    assertThat(blockQuestionIds(fixture.program(), 1L))
+        .containsExactly(enumeratorAfter.getId(), newInitialDraft.id);
+    assertThat(blockQuestionIds(fixture.program(), 2L))
+        .containsExactly(latestDefinition(fixture.repeatedQuestionId()).getId());
+  }
+
+  @Test
+  public void createOrUpdateDraft_reeditingInitialQuestionDraft_keepsEnumeratorBackReference()
+      throws UnsupportedQuestionTypeException {
+    // The second edit reuses the existing draft row rather than minting a new id, so the
+    // enumerator's back reference is already correct and must not churn.
+    EnumeratorFixture fixture = newEnumeratorFixture();
+    QuestionModel firstDraft =
+        repo.createOrUpdateDraft(
+            new QuestionDefinitionBuilder(lookupDefinition(fixture.initialQuestionId()))
+                .setDescription("first edit")
+                .build());
+    long enumeratorDraftId = latestDefinition(fixture.enumeratorId()).getId();
+
+    QuestionModel secondDraft =
+        repo.createOrUpdateDraft(
+            new QuestionDefinitionBuilder(lookupDefinition(firstDraft.id))
+                .setDescription("second edit")
+                .build());
+
+    assertThat(secondDraft.id).isEqualTo(firstDraft.id);
+    QuestionDefinition enumeratorAfter = latestDefinition(fixture.enumeratorId());
+    assertThat(enumeratorAfter.getId()).isEqualTo(enumeratorDraftId);
+    assertThat(enumeratorAfter.getEnumeratorInitialQuestionId()).hasValue(firstDraft.id);
+  }
+
+  /** Container for the entities made in {@code newEnumeratorFixture}. */
+  private record EnumeratorFixture(
+      long enumeratorId, long initialQuestionId, long repeatedQuestionId, ProgramModel program) {}
+
+  /**
+   * Builds a draft program with two blocks and three ACTIVE questions.
+   *
+   * <p>Block 1 holds the enumerator and its initial question, which point at each other. Block 2
+   * repeats on block 1 and holds a third question whose enumerator id is the block 1 enumerator.
+   */
+  private EnumeratorFixture newEnumeratorFixture() {
+    QuestionModel enumerator =
+        testQuestionBank.maybeSave(
+            new EnumeratorQuestionDefinition(
+                QuestionDefinitionConfig.builder()
+                    .setName("household members")
+                    .setDescription("The applicant's household members")
+                    .setQuestionText(LocalizedStrings.of(Locale.US, "Who is in your household?"))
+                    .build(),
+                LocalizedStrings.empty()),
+            LifecycleStage.ACTIVE);
+    QuestionModel initialQuestion = saveActiveRepeatedQuestion("household member name", enumerator);
+    // Complete the mutual reference in place, so no draft is created.
+    new QuestionModel(
+            repo.updateEnumeratorInitialQuestionId(
+                enumerator.getQuestionDefinition(), initialQuestion.id))
+        .update();
+    enumerator.refresh();
+    QuestionModel repeatedQuestion =
+        saveActiveRepeatedQuestion("household member nickname", enumerator);
+
+    ProgramModel program =
+        ProgramBuilder.newDraftProgram("enumerator program")
+            .withBlock("block 1")
+            .withRequiredQuestion(enumerator)
+            .withRequiredQuestion(initialQuestion)
+            .withRepeatedBlock("block 2")
+            .withRequiredQuestion(repeatedQuestion)
+            .build();
+    return new EnumeratorFixture(enumerator.id, initialQuestion.id, repeatedQuestion.id, program);
+  }
+
+  private QuestionModel saveActiveRepeatedQuestion(String name, QuestionModel enumerator) {
+    return testQuestionBank.maybeSave(
+        new TextQuestionDefinition(
+            QuestionDefinitionConfig.builder()
+                .setName(name)
+                .setDescription(name)
+                .setQuestionText(LocalizedStrings.of(Locale.US, "What is $this's " + name + "?"))
+                .setEnumeratorId(Optional.of(enumerator.id))
+                .build()),
+        LifecycleStage.ACTIVE);
+  }
+
+  private ImmutableList<Long> blockQuestionIds(ProgramModel program, long blockId)
+      throws ProgramBlockDefinitionNotFoundException {
+    program.refresh();
+    return program
+        .getProgramDefinition()
+        .getBlockDefinition(blockId)
+        .programQuestionDefinitions()
+        .stream()
+        .map(ProgramQuestionDefinition::id)
+        .collect(ImmutableList.toImmutableList());
+  }
+
+  /** The definition stored under {@code id} itself, ignoring any newer revision. */
+  private QuestionDefinition lookupDefinition(long id) {
+    return repo.lookupQuestion(id)
+        .toCompletableFuture()
+        .join()
+        .orElseThrow()
+        .getQuestionDefinition();
+  }
+
+  /** The draft revision of the question named by {@code id}, or the active one if there is none. */
+  private QuestionDefinition latestDefinition(long id) {
+    return versionRepo.getLatestVersionOfQuestion(id).orElseThrow().getQuestionDefinition();
   }
 
   private QuestionDefinition addTagToDefinition(QuestionModel question)

--- a/server/test/repository/QuestionRepositoryTest.java
+++ b/server/test/repository/QuestionRepositoryTest.java
@@ -537,8 +537,9 @@ public class QuestionRepositoryTest extends ResetPostgres {
     draftInitialQuestion(fixture);
 
     QuestionDefinition initialQuestionAfter = latestDefinition(fixture.initialQuestionId());
-    // There's a new initial question.
+    // There's a new initial question, and it kept the edit that created it.
     assertThat(initialQuestionAfter.getId()).isNotEqualTo(fixture.initialQuestionId());
+    assertThat(initialQuestionAfter.getDescription()).isEqualTo("updated");
     // There's a new enumerator which now points at the new initial question.
     QuestionDefinition enumeratorAfter = latestDefinition(fixture.enumeratorId());
     assertThat(enumeratorAfter.getId()).isNotEqualTo(fixture.enumeratorId());
@@ -563,12 +564,18 @@ public class QuestionRepositoryTest extends ResetPostgres {
 
     draftInitialQuestion(fixture);
 
+    QuestionDefinition enumeratorAfter = latestDefinition(fixture.enumeratorId());
+    QuestionDefinition initialQuestionAfter = latestDefinition(fixture.initialQuestionId());
     QuestionDefinition repeatedQuestionAfter = latestDefinition(fixture.repeatedQuestionId());
     // There's a new repeated question.
     assertThat(repeatedQuestionAfter.getId()).isNotEqualTo(fixture.repeatedQuestionId());
     // The new repeated question points at the new enumerator.
     assertThat(repeatedQuestionAfter.getEnumeratorId())
         .hasValue(latestDefinition(fixture.enumeratorId()).getId());
+    // The new enumerator points at its new initial question and not the
+    // new repeated question.
+    assertThat(enumeratorAfter.getEnumeratorInitialQuestionId())
+      .hasValue(initialQuestionAfter.getId());
     // Block 2 contains the new repeated question.
     assertThat(blockQuestionIds(fixture.program(), 2L))
         .containsExactly(repeatedQuestionAfter.getId());
@@ -629,10 +636,10 @@ public class QuestionRepositoryTest extends ResetPostgres {
     draftEnumerator(fixture);
 
     QuestionDefinition enumeratorAfter = latestDefinition(fixture.enumeratorId());
+    QuestionDefinition initialQuestionAfter = latestDefinition(fixture.initialQuestionId());
     // There's a new enumerator, and it kept the edit that created it.
     assertThat(enumeratorAfter.getId()).isNotEqualTo(fixture.enumeratorId());
     assertThat(enumeratorAfter.getDescription()).isEqualTo("updated");
-    QuestionDefinition initialQuestionAfter = latestDefinition(fixture.initialQuestionId());
     // There's a new initial question.
     assertThat(initialQuestionAfter.getId()).isNotEqualTo(fixture.initialQuestionId());
     // The new enumerator points at the new initial question.
@@ -714,23 +721,6 @@ public class QuestionRepositoryTest extends ResetPostgres {
     // Block 4 still contains the original questions.
     assertThat(blockQuestionIds(fixture.program(), 4L))
         .containsExactly(fixture.oldEnumeratorId(), fixture.oldRepeatedQuestionId());
-  }
-
-  /** Creates a new draft revision of the block 1 initial question. */
-  private void draftInitialQuestion(EnumeratorFixture fixture)
-      throws UnsupportedQuestionTypeException {
-    repo.createOrUpdateDraft(
-        new QuestionDefinitionBuilder(lookupDefinition(fixture.initialQuestionId()))
-            .setDescription("updated")
-            .build());
-  }
-
-  /** Creates a new draft revision of the block 1 enumerator. */
-  private void draftEnumerator(EnumeratorFixture fixture) throws UnsupportedQuestionTypeException {
-    repo.createOrUpdateDraft(
-        new QuestionDefinitionBuilder(lookupDefinition(fixture.enumeratorId()))
-            .setDescription("updated")
-            .build());
   }
 
   @Test
@@ -820,6 +810,23 @@ public class QuestionRepositoryTest extends ResetPostgres {
         oldEnumerator.id,
         oldRepeatedQuestion.id,
         program);
+  }
+
+  /** Creates a new draft revision of the block 1 initial question. */
+  private void draftInitialQuestion(EnumeratorFixture fixture)
+    throws UnsupportedQuestionTypeException {
+    repo.createOrUpdateDraft(
+      new QuestionDefinitionBuilder(lookupDefinition(fixture.initialQuestionId()))
+        .setDescription("updated")
+        .build());
+  }
+
+  /** Creates a new draft revision of the block 1 enumerator. */
+  private void draftEnumerator(EnumeratorFixture fixture) throws UnsupportedQuestionTypeException {
+    repo.createOrUpdateDraft(
+      new QuestionDefinitionBuilder(lookupDefinition(fixture.enumeratorId()))
+        .setDescription("updated")
+        .build());
   }
 
   private QuestionModel saveActiveEnumerator(String name, String questionText) {

--- a/server/test/repository/QuestionRepositoryTest.java
+++ b/server/test/repository/QuestionRepositoryTest.java
@@ -297,6 +297,33 @@ public class QuestionRepositoryTest extends ResetPostgres {
   }
 
   @Test
+  public void bulkCreateQuestions_withoutTransaction_throws() {
+    Exception e =
+        assertThrows(
+            IllegalStateException.class, () -> repo.bulkCreateQuestions(ImmutableList.of()));
+
+    assertThat(e)
+        .hasMessageContaining("bulkCreateQuestions must be called from within a transaction");
+  }
+
+  @Test
+  public void bulkCreateQuestions_createsAllQuestions() {
+    ImmutableList<QuestionDefinition> questionsToSave =
+        ImmutableList.of(
+            disconnectedQuestionBank.nameApplicantName().getQuestionDefinition(),
+            disconnectedQuestionBank.addressApplicantAddress().getQuestionDefinition());
+
+    ImmutableMap<String, QuestionDefinition> savedQuestions =
+        transactionManager.execute(
+            () -> {
+              return repo.bulkCreateQuestions(questionsToSave);
+            });
+
+    assertThat(savedQuestions).hasSize(2);
+    assertThat(repo.listQuestions().toCompletableFuture().join()).hasSize(2);
+  }
+
+  @Test
   public void createOrUpdateDraft_creatingDraftEnumeratorPreservesDraftRepeatedQuestions()
       throws UnsupportedQuestionTypeException {
     QuestionModel enumeratorQuestion = testQuestionBank.enumeratorApplicantHouseholdMembers();
@@ -501,33 +528,6 @@ public class QuestionRepositoryTest extends ResetPostgres {
   }
 
   @Test
-  public void bulkCreateQuestions_withoutTransaction_throws() {
-    Exception e =
-        assertThrows(
-            IllegalStateException.class, () -> repo.bulkCreateQuestions(ImmutableList.of()));
-
-    assertThat(e)
-        .hasMessageContaining("bulkCreateQuestions must be called from within a transaction");
-  }
-
-  @Test
-  public void bulkCreateQuestions_createsAllQuestions() {
-    ImmutableList<QuestionDefinition> questionsToSave =
-        ImmutableList.of(
-            disconnectedQuestionBank.nameApplicantName().getQuestionDefinition(),
-            disconnectedQuestionBank.addressApplicantAddress().getQuestionDefinition());
-
-    ImmutableMap<String, QuestionDefinition> savedQuestions =
-        transactionManager.execute(
-            () -> {
-              return repo.bulkCreateQuestions(questionsToSave);
-            });
-
-    assertThat(savedQuestions).hasSize(2);
-    assertThat(repo.listQuestions().toCompletableFuture().join()).hasSize(2);
-  }
-
-  @Test
   public void createOrUpdateDraft_draftingInitialQuestion_repointsEnumeratorAtNewDraft()
       throws ProgramBlockDefinitionNotFoundException, UnsupportedQuestionTypeException {
     // Creating a draft of an initial question creates an updated draft of its
@@ -575,7 +575,7 @@ public class QuestionRepositoryTest extends ResetPostgres {
     // The new enumerator points at its new initial question and not the
     // new repeated question.
     assertThat(enumeratorAfter.getEnumeratorInitialQuestionId())
-      .hasValue(initialQuestionAfter.getId());
+        .hasValue(initialQuestionAfter.getId());
     // Block 2 contains the new repeated question.
     assertThat(blockQuestionIds(fixture.program(), 2L))
         .containsExactly(repeatedQuestionAfter.getId());
@@ -590,18 +590,18 @@ public class QuestionRepositoryTest extends ResetPostgres {
 
     draftInitialQuestion(fixture);
 
-    QuestionDefinition newEnumerator = latestDefinition(fixture.newEnumeratorId());
-    QuestionDefinition newRepeatedQuestion = latestDefinition(fixture.newRepeatedQuestionId());
+    QuestionDefinition extraEnumerator = latestDefinition(fixture.extraEnumeratorId());
+    QuestionDefinition extraRepeatedQuestion = latestDefinition(fixture.extraRepeatedQuestionId());
     // There's no new enumerator, and it still points at the same initial question.
-    assertThat(newEnumerator.getId()).isEqualTo(fixture.newEnumeratorId());
-    assertThat(newEnumerator.getEnumeratorInitialQuestionId())
-        .hasValue(fixture.newRepeatedQuestionId());
+    assertThat(extraEnumerator.getId()).isEqualTo(fixture.extraEnumeratorId());
+    assertThat(extraEnumerator.getEnumeratorInitialQuestionId())
+        .hasValue(fixture.extraRepeatedQuestionId());
     // There's no new initial question, and it still points at the same enumerator.
-    assertThat(newRepeatedQuestion.getId()).isEqualTo(fixture.newRepeatedQuestionId());
-    assertThat(newRepeatedQuestion.getEnumeratorId()).hasValue(fixture.newEnumeratorId());
+    assertThat(extraRepeatedQuestion.getId()).isEqualTo(fixture.extraRepeatedQuestionId());
+    assertThat(extraRepeatedQuestion.getEnumeratorId()).hasValue(fixture.extraEnumeratorId());
     // Block 3 still contains the original questions.
     assertThat(blockQuestionIds(fixture.program(), 3L))
-        .containsExactly(fixture.newEnumeratorId(), fixture.newRepeatedQuestionId());
+        .containsExactly(fixture.extraEnumeratorId(), fixture.extraRepeatedQuestionId());
   }
 
   @Test
@@ -687,18 +687,18 @@ public class QuestionRepositoryTest extends ResetPostgres {
 
     draftEnumerator(fixture);
 
-    QuestionDefinition newEnumerator = latestDefinition(fixture.newEnumeratorId());
-    QuestionDefinition newRepeatedQuestion = latestDefinition(fixture.newRepeatedQuestionId());
+    QuestionDefinition extraEnumerator = latestDefinition(fixture.extraEnumeratorId());
+    QuestionDefinition extraRepeatedQuestion = latestDefinition(fixture.extraRepeatedQuestionId());
     // There's no new enumerator, and it still points at the same initial question.
-    assertThat(newEnumerator.getId()).isEqualTo(fixture.newEnumeratorId());
-    assertThat(newEnumerator.getEnumeratorInitialQuestionId())
-        .hasValue(fixture.newRepeatedQuestionId());
+    assertThat(extraEnumerator.getId()).isEqualTo(fixture.extraEnumeratorId());
+    assertThat(extraEnumerator.getEnumeratorInitialQuestionId())
+        .hasValue(fixture.extraRepeatedQuestionId());
     // There's no new initial question, and it still points at the same enumerator.
-    assertThat(newRepeatedQuestion.getId()).isEqualTo(fixture.newRepeatedQuestionId());
-    assertThat(newRepeatedQuestion.getEnumeratorId()).hasValue(fixture.newEnumeratorId());
+    assertThat(extraRepeatedQuestion.getId()).isEqualTo(fixture.extraRepeatedQuestionId());
+    assertThat(extraRepeatedQuestion.getEnumeratorId()).hasValue(fixture.extraEnumeratorId());
     // Block 3 still contains the original questions.
     assertThat(blockQuestionIds(fixture.program(), 3L))
-        .containsExactly(fixture.newEnumeratorId(), fixture.newRepeatedQuestionId());
+        .containsExactly(fixture.extraEnumeratorId(), fixture.extraRepeatedQuestionId());
   }
 
   @Test
@@ -748,17 +748,18 @@ public class QuestionRepositoryTest extends ResetPostgres {
     assertThat(enumeratorAfter.getEnumeratorInitialQuestionId()).hasValue(firstDraft.id);
   }
 
-  /** Container for the entities made in {@code newEnumeratorFixture}.
+  /**
+   * Container for the entities made in {@code newEnumeratorFixture}.
    *
-   * The default context is that items are for the new enumerator flow, and
-   * ones in the old flow are indicated with 'old'.
-  */
+   * <p>The default context is that items are for the new enumerator flow, and ones in the old flow
+   * are indicated with 'old'.
+   */
   private record EnumeratorFixture(
       long enumeratorId,
       long initialQuestionId,
       long repeatedQuestionId,
-      long newEnumeratorId,
-      long newRepeatedQuestionId,
+      long extraEnumeratorId,
+      long extraRepeatedQuestionId,
       long oldEnumeratorId,
       long oldRepeatedQuestionId,
       ProgramModel program) {}
@@ -782,10 +783,11 @@ public class QuestionRepositoryTest extends ResetPostgres {
     QuestionModel repeatedQuestion =
         saveActiveRepeatedQuestion("household member nickname", enumerator);
 
-    QuestionModel newEnumerator = saveActiveEnumerator("new enumerator", "Where have you worked?");
-    QuestionModel newRepeatedQuestion =
-        saveActiveRepeatedQuestion("new repeated question", newEnumerator);
-    pointAtInitialQuestion(newEnumerator, newRepeatedQuestion);
+    QuestionModel extraEnumerator =
+        saveActiveEnumerator("extra enumerator", "Where have you worked?");
+    QuestionModel extraRepeatedQuestion =
+        saveActiveRepeatedQuestion("extra repeated question", extraEnumerator);
+    pointAtInitialQuestion(extraEnumerator, extraRepeatedQuestion);
 
     QuestionModel oldEnumerator = saveActiveEnumerator("old enumerator", "Where have you lived?");
     QuestionModel oldRepeatedQuestion =
@@ -799,8 +801,8 @@ public class QuestionRepositoryTest extends ResetPostgres {
             .withRepeatedBlock("block 2")
             .withRequiredQuestion(repeatedQuestion)
             .withBlock("block 3")
-            .withRequiredQuestion(newEnumerator)
-            .withRequiredQuestion(newRepeatedQuestion)
+            .withRequiredQuestion(extraEnumerator)
+            .withRequiredQuestion(extraRepeatedQuestion)
             .withBlock("block 4")
             .withRequiredQuestion(oldEnumerator)
             .withRequiredQuestion(oldRepeatedQuestion)
@@ -809,8 +811,8 @@ public class QuestionRepositoryTest extends ResetPostgres {
         enumerator.id,
         initialQuestion.id,
         repeatedQuestion.id,
-        newEnumerator.id,
-        newRepeatedQuestion.id,
+        extraEnumerator.id,
+        extraRepeatedQuestion.id,
         oldEnumerator.id,
         oldRepeatedQuestion.id,
         program);
@@ -818,19 +820,19 @@ public class QuestionRepositoryTest extends ResetPostgres {
 
   /** Creates a new draft revision of the block 1 initial question. */
   private void draftInitialQuestion(EnumeratorFixture fixture)
-    throws UnsupportedQuestionTypeException {
+      throws UnsupportedQuestionTypeException {
     repo.createOrUpdateDraft(
-      new QuestionDefinitionBuilder(lookupDefinition(fixture.initialQuestionId()))
-        .setDescription("updated")
-        .build());
+        new QuestionDefinitionBuilder(lookupDefinition(fixture.initialQuestionId()))
+            .setDescription("updated")
+            .build());
   }
 
   /** Creates a new draft revision of the block 1 enumerator. */
   private void draftEnumerator(EnumeratorFixture fixture) throws UnsupportedQuestionTypeException {
     repo.createOrUpdateDraft(
-      new QuestionDefinitionBuilder(lookupDefinition(fixture.enumeratorId()))
-        .setDescription("updated")
-        .build());
+        new QuestionDefinitionBuilder(lookupDefinition(fixture.enumeratorId()))
+            .setDescription("updated")
+            .build());
   }
 
   private QuestionModel saveActiveEnumerator(String name, String questionText) {


### PR DESCRIPTION
### Description

When an initial question is first edited into a draft, that needs to cascade to update its enumerator.

This PR is mostly tests, and I recommend reading `EnumeratorFixture` and `newEnumeratorFixture` first as they setup a program with various enumerator configurations for all the next tests.

This PR additionally adds previously missing tests for the case where if new enumerator is made a draft, the initial question should also become a draft and the enumerator should point at the new draft.

AI: Claude wrote almost all the testing with my heavy direction; and only the tests.  So the idioms are its but they seem clean and efficient.  I tried to balance the testing to be focused but also reduce duplication and hopefully not go overboard.

### Checklist

Remove any sections below that do not apply to your PR. For sections that do apply, complete all of the appropriate checklist items and check them off. If a checklist item doesn't apply to your PR, leave it unchecked but do not delete it.

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [ ] Added an additional reviewer as required if changes potentially affect the security of the application.
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [x] Noted in the PR description which, if any, code in this PR was generated by AI.


### Issue(s) this completes

Fixes #13387
