### PR TITLE
Added a demo banner to applicant and admin UI

### DIFF
--- a/server/app/assets/stylesheets/northstar/_uswds-theme-custom-styles.scss
+++ b/server/app/assets/stylesheets/northstar/_uswds-theme-custom-styles.scss
@@ -933,3 +933,11 @@ main {
 main#main-content {
   outline: none;
 }
+
+// Demo banner custom background color
+.usa-site-alert.cf-demo-banner {
+  .usa-alert,
+  .usa-alert .usa-alert__body {
+    background-color: #e7f0f9;
+  }
+}

--- a/server/app/assets/stylesheets/uswds/_uswds-theme-custom-styles.scss
+++ b/server/app/assets/stylesheets/uswds/_uswds-theme-custom-styles.scss
@@ -581,3 +581,11 @@ hr.code-separator {
   @include u-margin-y(4);
   @include u-margin-x(0);
 }
+
+// Demo banner custom background color
+.usa-site-alert.cf-demo-banner {
+  .usa-alert,
+  .usa-alert .usa-alert__body {
+    background-color: #e7f0f9;
+  }
+}

--- a/server/app/services/settings/SettingsManifest.java
+++ b/server/app/services/settings/SettingsManifest.java
@@ -782,6 +782,11 @@ public final class SettingsManifest extends AbstractSettingsManifest {
     return getString("IMMIGRATION_STATUS_INFO_BANNER_LEARN_MORE_URL", request);
   }
 
+  /** The HREF for providing more information for the demo informational banner. */
+  public Optional<String> getDemoBannerLearnMoreUrl(RequestHeader request) {
+    return getString("DEMO_BANNER_LEARN_MORE_URL", request);
+  }
+
   /**
    * The [secret key](http://www.playframework.com/documentation/latest/ApplicationSecret) is used
    * to sign Play's session cookie. This must be changed for production.
@@ -1088,6 +1093,11 @@ public final class SettingsManifest extends AbstractSettingsManifest {
   /** Enable showing an immigration status informational banner to applicants. */
   public boolean getImmigrationStatusInfoBannerEnabled(RequestHeader request) {
     return getBool("IMMIGRATION_STATUS_INFO_BANNER_ENABLED", request);
+  }
+
+  /** Enable showing a demo informational banner to applicants and admins. */
+  public boolean getDemoBannerEnabled(RequestHeader request) {
+    return getBool("DEMO_BANNER_ENABLED", request);
   }
 
   /** Enable session timeout based on inactivity and maximum duration. */
@@ -2117,6 +2127,13 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                               + " informational banner.",
                           /* isRequired= */ false,
                           SettingType.STRING,
+                          SettingMode.ADMIN_WRITEABLE),
+                      SettingDescription.create(
+                          "DEMO_BANNER_LEARN_MORE_URL",
+                          "The HREF for providing more information for the demo informational"
+                              + " banner.",
+                          /* isRequired= */ false,
+                          SettingType.STRING,
                           SettingMode.ADMIN_WRITEABLE))))
           .put(
               "Observability",
@@ -2376,6 +2393,12 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                           "IMMIGRATION_STATUS_INFO_BANNER_ENABLED",
                           "Enable showing an immigration status informational banner to"
                               + " applicants.",
+                          /* isRequired= */ false,
+                          SettingType.BOOLEAN,
+                          SettingMode.ADMIN_WRITEABLE),
+                      SettingDescription.create(
+                          "DEMO_BANNER_ENABLED",
+                          "Enable showing a demo informational banner to applicants and admins.",
                           /* isRequired= */ false,
                           SettingType.BOOLEAN,
                           SettingMode.ADMIN_WRITEABLE),

--- a/server/app/services/settings/SettingsManifest.java
+++ b/server/app/services/settings/SettingsManifest.java
@@ -787,6 +787,11 @@ public final class SettingsManifest extends AbstractSettingsManifest {
     return getString("DEMO_BANNER_LEARN_MORE_URL", request);
   }
 
+  /** The expiration date for the demo instance formatted as yyyy-mm-dd. */
+  public Optional<String> getDemoBannerExpirationDate(RequestHeader request) {
+    return getString("DEMO_BANNER_EXPIRATION_DATE", request);
+  }
+
   /**
    * The [secret key](http://www.playframework.com/documentation/latest/ApplicationSecret) is used
    * to sign Play's session cookie. This must be changed for production.
@@ -2132,6 +2137,12 @@ public final class SettingsManifest extends AbstractSettingsManifest {
                           "DEMO_BANNER_LEARN_MORE_URL",
                           "The HREF for providing more information for the demo informational"
                               + " banner.",
+                          /* isRequired= */ false,
+                          SettingType.STRING,
+                          SettingMode.ADMIN_WRITEABLE),
+                      SettingDescription.create(
+                          "DEMO_BANNER_EXPIRATION_DATE",
+                          "The expiration date for the demo instance formatted as yyyy-mm-dd.",
                           /* isRequired= */ false,
                           SettingType.STRING,
                           SettingMode.ADMIN_WRITEABLE))))

--- a/server/app/views/BaseHtmlLayout.java
+++ b/server/app/views/BaseHtmlLayout.java
@@ -5,7 +5,6 @@ import static j2html.TagCreator.a;
 import static j2html.TagCreator.br;
 import static j2html.TagCreator.button;
 import static j2html.TagCreator.div;
-import static j2html.TagCreator.h4;
 import static j2html.TagCreator.header;
 import static j2html.TagCreator.img;
 import static j2html.TagCreator.link;
@@ -16,7 +15,6 @@ import static j2html.TagCreator.script;
 import static j2html.TagCreator.section;
 import static j2html.TagCreator.span;
 import static j2html.TagCreator.strong;
-import static j2html.TagCreator.text;
 import static j2html.TagCreator.title;
 import static views.BaseHtmlView.getCsrfToken;
 
@@ -29,6 +27,11 @@ import j2html.tags.specialized.HeaderTag;
 import j2html.tags.specialized.ScriptTag;
 import j2html.tags.specialized.SectionTag;
 import j2html.tags.specialized.SpanTag;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.ChronoUnit;
 import java.util.Optional;
 import javax.inject.Inject;
 import play.i18n.Messages;
@@ -397,30 +400,123 @@ public class BaseHtmlLayout {
    */
   public DivTag getDemoBanner(Http.RequestHeader request, Messages messages) {
     Optional<String> maybeLearnMoreUrl = settingsManifest.getDemoBannerLearnMoreUrl(request);
+    String civicEntityShortName =
+        settingsManifest.getWhitelabelCivicEntityShortName(request).orElse("");
+    String title = messages.at("label.demoBanner.heading", civicEntityShortName);
 
-    DomContent textContent;
+    Optional<Long> maybeDaysRemaining =
+        getDemoBannerDaysRemainingCount(
+            settingsManifest, request, viewUtils.getDateConverter().getCurrentDateForZoneId());
+
+    ImmutableList.Builder<DomContent> bodyElements = ImmutableList.builder();
+    bodyElements.add(p(title).withClass("usa-alert__text"));
+    if (maybeDaysRemaining.isPresent()) {
+      long daysRemaining = maybeDaysRemaining.get();
+      String daysRemainingText = messages.at("banner.demoBanner.daysRemaining", daysRemaining);
+      String tagColorClass = getDemoBannerTagColorClass(daysRemaining);
+      bodyElements.add(div(span(daysRemainingText).withClasses("usa-tag", tagColorClass)));
+    }
     if (maybeLearnMoreUrl.isPresent() && !maybeLearnMoreUrl.get().isBlank()) {
       String learnMoreUrl = maybeLearnMoreUrl.get();
       ATag moreInfoLink =
           a(messages.at("banner.demoBanner.linkText"))
               .withHref(learnMoreUrl)
               .withClasses("usa-link");
-      textContent = rawHtml(messages.at("banner.demoBanner.bodyWithLink", moreInfoLink.render()));
-    } else {
-      textContent = text(messages.at("banner.demoBanner.body"));
+      DomContent textContent =
+          rawHtml(messages.at("banner.demoBanner.bodyWithLink", moreInfoLink.render()));
+      bodyElements.add(p(textContent).withClass("usa-alert__text"));
     }
 
     return div(
         section(
-                div(div(
-                            h4(messages.at("label.demoBanner.heading"))
-                                .withClass("usa-alert__heading"),
-                            p(textContent).withClass("usa-alert__text"))
+                div(div(bodyElements.build().toArray(new DomContent[0]))
                         .withClass("usa-alert__body"))
                     .withClass("usa-alert"))
             .withClasses(
-                "usa-site-alert", "usa-site-alert--info", "usa-site-alert--slim", "cf-alert")
+                "usa-site-alert",
+                "usa-site-alert--slim",
+                "usa-site-alert--no-icon",
+                "cf-alert",
+                "cf-demo-banner")
             .attr("role", "region")
             .attr("aria-label", messages.at("label.demoBanner.label")));
+  }
+
+  /**
+   * Returns the demo banner days remaining count if an expiration date is set and valid.
+   *
+   * @param settingsManifest the settings manifest to get the expiration date from
+   * @param request the current request
+   * @param currentDate the current date to calculate remaining days against
+   * @return remaining days count, or empty if missing, invalid, or negative
+   */
+  public static Optional<Long> getDemoBannerDaysRemainingCount(
+      SettingsManifest settingsManifest, Http.RequestHeader request, LocalDate currentDate) {
+    Optional<String> maybeExpirationDate = settingsManifest.getDemoBannerExpirationDate(request);
+    if (maybeExpirationDate.isEmpty() || maybeExpirationDate.get().isBlank()) {
+      return Optional.empty();
+    }
+    try {
+      LocalDate expirationDate =
+          LocalDate.parse(maybeExpirationDate.get().trim(), DateTimeFormatter.ISO_LOCAL_DATE);
+      long daysRemaining = ChronoUnit.DAYS.between(currentDate, expirationDate);
+      if (daysRemaining < 0) {
+        return Optional.empty();
+      }
+      return Optional.of(daysRemaining);
+    } catch (DateTimeParseException e) {
+      return Optional.empty();
+    }
+  }
+
+  public static Optional<Long> getDemoBannerDaysRemainingCount(
+      SettingsManifest settingsManifest, Http.RequestHeader request, ZoneId zoneId) {
+    return getDemoBannerDaysRemainingCount(settingsManifest, request, LocalDate.now(zoneId));
+  }
+
+  public static Optional<Long> getDemoBannerDaysRemainingCount(
+      SettingsManifest settingsManifest, Http.RequestHeader request) {
+    return getDemoBannerDaysRemainingCount(settingsManifest, request, ZoneId.systemDefault());
+  }
+
+  /**
+   * Returns the CSS color classes for the demo banner expiration tag.
+   *
+   * @param daysRemaining the count of remaining days
+   * @return "bg-green" if > 5 days remain, "bg-yellow text-ink" if 5 or less days remain
+   */
+  public static String getDemoBannerTagColorClass(long daysRemaining) {
+    return daysRemaining > 5 ? "bg-green" : "bg-yellow text-ink";
+  }
+
+  /**
+   * Returns the demo banner days remaining message if an expiration date is set and valid.
+   *
+   * @param settingsManifest the settings manifest to get the expiration date from
+   * @param request the current request
+   * @param messages the messages provider for localization
+   * @param currentDate the current date to calculate remaining days against
+   * @return formatted days remaining message, or empty if missing, invalid, or negative
+   */
+  public static Optional<String> getDemoBannerDaysRemaining(
+      SettingsManifest settingsManifest,
+      Http.RequestHeader request,
+      Messages messages,
+      LocalDate currentDate) {
+    return getDemoBannerDaysRemainingCount(settingsManifest, request, currentDate)
+        .map(days -> messages.at("banner.demoBanner.daysRemaining", days));
+  }
+
+  public static Optional<String> getDemoBannerDaysRemaining(
+      SettingsManifest settingsManifest,
+      Http.RequestHeader request,
+      Messages messages,
+      ZoneId zoneId) {
+    return getDemoBannerDaysRemaining(settingsManifest, request, messages, LocalDate.now(zoneId));
+  }
+
+  public static Optional<String> getDemoBannerDaysRemaining(
+      SettingsManifest settingsManifest, Http.RequestHeader request, Messages messages) {
+    return getDemoBannerDaysRemaining(settingsManifest, request, messages, ZoneId.systemDefault());
   }
 }

