### PR TITLE
Allow creating patch releases

### DIFF
--- a/.github/workflows/build-push-image-from-branch.yml
+++ b/.github/workflows/build-push-image-from-branch.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       branch_name:
-        description: 'The name of the branch to build from'
+        description: 'The branch to build from. release/* branches produce a RELEASE- image that can be promoted with the Release workflow; any other branch produces a DEV- image for testing only.'
         required: true
 
 permissions: read-all
@@ -22,10 +22,10 @@ jobs:
         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
-      - name: Run build-and-push-image-for-testing
-        id: build_and_push_image_for_testing
+      - name: Build and push server image
+        id: build_and_push_image
         env:
-          DEV_BRANCH_NAME: ${{ github.event.inputs.branch_name }}
+          BRANCH_NAME: ${{ github.event.inputs.branch_name }}
           DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
           DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USER_NAME }}
         run: bin/build-and-push-image-for-testing

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,8 +4,14 @@ on:
   workflow_dispatch:
     inputs:
       commit_sha:
-        description: 'The commit SHA on main for this release'
+        description: 'The commit SHA on the selected branch for this release. A SNAPSHOT- (from main CI) or RELEASE- (from the branch build workflow on a release/* branch) image must already exist on Docker Hub.'
         required: true
+
+      branch:
+        description: 'The branch containing the release commit'
+        type: string
+        default: 'main'
+        required: false
 
       cloud_deploy_infra_sha:
         description: 'The commit SHA in the cloud-deploy-infra repo corresponding to the version that was used to test the CiviForm commit SHA for the release. This can generally be left as "main" unless recent changes have landed in that repo.'
@@ -36,7 +42,12 @@ jobs:
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
       - name: Run bin/create-release
-        run: 'GH_TOKEN=${{ secrets.GITHUB_TOKEN }} bin/create-release ${{ github.event.inputs.commit_sha }} ${{ github.event.inputs.release_number }}'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMMIT_SHA: ${{ inputs.commit_sha }}
+          RELEASE_NUMBER: ${{ inputs.release_number }}
+          RELEASE_BRANCH: ${{ inputs.branch || 'main' }}
+        run: bin/create-release "$COMMIT_SHA" "$RELEASE_NUMBER" --branch "$RELEASE_BRANCH"
 
       - name: Tag cloud-deploy-infra
         env:

--- a/bin/build-and-push-image-for-testing
+++ b/bin/build-and-push-image-for-testing
@@ -1,14 +1,17 @@
 #! /usr/bin/env bash
 
-# DOC: Build a new server docker image from the local branch
-# DOC: and push to docker hub for testing purposes. Requires
-# DOC: docker hub credentials to be set in the environment
-# DOC: along with DEV_BRANCH_NAME.
+# DOC: Build a server docker image from the checked out branch and push it to
+# DOC: Docker Hub. Images built from a release/* branch are tagged
+# DOC: RELEASE-<short sha>-<unix seconds>-<branch> and can be promoted with
+# DOC: bin/create-release. Images built from any other branch are tagged
+# DOC: DEV-<short sha>-<unix seconds>-<branch> and are for testing only.
+# DOC: Requires Docker Hub credentials to be set in the environment along with
+# DOC: BRANCH_NAME.
 
 source bin/lib.sh
 
-if [[ -z "${DEV_BRANCH_NAME}" ]]; then
-  echo "DEV_BRANCH_NAME must be set"
+if [[ -z "${BRANCH_NAME}" ]]; then
+  echo "BRANCH_NAME must be set"
   exit 1
 fi
 
@@ -24,14 +27,25 @@ fi
 
 docker::do_dockerhub_login
 
