### PR TITLE
Sign renovate commits

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -95,6 +95,8 @@ jobs:
           RENOVATE_REPOSITORIES: ${{ github.repository }}
           # Keep updating branches created by the Mend-hosted bot before migration.
           RENOVATE_GIT_IGNORED_AUTHORS: "29139614+renovate[bot]@users.noreply.github.com"
+          # Set the key to sign the PRs
+          RENOVATE_GIT_PRIVATE_KEY: ${{ secrets.CIVIFORM_AUTOMATION_SELF_HOSTED_RENOVATE_PRIVKEY }}
           # renovate.json5 is already committed: never open an onboarding PR,
           # and refuse to run without a repository config.
           RENOVATE_ONBOARDING: "false"


### PR DESCRIPTION
### Description

I setup the civiform automation github account with a signing key. The public/private key is stored in the password manager.

The new secret `CIVIFORM_AUTOMATION_SELF_HOSTED_RENOVATE_PRIVKEY` is used pass it to the renovate action. This will update previous PRs (already verified) and should do the same with new ones (will watch for new ones).



### Checklist

Remove any sections below that do not apply to your PR. For sections that do apply, complete all of the appropriate checklist items and check them off. If a checklist item doesn't apply to your PR, leave it unchecked but do not delete it.

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [ ] Added an additional reviewer as required if changes potentially affect the security of the application.
- [ ] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