--- a/server/app/views/BaseHtmlLayout.java
+++ b/server/app/views/BaseHtmlLayout.java
@@ -1,9 +1,11 @@
 package views;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static j2html.TagCreator.a;
 import static j2html.TagCreator.br;
 import static j2html.TagCreator.button;
 import static j2html.TagCreator.div;
+import static j2html.TagCreator.h4;
 import static j2html.TagCreator.header;
 import static j2html.TagCreator.img;
 import static j2html.TagCreator.link;
@@ -14,11 +16,14 @@ import static j2html.TagCreator.script;
 import static j2html.TagCreator.section;
 import static j2html.TagCreator.span;
 import static j2html.TagCreator.strong;
+import static j2html.TagCreator.text;
 import static j2html.TagCreator.title;
 import static views.BaseHtmlView.getCsrfToken;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
+import j2html.tags.DomContent;
+import j2html.tags.specialized.ATag;
 import j2html.tags.specialized.DivTag;
 import j2html.tags.specialized.HeaderTag;
 import j2html.tags.specialized.ScriptTag;
@@ -383,5 +388,39 @@ public class BaseHtmlLayout {
                 ? maybeMessages.get().at(MessageKey.BANNER_TITLE.getKeyName())
                 : "This is an official government website.")
         .with(div().withClass("usa-accordion").with(bannerHeader, bannerContent));
+  }
+
+  /**
+   * Creates the demo banner which warns users that they are in a demo environment.
+   *
+   * @return a html div tag
+   */
+  public DivTag getDemoBanner(Http.RequestHeader request, Messages messages) {
+    Optional<String> maybeLearnMoreUrl = settingsManifest.getDemoBannerLearnMoreUrl(request);
+
+    DomContent textContent;
+    if (maybeLearnMoreUrl.isPresent() && !maybeLearnMoreUrl.get().isBlank()) {
+      String learnMoreUrl = maybeLearnMoreUrl.get();
+      ATag moreInfoLink =
+          a(messages.at("banner.demoBanner.linkText"))
+              .withHref(learnMoreUrl)
+              .withClasses("usa-link");
+      textContent = rawHtml(messages.at("banner.demoBanner.bodyWithLink", moreInfoLink.render()));
+    } else {
+      textContent = text(messages.at("banner.demoBanner.body"));
+    }
+
+    return div(
+        section(
+                div(div(
+                            h4(messages.at("label.demoBanner.heading"))
+                                .withClass("usa-alert__heading"),
+                            p(textContent).withClass("usa-alert__text"))
+                        .withClass("usa-alert__body"))
+                    .withClass("usa-alert"))
+            .withClasses(
+                "usa-site-alert", "usa-site-alert--info", "usa-site-alert--slim", "cf-alert")
+            .attr("role", "region")
+            .attr("aria-label", messages.at("label.demoBanner.label")));
   }
 }