-echo "Building ${IMAGE_TAG}..."
+# Only release/* branches get the RELEASE- prefix. bin/create-release refuses to
+# promote DEV- images, so a feature branch can't be turned into a release.
+if [[ "${BRANCH_NAME}" == release/* ]]; then
+  readonly TAG_PREFIX="RELEASE"
+else
+  readonly TAG_PREFIX="DEV"
+fi
 
+# Match the SNAPSHOT tag layout from bin/build-prod. The timestamp keeps
+# re-runs on the same commit from overwriting each other.
 readonly SHORT_SHA="$(git rev-parse --short HEAD)"
-readonly IMAGE_TAG="DEV-${SHORT_SHA}-${DEV_BRANCH_NAME/\//-}"
+readonly DATE_IN_UNIX_SECONDS="$(date +%s)"
+readonly IMAGE_TAG="${TAG_PREFIX}-${SHORT_SHA}-${DATE_IN_UNIX_SECONDS}-${BRANCH_NAME//\//-}"
 readonly GIT_SHA="$(git rev-parse HEAD)"
 export DOCKER_BUILDKIT=1
 
-# Push the image and push to docker hub
+echo "Building ${IMAGE_TAG}..."
+
+# Build the image and push it to Docker Hub
 docker buildx build --push \
   -f prod.Dockerfile \
   -t "civiform/civiform:${IMAGE_TAG}" \

--- a/bin/create-release
+++ b/bin/create-release
@@ -1,5 +1,6 @@
 #! /usr/bin/env python3
 
+import argparse
 import os
 import re
 import requests
@@ -7,7 +8,11 @@ import subprocess
 import shlex
 import sys
 
-# DOC: Create a new draft CiviForm image release. Usage: bin/create-release COMMIT_SHA RELEASE_NUMBER
+# DOC: Create a new draft CiviForm image release.
+# DOC: Usage: bin/create-release COMMIT_SHA RELEASE_NUMBER [--branch BRANCH]
+# DOC: BRANCH defaults to main. A SNAPSHOT- (built from main) or RELEASE- (built from
+# DOC: a release/* branch) Docker Hub image must already exist for COMMIT_SHA.
+# DOC: Versions must have patch 0 on main and patch greater than 0 on release/*.
 #
 # Requirements:
 #   Must have creds to login to docker hub as 'civiform' user.
@@ -40,13 +45,22 @@ def shell_cmd(command_string, timeout=None):
 GH_RELEASE_TOKEN_FILENAME = 'gh-release-token.txt'
 GH_RELEASE_TOKEN_ENV_VAR_NAME = 'GH_TOKEN'
 
+# Only images built by CI from main (SNAPSHOT-) or by the branch build workflow
+# from a release/* branch (RELEASE-) may be promoted to a release. DEV- images built
+# from feature branches are for testing only.
+RELEASABLE_TAG_PREFIXES = ('SNAPSHOT-', 'RELEASE-')
+
 
 def main():
-    if len(sys.argv) != 3:
-        print(
-            'Usage: bin/create-release COMMIT_SHA RELEASE_NUMBER',
-            file=sys.stderr)
-        exit(1)
+    parser = argparse.ArgumentParser(
+        description='Create a new draft CiviForm image release.')
+    parser.add_argument('commit_sha', metavar='COMMIT_SHA')
+    parser.add_argument('release_number', metavar='RELEASE_NUMBER')
+    parser.add_argument(
+        '--branch',
+        default='main',
+        help='Origin branch containing the release commit (default: main)')
+    args = parser.parse_args()
 
     if not os.path.exists(GH_RELEASE_TOKEN_FILENAME
                          ) and not GH_RELEASE_TOKEN_ENV_VAR_NAME in os.environ:
@@ -62,8 +76,8 @@ def main():
     # Set release variables
     ################################################################################
 
-    commit_sha = sys.argv[1]
-    release_number = sys.argv[2]
+    commit_sha = args.commit_sha
+    release_number = args.release_number
     if 'GITHUB_ACTOR' in os.environ:
         shell_cmd(
             f'git config user.email ' +
@@ -104,36 +118,63 @@ def main():
     # Validate release version number
     ################################################################################
 
-    if not re.match('^v\d+\.\d+\.\d+$', release_number):
+    if not re.match(r'^v\d+\.\d+\.\d+$', release_number):
         print('Invalid version number: ' + release_number, file=sys.stderr)
+        exit(1)
+
+    patch = int(release_number.split('.')[2])
+    if args.branch == 'main' and patch != 0:
+        print(
+            f'Invalid version number: {release_number}. Releases from main must have patch 0.',
+            file=sys.stderr)
+        exit(1)
+
+    if args.branch.startswith('release/') and patch == 0:
+        print(
+            f'Invalid version number: {release_number}. Releases from release/* must have patch greater than 0.',
+            file=sys.stderr)
         exit(1)
 
     ################################################################################
     # Validate commit SHA
     ################################################################################
 
-    # Validate commit SHA exists in main branch
+    # Validate commit SHA exists in the selected remote branch.
     branches_containing_commit_sha = shell_cmd(
         'git --no-pager branch -r --contains ' + commit_sha)
     branches_containing_commit_sha = [
         # The output of the command is a list of branch names, with a '*' at the
         # beginning of the current branch. This regex and the strip transform
         # the list to only branch names with no trailing or preceding whitespace.
-        re.sub('\*', '', x).strip()
+        re.sub(r'\*', '', x).strip()
         for x in branches_containing_commit_sha.split('\n')
     ]
-    if not 'origin/main' in branches_containing_commit_sha:
-        print('Invalid commit SHA: ' + commit_sha, file=sys.stderr)
+    # Only allow releases from main or a release/* branch so a typo in the
+    # workflow input can't tag and publish a commit from a feature branch.
+    if not re.fullmatch(r'main|release/.+', args.branch):
+        print(
+            f'Invalid branch: {args.branch}. Releases must come from main or a release/* branch.',
+            file=sys.stderr)
+        exit(1)
+
+    # The commit must already be pushed to the selected branch on origin.
+    # This catches a SHA that only exists locally or on a different branch.
+    if f'origin/{args.branch}' not in branches_containing_commit_sha:
+        print(
+            f'Invalid commit SHA: {commit_sha} is not on origin/{args.branch}',
+            file=sys.stderr)
         exit(1)
 
     ################################################################################
-    # Find Docker Hub snapshot tag that matches commit SHA
+    # Find Docker Hub SNAPSHOT or RELEASE tag that matches commit SHA
     ################################################################################
 
     # Git defaults to using the first 7 chars of the full SHA for the short SHA.
     short_sha = shell_cmd('git rev-parse --short ' + commit_sha)[:7]
 
-    print(f'Searching for an image tag with short SHA {short_sha}')
+    print(
+        f'Searching for a {" or ".join(RELEASABLE_TAG_PREFIXES)} image tag with short SHA {short_sha}'
+    )
 
     tags_url = 'https://registry.hub.docker.com/v2/repositories/civiform/civiform/tags?order=-last_activity&page_size=100'
     while True:
@@ -149,8 +190,10 @@ def main():
         response_json = response.json()
 
         for tag_info in response_json['results']:
-            if short_sha in tag_info['name']:
-                snapshot_tag = tag_info['name']
+            tag_name = tag_info['name']
+            if short_sha in tag_name and tag_name.startswith(
+                    RELEASABLE_TAG_PREFIXES):
+                snapshot_tag = tag_name
                 break
 
         if snapshot_tag is not None:
@@ -158,7 +201,8 @@ def main():
 
         if response_json['next'] is None:
             print(
-                f'No snapshot tag found with short SHA: {short_sha}',
+                f'No {" or ".join(RELEASABLE_TAG_PREFIXES)} image tag found with short SHA: {short_sha}. '
+                'DEV- images built from feature branches cannot be released.',
                 file=sys.stderr)
             exit(1)
 

--- a/bin/create-release-test.py
+++ b/bin/create-release-test.py
@@ -1,0 +1,246 @@
+# Unit tests for `bin/create-release`. Run manually; right now we don't
+# have automation to find any kind of tests in this folder.
+#
+# Run with "python bin/create-release-test.py -v"
+
+import contextlib
+import importlib.machinery
+import importlib.util
+import io
+from pathlib import Path
+import unittest
+from unittest import mock
+
+loader = importlib.machinery.SourceFileLoader(
+    'create_release', str(Path(__file__).with_name('create-release')))
+spec = importlib.util.spec_from_loader(loader.name, loader)
+create_release = importlib.util.module_from_spec(spec)
+loader.exec_module(create_release)
+
+
+class CreateReleaseTest(unittest.TestCase):
+
+    # Mock out everything main() touches so nothing actually runs or gets
+    # pushed. Tests just set self.branches to say where the commit lives.
+    def setUp(self):
+        self.shell = self.enterContext(
+            mock.patch.object(create_release, 'shell_cmd'))
+        self.shell.side_effect = self.shell_output
+        self.get = self.enterContext(
+            mock.patch.object(create_release.requests, 'get'))
+        self.get.return_value.status_code = 200
+        self.set_docker_tags(['SNAPSHOT-abcdef0-12345'])
+        self.post = self.enterContext(
+            mock.patch.object(create_release.requests, 'post'))
+        self.post.return_value.status_code = 201
+        self.post.return_value.json.return_value = {
+            'html_url': 'https://github.com/civiform/civiform/releases/1'
+        }
+        self.enterContext(
+            mock.patch.dict(
+                create_release.os.environ, {'GH_TOKEN': 'test-token'},
+                clear=True))
+        self.enterContext(contextlib.redirect_stdout(io.StringIO()))
+        self.stderr = self.enterContext(
+            contextlib.redirect_stderr(io.StringIO()))
+        self.branches = '  origin/main\n'
+
+    # Fake a single page of Docker Hub tag results.
+    def set_docker_tags(self, names):
+        self.get.return_value.json.return_value = {
+            'results': [{
+                'name': name
+            } for name in names],
+            'next': None
+        }
+
+    # Fake output for the shell commands we care about. Anything else
+    # (git tag, git push, docker pull/tag/push) just returns an empty string.
+    def shell_output(self, command, timeout=None):
+        return {
+            'git config --get user.email': 'releaser@example.com',
+            'docker login': 'Login Succeeded',
+            'git --no-pager branch -r --contains abcdef0': self.branches,
+            'git rev-parse --short abcdef0': 'abcdef0\n',
+        }.get(command, '')
+
+    # Run the script with a fixed SHA, a version, and any extra flags.
+    def run_release(self, *args, version='v1.2.0'):
+        with mock.patch.object(
+                create_release.sys, 'argv',
+            ['bin/create-release', 'abcdef0', version, *args]):
+            create_release.main()
+
+    # No --branch and the commit is on main, so this should just work.
+    def test_defaults_to_main(self):
+        self.run_release()
+
+        self.post.assert_called_once()
+        self.shell.assert_any_call('git push origin v1.2.0')
+
+    # Passing --branch main with patch 0 should work just like leaving
+    # --branch out.
+    def test_accepts_zero_patch_on_explicit_main(self):
+        self.run_release('--branch', 'main')
+
+        self.post.assert_called_once()
+        self.shell.assert_any_call('git push origin v1.2.0')
+
+    # Main only allows patch 0, whether we pass --branch or leave it out.
+    # Check we bail out before tagging or pushing anything.
+    def test_rejects_positive_patch_on_main(self):
+        for args in [(), ('--branch', 'main')]:
+            with self.subTest(args=args):
+                self.shell.reset_mock()
+                self.get.reset_mock()
+
+                with self.assertRaises(SystemExit) as error:
+                    self.run_release(*args, version='v1.2.1')
+
+                self.assertEqual(error.exception.code, 1)
+                self.assertIn(
+                    'Releases from main must have patch 0.',
+                    self.stderr.getvalue())
+                self.post.assert_not_called()
+                self.assertEqual(self.get.call_count, 1)
+                self.assertEqual(self.shell.call_count, 2)
+
+    # Release branches need a patch greater than 0. Patch 0 should be
+    # rejected even if the commit really is on the selected branch.
+    def test_rejects_zero_patch_on_release_branch(self):
+        self.branches = '  origin/release/1.2\n'
+
+        with self.assertRaises(SystemExit) as error:
+            self.run_release('--branch', 'release/1.2')
+
+        self.assertEqual(error.exception.code, 1)
+        self.assertIn(
+            'Releases from release/* must have patch greater than 0.',
+            self.stderr.getvalue())
+        self.post.assert_not_called()
+        self.assertEqual(self.get.call_count, 1)
+        self.assertEqual(self.shell.call_count, 2)
+
+    # The commit is only on the release branch, not main. Passing --branch
+    # should be enough to let it through.
+    def test_accepts_selected_branch_without_main(self):
+        self.branches = '  origin/release/1.2\n'
+
+        self.run_release('--branch', 'release/1.2', version='v1.2.1')
+
+        self.post.assert_called_once()
+        self.shell.assert_any_call('git push origin v1.2.1')
+
+    # release/1.20 should not match release/1.2. Also check we bail out right
+    # after the branch check and don't tag or push anything.
+    def test_rejects_commit_outside_selected_branch(self):
+        self.branches = '  origin/main\n  origin/release/1.20\n'
+
+        with self.assertRaises(SystemExit) as error:
+            self.run_release('--branch', 'release/1.2', version='v1.2.3')
+
+        self.assertEqual(error.exception.code, 1)
+        self.assertIn(
+            'abcdef0 is not on origin/release/1.2', self.stderr.getvalue())
+        self.post.assert_not_called()
+        self.assertEqual(self.get.call_count, 1)
+        self.assertEqual(self.shell.call_count, 3)
+
+    # We only release from main or release/*. A feature branch should be
+    # rejected even if the commit really is on it.
+    def test_rejects_branch_outside_release_pattern(self):
+        self.branches = '  origin/feature/foo\n'
+
+        with self.assertRaises(SystemExit) as error:
+            self.run_release('--branch', 'feature/foo')
+
+        self.assertEqual(error.exception.code, 1)
+        self.assertIn('Invalid branch: feature/foo', self.stderr.getvalue())
+        self.post.assert_not_called()
+
+    # The version must look like vMAJOR.MINOR.PATCH. Anything else should
+    # be rejected before we touch the branch list, tag, or push.
+    def test_rejects_malformed_version(self):
+        for version in ['1.2.0', 'v1.2', 'v1.2.0-rc1', 'vx.y.z', 'v1x2x0']:
+            with self.subTest(version=version):
+                self.shell.reset_mock()
+
+                with self.assertRaises(SystemExit) as error:
+                    self.run_release(version=version)
+
+                self.assertEqual(error.exception.code, 1)
+                self.assertIn(
+                    f'Invalid version number: {version}',
+                    self.stderr.getvalue())
+                self.post.assert_not_called()
+                self.assertEqual(self.shell.call_count, 2)
+
+    # git marks the current branch with a leading '*'. That marker has to
+    # be stripped so the branch still matches what we're releasing from.
+    def test_strips_current_branch_marker(self):
+        self.branches = '* origin/main\n  origin/release/1.2\n'
+
+        self.run_release()
+
+        self.post.assert_called_once()
+        self.shell.assert_any_call('git push origin v1.2.0')
+
+    # A RELEASE- image built from a release branch is allowed to be released.
+    def test_accepts_release_tag_on_release_branch(self):
+        self.branches = '  origin/release/1.2\n'
+        self.set_docker_tags(['RELEASE-abcdef0-12345-release-1.2'])
+
+        self.run_release('--branch', 'release/1.2', version='v1.2.1')
+
+        self.post.assert_called_once()
+        self.shell.assert_any_call(
+            'docker pull civiform/civiform:RELEASE-abcdef0-12345-release-1.2')
+        self.shell.assert_any_call('git push origin v1.2.1')
+
+    # A DEV- image built from a feature branch must not be released, even if
+    # the commit is on the selected branch. Nothing should be tagged or pushed.
+    def test_rejects_dev_tag(self):
+        self.branches = '  origin/release/1.2\n'
+        self.set_docker_tags(['DEV-abcdef0-12345-my-feature'])
+
+        with self.assertRaises(SystemExit) as error:
+            self.run_release('--branch', 'release/1.2', version='v1.2.1')
+
+        self.assertEqual(error.exception.code, 1)
+        self.assertIn(
+            'No SNAPSHOT- or RELEASE- image tag found with short SHA: abcdef0',
+            self.stderr.getvalue())
+        self.post.assert_not_called()
+        for call in self.shell.call_args_list:
+            self.assertNotIn('git tag', call.args[0])
+            self.assertNotIn('git push', call.args[0])
+            self.assertNotIn('docker push', call.args[0])
+
+    # A DEV- tag for the same SHA should be skipped in favor of a releasable
+    # tag further down the list.
+    def test_skips_dev_tag_when_releasable_tag_exists(self):
+        self.set_docker_tags(
+            ['DEV-abcdef0-12345-my-feature', 'SNAPSHOT-abcdef0-12345'])
+
+        self.run_release()
+
+        self.post.assert_called_once()
+        self.shell.assert_any_call(
+            'docker pull civiform/civiform:SNAPSHOT-abcdef0-12345')
+
+    # No --branch means main. A commit that's only on a release branch
+    # should be rejected.
+    def test_default_rejects_commit_only_on_other_branch(self):
+        self.branches = '  origin/release/1.2\n'
+
+        with self.assertRaises(SystemExit) as error:
+            self.run_release()
+
+        self.assertEqual(error.exception.code, 1)
+        self.assertIn('abcdef0 is not on origin/main', self.stderr.getvalue())
+        self.post.assert_not_called()
+        self.assertEqual(self.shell.call_count, 3)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Description

Until now `bin/create-release` hard-coded `origin/main`. If we wanted to ship a patch off a `release/1.2` branch there was no supported path. The Release workflow took a SHA, checked it was on main, found the SNAPSHOT image CI built for it, and promoted that. Anything else was a manual docker tag and a prayer.

This still requires releases to come from the `civiform/civiform` repo so code does have to land in main or a public branch. If we want to be able to create releases from a private fork there's much more plumbing needed to figure out how to keep that history in the public repo. Given a public docker image would be out there anyway for bots to decompile I'm don't think it's worth the effort.

### High level

__Normal__ releases still come from `main` and deploy like always. They get versions `major.minor.0`. These already have docker images pushed when merged to main.

__Out of band__ patch releases come from `release/*` and deploy similarly but you have to provide the branch name. They get versions `major.minor.n` where n > 0. A manual creation of a docker image with the github action `Build a server image from a branch` has to be done first. We can revisit further automation of release branches once we find this works and are happy with it. The new release branches should get created as branches of the latest version tag and only have the specific fixes put into them. Due to shift in main it may be that separate commits are necessary rather than a single cherry pick if there are complicated code changes.

This follow how we have [release versions documented](https://docs.civiform.us/it-manual/sre-playbook/upgrading-to-a-new-release#version-numbers) on the documentation site.

There's probably room to simplify the release github action workflow ui by figuring out the branch based on the commit, but I wanted to keep it as an intentional settings for the time being.

I have also already added branch protection rules so that only admins can create `release/*` branches now.

### Details

**`.github/workflows/release.yaml`**

The Release workflow now has a `branch` input defaulting to main. I've also moved the script arguments into `env:` to protect against possible shell injection. Workflow inputs are attacker-influenced text and they were being pasted into a shell line.

**`bin/build-and-push-image-for-testing`**

The script now decides the tag prefix from the branch name. `release/*` produces `RELEASE-<sha>-<timestamp>-<branch>`. Everything else still produces a `DEV<timestamp>-<branch>` image. The `create-release` release script will not allow using 'DEV-' prefixes for releases. I also added the timestamp to align with the `SNAPSHOT-` format.

**`bin/create-release`**

Now enforces

- The branch must match `main` or `release/*`. Nothing else.
- Versions from `main` must be patch 0. Versions from `release/*` must have patch greater than 0. It was always that was, but now enforced by the code.
- The Docker Hub tag search only accepts `SNAPSHOT-` or `RELEASE-` prefixes. Before, any tag containing the short SHA would do, which meant a DEV image could have been released by accident.

**`bin/create-release-test.py`**

I had some unit tests for `create-release` added. For now it will just be a manual thing to run. We should add the ability to run tests like this or the typescript one Chelsea was adding in her first PR. But that's out of scope here.

Here are some diagrams for the heck of it.

### Where images come from and which can be released

```mermaid
flowchart LR
    subgraph triggers
        push["push to main"]
        dispatch["Build from branch workflow dispatch"]
    end

    push -->|"build_push_ci.yaml"| buildprod["bin/build-prod"]
    dispatch -->|"build-push-image-from-branch.yml"| buildtest["bin/build-and-push-image-for-testing"]

    buildprod --> snap["SNAPSHOT-sha-ts"]
    buildtest -->|"branch matches release/*"| rel["RELEASE-sha-ts-branch"]
    buildtest -->|"any other branch"| dev["DEV-sha-ts-branch"]

    snap -->|"promotable"| cr["bin/create-release"]
    rel -->|"promotable"| cr
    dev -.->|"rejected"| cr

    cr --> out["civiform/civiform:vX.Y.Z"]
```

### Release workflow, end to end

```mermaid
sequenceDiagram
    participant U as Operator
    participant GH as GitHub Actions
    participant CR as bin/create-release
    participant Git as origin
    participant Hub as Docker Hub
    participant API as GitHub API
    participant Infra as cloud-deploy-infra

    U->>GH: dispatch release.yaml (commit_sha, branch, release_number)
    GH->>CR: create-release SHA VERSION --branch BRANCH (via env)
    CR->>API: GET /repos/civiform/civiform (auth check)
    CR->>Hub: docker login
    CR->>CR: validate version format and patch rule for branch
    CR->>Git: git branch -r --contains SHA
    CR->>CR: validate branch name and origin/BRANCH membership
    loop until found or no next page
        CR->>Hub: GET /tags?order=-last_activity
        Hub-->>CR: page of tag names
    end
    CR->>Git: git tag -a VERSION SHA, git push origin VERSION
    CR->>Hub: docker pull SNAPSHOT or RELEASE tag
    CR->>Hub: docker tag and push civiform/civiform:VERSION
    CR->>API: POST /releases (draft, generated notes)
    API-->>CR: html_url
    CR-->>GH: exit 0
    GH->>Infra: dispatch tag.yaml (cloud_deploy_infra_sha, VERSION)
```

### Which branch and version combinations are allowed

```mermaid
flowchart TD
    b{"branch"}
    b -->|"main"| m{"patch"}
    m -->|"0"| mok["accepted"]
    m -->|"> 0"| mno["rejected: main must have patch 0"]
    b -->|"release/anything"| r{"patch"}
    r -->|"0"| rno["rejected: release/* must have patch > 0"]
    r -->|"> 0"| rok["accepted"]
    b -->|"anything else"| fno["rejected: invalid branch"]
```

### LLM Tooling

I dusted off an old PR I started and had Astra clean it up at my direction and then Claude and I have reviewed it.

Assisted-by: opencode:openai/gpt-6-astra (implementer)
Assisted-by: Claude Code:claude-fable-5-1 (reviewer)


### Checklist

Remove any sections below that do not apply to your PR. For sections that do apply, complete all of the appropriate checklist items and check them off. If a checklist item doesn't apply to your PR, leave it unchecked but do not delete it.

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [x] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [x] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [x] Added an additional reviewer as required if changes potentially affect the security of the application.
- [ ] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [ ] Created unit and/or browser tests which fail without the change (if possible)
- [ ] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [x] Noted in the PR description which, if any, code in this PR was generated by AI.

