### PR TITLE
[Enumerators] Detect initial is archived or draft

### DIFF
--- a/server/app/controllers/admin/AdminProgramBlockQuestionsController.java
+++ b/server/app/controllers/admin/AdminProgramBlockQuestionsController.java
@@ -160,8 +160,6 @@ public class AdminProgramBlockQuestionsController extends Controller {
   /** HTMX POST endpoint for creating a new enumerator question and adding it to a screen. */
   @Secure(authorizers = Labels.CIVIFORM_ADMIN)
   public Result hxCreateEnumerator(Request request, long programId, long blockId) {
-    // stack 1 DO NOT SUBMIT
-
     Messages messages = messagesApi.preferred(request);
     requestChecker.throwIfProgramNotDraft(programId);
 

--- a/server/app/controllers/admin/AdminProgramBlockQuestionsController.java
+++ b/server/app/controllers/admin/AdminProgramBlockQuestionsController.java
@@ -159,6 +159,7 @@ public class AdminProgramBlockQuestionsController extends Controller {
   /** HTMX POST endpoint for creating a new enumerator question and adding it to a screen. */
   @Secure(authorizers = Labels.CIVIFORM_ADMIN)
   public Result hxCreateEnumerator(Request request, long programId, long blockId) {
+
     Messages messages = messagesApi.preferred(request);
     requestChecker.throwIfProgramNotDraft(programId);
 

--- a/server/app/controllers/admin/AdminProgramBlockQuestionsController.java
+++ b/server/app/controllers/admin/AdminProgramBlockQuestionsController.java
@@ -17,6 +17,7 @@ import java.util.Optional;
 import java.util.OptionalLong;
 import javax.inject.Inject;
 import models.QuestionModel;
+import models.VersionModel;
 import org.pac4j.play.java.Secure;
 import play.data.DynamicForm;
 import play.data.FormFactory;
@@ -202,13 +203,19 @@ public class AdminProgramBlockQuestionsController extends Controller {
                                   .getKeyName())))
                   .build());
     } else {
-      QuestionDefinition originalInitialQuestion =
-          questionService
-              .getReadOnlyQuestionServiceSync()
-              .getQuestionDefinition(initialQuestionIdFromForm.getAsLong());
-      if (originalInitialQuestion instanceof NullQuestionDefinition) {
+      Optional<QuestionModel> maybeOriginalInitialQuestion =
+          versionRepository.getLatestVersionOfQuestion(initialQuestionIdFromForm.getAsLong());
+      if (maybeOriginalInitialQuestion.isEmpty()) {
         return notFound(
             String.format("Question not found for ID: %d", initialQuestionIdFromForm.getAsLong()));
+      }
+      QuestionDefinition originalInitialQuestion =
+          maybeOriginalInitialQuestion.get().getQuestionDefinition();
+      VersionModel draft = versionRepository.getDraftVersionOrCreate();
+      if (draft.getTombstonedQuestionNames().contains(originalInitialQuestion.getName())) {
+        return notFound(
+            String.format(
+                "Question has been archived for ID: %d", initialQuestionIdFromForm.getAsLong()));
       }
       optionalOriginalInitialQuestion = Optional.of(originalInitialQuestion);
       result =

--- a/server/app/controllers/admin/AdminProgramBlockQuestionsController.java
+++ b/server/app/controllers/admin/AdminProgramBlockQuestionsController.java
@@ -159,6 +159,7 @@ public class AdminProgramBlockQuestionsController extends Controller {
   /** HTMX POST endpoint for creating a new enumerator question and adding it to a screen. */
   @Secure(authorizers = Labels.CIVIFORM_ADMIN)
   public Result hxCreateEnumerator(Request request, long programId, long blockId) {
+    // stack 1 DO NOT SUBMIT
 
     Messages messages = messagesApi.preferred(request);
     requestChecker.throwIfProgramNotDraft(programId);

--- a/server/test/controllers/admin/AdminProgramBlockQuestionsControllerTest.java
+++ b/server/test/controllers/admin/AdminProgramBlockQuestionsControllerTest.java
@@ -27,6 +27,8 @@ import services.program.ProgramBlockDefinitionNotFoundException;
 import services.program.ProgramNotFoundException;
 import services.program.ProgramQuestionDefinition;
 import services.program.ProgramService;
+import services.question.QuestionService;
+import services.question.exceptions.InvalidUpdateException;
 import services.question.exceptions.UnsupportedQuestionTypeException;
 import services.question.types.QuestionDefinition;
 import services.question.types.QuestionDefinitionBuilder;
@@ -39,11 +41,13 @@ public class AdminProgramBlockQuestionsControllerTest extends ResetPostgres {
 
   private AdminProgramBlockQuestionsController controller;
   private ProgramService programService;
+  private QuestionService questionService;
 
   @Before
   public void setUp() {
     controller = instanceOf(AdminProgramBlockQuestionsController.class);
     programService = instanceOf(ProgramService.class);
+    questionService = instanceOf(QuestionService.class);
   }
 
   @Test
@@ -246,6 +250,89 @@ public class AdminProgramBlockQuestionsControllerTest extends ResetPostgres {
     Result result = controller.hxCreateEnumerator(request, program.id, 1);
 
     assertThat(result.status()).isEqualTo(NOT_FOUND);
+    assertThat(contentAsString(result)).contains("Question not found for ID: 99999");
+  }
+
+  @Test
+  public void hxCreateEnumerator_withArchivedInitialQuestion_returnsNotFound()
+      throws InvalidUpdateException, ProgramBlockDefinitionNotFoundException, ProgramNotFoundException {
+    QuestionDefinition initialQuestion =
+        testQuestionBank.nameApplicantName().getQuestionDefinition();
+    // Archiving tombstones the question's name on the draft version.
+    questionService.archiveQuestion(initialQuestion.getId());
+    ProgramModel program = ProgramBuilder.newDraftProgram().withEnumeratorBlock().build();
+
+    Request request =
+        fakeRequestBuilder()
+            .addCiviFormSetting("ENUMERATOR_IMPROVEMENTS_ENABLED", "true")
+            .bodyForm(
+                ImmutableMap.of(
+                    "entityType", "Pets",
+                    "questionName", "pets enumerator",
+                    "questionText", "List your pets.",
+                    "questionHelpText", "help text",
+                    "initialQuestionId", String.valueOf(initialQuestion.getId())))
+            .build();
+
+    Result result = controller.hxCreateEnumerator(request, program.id, 1);
+
+    assertThat(result.status()).isEqualTo(NOT_FOUND);
+    assertThat(contentAsString(result))
+        .contains("Question has been archived for ID: " + initialQuestion.getId());
+    // The controller bails before creating the enumerator question or touching the block.
+    assertThat(
+            questionService.getReadOnlyQuestionServiceSync().getAllQuestions().stream()
+                .map(QuestionDefinition::getName))
+        .doesNotContain("pets enumerator");
+    assertThat(
+            programService
+                .getFullProgramDefinition(program.id)
+                .getBlockDefinition(1L)
+                .programQuestionDefinitions())
+        .isEmpty();
+  }
+
+  @Test
+  public void hxCreateEnumerator_withOldRevisionInitialQuestionId_usesLatestRevision()
+      throws ProgramBlockDefinitionNotFoundException,
+          ProgramNotFoundException,
+          UnsupportedQuestionTypeException {
+    // The admin's browser may hold a stale id. The controller resolves it to the latest revision
+    // rather than using the id verbatim.
+    QuestionDefinition activeQuestion =
+        testQuestionBank.nameApplicantName().getQuestionDefinition();
+    QuestionDefinition draftRevision =
+        new QuestionDefinitionBuilder(activeQuestion)
+            .setId(activeQuestion.getId() + 100000)
+            .setQuestionText(LocalizedStrings.withDefaultValue("draft version"))
+            .build();
+    testQuestionBank.maybeSave(draftRevision, LifecycleStage.DRAFT);
+    ProgramModel program = ProgramBuilder.newDraftProgram().withEnumeratorBlock().build();
+
+    Request request =
+        fakeRequestBuilder()
+            .addCiviFormSetting("ENUMERATOR_IMPROVEMENTS_ENABLED", "true")
+            .bodyForm(
+                ImmutableMap.of(
+                    "entityType", "Pets",
+                    "questionName", "pets enumerator",
+                    "questionText", "List your pets.",
+                    "questionHelpText", "help text",
+                    // Submit the *active* (stale) id.
+                    "initialQuestionId", String.valueOf(activeQuestion.getId())))
+            .build();
+
+    Result result = controller.hxCreateEnumerator(request, program.id, 1);
+
+    assertThat(result.status()).withFailMessage(contentAsString(result)).isEqualTo(OK);
+    BlockDefinition blockAfter =
+        programService.getFullProgramDefinition(program.id).getBlockDefinition(1L);
+    assertThat(blockAfter.programQuestionDefinitions()).hasSize(2);
+    QuestionDefinition initialOnBlock =
+        blockAfter.programQuestionDefinitions().get(1).getQuestionDefinition();
+    // The question is a copy so we can't check the ID; instead check the
+    // draft text.
+    assertThat(initialOnBlock.getQuestionText().getDefault()).isEqualTo("draft version");
   }
 
   @Test

--- a/server/test/controllers/admin/AdminProgramBlockQuestionsControllerTest.java
+++ b/server/test/controllers/admin/AdminProgramBlockQuestionsControllerTest.java
@@ -255,7 +255,9 @@ public class AdminProgramBlockQuestionsControllerTest extends ResetPostgres {
 
   @Test
   public void hxCreateEnumerator_withArchivedInitialQuestion_returnsNotFound()
-      throws InvalidUpdateException, ProgramBlockDefinitionNotFoundException, ProgramNotFoundException {
+      throws InvalidUpdateException,
+          ProgramBlockDefinitionNotFoundException,
+          ProgramNotFoundException {
     QuestionDefinition initialQuestion =
         testQuestionBank.nameApplicantName().getQuestionDefinition();
     // Archiving tombstones the question's name on the draft version.


### PR DESCRIPTION
### Description

In `hxCreateEnumerator` detect if the Initial Question has changed since it was selected, in particular 1. Active -> Draft and 2. Archived

1. Active -> Draft: Automatically use the draft
2. Archived: Return a notFound error.

AI: Claude wrote the tests

Note: The issue includes UX changes to show the error but this PR doesn't address that. I recommend we wait on that until the UI is migrated to Thymeleaf so we don't do bespoke throw away work in J2html

### Checklist

Remove any sections below that do not apply to your PR. For sections that do apply, complete all of the appropriate checklist items and check them off. If a checklist item doesn't apply to your PR, leave it unchecked but do not delete it.

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [ ] Added an additional reviewer as required if changes potentially affect the security of the application.
- [x] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [x] Created unit and/or browser tests which fail without the change (if possible)
- [x] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [x] Noted in the PR description which, if any, code in this PR was generated by AI.


### Issue(s) this completes

Addresses: #13387