--- a/server/app/views/BaseView.java
+++ b/server/app/views/BaseView.java
@@ -146,6 +146,19 @@ public abstract class BaseView<TModel extends BaseViewModel> {
     if (demoBannerEnabled) {
       context.setVariable(
           "demoBannerLearnMoreUrl", settingsManifest.getDemoBannerLearnMoreUrl(request).orElse(""));
+      String civicEntityShortName =
+          settingsManifest.getWhitelabelCivicEntityShortName(request).orElse("");
+      context.setVariable("civicEntityShortName", civicEntityShortName);
+      Optional<Long> maybeDaysRemaining =
+          BaseHtmlLayout.getDemoBannerDaysRemainingCount(settingsManifest, request);
+      context.setVariable(
+          "demoBannerDaysRemaining",
+          maybeDaysRemaining
+              .map(days -> messages.at("banner.demoBanner.daysRemaining", days))
+              .orElse(""));
+      context.setVariable(
+          "demoBannerTagColorClass",
+          maybeDaysRemaining.map(BaseHtmlLayout::getDemoBannerTagColorClass).orElse(""));
     }
 
     // This gives the Thymeleaf template a reference to this view class. Methods can be added

--- a/server/app/views/BaseView.java
+++ b/server/app/views/BaseView.java
@@ -117,6 +117,7 @@ public abstract class BaseView<TModel extends BaseViewModel> {
             .layoutType(layoutType())
             .civiformImageTag(settingsManifest.getCiviformImageTag().orElse("UNKNOWN"))
             .addNoIndexMetaTag(settingsManifest.getStagingAddNoindexMetaTag())
+            .addDemoModeBanner(settingsManifest.getDemoBannerEnabled(request))
             .favicon(FAVICON_DATAURI)
             .measurementId(settingsManifest.getMeasurementId())
             .stylesheets(getStylesheets())
@@ -139,6 +140,13 @@ public abstract class BaseView<TModel extends BaseViewModel> {
     // Set values for feature flags
     context.setVariable(
         "featureFlags", FeatureFlags.fromSettingsManifest(settingsManifest, request));
+
+    boolean demoBannerEnabled = settingsManifest.getDemoBannerEnabled(request);
+    context.setVariable("demoBannerEnabled", demoBannerEnabled);
+    if (demoBannerEnabled) {
+      context.setVariable(
+          "demoBannerLearnMoreUrl", settingsManifest.getDemoBannerLearnMoreUrl(request).orElse(""));
+    }
 
     // This gives the Thymeleaf template a reference to this view class. Methods can be added
     // to the view to aid in custom formatting. Ideally keep these to a minimum and prefer

--- a/server/app/views/HtmlBundle.java
+++ b/server/app/views/HtmlBundle.java
@@ -109,6 +109,11 @@ public final class HtmlBundle {
     return this;
   }
 
+  public HtmlBundle addHeaderStyles(String... styles) {
+    headerStyles.addAll(Arrays.asList(styles));
+    return this;
+  }
+
   public HtmlBundle addMainContent(Tag... tags) {
     mainContent.addAll(Arrays.asList(tags));
     return this;

--- a/server/app/views/ViewUtils.java
+++ b/server/app/views/ViewUtils.java
@@ -56,6 +56,10 @@ public final class ViewUtils {
     this.dateConverter = checkNotNull(dateConverter);
   }
 
+  public DateConverter getDateConverter() {
+    return dateConverter;
+  }
+
   public ImgTag makeLocalImageTag(String filename) {
     return img().withSrc(assetsFinder.path("Images/" + filename + ".png"));
   }

--- a/server/app/views/admin/AdminLayout.html
+++ b/server/app/views/admin/AdminLayout.html
@@ -80,15 +80,22 @@
   </head>
 
   <!--/* Body sets HTMX header so the CSRF token is always there */-->
+
   <body th:hx-headers='|{"CSRF-TOKEN":"${templateGlobals.csrfToken()}"}|'>
     <th:block
       th:if="${featureFlags.isAdminUiMigrationUxRedesignScEnabled()}"
       th:insert="~{admin/shared/Banner}"
-    ></th:block>
+    >
+    </th:block>
     <th:block
       th:unless="${featureFlags.isAdminUiMigrationUxRedesignScEnabled()}"
       th:insert="~{admin/shared/TransitionalAdminCommonHeader}"
     ></th:block>
+    <th:block th:if="${layoutParams.addDemoModeBanner()}">
+      <div
+        th:replace="~{applicant/shared/NavigationFragment :: demoBanner}"
+      ></div>
+    </th:block>
 
     <div
       class="cf-admin-page-wrapper spacing-0 bg-white maxw-full margin-x-auto desktop-lg:maxw-desktop-lg"
@@ -98,7 +105,8 @@
       <th:block
         th:if="${featureFlags.isAdminUiMigrationUxRedesignScEnabled()}"
         th:insert="~{admin/shared/AdminCommonHeader}"
-      ></th:block>
+      >
+      </th:block>
 
       <!--/* Heading */-->
       <section
@@ -165,12 +173,14 @@
       <th:block
         th:if="${featureFlags.isAdminUiMigrationUxRedesignScEnabled()}"
         th:insert="~{admin/shared/Footer}"
-      ></th:block>
+      >
+      </th:block>
 
       <!--/* Google Tag Manager */-->
       <th:block
         th:insert="~{components/GoogleTagManagerFragment :: tagManager(${layoutParams.measurementId()}, ${templateGlobals.cspNonce()})}"
-      ></th:block>
+      >
+      </th:block>
 
       <!--/* Scripts to be added at the end */-->
       <script

--- a/server/app/views/admin/AdminLayout.java
+++ b/server/app/views/admin/AdminLayout.java
@@ -101,6 +101,7 @@ public final class AdminLayout extends BaseHtmlLayout {
     bundle.addMainStyles(
         AdminStyles.MAIN, isCentered ? AdminStyles.MAIN_CENTERED : AdminStyles.MAIN_FULL);
     bundle.addBodyStyles(AdminStyles.BODY);
+    bundle.addHeaderStyles(AdminStyles.HEADER);
     addSessionTimeoutModals(bundle, messagesApi.preferred(bundle.getRequest()));
 
     return super.render(bundle);
@@ -181,7 +182,7 @@ public final class AdminLayout extends BaseHtmlLayout {
             .condWith(
                 settingsManifest.getDemoBannerEnabled(request),
                 getDemoBanner(request, messagesApi.preferred(request)))
-            .withClasses("position-fixed", "top-0", "width-full", "z-10");
+            .withClasses("width-full");
 
     HeaderTag headerAccordion =
         header()

--- a/server/app/views/admin/AdminLayout.java
+++ b/server/app/views/admin/AdminLayout.java
@@ -178,6 +178,9 @@ public final class AdminLayout extends BaseHtmlLayout {
             .condWith(
                 !settingsManifest.getShowNotProductionBannerEnabled(request),
                 getGovBanner(Optional.empty()))
+            .condWith(
+                settingsManifest.getDemoBannerEnabled(request),
+                getDemoBanner(request, messagesApi.preferred(request)))
             .withClasses("position-fixed", "top-0", "width-full", "z-10");
 
     HeaderTag headerAccordion =

--- a/server/app/views/admin/LegacyTailwindLayout.html
+++ b/server/app/views/admin/LegacyTailwindLayout.html
@@ -58,7 +58,7 @@
   */-->
   <!--/* Body sets HTMX header so the CSRF token is always there */-->
   <body
-    class="bg-gradient-to-r from-gray-100 via-white to-gray-100 box-border flex min-h-screen mt-5"
+    class="bg-gradient-to-r from-gray-100 via-white to-gray-100 box-border flex flex-col min-h-screen"
     th:hx-headers='|{"CSRF-TOKEN":"${templateGlobals.csrfToken()}"}|'
   >
     <!--/* Header navigation */-->
@@ -73,7 +73,7 @@
 
     <!--/* Main */-->
     <main
-      class="bg-white border border-gray-200 mt-12 shadow-lg w-screen admin-responsive-main-padding"
+      class="bg-white border border-gray-200 shadow-lg w-screen admin-responsive-main-padding"
       th:classappend="${layoutParams.isWidescreen() ? 'flex flex-row' : 'px-2 max-w-screen-2xl mx-auto'}"
     >
       <th:block

--- a/server/app/views/admin/LegacyTailwindLayout.html
+++ b/server/app/views/admin/LegacyTailwindLayout.html
@@ -65,6 +65,11 @@
     <th:block
       th:insert="~{admin/shared/TransitionalAdminCommonHeader}"
     ></th:block>
+    <th:block th:if="${layoutParams.addDemoModeBanner()}">
+      <div
+        th:replace="~{applicant/shared/NavigationFragment :: demoBanner}"
+      ></div>
+    </th:block>
 
     <!--/* Main */-->
     <main

--- a/server/app/views/admin/TransitionalLayout.html
+++ b/server/app/views/admin/TransitionalLayout.html
@@ -52,6 +52,7 @@
   </head>
 
   <!--/* Body sets HTMX header so the CSRF token is always there */-->
+
   <body
     class="display-flex minh-viewport body-background-gradient"
     th:hx-headers='|{"CSRF-TOKEN":"${templateGlobals.csrfToken()}"}|'
@@ -60,6 +61,11 @@
     <th:block
       th:insert="~{admin/shared/TransitionalAdminCommonHeader}"
     ></th:block>
+    <th:block th:if="${layoutParams.addDemoModeBanner()}">
+      <div
+        th:replace="~{applicant/shared/NavigationFragment :: demoBanner}"
+      ></div>
+    </th:block>
 
     <!--/* Main */-->
     <main
@@ -74,7 +80,8 @@
     <!--/* Google Tag Manager */-->
     <th:block
       th:insert="~{components/GoogleTagManagerFragment :: tagManager(${layoutParams.measurementId()}, ${templateGlobals.cspNonce()})}"
-    ></th:block>
+    >
+    </th:block>
 
     <!--/* Scripts to be added at the end */-->
     <script

--- a/server/app/views/admin/TransitionalLayout.html
+++ b/server/app/views/admin/TransitionalLayout.html
@@ -52,9 +52,8 @@
   </head>
 
   <!--/* Body sets HTMX header so the CSRF token is always there */-->
-
   <body
-    class="display-flex minh-viewport body-background-gradient"
+    class="display-flex flex-column minh-viewport body-background-gradient"
     th:hx-headers='|{"CSRF-TOKEN":"${templateGlobals.csrfToken()}"}|'
   >
     <!--/* Header navigation */-->
@@ -80,8 +79,7 @@
     <!--/* Google Tag Manager */-->
     <th:block
       th:insert="~{components/GoogleTagManagerFragment :: tagManager(${layoutParams.measurementId()}, ${templateGlobals.cspNonce()})}"
-    >
-    </th:block>
+    ></th:block>
 
     <!--/* Scripts to be added at the end */-->
     <script

--- a/server/app/views/admin/shared/TransitionalAdminCommonHeader.html
+++ b/server/app/views/admin/shared/TransitionalAdminCommonHeader.html
@@ -1,7 +1,10 @@
 <!--/*@thymesVar id="adminCommonHeader" type="views.admin.shared.AdminCommonHeader"*/-->
 <th:block xmlns:cf="https://civiform.us/2024/html/icon">
-  <header aria-label="Site navigation" class="z-10">
-    <nav class="position-fixed top-0 width-full z-10">
+  <header
+    aria-label="Site navigation"
+    class="position-sticky sticky top-0 z-10 width-full"
+  >
+    <nav class="width-full">
       <section
         class="usa-banner cf-admin-heading-background-color"
         aria-label="This is an official government website."

--- a/server/app/views/applicant/ApplicantBaseView.java
+++ b/server/app/views/applicant/ApplicantBaseView.java
@@ -173,6 +173,13 @@ public abstract class ApplicantBaseView {
 
     context.setVariable("isDevOrStaging", isDevOrStaging);
 
+    boolean demoBannerEnabled = settingsManifest.getDemoBannerEnabled(request);
+    context.setVariable("demoBannerEnabled", demoBannerEnabled);
+    if (demoBannerEnabled) {
+      context.setVariable(
+          "demoBannerLearnMoreUrl", settingsManifest.getDemoBannerLearnMoreUrl(request).orElse(""));
+    }
+
     maybeSetUpNotProductionBanner(context, request, messages);
     boolean sessionTimeoutEnabled = settingsManifest.getSessionTimeoutEnabled();
     context.setVariable("sessionTimeoutEnabled", sessionTimeoutEnabled);

--- a/server/app/views/applicant/ApplicantBaseView.java
+++ b/server/app/views/applicant/ApplicantBaseView.java
@@ -25,6 +25,7 @@ import services.DeploymentType;
 import services.MessageKey;
 import services.applicant.ApplicantPersonalInfo;
 import services.settings.SettingsManifest;
+import views.BaseHtmlLayout;
 import views.CspUtil;
 import views.components.Icons;
 import views.html.helper.CSRF;
@@ -178,6 +179,19 @@ public abstract class ApplicantBaseView {
     if (demoBannerEnabled) {
       context.setVariable(
           "demoBannerLearnMoreUrl", settingsManifest.getDemoBannerLearnMoreUrl(request).orElse(""));
+      String civicEntityShortName =
+          settingsManifest.getWhitelabelCivicEntityShortName(request).orElse("");
+      context.setVariable("civicEntityShortName", civicEntityShortName);
+      Optional<Long> maybeDaysRemaining =
+          BaseHtmlLayout.getDemoBannerDaysRemainingCount(settingsManifest, request);
+      context.setVariable(
+          "demoBannerDaysRemaining",
+          maybeDaysRemaining
+              .map(days -> messages.at("banner.demoBanner.daysRemaining", days))
+              .orElse(""));
+      context.setVariable(
+          "demoBannerTagColorClass",
+          maybeDaysRemaining.map(BaseHtmlLayout::getDemoBannerTagColorClass).orElse(""));
     }
 
     maybeSetUpNotProductionBanner(context, request, messages);

--- a/server/app/views/applicant/shared/NavigationFragment.html
+++ b/server/app/views/applicant/shared/NavigationFragment.html
@@ -1,5 +1,8 @@
 <!--/*@thymesVar id="demoBannerEnabled" type="boolean"*/-->
 <!--/*@thymesVar id="demoBannerLearnMoreUrl" type=""*/-->
+<!--/*@thymesVar id="demoBannerDaysRemaining" type=""*/-->
+<!--/*@thymesVar id="demoBannerTagColorClass" type=""*/-->
+<!--/*@thymesVar id="civicEntityShortName" type=""*/-->
 <!--/*@thymesVar id="immigrationStatusInfoBannerEnabled" type="boolean"*/-->
 <!--/*@thymesVar id="immigrationStatusInfoBannerLearnMoreUrl" type=""*/-->
 <th:block th:fragment="pageHeader">
@@ -234,27 +237,28 @@
 </section>
 <div th:fragment="demoBanner" th:if="${demoBannerEnabled}">
   <section
-    class="usa-site-alert usa-site-alert--info usa-site-alert--slim cf-alert"
+    class="usa-site-alert usa-site-alert--slim usa-site-alert--no-icon cf-alert cf-demo-banner"
     role="region"
     th:aria-label="#{label.demoBanner.label}"
   >
     <div class="usa-alert">
       <div class="usa-alert__body">
-        <h4
-          class="usa-alert__heading"
-          th:text="#{label.demoBanner.heading}"
-        ></h4>
+        <p
+          class="usa-alert__text"
+          th:text="#{label.demoBanner.heading(${civicEntityShortName})}"
+        ></p>
+        <div th:if="${demoBannerDaysRemaining != ''}">
+          <span
+            th:class="|usa-tag ${demoBannerTagColorClass}|"
+            th:text="${demoBannerDaysRemaining}"
+          ></span>
+        </div>
         <!-- Only display the 'learn more here' url if one is provided by CiviForm admins -->
         <p
           th:if="${demoBannerLearnMoreUrl != ''}"
           class="usa-alert__text"
           th:with="moreInfoUrl='<a class=\'usa-link\' href=\'' + ${demoBannerLearnMoreUrl} + '\'>' + #{banner.demoBanner.linkText} + '</a>'"
           th:utext="#{banner.demoBanner.bodyWithLink(${moreInfoUrl})}"
-        ></p>
-        <p
-          th:if="${demoBannerLearnMoreUrl == ''}"
-          class="usa-alert__text"
-          th:text="#{banner.demoBanner.body}"
         ></p>
       </div>
     </div>

--- a/server/app/views/applicant/shared/NavigationFragment.html
+++ b/server/app/views/applicant/shared/NavigationFragment.html
@@ -1,3 +1,5 @@
+<!--/*@thymesVar id="demoBannerEnabled" type="boolean"*/-->
+<!--/*@thymesVar id="demoBannerLearnMoreUrl" type=""*/-->
 <!--/*@thymesVar id="immigrationStatusInfoBannerEnabled" type="boolean"*/-->
 <!--/*@thymesVar id="immigrationStatusInfoBannerLearnMoreUrl" type=""*/-->
 <th:block th:fragment="pageHeader">
@@ -9,6 +11,9 @@
   <div th:unless="${showNotProductionBannerEnabled}">
     <div th:replace="~{this :: officialGovermentWebsiteBanner}"></div>
   </div>
+  <th:block th:if="${demoBannerEnabled}">
+    <div th:replace="~{this :: demoBanner}"></div>
+  </th:block>
   <!--/* The immigration status info banner is only shown on the program index page,
   so all immigration status info banner variables are only set in ProgramIndexView and are unset otherwise. */-->
   <th:block
@@ -227,6 +232,34 @@
     </div>
   </div>
 </section>
+<div th:fragment="demoBanner" th:if="${demoBannerEnabled}">
+  <section
+    class="usa-site-alert usa-site-alert--info usa-site-alert--slim cf-alert"
+    role="region"
+    th:aria-label="#{label.demoBanner.label}"
+  >
+    <div class="usa-alert">
+      <div class="usa-alert__body">
+        <h4
+          class="usa-alert__heading"
+          th:text="#{label.demoBanner.heading}"
+        ></h4>
+        <!-- Only display the 'learn more here' url if one is provided by CiviForm admins -->
+        <p
+          th:if="${demoBannerLearnMoreUrl != ''}"
+          class="usa-alert__text"
+          th:with="moreInfoUrl='<a class=\'usa-link\' href=\'' + ${demoBannerLearnMoreUrl} + '\'>' + #{banner.demoBanner.linkText} + '</a>'"
+          th:utext="#{banner.demoBanner.bodyWithLink(${moreInfoUrl})}"
+        ></p>
+        <p
+          th:if="${demoBannerLearnMoreUrl == ''}"
+          class="usa-alert__text"
+          th:text="#{banner.demoBanner.body}"
+        ></p>
+      </div>
+    </div>
+  </section>
+</div>
 <div
   th:fragment="immigrationStatusInfoBanner"
   th:if="${immigrationStatusInfoBannerEnabled}"

--- a/server/app/views/shared/LayoutParams.java
+++ b/server/app/views/shared/LayoutParams.java
@@ -14,6 +14,7 @@ import views.LayoutType;
  * @param layoutType Determines if the layout has an aside
  * @param civiformImageTag Docker image tag for the running container
  * @param addNoIndexMetaTag Include robots meta tag
+ * @param addDemoModeBanner Include demo mode banner
  * @param favicon Link to the favicon
  * @param measurementId Measurement ID used by tracking service, i.e. Google Analytics
  * @param stylesheets List of stylesheets
@@ -27,6 +28,7 @@ public record LayoutParams(
     LayoutType layoutType,
     String civiformImageTag,
     Boolean addNoIndexMetaTag,
+    Boolean addDemoModeBanner,
     String favicon,
     Optional<String> measurementId,
     ImmutableList<String> stylesheets,

--- a/server/app/views/style/AdminStyles.java
+++ b/server/app/views/style/AdminStyles.java
@@ -38,7 +38,7 @@ public final class AdminStyles {
           StyleUtils.hover("bg-gray-200", "text-gray-900"));
 
   public static final String BODY =
-      StyleUtils.joinStyles(BODY_GRADIENT_STYLE, "box-border", "flex", "min-h-screen", "mt-5");
+      StyleUtils.joinStyles(BODY_GRADIENT_STYLE, "box-border", "flex", "flex-col", "min-h-screen");
 
   public static final String MAIN_CENTERED =
       StyleUtils.joinStyles("px-2", "max-w-screen-2xl", "mx-auto");
@@ -50,10 +50,12 @@ public final class AdminStyles {
           "bg-white",
           "border",
           "border-gray-200",
-          "mt-12",
           "shadow-lg",
           "w-screen",
           "admin-responsive-main-padding");
+
+  public static final String HEADER =
+      StyleUtils.joinStyles("position-sticky", "sticky", "top-0", "z-10", "width-full");
 
   public static final String HEADER_BUTTON_STYLES =
       StyleUtils.joinStyles(ButtonStyles.OUTLINED_WHITE_WITH_ICON, "my-5", "mr-2");

--- a/server/app/views/trustedintermediary/ApplicantLayout.java
+++ b/server/app/views/trustedintermediary/ApplicantLayout.java
@@ -230,6 +230,7 @@ public class ApplicantLayout extends BaseHtmlLayout {
         .condWith(
             !settingsManifest.getShowNotProductionBannerEnabled(request),
             getGovBanner(Optional.of(messages)))
+        .condWith(settingsManifest.getDemoBannerEnabled(request), getDemoBanner(request, messages))
         .with(
             div()
                 .withClasses(

--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -689,3 +689,7 @@ session_inactivity_warning_threshold_minutes = ${?SESSION_INACTIVITY_WARNING_THR
 # URL linked in the immigration status informational banner that applicants can click to learn more about how immigration data is used
 immigration_status_info_banner_learn_more_url = ""
 immigration_status_info_banner_learn_more_url = ${?IMMIGRATION_STATUS_INFO_BANNER_LEARN_MORE_URL}
+
+# URL linked in the demo banner that users can click to learn more about the demo environment
+demo_banner_learn_more_url = ""
+demo_banner_learn_more_url = ${?DEMO_BANNER_LEARN_MORE_URL}

--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -693,3 +693,8 @@ immigration_status_info_banner_learn_more_url = ${?IMMIGRATION_STATUS_INFO_BANNE
 # URL linked in the demo banner that users can click to learn more about the demo environment
 demo_banner_learn_more_url = ""
 demo_banner_learn_more_url = ${?DEMO_BANNER_LEARN_MORE_URL}
+
+# Expiration date for the demo banner formatted as yyyy-mm-dd
+demo_banner_expiration_date = ""
+demo_banner_expiration_date = ${?DEMO_BANNER_EXPIRATION_DATE}
+

--- a/server/conf/env-var-docs.json
+++ b/server/conf/env-var-docs.json
@@ -691,6 +691,11 @@
         "mode": "ADMIN_WRITEABLE",
         "description": "The HREF for providing more information for the demo informational banner.",
         "type": "string"
+      },
+      "DEMO_BANNER_EXPIRATION_DATE": {
+        "mode": "ADMIN_WRITEABLE",
+        "description": "The expiration date for the demo instance formatted as yyyy-mm-dd.",
+        "type": "string"
       }
     }
   },

--- a/server/conf/env-var-docs.json
+++ b/server/conf/env-var-docs.json
@@ -686,6 +686,11 @@
         "mode": "ADMIN_WRITEABLE",
         "description": "The HREF for providing more information for the immigration status informational banner.",
         "type": "string"
+      },
+      "DEMO_BANNER_LEARN_MORE_URL": {
+        "mode": "ADMIN_WRITEABLE",
+        "description": "The HREF for providing more information for the demo informational banner.",
+        "type": "string"
       }
     }
   },
@@ -943,6 +948,12 @@
       "IMMIGRATION_STATUS_INFO_BANNER_ENABLED": {
         "mode": "ADMIN_WRITEABLE",
         "description": "Enable showing an immigration status informational banner to applicants.",
+        "type": "bool",
+        "required": false
+      },
+      "DEMO_BANNER_ENABLED": {
+        "mode": "ADMIN_WRITEABLE",
+        "description": "Enable showing a demo informational banner to applicants and admins.",
         "type": "bool",
         "required": false
       },

--- a/server/conf/helper/feature-flags.conf
+++ b/server/conf/helper/feature-flags.conf
@@ -87,6 +87,10 @@ admin_ui_migration_ux_redesign_sc_enabled = ${?ADMIN_UI_MIGRATION_UX_REDESIGN_SC
 immigration_status_info_banner_enabled = false
 immigration_status_info_banner_enabled = ${?IMMIGRATION_STATUS_INFO_BANNER_ENABLED}
 
+# Enables a demo mode informational banner
+demo_banner_enabled = false
+demo_banner_enabled = ${?DEMO_BANNER_ENABLED}
+
 # Enable the new applicant-guest merging strategy
 new_applicant_guest_merging_strategy_enabled = false
 new_applicant_guest_merging_strategy_enabled = ${?NEW_APPLICANT_GUEST_MERGING_STRATEGY_ENABLED}

--- a/server/conf/i18n/messages
+++ b/server/conf/i18n/messages
@@ -1122,15 +1122,15 @@ banner.immigrationStatusInfoBanner.linkText=here
 #------------------------------------------------------------------------------#
 
 # Header for demo banner alert
-label.demoBanner.heading=This is a demo site
+label.demoBanner.heading=Demo: {0}
 # Aria-label for demo banner alert
 label.demoBanner.label=Demo mode informational alert
-# Text in the demo banner explaining that this is a demo environment when no learn more link is configured
-banner.demoBanner.body=Do not enter actual or personal data in this demo site.
-# Text in the demo banner explaining that this is a demo environment - the placeholder says 'here' and is a link to more information
-banner.demoBanner.bodyWithLink=Do not enter actual or personal data in this demo site. You can learn more {0}.
+# Text in the demo banner explaining how to learn more - the placeholder says 'here' and is a link to more information
+banner.demoBanner.bodyWithLink=You can learn more {0}.
 # Link for more info about the demo banner
 banner.demoBanner.linkText=here
+# Count of remaining days for the demo environment
+banner.demoBanner.daysRemaining={0} days remaining
 
 #------------------------------------------------------------------------------#
 # CATEGORIES - tags that admins can choose to specify the type of program #

--- a/server/conf/i18n/messages
+++ b/server/conf/i18n/messages
@@ -1118,6 +1118,21 @@ banner.immigrationStatusInfoBanner.bodyWithLink=We will not ask about your citiz
 banner.immigrationStatusInfoBanner.linkText=here
 
 #------------------------------------------------------------------------------#
+# DEMO BANNER - alert explaining that this is a demo environment               #
+#------------------------------------------------------------------------------#
+
+# Header for demo banner alert
+label.demoBanner.heading=This is a demo site
+# Aria-label for demo banner alert
+label.demoBanner.label=Demo mode informational alert
+# Text in the demo banner explaining that this is a demo environment when no learn more link is configured
+banner.demoBanner.body=Do not enter actual or personal data in this demo site.
+# Text in the demo banner explaining that this is a demo environment - the placeholder says 'here' and is a link to more information
+banner.demoBanner.bodyWithLink=Do not enter actual or personal data in this demo site. You can learn more {0}.
+# Link for more info about the demo banner
+banner.demoBanner.linkText=here
+
+#------------------------------------------------------------------------------#
 # CATEGORIES - tags that admins can choose to specify the type of program #
 # Note for developers: these messages aren't used in static text, but instead they #
 #  are seeded into the database, since these will be admin defined in the future #

--- a/server/test/views/BaseHtmlLayoutTest.java
+++ b/server/test/views/BaseHtmlLayoutTest.java
@@ -26,7 +26,8 @@ public class BaseHtmlLayoutTest extends ResetPostgres {
           "base_url", "http://localhost",
           "staging_hostname", "localhost",
           "civiform_image_tag", "image",
-          "favicon_url", "favicon");
+          "favicon_url", "favicon",
+          "whitelabel_civic_entity_short_name", "TestCity");
 
   private BaseHtmlLayout layout;
 
@@ -130,14 +131,19 @@ public class BaseHtmlLayoutTest extends ResetPostgres {
   }
 
   @Test
-  public void getDemoBanner_returnsBannerWithHeadingAndBody() {
+  public void getDemoBanner_returnsBannerWithTitle() {
     play.i18n.Messages messages = instanceOf(play.i18n.MessagesApi.class).preferred(fakeRequest());
     j2html.tags.specialized.DivTag banner = layout.getDemoBanner(fakeRequest(), messages);
 
     String rendered = banner.render();
-    assertThat(rendered).contains("This is a demo site");
+    assertThat(rendered).contains("Demo: TestCity");
     assertThat(rendered).contains("Demo mode informational alert");
-    assertThat(rendered).contains("Do not enter actual or personal data in this demo site.");
+    assertThat(rendered).doesNotContain("Do not enter actual or personal data in this demo site.");
+    assertThat(rendered).contains("usa-site-alert--slim");
+    assertThat(rendered).contains("usa-site-alert--no-icon");
+    assertThat(rendered).contains("cf-demo-banner");
+    assertThat(rendered).doesNotContain("usa-alert__heading");
+    assertThat(rendered).doesNotContain("usa-tag");
   }
 
   @Test
@@ -155,8 +161,160 @@ public class BaseHtmlLayoutTest extends ResetPostgres {
     j2html.tags.specialized.DivTag banner = layout.getDemoBanner(fakeRequest(), messages);
 
     String rendered = banner.render();
-    assertThat(rendered).contains("This is a demo site");
+    assertThat(rendered).contains("Demo: TestCity");
     assertThat(rendered).contains("https://example.com/demo-info");
     assertThat(rendered).contains("here");
+    assertThat(rendered).contains("You can learn more");
+    assertThat(rendered).doesNotContain("Do not enter actual or personal data in this demo site.");
+  }
+
+  @Test
+  public void getDemoBanner_withMoreThan5DaysRemaining_containsGreenTag() {
+    java.time.LocalDate futureDate =
+        java.time.LocalDate.now(java.time.ZoneId.systemDefault()).plusDays(7);
+    HashMap<String, String> config = new HashMap<>(DEFAULT_CONFIG);
+    config.put(
+        "demo_banner_expiration_date",
+        futureDate.format(java.time.format.DateTimeFormatter.ISO_LOCAL_DATE));
+    layout =
+        new BaseHtmlLayout(
+            instanceOf(ViewUtils.class),
+            new SettingsManifest(ConfigFactory.parseMap(config)),
+            instanceOf(DeploymentType.class),
+            instanceOf(BundledAssetsFinder.class));
+
+    play.i18n.Messages messages = instanceOf(play.i18n.MessagesApi.class).preferred(fakeRequest());
+    j2html.tags.specialized.DivTag banner = layout.getDemoBanner(fakeRequest(), messages);
+
+    String rendered = banner.render();
+    assertThat(rendered).contains("Demo: TestCity");
+    assertThat(rendered).contains("usa-tag bg-green");
+    assertThat(rendered).contains("7 days remaining");
+  }
+
+  @Test
+  public void getDemoBanner_with5OrLessDaysRemaining_containsYellowTag() {
+    java.time.LocalDate futureDate =
+        java.time.LocalDate.now(java.time.ZoneId.systemDefault()).plusDays(3);
+    HashMap<String, String> config = new HashMap<>(DEFAULT_CONFIG);
+    config.put(
+        "demo_banner_expiration_date",
+        futureDate.format(java.time.format.DateTimeFormatter.ISO_LOCAL_DATE));
+    layout =
+        new BaseHtmlLayout(
+            instanceOf(ViewUtils.class),
+            new SettingsManifest(ConfigFactory.parseMap(config)),
+            instanceOf(DeploymentType.class),
+            instanceOf(BundledAssetsFinder.class));
+
+    play.i18n.Messages messages = instanceOf(play.i18n.MessagesApi.class).preferred(fakeRequest());
+    j2html.tags.specialized.DivTag banner = layout.getDemoBanner(fakeRequest(), messages);
+
+    String rendered = banner.render();
+    assertThat(rendered).contains("Demo: TestCity");
+    assertThat(rendered).contains("usa-tag bg-yellow text-ink");
+    assertThat(rendered).contains("3 days remaining");
+  }
+
+  @Test
+  public void getDemoBanner_withPastExpirationDate_doesNotMentionExpiration() {
+    java.time.LocalDate pastDate =
+        java.time.LocalDate.now(java.time.ZoneId.systemDefault()).minusDays(2);
+    HashMap<String, String> config = new HashMap<>(DEFAULT_CONFIG);
+    config.put(
+        "demo_banner_expiration_date",
+        pastDate.format(java.time.format.DateTimeFormatter.ISO_LOCAL_DATE));
+    layout =
+        new BaseHtmlLayout(
+            instanceOf(ViewUtils.class),
+            new SettingsManifest(ConfigFactory.parseMap(config)),
+            instanceOf(DeploymentType.class),
+            instanceOf(BundledAssetsFinder.class));
+
+    play.i18n.Messages messages = instanceOf(play.i18n.MessagesApi.class).preferred(fakeRequest());
+    j2html.tags.specialized.DivTag banner = layout.getDemoBanner(fakeRequest(), messages);
+
+    String rendered = banner.render();
+    assertThat(rendered).contains("Demo: TestCity");
+    assertThat(rendered).doesNotContain("usa-tag");
+    assertThat(rendered).doesNotContain("days remaining");
+  }
+
+  @Test
+  public void getDemoBanner_withInvalidExpirationDate_doesNotMentionExpiration() {
+    HashMap<String, String> config = new HashMap<>(DEFAULT_CONFIG);
+    config.put("demo_banner_expiration_date", "not-a-valid-date");
+    layout =
+        new BaseHtmlLayout(
+            instanceOf(ViewUtils.class),
+            new SettingsManifest(ConfigFactory.parseMap(config)),
+            instanceOf(DeploymentType.class),
+            instanceOf(BundledAssetsFinder.class));
+
+    play.i18n.Messages messages = instanceOf(play.i18n.MessagesApi.class).preferred(fakeRequest());
+    j2html.tags.specialized.DivTag banner = layout.getDemoBanner(fakeRequest(), messages);
+
+    String rendered = banner.render();
+    assertThat(rendered).contains("Demo: TestCity");
+    assertThat(rendered).doesNotContain("usa-tag");
+    assertThat(rendered).doesNotContain("days remaining");
+  }
+
+  @Test
+  public void getDemoBannerTagColorClass_returnsExpectedColor() {
+    assertThat(BaseHtmlLayout.getDemoBannerTagColorClass(6)).isEqualTo("bg-green");
+    assertThat(BaseHtmlLayout.getDemoBannerTagColorClass(5)).isEqualTo("bg-yellow text-ink");
+    assertThat(BaseHtmlLayout.getDemoBannerTagColorClass(0)).isEqualTo("bg-yellow text-ink");
+  }
+
+  @Test
+  public void getDemoBannerDaysRemaining_returnsExpectedValues() {
+    play.i18n.Messages messages = instanceOf(play.i18n.MessagesApi.class).preferred(fakeRequest());
+    java.time.LocalDate fixedToday = java.time.LocalDate.of(2026, 9, 1);
+
+    // Future date
+    SettingsManifest futureManifest =
+        new SettingsManifest(
+            ConfigFactory.parseMap(ImmutableMap.of("demo_banner_expiration_date", "2026-09-06")));
+    assertThat(
+            BaseHtmlLayout.getDemoBannerDaysRemaining(
+                futureManifest, fakeRequest(), messages, fixedToday))
+        .contains("5 days remaining");
+
+    // Same day (0 days)
+    SettingsManifest todayManifest =
+        new SettingsManifest(
+            ConfigFactory.parseMap(ImmutableMap.of("demo_banner_expiration_date", "2026-09-01")));
+    assertThat(
+            BaseHtmlLayout.getDemoBannerDaysRemaining(
+                todayManifest, fakeRequest(), messages, fixedToday))
+        .contains("0 days remaining");
+
+    // Past date (negative)
+    SettingsManifest pastManifest =
+        new SettingsManifest(
+            ConfigFactory.parseMap(ImmutableMap.of("demo_banner_expiration_date", "2026-08-31")));
+    assertThat(
+            BaseHtmlLayout.getDemoBannerDaysRemaining(
+                pastManifest, fakeRequest(), messages, fixedToday))
+        .isEmpty();
+
+    // Invalid date format
+    SettingsManifest invalidManifest =
+        new SettingsManifest(
+            ConfigFactory.parseMap(ImmutableMap.of("demo_banner_expiration_date", "2026/09/06")));
+    assertThat(
+            BaseHtmlLayout.getDemoBannerDaysRemaining(
+                invalidManifest, fakeRequest(), messages, fixedToday))
+        .isEmpty();
+
+    // Blank date
+    SettingsManifest blankManifest =
+        new SettingsManifest(
+            ConfigFactory.parseMap(ImmutableMap.of("demo_banner_expiration_date", "  ")));
+    assertThat(
+            BaseHtmlLayout.getDemoBannerDaysRemaining(
+                blankManifest, fakeRequest(), messages, fixedToday))
+        .isEmpty();
   }
 }

--- a/server/test/views/BaseHtmlLayoutTest.java
+++ b/server/test/views/BaseHtmlLayoutTest.java
@@ -128,4 +128,35 @@ public class BaseHtmlLayoutTest extends ResetPostgres {
     String contentDiv = String.format("<div class=\"%s", "usa-banner__content");
     assertThat(banner.render()).contains(contentDiv);
   }
+
+  @Test
+  public void getDemoBanner_returnsBannerWithHeadingAndBody() {
+    play.i18n.Messages messages = instanceOf(play.i18n.MessagesApi.class).preferred(fakeRequest());
+    j2html.tags.specialized.DivTag banner = layout.getDemoBanner(fakeRequest(), messages);
+
+    String rendered = banner.render();
+    assertThat(rendered).contains("This is a demo site");
+    assertThat(rendered).contains("Demo mode informational alert");
+    assertThat(rendered).contains("Do not enter actual or personal data in this demo site.");
+  }
+
+  @Test
+  public void getDemoBanner_withLearnMoreUrl_containsLink() {
+    HashMap<String, String> config = new HashMap<>(DEFAULT_CONFIG);
+    config.put("demo_banner_learn_more_url", "https://example.com/demo-info");
+    layout =
+        new BaseHtmlLayout(
+            instanceOf(ViewUtils.class),
+            new SettingsManifest(ConfigFactory.parseMap(config)),
+            instanceOf(DeploymentType.class),
+            instanceOf(BundledAssetsFinder.class));
+
+    play.i18n.Messages messages = instanceOf(play.i18n.MessagesApi.class).preferred(fakeRequest());
+    j2html.tags.specialized.DivTag banner = layout.getDemoBanner(fakeRequest(), messages);
+
+    String rendered = banner.render();
+    assertThat(rendered).contains("This is a demo site");
+    assertThat(rendered).contains("https://example.com/demo-info");
+    assertThat(rendered).contains("here");
+  }
 }

--- a/server/test/views/HtmlBundleTest.java
+++ b/server/test/views/HtmlBundleTest.java
@@ -152,4 +152,18 @@ public class HtmlBundleTest extends ResetPostgres {
 
     assertThat(html).doesNotContain("<div id=\"uswds-modal-container\"></div>");
   }
+
+  @Test
+  public void testAddHeaderStyles() {
+    HtmlBundle bundle = new HtmlBundle(fakeRequest());
+    bundle
+        .addHeaderStyles("position-sticky", "top-0", "z-10")
+        .setJsBundle(JsBundle.ADMIN)
+        .setBundledAssetsFinder(bundledAssetsFinder);
+
+    Content content = bundle.render();
+    String html = content.body();
+
+    assertThat(html).contains("<header class=\"position-sticky top-0 z-10\">");
+  }
 }

--- a/server/test/views/admin/AdminLayoutBaseViewTest.java
+++ b/server/test/views/admin/AdminLayoutBaseViewTest.java
@@ -1,13 +1,19 @@
 package views.admin;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static support.FakeRequestBuilder.fakeRequest;
 
 import controllers.WithMockedProfiles;
+import java.util.Optional;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 import play.i18n.Messages;
+import services.settings.SettingsManifest;
 import views.BaseViewModel;
+import views.shared.BaseViewDeps;
 import views.shared.LayoutDeps;
 
 public class AdminLayoutBaseViewTest extends WithMockedProfiles {
@@ -34,6 +40,21 @@ public class AdminLayoutBaseViewTest extends WithMockedProfiles {
 
   private CustomView createView(String pageTemplate) {
     return new CustomView(instanceOf(LayoutDeps.class), pageTemplate);
+  }
+
+  private CustomView createViewWithSettings(
+      String pageTemplate, SettingsManifest settingsManifest) {
+    LayoutDeps defaultDeps = instanceOf(LayoutDeps.class);
+    BaseViewDeps baseViewDeps =
+        new BaseViewDeps(
+            defaultDeps.baseViewDeps().templateEngine(),
+            defaultDeps.baseViewDeps().playThymeleafContextFactory(),
+            settingsManifest,
+            defaultDeps.baseViewDeps().messagesApi(),
+            defaultDeps.baseViewDeps().environment());
+    LayoutDeps layoutDeps =
+        new LayoutDeps(baseViewDeps, defaultDeps.bundledAssetsFinder(), defaultDeps.profileUtils());
+    return new CustomView(layoutDeps, pageTemplate);
   }
 
   @Before
@@ -76,5 +97,61 @@ public class AdminLayoutBaseViewTest extends WithMockedProfiles {
     assertThat(result).contains("page-title-1");
     assertThat(result).contains("page-content-1");
     assertThat(result).doesNotContain("page-scripts-1");
+  }
+
+  @Test
+  public void render_demoBanner_whenDisabled_doesNotContainDemoBanner() {
+    SettingsManifest settingsManifest = mock(SettingsManifest.class);
+    when(settingsManifest.getCiviformImageTag()).thenReturn(Optional.of("civiform-image-tag"));
+    when(settingsManifest.getFaviconUrl()).thenReturn(Optional.of("favicon-url"));
+    when(settingsManifest.getDemoBannerEnabled(Mockito.any())).thenReturn(false);
+
+    CustomView customView =
+        createViewWithSettings(
+            "../../test/views/admin/testTemplateWithoutScriptBlock.html", settingsManifest);
+
+    String result = customView.render(fakeRequest(), new CustomViewModel());
+
+    assertThat(result).doesNotContain("This is a demo site");
+    assertThat(result).doesNotContain("Demo mode informational alert");
+  }
+
+  @Test
+  public void render_demoBanner_whenEnabled_containsDemoBanner() {
+    SettingsManifest settingsManifest = mock(SettingsManifest.class);
+    when(settingsManifest.getCiviformImageTag()).thenReturn(Optional.of("civiform-image-tag"));
+    when(settingsManifest.getFaviconUrl()).thenReturn(Optional.of("favicon-url"));
+    when(settingsManifest.getDemoBannerEnabled(Mockito.any())).thenReturn(true);
+    when(settingsManifest.getDemoBannerLearnMoreUrl(Mockito.any())).thenReturn(Optional.empty());
+
+    CustomView customView =
+        createViewWithSettings(
+            "../../test/views/admin/testTemplateWithoutScriptBlock.html", settingsManifest);
+
+    String result = customView.render(fakeRequest(), new CustomViewModel());
+
+    assertThat(result).contains("This is a demo site");
+    assertThat(result).contains("Demo mode informational alert");
+    assertThat(result).contains("Do not enter actual or personal data in this demo site.");
+  }
+
+  @Test
+  public void render_demoBanner_whenEnabledWithLearnMoreUrl_containsLearnMoreUrl() {
+    SettingsManifest settingsManifest = mock(SettingsManifest.class);
+    when(settingsManifest.getCiviformImageTag()).thenReturn(Optional.of("civiform-image-tag"));
+    when(settingsManifest.getFaviconUrl()).thenReturn(Optional.of("favicon-url"));
+    when(settingsManifest.getDemoBannerEnabled(Mockito.any())).thenReturn(true);
+    when(settingsManifest.getDemoBannerLearnMoreUrl(Mockito.any()))
+        .thenReturn(Optional.of("https://example.com/demo-learn-more"));
+
+    CustomView customView =
+        createViewWithSettings(
+            "../../test/views/admin/testTemplateWithoutScriptBlock.html", settingsManifest);
+
+    String result = customView.render(fakeRequest(), new CustomViewModel());
+
+    assertThat(result).contains("This is a demo site");
+    assertThat(result).contains("https://example.com/demo-learn-more");
+    assertThat(result).contains("here");
   }
 }

--- a/server/test/views/admin/AdminLayoutBaseViewTest.java
+++ b/server/test/views/admin/AdminLayoutBaseViewTest.java
@@ -112,7 +112,7 @@ public class AdminLayoutBaseViewTest extends WithMockedProfiles {
 
     String result = customView.render(fakeRequest(), new CustomViewModel());
 
-    assertThat(result).doesNotContain("This is a demo site");
+    assertThat(result).doesNotContain("Demo: TestCity");
     assertThat(result).doesNotContain("Demo mode informational alert");
   }
 
@@ -121,6 +121,8 @@ public class AdminLayoutBaseViewTest extends WithMockedProfiles {
     SettingsManifest settingsManifest = mock(SettingsManifest.class);
     when(settingsManifest.getCiviformImageTag()).thenReturn(Optional.of("civiform-image-tag"));
     when(settingsManifest.getFaviconUrl()).thenReturn(Optional.of("favicon-url"));
+    when(settingsManifest.getWhitelabelCivicEntityShortName(Mockito.any()))
+        .thenReturn(Optional.of("TestCity"));
     when(settingsManifest.getDemoBannerEnabled(Mockito.any())).thenReturn(true);
     when(settingsManifest.getDemoBannerLearnMoreUrl(Mockito.any())).thenReturn(Optional.empty());
 
@@ -130,9 +132,14 @@ public class AdminLayoutBaseViewTest extends WithMockedProfiles {
 
     String result = customView.render(fakeRequest(), new CustomViewModel());
 
-    assertThat(result).contains("This is a demo site");
+    assertThat(result).contains("Demo: TestCity");
     assertThat(result).contains("Demo mode informational alert");
-    assertThat(result).contains("Do not enter actual or personal data in this demo site.");
+    assertThat(result).doesNotContain("Do not enter actual or personal data in this demo site.");
+    assertThat(result).contains("usa-site-alert--slim");
+    assertThat(result).contains("usa-site-alert--no-icon");
+    assertThat(result).contains("cf-demo-banner");
+    assertThat(result).doesNotContain("usa-alert__heading");
+    assertThat(result).doesNotContain("usa-tag");
   }
 
   @Test
@@ -140,6 +147,8 @@ public class AdminLayoutBaseViewTest extends WithMockedProfiles {
     SettingsManifest settingsManifest = mock(SettingsManifest.class);
     when(settingsManifest.getCiviformImageTag()).thenReturn(Optional.of("civiform-image-tag"));
     when(settingsManifest.getFaviconUrl()).thenReturn(Optional.of("favicon-url"));
+    when(settingsManifest.getWhitelabelCivicEntityShortName(Mockito.any()))
+        .thenReturn(Optional.of("TestCity"));
     when(settingsManifest.getDemoBannerEnabled(Mockito.any())).thenReturn(true);
     when(settingsManifest.getDemoBannerLearnMoreUrl(Mockito.any()))
         .thenReturn(Optional.of("https://example.com/demo-learn-more"));
@@ -150,8 +159,62 @@ public class AdminLayoutBaseViewTest extends WithMockedProfiles {
 
     String result = customView.render(fakeRequest(), new CustomViewModel());
 
-    assertThat(result).contains("This is a demo site");
+    assertThat(result).contains("Demo: TestCity");
     assertThat(result).contains("https://example.com/demo-learn-more");
     assertThat(result).contains("here");
+    assertThat(result).contains("You can learn more");
+    assertThat(result).doesNotContain("Do not enter actual or personal data in this demo site.");
+  }
+
+  @Test
+  public void render_demoBanner_whenEnabledWithExpirationDate_containsDaysRemaining() {
+    java.time.LocalDate futureDate =
+        java.time.LocalDate.now(java.time.ZoneId.systemDefault()).plusDays(6);
+    SettingsManifest settingsManifest = mock(SettingsManifest.class);
+    when(settingsManifest.getCiviformImageTag()).thenReturn(Optional.of("civiform-image-tag"));
+    when(settingsManifest.getFaviconUrl()).thenReturn(Optional.of("favicon-url"));
+    when(settingsManifest.getWhitelabelCivicEntityShortName(Mockito.any()))
+        .thenReturn(Optional.of("TestCity"));
+    when(settingsManifest.getDemoBannerEnabled(Mockito.any())).thenReturn(true);
+    when(settingsManifest.getDemoBannerLearnMoreUrl(Mockito.any())).thenReturn(Optional.empty());
+    when(settingsManifest.getDemoBannerExpirationDate(Mockito.any()))
+        .thenReturn(
+            Optional.of(futureDate.format(java.time.format.DateTimeFormatter.ISO_LOCAL_DATE)));
+
+    CustomView customView =
+        createViewWithSettings(
+            "../../test/views/admin/testTemplateWithoutScriptBlock.html", settingsManifest);
+
+    String result = customView.render(fakeRequest(), new CustomViewModel());
+
+    assertThat(result).contains("Demo: TestCity");
+    assertThat(result).contains("usa-tag bg-green");
+    assertThat(result).contains("6 days remaining");
+  }
+
+  @Test
+  public void render_demoBanner_whenEnabledWith5OrLessDaysRemaining_containsYellowTag() {
+    java.time.LocalDate futureDate =
+        java.time.LocalDate.now(java.time.ZoneId.systemDefault()).plusDays(3);
+    SettingsManifest settingsManifest = mock(SettingsManifest.class);
+    when(settingsManifest.getCiviformImageTag()).thenReturn(Optional.of("civiform-image-tag"));
+    when(settingsManifest.getFaviconUrl()).thenReturn(Optional.of("favicon-url"));
+    when(settingsManifest.getWhitelabelCivicEntityShortName(Mockito.any()))
+        .thenReturn(Optional.of("TestCity"));
+    when(settingsManifest.getDemoBannerEnabled(Mockito.any())).thenReturn(true);
+    when(settingsManifest.getDemoBannerLearnMoreUrl(Mockito.any())).thenReturn(Optional.empty());
+    when(settingsManifest.getDemoBannerExpirationDate(Mockito.any()))
+        .thenReturn(
+            Optional.of(futureDate.format(java.time.format.DateTimeFormatter.ISO_LOCAL_DATE)));
+
+    CustomView customView =
+        createViewWithSettings(
+            "../../test/views/admin/testTemplateWithoutScriptBlock.html", settingsManifest);
+
+    String result = customView.render(fakeRequest(), new CustomViewModel());
+
+    assertThat(result).contains("Demo: TestCity");
+    assertThat(result).contains("usa-tag bg-yellow text-ink");
+    assertThat(result).contains("3 days remaining");
   }
 }

--- a/server/test/views/admin/AdminLayoutTest.java
+++ b/server/test/views/admin/AdminLayoutTest.java
@@ -139,4 +139,48 @@ public class AdminLayoutTest extends ResetPostgres {
     assertThat(html).doesNotContain("session-inactivity-warning-modal");
     assertThat(html).doesNotContain("session-length-warning-modal");
   }
+
+  @Test
+  public void getBundle_includesDemoBanner_whenEnabled() {
+    Http.Request request = fakeRequestBuilder().build();
+    when(settingsManifest.getDemoBannerEnabled(request)).thenReturn(true);
+    when(settingsManifest.getDemoBannerLearnMoreUrl(request)).thenReturn(Optional.empty());
+
+    HtmlBundle bundle = adminLayout.getBundle(new HtmlBundle(request));
+    Content content = adminLayout.render(bundle);
+    String html = content.body();
+
+    assertThat(html).contains("This is a demo site");
+    assertThat(html).contains("Demo mode informational alert");
+    assertThat(html).contains("Do not enter actual or personal data in this demo site.");
+  }
+
+  @Test
+  public void getBundle_includesDemoBannerWithLearnMoreUrl_whenConfigured() {
+    Http.Request request = fakeRequestBuilder().build();
+    when(settingsManifest.getDemoBannerEnabled(request)).thenReturn(true);
+    when(settingsManifest.getDemoBannerLearnMoreUrl(request))
+        .thenReturn(Optional.of("https://example.com/demo-learn-more"));
+
+    HtmlBundle bundle = adminLayout.getBundle(new HtmlBundle(request));
+    Content content = adminLayout.render(bundle);
+    String html = content.body();
+
+    assertThat(html).contains("This is a demo site");
+    assertThat(html).contains("https://example.com/demo-learn-more");
+    assertThat(html).contains("here");
+  }
+
+  @Test
+  public void getBundle_doesNotIncludeDemoBanner_whenDisabled() {
+    Http.Request request = fakeRequestBuilder().build();
+    when(settingsManifest.getDemoBannerEnabled(request)).thenReturn(false);
+
+    HtmlBundle bundle = adminLayout.getBundle(new HtmlBundle(request));
+    Content content = adminLayout.render(bundle);
+    String html = content.body();
+
+    assertThat(html).doesNotContain("This is a demo site");
+    assertThat(html).doesNotContain("Demo mode informational alert");
+  }
 }

--- a/server/test/views/admin/AdminLayoutTest.java
+++ b/server/test/views/admin/AdminLayoutTest.java
@@ -1,6 +1,7 @@
 package views.admin;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static support.FakeRequestBuilder.fakeRequestBuilder;
@@ -36,6 +37,8 @@ public class AdminLayoutTest extends ResetPostgres {
     settingsManifest = mock(SettingsManifest.class);
     when(settingsManifest.getCiviformImageTag()).thenReturn(Optional.of("fake-image-tag"));
     when(settingsManifest.getFaviconUrl()).thenReturn(Optional.of("favicon-url"));
+    when(settingsManifest.getWhitelabelCivicEntityShortName(any()))
+        .thenReturn(Optional.of("TestCity"));
 
     translationLocales = mock(TranslationLocales.class);
     when(translationLocales.translatableLocales()).thenReturn(ImmutableList.of(Locale.CHINESE));
@@ -150,9 +153,14 @@ public class AdminLayoutTest extends ResetPostgres {
     Content content = adminLayout.render(bundle);
     String html = content.body();
 
-    assertThat(html).contains("This is a demo site");
+    assertThat(html).contains("Demo: TestCity");
     assertThat(html).contains("Demo mode informational alert");
-    assertThat(html).contains("Do not enter actual or personal data in this demo site.");
+    assertThat(html).doesNotContain("Do not enter actual or personal data in this demo site.");
+    assertThat(html).contains("usa-site-alert--slim");
+    assertThat(html).contains("usa-site-alert--no-icon");
+    assertThat(html).contains("cf-demo-banner");
+    assertThat(html).doesNotContain("usa-alert__heading");
+    assertThat(html).doesNotContain("usa-tag");
   }
 
   @Test
@@ -166,9 +174,11 @@ public class AdminLayoutTest extends ResetPostgres {
     Content content = adminLayout.render(bundle);
     String html = content.body();
 
-    assertThat(html).contains("This is a demo site");
+    assertThat(html).contains("Demo: TestCity");
     assertThat(html).contains("https://example.com/demo-learn-more");
     assertThat(html).contains("here");
+    assertThat(html).contains("You can learn more");
+    assertThat(html).doesNotContain("Do not enter actual or personal data in this demo site.");
   }
 
   @Test
@@ -180,7 +190,47 @@ public class AdminLayoutTest extends ResetPostgres {
     Content content = adminLayout.render(bundle);
     String html = content.body();
 
-    assertThat(html).doesNotContain("This is a demo site");
+    assertThat(html).doesNotContain("Demo: TestCity");
     assertThat(html).doesNotContain("Demo mode informational alert");
+  }
+
+  @Test
+  public void getBundle_includesDemoBannerWithExpirationDate_whenConfigured() {
+    Http.Request request = fakeRequestBuilder().build();
+    java.time.LocalDate futureDate =
+        java.time.LocalDate.now(java.time.ZoneId.systemDefault()).plusDays(4);
+    when(settingsManifest.getDemoBannerEnabled(request)).thenReturn(true);
+    when(settingsManifest.getDemoBannerLearnMoreUrl(request)).thenReturn(Optional.empty());
+    when(settingsManifest.getDemoBannerExpirationDate(request))
+        .thenReturn(
+            Optional.of(futureDate.format(java.time.format.DateTimeFormatter.ISO_LOCAL_DATE)));
+
+    HtmlBundle bundle = adminLayout.getBundle(new HtmlBundle(request));
+    Content content = adminLayout.render(bundle);
+    String html = content.body();
+
+    assertThat(html).contains("Demo: TestCity");
+    assertThat(html).contains("usa-tag bg-yellow text-ink");
+    assertThat(html).contains("4 days remaining");
+  }
+
+  @Test
+  public void getBundle_includesDemoBannerWithExpirationDate_greenTagWhenMoreThan5Days() {
+    Http.Request request = fakeRequestBuilder().build();
+    java.time.LocalDate futureDate =
+        java.time.LocalDate.now(java.time.ZoneId.systemDefault()).plusDays(7);
+    when(settingsManifest.getDemoBannerEnabled(request)).thenReturn(true);
+    when(settingsManifest.getDemoBannerLearnMoreUrl(request)).thenReturn(Optional.empty());
+    when(settingsManifest.getDemoBannerExpirationDate(request))
+        .thenReturn(
+            Optional.of(futureDate.format(java.time.format.DateTimeFormatter.ISO_LOCAL_DATE)));
+
+    HtmlBundle bundle = adminLayout.getBundle(new HtmlBundle(request));
+    Content content = adminLayout.render(bundle);
+    String html = content.body();
+
+    assertThat(html).contains("Demo: TestCity");
+    assertThat(html).contains("usa-tag bg-green");
+    assertThat(html).contains("7 days remaining");
   }
 }


### PR DESCRIPTION
### Description

This change adds a banner to be used on demo instances of civiform (e.g. https://demo.civiform.dev/). It shows a simple "Demo: <city name" header, and an optional expiration countdown when an instance has a limited evaluation period.

Additionally this changes the civiform admin header to use position:sticky instead of relying on position:fixed and manually calculated margins.

The banner can be enabled with the DEMO_BANNER_ENABLED parameter, and the expiration date is set in DEMO_BANNER_EXPIRATION_DATE as a "yyyy-mm-dd" string.

As follow-up work we'll add buttons to switch between admin and applicant views, similar to the ones on the dev tools menu.

Assisted-by: Antigravity:gemini-3.1-pro

### Checklist

Remove any sections below that do not apply to your PR. For sections that do apply, complete all of the appropriate checklist items and check them off. If a checklist item doesn't apply to your PR, leave it unchecked but do not delete it.

#### General

Read the full guidelines for PRs [here](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#creating-a-pull-request)

- [X] Added the correct label (see [docs](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-appropriate-labels) for more info): < feature | enhancement | bug | under-development | dependencies | infrastructure | ignore-for-release | database >
- [X] Assigned to a specific person, `civiform/developers`, or a [more specific round-robin list](https://github.com/civiform/civiform/wiki/Technical-contribution-guide#adding-reviewers)
- [ ] Added an additional reviewer from `civiform/eng-admin` as FYI (if this PR includes functionality changes and neither you nor the primary reviewer is an admin)
- [ ] Added an additional reviewer as required if changes potentially affect the security of the application.
- [X] Removed the release notes section if the title is sufficient for the release notes description, or put more details in that section.
- [X] Created unit and/or browser tests which fail without the change (if possible)
- [X] Performed manual testing (Chrome and Firefox if it includes front-end changes)
- [ ] Extended the README / documentation, if necessary. For user-facing features, consider updating [the user docs](https://github.com/civiform/docs). For "under-the-hood" changes or things more relevant to developers, consider updating [the dev wiki](https://github.com/civiform/civiform/wiki).
- [ ] Ensured PII wasn't added to any new logs, unless it was guarded by `isDevOrStaging`
- [ ] Noted in the PR description which, if any, code in this PR was generated by AI.

#### User visible changes

- [X] Followed steps to [internationalize](https://github.com/civiform/civiform/wiki/Internationalization-%28i18n%29#application-strings) any new strings
  - [X] Added context strings to new [messages](https://github.com/civiform/civiform/blob/main/server/conf/i18n/messages)
  - [X] Didn't use a message in applicant facing code that isn't translated yet (unless behind a flag)
- [ ] Wrote browser tests using the [validateAccessibility](https://sourcegraph.com/github.com/civiform/civiform/-/blob/browser-test/src/support/index.ts?L437:14&subtree=true) method
- [ ] Tested on mobile view. See [mobile device mode](https://developer.chrome.com/docs/devtools/device-mode/)
- [ ] Manually tested at 200% size
- [ ] Manually evaluated tab order
- [ ] Performed manual accessibility tests for any applicant-facing changes or any new admin-facing features. See [manual-accessibility-testing](https://github.com/civiform/civiform/wiki/Accessibility#manual-accessibility-testing)
- [ ] Manually tested with a right-to-left language

#### New Features

- [X] Add new FeatureFlag env vars to `server/conf/helper/feature-flags.conf`
- [X] Conditioned new functionality on a [FeatureFlag](https://github.com/civiform/civiform/wiki/Feature-Flags)
- [X] Wrote browser tests with the feature flag off and on, etc.

### Instructions for manual testing

- Go to admin/settings
- Enable DEMO_BANNER_ENABLED
- Save changes, demo banner should be visible in admin and applicant pages
- In admin/settings enter a future date in yyyy-mm-dd format in DEMO_BANNER_EXPIRATION_DATE
- Demo banner should now contain an expiration countdown